### PR TITLE
chore: rename Signed to KeyedSig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "safe_network"
 readme = "README.md"
-repository = "https://github.com/maidsafe/the_safe_network"
+repository = "https://github.com/maidsafe/safe_network"
 version = "0.0.1"
 
 [[bin]]
@@ -101,8 +101,6 @@ tempdir = "~0.3.7"
   version = "2.0.2"
   features = [ "sha3" ]
 
-
-
   [dependencies.bytes]
   version = "1.0.1"
   features = [ "serde" ]
@@ -136,6 +134,5 @@ tempdir = "~0.3.7"
   version = "1.3.0"
   features = [ "macros", "fs", "sync", "io-util" , "rt", "rt-multi-thread"]
 
-[dev_dependencies]
-tempdir = "~0.3.7"
-
+  [dev_dependencies]
+  tempdir = "~0.3.7"

--- a/src/client/client_api/commands.rs
+++ b/src/client/client_api/commands.rs
@@ -8,7 +8,7 @@
 
 use super::Client;
 use crate::client::Error;
-use crate::messaging::client::{ClientSigned, Cmd};
+use crate::messaging::client::{ClientSig, Cmd};
 use log::debug;
 use sn_data_types::{PublicKey, Signature};
 
@@ -21,12 +21,12 @@ impl Client {
         signature: Signature,
     ) -> Result<(), Error> {
         debug!("Sending Cmd: {:?}", cmd);
-        let client_signed = ClientSigned {
+        let client_sig = ClientSig {
             public_key: client_pk,
             signature,
         };
 
-        self.session.send_cmd(cmd, client_signed).await
+        self.session.send_cmd(cmd, client_sig).await
     }
 
     // Send a Cmd to the network without awaiting for a response.

--- a/src/client/client_api/queries.rs
+++ b/src/client/client_api/queries.rs
@@ -8,7 +8,7 @@
 
 use super::Client;
 use crate::client::{connections::QueryResult, errors::Error};
-use crate::messaging::client::{ClientSigned, Query};
+use crate::messaging::client::{ClientSig, Query};
 use log::debug;
 use sn_data_types::{PublicKey, Signature};
 
@@ -21,12 +21,12 @@ impl Client {
         signature: Signature,
     ) -> Result<QueryResult, Error> {
         debug!("Sending Query: {:?}", query);
-        let client_signed = ClientSigned {
+        let client_sig = ClientSig {
             public_key: client_pk,
             signature,
         };
 
-        self.session.send_query(query, client_signed).await
+        self.session.send_query(query, client_sig).await
     }
 
     // Send a Query to the network and await a response.

--- a/src/client/client_api/transfer_actor/mod.rs
+++ b/src/client/client_api/transfer_actor/mod.rs
@@ -15,7 +15,7 @@ mod write_apis;
 
 use crate::client::{Client, Error};
 use crate::messaging::client::{
-    ClientSigned, Cmd, DataCmd, Query, QueryResponse, TransferCmd, TransferQuery,
+    ClientSig, Cmd, DataCmd, Query, QueryResponse, TransferCmd, TransferQuery,
 };
 use bincode::serialize;
 use log::{debug, error, info, trace, warn};
@@ -264,14 +264,14 @@ impl Client {
 
         let client_pk = self.public_key();
         let signature = self.keypair.sign(b"TODO");
-        let client_signed = ClientSigned {
+        let client_sig = ClientSig {
             public_key: client_pk,
             signature,
         };
 
         let msg_id = self
             .session
-            .send_transfer_validation(cmd, client_signed, sender)
+            .send_transfer_validation(cmd, client_sig, sender)
             .await?;
 
         let mut returned_errors = vec![];

--- a/src/messaging/client/mod.rs
+++ b/src/messaging/client/mod.rs
@@ -55,10 +55,9 @@ use xor_name::XorName;
 
 /// Public key and signature provided by the client
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub struct ClientSigned {
+pub struct ClientSig {
     /// Client public key.
     pub public_key: PublicKey,
-
     /// Client signature.
     pub signature: Signature,
 }
@@ -244,7 +243,7 @@ pub enum ProcessMsg {
         /// Cmd.
         cmd: Cmd,
         /// Public key and corresponding signature over the command
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
     },
     /// Queries is a read-only operation.
     Query {
@@ -253,7 +252,7 @@ pub enum ProcessMsg {
         /// Query.
         query: Query,
         /// Public key and corresponding signature over the query
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
     },
     /// An Event is a fact about something that happened.
     Event {
@@ -546,7 +545,7 @@ mod tests {
             let msg = ProcessMsg::Query {
                 id: MessageId::new(),
                 query: Query::Transfer(TransferQuery::GetBalance(public_key)),
-                client_signed: ClientSigned {
+                client_sig: ClientSig {
                     public_key,
                     signature,
                 },
@@ -579,7 +578,7 @@ mod tests {
                 source_message: Some(ProcessMsg::Query {
                     id: MessageId::new(),
                     query: Query::Transfer(TransferQuery::GetBalance(public_key)),
-                    client_signed: ClientSigned {
+                    client_sig: ClientSig {
                         public_key,
                         signature,
                     },
@@ -651,7 +650,7 @@ mod tests {
         let message = ClientMsg::Process(ProcessMsg::Query {
             id,
             query: Query::Transfer(TransferQuery::GetBalance(public_key)),
-            client_signed: ClientSigned {
+            client_sig: ClientSig {
                 public_key,
                 signature,
             },

--- a/src/messaging/node/mod.rs
+++ b/src/messaging/node/mod.rs
@@ -20,7 +20,7 @@ mod signed;
 mod src_authority;
 mod variant;
 
-pub use agreement::{DkgFailureSigned, DkgFailureSignedSet, DkgKey, Proposal, SectionSigned};
+pub use agreement::{DkgFailureSig, DkgFailureSigSet, DkgKey, Proposal, SectionSigned};
 pub use join::{JoinRejectionReason, JoinRequest, JoinResponse, ResourceProofResponse};
 pub use join_as_relocated::{JoinAsRelocatedRequest, JoinAsRelocatedResponse};
 pub use network::{Network, OtherSection};
@@ -34,7 +34,7 @@ pub use prefix_map::PrefixMap;
 pub use relocation::{RelocateDetails, RelocatePayload, RelocatePromise, SignedRelocateDetails};
 pub use section::{ElderCandidates, MembershipState, NodeState, Peer, Section, SectionPeers};
 pub use signature_aggregator::{Error, SignatureAggregator};
-pub use signed::{Signed, SignedShare};
+pub use signed::{KeyedSig, SigShare};
 pub use src_authority::SrcAuthority;
 pub use variant::Variant;
 

--- a/src/messaging/node/network.rs
+++ b/src/messaging/node/network.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{agreement::SectionSigned, prefix_map::PrefixMap, signed::Signed};
+use super::{agreement::SectionSigned, prefix_map::PrefixMap, signed::KeyedSig};
 use crate::messaging::SectionAuthorityProvider;
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
@@ -24,10 +24,10 @@ pub struct Network {
 pub struct OtherSection {
     /// Section authority so we know this info was valid
     pub section_auth: SectionSigned<SectionAuthorityProvider>,
-    /// If this is signed by our section, then `key_signed` is `None`. If this is signed by our
-    /// sibling section, then `key_signed` contains the proof of the signing key itself signed by our
+    /// If this is signed by our section, then `key_sig` is `None`. If this is signed by our
+    /// sibling section, then `key_sig` contains the proof of the signing key itself signed by our
     /// section.
-    pub key_signed: Option<Signed>,
+    pub key_sig: Option<KeyedSig>,
 }
 
 impl Borrow<Prefix> for OtherSection {

--- a/src/messaging/node/node_msg.rs
+++ b/src/messaging/node/node_msg.rs
@@ -11,7 +11,7 @@
 use crate::messaging::client::{CmdError, Error, Result};
 use crate::messaging::{
     client::{
-        ChunkRead, ChunkWrite, ClientSigned, DataCmd as NodeDataCmd, DataExchange,
+        ChunkRead, ChunkWrite, ClientSig, DataCmd as NodeDataCmd, DataExchange,
         DataQuery as NodeDataQuery,
     },
     EndUser, MessageId, MessageType, WireMsg,
@@ -134,7 +134,7 @@ pub enum NodeCmd {
         /// The contianed command
         cmd: NodeDataCmd,
         /// Client pk and signature
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
         /// Message source
         origin: EndUser,
     },
@@ -143,7 +143,7 @@ pub enum NodeCmd {
         /// The contianed command
         cmd: ChunkWrite,
         /// Client pk and signature
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
         /// Message source
         origin: EndUser,
     },
@@ -222,7 +222,7 @@ pub enum NodeQuery {
         /// The actual query message
         query: NodeDataQuery,
         /// Client signature
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
         /// The user that has initiated this query
         origin: EndUser,
     },

--- a/src/messaging/node/section/mod.rs
+++ b/src/messaging/node/section/mod.rs
@@ -24,6 +24,7 @@ use std::{
 };
 use xor_name::XorName;
 
+/// Container for storing information about a section.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// All information about a section
 pub struct Section {

--- a/src/messaging/node/signed.rs
+++ b/src/messaging/node/signed.rs
@@ -9,35 +9,35 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Formatter};
 
-/// Signed that a quorum of the section elders has agreed on something.
+/// Signature created when a quorum of the section elders has agreed on something.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
-pub struct Signed {
+pub struct KeyedSig {
     /// The BLS public key.
     pub public_key: bls::PublicKey,
     /// The BLS signature corresponding to the public key.
     pub signature: bls::Signature,
 }
 
-impl Signed {
-    /// Verifies this signed against the payload.
+impl KeyedSig {
+    /// Verifies this signature against the payload.
     pub fn verify(&self, payload: &[u8]) -> bool {
         self.public_key.verify(&self.signature, payload)
     }
 }
 
-/// Single share of `Signed`.
+/// Single share of `KeyedSig`.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct SignedShare {
+pub struct SigShare {
     /// BLS public key set.
     pub public_key_set: bls::PublicKeySet,
-    /// Index of the node that created this signed share.
+    /// Index of the node that created this signature share.
     pub index: usize,
     /// BLS signature share corresponding to the `index`-th public key share of the public key set.
     pub signature_share: bls::SignatureShare,
 }
 
-impl SignedShare {
-    /// Creates new signed share.
+impl SigShare {
+    /// Creates new signature share.
     pub fn new(
         public_key_set: bls::PublicKeySet,
         index: usize,
@@ -51,7 +51,7 @@ impl SignedShare {
         }
     }
 
-    /// Verifies this signed share against the payload.
+    /// Verifies this signature share against the payload.
     pub fn verify(&self, payload: &[u8]) -> bool {
         self.public_key_set
             .public_key_share(self.index)
@@ -59,11 +59,11 @@ impl SignedShare {
     }
 }
 
-impl Debug for SignedShare {
+impl Debug for SigShare {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(
             formatter,
-            "SignedShare {{ public_key: {:?}, index: {}, .. }}",
+            "SigShare {{ public_key: {:?}, index: {}, .. }}",
             self.public_key_set.public_key(),
             self.index
         )
@@ -76,15 +76,15 @@ mod tests {
     use bls::SecretKey;
 
     #[test]
-    fn verify_signed() {
+    fn verify_keyed_sig() {
         let sk = SecretKey::random();
         let public_key = sk.public_key();
         let data = "hello".to_string();
         let signature = sk.sign(&data);
-        let signed = Signed {
+        let sig = KeyedSig {
             public_key,
             signature,
         };
-        assert!(signed.verify(&data.as_bytes()));
+        assert!(sig.verify(&data.as_bytes()));
     }
 }

--- a/src/messaging/node/src_authority.rs
+++ b/src/messaging/node/src_authority.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::signed::{Signed, SignedShare};
+use super::signed::{KeyedSig, SigShare};
 use ed25519_dalek::PublicKey;
 use ed25519_dalek::Signature;
 use secured_linked_list::SecuredLinkedList;
@@ -33,7 +33,7 @@ pub enum SrcAuthority {
         /// Name in the source section
         src_name: XorName,
         /// Proof Share signed by the peer's BLS KeyShare
-        signed_share: SignedShare,
+        sig_share: SigShare,
         /// SectionChain of the sender's section.
         section_chain: SecuredLinkedList,
     },
@@ -42,7 +42,7 @@ pub enum SrcAuthority {
         /// Name in the source section.
         src_name: XorName,
         /// BLS proof of the message corresponding to the source section.
-        signed: Signed,
+        sig: KeyedSig,
         /// SectionChain of the sender's section.
         section_chain: SecuredLinkedList,
     },

--- a/src/node/event_mapping/client_msg.rs
+++ b/src/node/event_mapping/client_msg.rs
@@ -62,12 +62,12 @@ fn map_client_process_msg(process_msg: ProcessMsg, origin: EndUser) -> NodeDuty 
     match process_msg {
         ProcessMsg::Query {
             query: Query::Data(query),
-            client_signed,
+            client_sig,
             ..
         } => NodeDuty::ProcessRead {
             query,
             msg_id,
-            client_signed,
+            client_sig,
             origin,
         },
         ProcessMsg::Cmd {

--- a/src/node/event_mapping/node_msg.rs
+++ b/src/node/event_mapping/node_msg.rs
@@ -130,7 +130,7 @@ fn match_node_msg(msg: NodeMsg, origin: SrcLocation) -> NodeDuty {
             query:
                 NodeQuery::Metadata {
                     query,
-                    client_signed,
+                    client_sig,
                     origin,
                 },
             id,
@@ -141,7 +141,7 @@ fn match_node_msg(msg: NodeMsg, origin: SrcLocation) -> NodeDuty {
             NodeDuty::ProcessRead {
                 query,
                 msg_id: id,
-                client_signed,
+                client_sig,
                 origin,
             }
         }
@@ -149,7 +149,7 @@ fn match_node_msg(msg: NodeMsg, origin: SrcLocation) -> NodeDuty {
             cmd:
                 NodeCmd::Metadata {
                     cmd,
-                    client_signed,
+                    client_sig,
                     origin,
                 },
             id,
@@ -160,7 +160,7 @@ fn match_node_msg(msg: NodeMsg, origin: SrcLocation) -> NodeDuty {
             NodeDuty::ProcessWrite {
                 cmd,
                 msg_id: id,
-                client_signed,
+                client_sig,
                 origin,
             }
         }
@@ -176,14 +176,14 @@ fn match_node_msg(msg: NodeMsg, origin: SrcLocation) -> NodeDuty {
         },
         NodeMsg::NodeCmd {
             cmd: NodeCmd::Chunks {
-                cmd, client_signed, ..
+                cmd, client_sig, ..
             },
             id,
             ..
         } => NodeDuty::WriteChunk {
             write: cmd,
             msg_id: id,
-            client_signed,
+            client_sig,
         },
         // this cmd is accumulated, thus has authority
         NodeMsg::NodeCmd {

--- a/src/node/metadata/elder_stores.rs
+++ b/src/node/metadata/elder_stores.rs
@@ -11,7 +11,7 @@ use super::{
     sequence_storage::SequenceStorage,
 };
 use crate::messaging::{
-    client::{ClientSigned, DataCmd, DataExchange, DataQuery},
+    client::{ClientSig, DataCmd, DataExchange, DataQuery},
     EndUser, MessageId,
 };
 use crate::node::{node_ops::NodeDuty, Error, Result};
@@ -70,7 +70,7 @@ impl ElderStores {
         &mut self,
         cmd: DataCmd,
         msg_id: MessageId,
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
         origin: EndUser,
     ) -> Result<NodeDuty> {
         info!("Writing Data");
@@ -78,25 +78,25 @@ impl ElderStores {
             DataCmd::Blob(write) => {
                 info!("Writing Blob");
                 self.chunk_records
-                    .write(write, msg_id, client_signed, origin)
+                    .write(write, msg_id, client_sig, origin)
                     .await
             }
             DataCmd::Map(write) => {
                 info!("Writing Map");
                 self.map_storage
-                    .write(write, msg_id, client_signed.public_key, origin)
+                    .write(write, msg_id, client_sig.public_key, origin)
                     .await
             }
             DataCmd::Sequence(write) => {
                 info!("Writing Sequence");
                 self.sequence_storage
-                    .write(write, msg_id, client_signed.public_key, origin)
+                    .write(write, msg_id, client_sig.public_key, origin)
                     .await
             }
             DataCmd::Register(write) => {
                 info!("Writing Register");
                 self.register_storage
-                    .write(write, msg_id, client_signed.public_key, origin)
+                    .write(write, msg_id, client_sig.public_key, origin)
                     .await
             }
         }

--- a/src/node/metadata/mod.rs
+++ b/src/node/metadata/mod.rs
@@ -16,8 +16,7 @@ mod sequence_storage;
 
 use crate::messaging::{
     client::{
-        ClientMsg, ClientSigned, CmdError, DataCmd, DataExchange, DataQuery, ProcessMsg,
-        QueryResponse,
+        ClientMsg, ClientSig, CmdError, DataCmd, DataExchange, DataQuery, ProcessMsg, QueryResponse,
     },
     Aggregation, DstLocation, EndUser, MessageId,
 };
@@ -99,12 +98,10 @@ impl Metadata {
         &mut self,
         cmd: DataCmd,
         id: MessageId,
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
         origin: EndUser,
     ) -> Result<NodeDuty> {
-        self.elder_stores
-            .write(cmd, id, client_signed, origin)
-            .await
+        self.elder_stores.write(cmd, id, client_sig, origin).await
     }
 
     /// Adds a given node to the list of full nodes.

--- a/src/node/node_api/handle.rs
+++ b/src/node/node_api/handle.rs
@@ -460,7 +460,7 @@ impl Node {
             NodeDuty::WriteChunk {
                 write,
                 msg_id,
-                client_signed,
+                client_sig,
             } => {
                 let adult = self.role.as_adult()?.clone();
                 let handle = tokio::spawn(async move {
@@ -469,7 +469,7 @@ impl Node {
                             .chunks
                             .write()
                             .await
-                            .write(&write, msg_id, client_signed.public_key)
+                            .write(&write, msg_id, client_sig.public_key)
                             .await?,
                     ];
                     ops.extend(adult.chunks.read().await.check_storage().await?);
@@ -563,7 +563,7 @@ impl Node {
             NodeDuty::ProcessRead {
                 query,
                 msg_id,
-                client_signed,
+                client_sig,
                 origin,
             } => {
                 // TODO: remove this conditional branching
@@ -579,7 +579,7 @@ impl Node {
                                 // this is a write here as we write the liveness check for each adult
                                 .write()
                                 .await
-                                .read(query, msg_id, client_signed.public_key, origin)
+                                .read(query, msg_id, client_sig.public_key, origin)
                                 .await?,
                         ]
                     } else {
@@ -594,7 +594,7 @@ impl Node {
                             msg: NodeMsg::NodeQuery {
                                 query: NodeQuery::Metadata {
                                     query,
-                                    client_signed,
+                                    client_sig,
                                     origin,
                                 },
                                 id: msg_id,
@@ -611,7 +611,7 @@ impl Node {
                 cmd,
                 msg_id,
                 origin,
-                client_signed,
+                client_sig,
             } => {
                 let elder = self.role.as_elder_mut()?.clone();
                 let handle = tokio::spawn(async move {
@@ -620,7 +620,7 @@ impl Node {
                             .meta_data
                             .write()
                             .await
-                            .write(cmd, msg_id, client_signed, origin)
+                            .write(cmd, msg_id, client_sig, origin)
                             .await?,
                     ]))
                 });
@@ -650,7 +650,7 @@ impl Node {
                     ProcessMsg::Cmd {
                         id,
                         cmd: Cmd::Data { payment, cmd },
-                        client_signed,
+                        client_sig,
                     },
                 origin,
                 ..
@@ -662,7 +662,7 @@ impl Node {
                             .transfers
                             .write()
                             .await
-                            .process_payment(id, payment, cmd, client_signed, origin)
+                            .process_payment(id, payment, cmd, client_sig, origin)
                             .await?,
                     ))
                 });

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -9,7 +9,7 @@
 use crate::messaging::client::ClientMsg;
 use crate::messaging::{
     client::{
-        ChunkRead, ChunkWrite, ClientSigned, DataCmd, DataExchange, DataQuery, ProcessMsg,
+        ChunkRead, ChunkWrite, ClientSig, DataCmd, DataExchange, DataQuery, ProcessMsg,
         ProcessingError, QueryResponse, SupportingInfo,
     },
     node::NodeMsg,
@@ -90,7 +90,7 @@ pub enum NodeDuty {
     WriteChunk {
         write: ChunkWrite,
         msg_id: MessageId,
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
     },
     ProcessRepublish {
         chunk: Chunk,
@@ -211,14 +211,14 @@ pub enum NodeDuty {
     ProcessRead {
         query: DataQuery,
         msg_id: MessageId,
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
         origin: EndUser,
     },
     /// Process write of data
     ProcessWrite {
         cmd: DataCmd,
         msg_id: MessageId,
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
         origin: EndUser,
     },
     /// Process Payment for a DataCmd

--- a/src/node/transfers/mod.rs
+++ b/src/node/transfers/mod.rs
@@ -15,7 +15,7 @@ mod test_utils;
 use self::replicas::{ReplicaInfo, Replicas};
 use crate::messaging::{
     client::{
-        ClientMsg, ClientSigned, CmdError, DataCmd, Error as ErrorMessage, Event, ProcessMsg,
+        ClientMsg, ClientSig, CmdError, DataCmd, Error as ErrorMessage, Event, ProcessMsg,
         QueryResponse, TransferError,
     },
     node::{
@@ -165,7 +165,7 @@ impl Transfers {
         msg_id: MessageId,
         payment: TransferAgreementProof,
         data_cmd: DataCmd,
-        client_signed: ClientSigned,
+        client_sig: ClientSig,
         origin: EndUser,
     ) -> Result<NodeDuties> {
         let num_bytes = utils::serialise(&data_cmd)?.len() as u64;
@@ -253,7 +253,7 @@ impl Transfers {
                     msg: MsgType::Node(NodeMsg::NodeCmd {
                         cmd: NodeCmd::Metadata {
                             cmd: data_cmd.clone(),
-                            client_signed,
+                            client_sig,
                             origin,
                         },
                         id: MessageId::in_response_to(&msg_id),

--- a/src/routing/agreement/dkg_msgs_utils.rs
+++ b/src/routing/agreement/dkg_msgs_utils.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::node::{DkgFailureSigned, DkgFailureSignedSet, DkgKey, ElderCandidates};
+use crate::messaging::node::{DkgFailureSig, DkgFailureSigSet, DkgKey, ElderCandidates};
 use crate::routing::routing_api::{
     crypto::{self, Digest256, Keypair, Verifier},
     peer::PeerUtils,
@@ -39,72 +39,72 @@ impl DkgKeyUtils for DkgKey {
     }
 }
 
-pub trait DkgFailureSignedUtils {
-    fn new(keypair: &Keypair, non_participants: &BTreeSet<XorName>, dkg_key: &DkgKey) -> Self;
+pub trait DkgFailureSigUtils {
+    fn new(keypair: &Keypair, failed_participants: &BTreeSet<XorName>, dkg_key: &DkgKey) -> Self;
 
-    fn verify(&self, dkg_key: &DkgKey, non_participants: &BTreeSet<XorName>) -> bool;
+    fn verify(&self, dkg_key: &DkgKey, failed_participants: &BTreeSet<XorName>) -> bool;
 }
 
-impl DkgFailureSignedUtils for DkgFailureSigned {
-    fn new(keypair: &Keypair, non_participants: &BTreeSet<XorName>, dkg_key: &DkgKey) -> Self {
-        DkgFailureSigned {
+impl DkgFailureSigUtils for DkgFailureSig {
+    fn new(keypair: &Keypair, failed_participants: &BTreeSet<XorName>, dkg_key: &DkgKey) -> Self {
+        DkgFailureSig {
             public_key: keypair.public,
-            signature: crypto::sign(&failure_signed_hash(dkg_key, non_participants), keypair),
+            signature: crypto::sign(&hashed_failure(dkg_key, failed_participants), keypair),
         }
     }
 
-    fn verify(&self, dkg_key: &DkgKey, non_participants: &BTreeSet<XorName>) -> bool {
-        let hash = failure_signed_hash(dkg_key, non_participants);
+    fn verify(&self, dkg_key: &DkgKey, failed_participants: &BTreeSet<XorName>) -> bool {
+        let hash = hashed_failure(dkg_key, failed_participants);
         self.public_key.verify(&hash, &self.signature).is_ok()
     }
 }
 
-pub trait DkgFailureSignedSetUtils {
-    fn insert(&mut self, signed: DkgFailureSigned, non_participants: &BTreeSet<XorName>) -> bool;
+pub trait DkgFailureSigSetUtils {
+    fn insert(&mut self, sig: DkgFailureSig, failed_participants: &BTreeSet<XorName>) -> bool;
 
     fn has_agreement(&self, elder_candidates: &ElderCandidates) -> bool;
 
     fn verify(&self, elder_candidates: &ElderCandidates, generation: u64) -> bool;
 }
 
-impl DkgFailureSignedSetUtils for DkgFailureSignedSet {
-    // Insert a signed into this set. The signed is assumed valid. Returns `true` if the signed was
+impl DkgFailureSigSetUtils for DkgFailureSigSet {
+    // Insert a signature into this set. The signature is assumed valid. Returns `true` if the signature was
     // not already present in the set and `false` otherwise.
-    fn insert(&mut self, signed: DkgFailureSigned, non_participants: &BTreeSet<XorName>) -> bool {
-        if self.non_participants.is_empty() {
-            self.non_participants = non_participants.clone();
+    fn insert(&mut self, sig: DkgFailureSig, failed_participants: &BTreeSet<XorName>) -> bool {
+        if self.failed_participants.is_empty() {
+            self.failed_participants = failed_participants.clone();
         }
         if self
-            .signeds
+            .sigs
             .iter()
-            .all(|existing_signed| existing_signed.public_key != signed.public_key)
+            .all(|existing_sig| existing_sig.public_key != sig.public_key)
         {
-            self.signeds.push(signed);
+            self.sigs.push(sig);
             true
         } else {
             false
         }
     }
 
-    // Check whether we have enough signeds to reach agreement on the failure. The contained signeds
+    // Check whether we have enough signatures to reach agreement on the failure. The contained signatures
     // are assumed valid.
     fn has_agreement(&self, elder_candidates: &ElderCandidates) -> bool {
-        has_failure_agreement(elder_candidates.elders.len(), self.signeds.len())
+        has_failure_agreement(elder_candidates.elders.len(), self.failures.len())
     }
 
     fn verify(&self, elder_candidates: &ElderCandidates, generation: u64) -> bool {
-        let hash = failure_signed_hash(
+        let hash = hashed_failure(
             &DkgKey::new(elder_candidates, generation),
-            &self.non_participants,
+            &self.failed_participants,
         );
         let votes = self
-            .signeds
+            .sigs
             .iter()
-            .filter(|signed| {
+            .filter(|sig| {
                 elder_candidates
                     .elders
-                    .contains_key(&crypto::name(&signed.public_key))
-                    && signed.public_key.verify(&hash, &signed.signature).is_ok()
+                    .contains_key(&crypto::name(&sig.public_key))
+                    && sig.public_key.verify(&hash, &sig.signature).is_ok()
             })
             .count();
 
@@ -112,21 +112,21 @@ impl DkgFailureSignedSetUtils for DkgFailureSignedSet {
     }
 }
 
-// Check whether we have enough signeds to reach agreement on the failure. We only need
-// `N - supermajority(N) + 1` signeds, because that already makes a supermajority agreement on a
+// Check whether we have enough signatures to reach agreement on the failure. We only need
+// `N - supermajority(N) + 1` signatures, because that already makes a supermajority agreement on a
 // successful outcome impossible.
 fn has_failure_agreement(num_participants: usize, num_votes: usize) -> bool {
     num_votes > num_participants - supermajority(num_participants)
 }
 
-// Create a value whose signature serves as the signed that a failure of a DKG session with the given
+// Create a value whose signature proves that a failure of a DKG session with the given
 // `dkg_key` was observed.
-fn failure_signed_hash(dkg_key: &DkgKey, non_participants: &BTreeSet<XorName>) -> Digest256 {
+fn hashed_failure(dkg_key: &DkgKey, failed_participants: &BTreeSet<XorName>) -> Digest256 {
     let mut hasher = Sha3::v256();
     let mut hash = Digest256::default();
     hasher.update(&dkg_key.hash);
     hasher.update(&dkg_key.generation.to_le_bytes());
-    for name in non_participants.iter() {
+    for name in failed_participants.iter() {
         hasher.update(&name.0);
     }
     hasher.update(b"failure");

--- a/src/routing/agreement/mod.rs
+++ b/src/routing/agreement/mod.rs
@@ -15,16 +15,16 @@ pub mod test_utils;
 
 pub(crate) use self::{
     dkg::{DkgCommands, DkgVoter},
-    dkg_msgs_utils::{DkgFailureSignedSetUtils, DkgFailureSignedUtils, DkgKeyUtils},
+    dkg_msgs_utils::{DkgFailureSigSetUtils, DkgFailureSigUtils, DkgKeyUtils},
     proposal::{ProposalAggregator, ProposalError, ProposalUtils},
 };
-pub(crate) use crate::messaging::node::{SignatureAggregator, Signed, SignedShare};
+pub(crate) use crate::messaging::node::{SignatureAggregator, KeyedSig, SigShare};
 pub use proven::ProvenUtils;
 use serde::Serialize;
 
-// Verify the integrity of `message` against `signed`.
-pub(crate) fn verify_signed<T: Serialize>(signed: &Signed, message: &T) -> bool {
+// Verify the integrity of `message` against signature.
+pub(crate) fn verify_sig<T: Serialize>(sig: &KeyedSig, message: &T) -> bool {
     bincode::serialize(message)
-        .map(|bytes| signed.verify(&bytes))
+        .map(|bytes| sig.verify(&bytes))
         .unwrap_or(false)
 }

--- a/src/routing/agreement/proven.rs
+++ b/src/routing/agreement/proven.rs
@@ -6,13 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{verify_signed, Signed};
+use super::{verify_sig, KeyedSig};
 use crate::messaging::node::Proven;
 use secured_linked_list::SecuredLinkedList;
 use serde::Serialize;
 
 pub trait ProvenUtils<T: Serialize> {
-    fn new(value: T, signed: Signed) -> Self;
+    fn new(value: T, sig: KeyedSig) -> Self;
 
     fn verify(&self, section_chain: &SecuredLinkedList) -> bool;
 
@@ -20,12 +20,12 @@ pub trait ProvenUtils<T: Serialize> {
 }
 
 impl<T: Serialize> ProvenUtils<T> for Proven<T> {
-    fn new(value: T, signed: Signed) -> Self {
+    fn new(value: T, sig: KeyedSig) -> Self {
         Self { value, signed }
     }
 
     fn verify(&self, section_chain: &SecuredLinkedList) -> bool {
-        section_chain.has_key(&self.signed.public_key) && self.self_verify()
+        section_chain.has_key(&self.sig.public_key) && self.self_verify()
     }
 
     fn self_verify(&self) -> bool {

--- a/src/routing/agreement/test_utils.rs
+++ b/src/routing/agreement/test_utils.rs
@@ -6,13 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{ProvenUtils, Signed};
+use super::{ProvenUtils, KeyedSig};
 use crate::messaging::node::Proven;
 use crate::routing::routing_api::{Error, Result};
 use serde::Serialize;
 
 // Create signed for the given payload using the given secret key.
-pub fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<Signed> {
+pub fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<KeyedSig> {
     let bytes = bincode::serialize(payload).map_err(|_| Error::InvalidPayload)?;
     Ok(Signed {
         public_key: secret_key.public_key(),
@@ -22,6 +22,6 @@ pub fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<S
 
 // Wrap the given payload in `Proven`
 pub fn proven<T: Serialize>(secret_key: &bls::SecretKey, payload: T) -> Result<Proven<T>> {
-    let signed = prove(secret_key, &payload)?;
+    let sig = prove(secret_key, &payload)?;
     Ok(Proven::new(payload, signed))
 }

--- a/src/routing/dkg/commands.rs
+++ b/src/routing/dkg/commands.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    node::{DkgFailureSigned, DkgFailureSignedSet, DkgKey, RoutingMsg, Variant},
+    node::{DkgFailureSig, DkgFailureSigSet, DkgKey, RoutingMsg, Variant},
     DstInfo, DstLocation, SectionAuthorityProvider,
 };
 use crate::routing::{
@@ -35,10 +35,10 @@ pub(crate) enum DkgCommand {
     SendFailureObservation {
         recipients: Vec<(XorName, SocketAddr)>,
         dkg_key: DkgKey,
-        signed: DkgFailureSigned,
-        non_participants: BTreeSet<XorName>,
+        sig: DkgFailureSig,
+        failed_participants: BTreeSet<XorName>,
     },
-    HandleFailureAgreement(DkgFailureSignedSet),
+    HandleFailureAgreement(DkgFailureSigSet),
 }
 
 impl DkgCommand {
@@ -76,13 +76,13 @@ impl DkgCommand {
             Self::SendFailureObservation {
                 recipients,
                 dkg_key,
-                signed,
-                non_participants,
+                sig,
+                failed_participants,
             } => {
                 let variant = Variant::DkgFailureObservation {
                     dkg_key,
-                    signed,
-                    non_participants,
+                    sig,
+                    failed_participants,
                 };
                 let message =
                     RoutingMsg::single_src(node, DstLocation::DirectAndUnrouted, variant, key)?;

--- a/src/routing/dkg/dkg_msgs_utils.rs
+++ b/src/routing/dkg/dkg_msgs_utils.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::node::{DkgFailureSigned, DkgFailureSignedSet, DkgKey, ElderCandidates};
+use crate::messaging::node::{DkgFailureSig, DkgFailureSigSet, DkgKey, ElderCandidates};
 use crate::routing::{
     ed25519::{self, Digest256, Keypair, Verifier},
     peer::PeerUtils,
@@ -39,72 +39,72 @@ impl DkgKeyUtils for DkgKey {
     }
 }
 
-pub trait DkgFailureSignedUtils {
-    fn new(keypair: &Keypair, non_participants: &BTreeSet<XorName>, dkg_key: &DkgKey) -> Self;
+pub trait DkgFailureSigUtils {
+    fn new(keypair: &Keypair, failed_participants: &BTreeSet<XorName>, dkg_key: &DkgKey) -> Self;
 
-    fn verify(&self, dkg_key: &DkgKey, non_participants: &BTreeSet<XorName>) -> bool;
+    fn verify(&self, dkg_key: &DkgKey, failed_participants: &BTreeSet<XorName>) -> bool;
 }
 
-impl DkgFailureSignedUtils for DkgFailureSigned {
-    fn new(keypair: &Keypair, non_participants: &BTreeSet<XorName>, dkg_key: &DkgKey) -> Self {
-        DkgFailureSigned {
+impl DkgFailureSigUtils for DkgFailureSig {
+    fn new(keypair: &Keypair, failed_participants: &BTreeSet<XorName>, dkg_key: &DkgKey) -> Self {
+        DkgFailureSig {
             public_key: keypair.public,
-            signature: ed25519::sign(&failure_signed_hash(dkg_key, non_participants), keypair),
+            signature: ed25519::sign(&hashed_failure(dkg_key, failed_participants), keypair),
         }
     }
 
-    fn verify(&self, dkg_key: &DkgKey, non_participants: &BTreeSet<XorName>) -> bool {
-        let hash = failure_signed_hash(dkg_key, non_participants);
+    fn verify(&self, dkg_key: &DkgKey, failed_participants: &BTreeSet<XorName>) -> bool {
+        let hash = hashed_failure(dkg_key, failed_participants);
         self.public_key.verify(&hash, &self.signature).is_ok()
     }
 }
 
-pub trait DkgFailureSignedSetUtils {
-    fn insert(&mut self, signed: DkgFailureSigned, non_participants: &BTreeSet<XorName>) -> bool;
+pub trait DkgFailureSigSetUtils {
+    fn insert(&mut self, sig: DkgFailureSig, failed_participants: &BTreeSet<XorName>) -> bool;
 
     fn has_agreement(&self, elder_candidates: &ElderCandidates) -> bool;
 
     fn verify(&self, elder_candidates: &ElderCandidates, generation: u64) -> bool;
 }
 
-impl DkgFailureSignedSetUtils for DkgFailureSignedSet {
-    // Insert a signed into this set. The signed is assumed valid. Returns `true` if the signed was
+impl DkgFailureSigSetUtils for DkgFailureSigSet {
+    // Insert a signature into this set. The signature is assumed valid. Returns `true` if the signature was
     // not already present in the set and `false` otherwise.
-    fn insert(&mut self, signed: DkgFailureSigned, non_participants: &BTreeSet<XorName>) -> bool {
-        if self.non_participants.is_empty() {
-            self.non_participants = non_participants.clone();
+    fn insert(&mut self, sig: DkgFailureSig, failed_participants: &BTreeSet<XorName>) -> bool {
+        if self.failed_participants.is_empty() {
+            self.failed_participants = failed_participants.clone();
         }
         if self
-            .signeds
+            .sigs
             .iter()
-            .all(|existing_signed| existing_signed.public_key != signed.public_key)
+            .all(|existing_sig| existing_sig.public_key != sig.public_key)
         {
-            self.signeds.push(signed);
+            self.sigs.push(sig);
             true
         } else {
             false
         }
     }
 
-    // Check whether we have enough signeds to reach agreement on the failure. The contained signeds
+    // Check whether we have enough signatures to reach agreement on the failure. The contained signatures
     // are assumed valid.
     fn has_agreement(&self, elder_candidates: &ElderCandidates) -> bool {
-        has_failure_agreement(elder_candidates.elders.len(), self.signeds.len())
+        has_failure_agreement(elder_candidates.elders.len(), self.sigs.len())
     }
 
     fn verify(&self, elder_candidates: &ElderCandidates, generation: u64) -> bool {
-        let hash = failure_signed_hash(
+        let hash = hashed_failure(
             &DkgKey::new(elder_candidates, generation),
-            &self.non_participants,
+            &self.failed_participants,
         );
         let votes = self
-            .signeds
+            .sigs
             .iter()
-            .filter(|signed| {
+            .filter(|sig| {
                 elder_candidates
                     .elders
-                    .contains_key(&ed25519::name(&signed.public_key))
-                    && signed.public_key.verify(&hash, &signed.signature).is_ok()
+                    .contains_key(&ed25519::name(&sig.public_key))
+                    && sig.public_key.verify(&hash, &sig.signature).is_ok()
             })
             .count();
 
@@ -121,12 +121,12 @@ fn has_failure_agreement(num_participants: usize, num_votes: usize) -> bool {
 
 // Create a value whose signature serves as the signed that a failure of a DKG session with the given
 // `dkg_key` was observed.
-fn failure_signed_hash(dkg_key: &DkgKey, non_participants: &BTreeSet<XorName>) -> Digest256 {
+fn hashed_failure(dkg_key: &DkgKey, failed_participants: &BTreeSet<XorName>) -> Digest256 {
     let mut hasher = Sha3::v256();
     let mut hash = Digest256::default();
     hasher.update(&dkg_key.hash);
     hasher.update(&dkg_key.generation.to_le_bytes());
-    for name in non_participants.iter() {
+    for name in failed_participants.iter() {
         hasher.update(&name.0);
     }
     hasher.update(b"failure");

--- a/src/routing/dkg/mod.rs
+++ b/src/routing/dkg/mod.rs
@@ -16,17 +16,17 @@ pub mod test_utils;
 mod voter;
 
 pub(crate) use self::{
-    dkg_msgs_utils::{DkgFailureSignedSetUtils, DkgKeyUtils},
+    dkg_msgs_utils::{DkgFailureSigSetUtils, DkgKeyUtils},
     proposal::{ProposalAggregator, ProposalError, ProposalUtils},
     voter::DkgVoter,
 };
-pub(crate) use crate::messaging::node::{SignatureAggregator, Signed, SignedShare};
+pub(crate) use crate::messaging::node::{KeyedSig, SigShare, SignatureAggregator};
 pub use section_signed::SectionSignedUtils;
 use serde::Serialize;
 
-// Verify the integrity of `message` against `signed`.
-pub(crate) fn verify_signed<T: Serialize>(signed: &Signed, message: &T) -> bool {
+// Verify the integrity of `message` against `sig`.
+pub(crate) fn verify_sig<T: Serialize>(sig: &KeyedSig, message: &T) -> bool {
     bincode::serialize(message)
-        .map(|bytes| signed.verify(&bytes))
+        .map(|bytes| sig.verify(&bytes))
         .unwrap_or(false)
 }

--- a/src/routing/dkg/proposal.rs
+++ b/src/routing/dkg/proposal.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{SignatureAggregator, Signed, SignedShare};
+use super::{KeyedSig, SigShare, SignatureAggregator};
 use crate::messaging::node::Proposal;
 use crate::routing::{error::Result, messages::PlainMessageUtils};
 use serde::{Serialize, Serializer};
@@ -18,20 +18,20 @@ pub trait ProposalUtils {
         public_key_set: bls::PublicKeySet,
         index: usize,
         secret_key_share: &bls::SecretKeyShare,
-    ) -> Result<SignedShare>;
+    ) -> Result<SigShare>;
 
     fn as_signable(&self) -> SignableView;
 }
 
 impl ProposalUtils for Proposal {
-    /// Create SignedShare for this proposal.
+    /// Create SigShare for this proposal.
     fn prove(
         &self,
         public_key_set: bls::PublicKeySet,
         index: usize,
         secret_key_share: &bls::SecretKeyShare,
-    ) -> Result<SignedShare> {
-        Ok(SignedShare::new(
+    ) -> Result<SigShare> {
+        Ok(SigShare::new(
             public_key_set,
             index,
             secret_key_share,
@@ -53,7 +53,7 @@ impl<'a> Serialize for SignableView<'a> {
             Proposal::Online { node_state, .. } => node_state.serialize(serializer),
             Proposal::Offline(node_state) => node_state.serialize(serializer),
             Proposal::SectionInfo(info) => info.serialize(serializer),
-            Proposal::OurElders(info) => info.signed.public_key.serialize(serializer),
+            Proposal::OurElders(info) => info.sig.public_key.serialize(serializer),
             // Proposal::TheirKey { prefix, key } => (prefix, key).serialize(serializer),
             // Proposal::TheirKnowledge { prefix, key } => (prefix, key).serialize(serializer),
             Proposal::AccumulateAtSrc { message, .. } => {
@@ -72,12 +72,12 @@ impl ProposalAggregator {
     pub fn add(
         &mut self,
         proposal: Proposal,
-        signed_share: SignedShare,
-    ) -> Result<(Proposal, Signed), ProposalError> {
+        sig_share: SigShare,
+    ) -> Result<(Proposal, KeyedSig), ProposalError> {
         let bytes =
             bincode::serialize(&SignableView(&proposal)).map_err(|_| ProposalError::Invalid)?;
-        let signed = self.0.add(&bytes, signed_share)?;
-        Ok((proposal, signed))
+        let sig = self.0.add(&bytes, sig_share)?;
+        Ok((proposal, sig))
     }
 }
 

--- a/src/routing/dkg/section_signed.rs
+++ b/src/routing/dkg/section_signed.rs
@@ -6,13 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{verify_signed, Signed};
+use super::{verify_sig, KeyedSig};
 use crate::messaging::node::SectionSigned;
 use secured_linked_list::SecuredLinkedList;
 use serde::Serialize;
 
 pub trait SectionSignedUtils<T: Serialize> {
-    fn new(value: T, signed: Signed) -> Self;
+    fn new(value: T, sig: KeyedSig) -> Self;
 
     fn verify(&self, section_chain: &SecuredLinkedList) -> bool;
 
@@ -20,15 +20,15 @@ pub trait SectionSignedUtils<T: Serialize> {
 }
 
 impl<T: Serialize> SectionSignedUtils<T> for SectionSigned<T> {
-    fn new(value: T, signed: Signed) -> Self {
-        Self { value, signed }
+    fn new(value: T, sig: KeyedSig) -> Self {
+        Self { value, sig }
     }
 
     fn verify(&self, section_chain: &SecuredLinkedList) -> bool {
-        section_chain.has_key(&self.signed.public_key) && self.self_verify()
+        section_chain.has_key(&self.sig.public_key) && self.self_verify()
     }
 
     fn self_verify(&self) -> bool {
-        verify_signed(&self.signed, &self.value)
+        verify_sig(&self.sig, &self.value)
     }
 }

--- a/src/routing/dkg/test_utils.rs
+++ b/src/routing/dkg/test_utils.rs
@@ -6,15 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{SectionSignedUtils, Signed};
+use super::{KeyedSig, SectionSignedUtils};
 use crate::messaging::node::SectionSigned;
 use crate::routing::{Error, Result};
 use serde::Serialize;
 
-// Create signed for the given payload using the given secret key.
-pub fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<Signed> {
+// Create signature for the given payload using the given secret key.
+pub fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<KeyedSig> {
     let bytes = bincode::serialize(payload).map_err(|_| Error::InvalidPayload)?;
-    Ok(Signed {
+    Ok(KeyedSig {
         public_key: secret_key.public_key(),
         signature: secret_key.sign(&bytes),
     })
@@ -25,6 +25,6 @@ pub fn section_signed<T: Serialize>(
     secret_key: &bls::SecretKey,
     payload: T,
 ) -> Result<SectionSigned<T>> {
-    let signed = prove(secret_key, &payload)?;
-    Ok(SectionSigned::new(payload, signed))
+    let sig = prove(secret_key, &payload)?;
+    Ok(SectionSigned::new(payload, sig))
 }

--- a/src/routing/dkg/voter.rs
+++ b/src/routing/dkg/voter.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    node::{DkgFailureSigned, DkgFailureSignedSet, DkgKey, ElderCandidates},
+    node::{DkgFailureSig, DkgFailureSigSet, DkgKey, ElderCandidates},
     SectionAuthorityProvider,
 };
 use crate::routing::{
@@ -109,7 +109,7 @@ impl DkgVoter {
                     elder_candidates,
                     participant_index,
                     timer_token: 0,
-                    failures: DkgFailureSignedSet::default(),
+                    failures: DkgFailureSigSet::default(),
                     complete: false,
                 };
 
@@ -171,11 +171,11 @@ impl DkgVoter {
     pub fn process_failure(
         &mut self,
         dkg_key: &DkgKey,
-        non_participants: &BTreeSet<XorName>,
-        signed: DkgFailureSigned,
+        failed_participants: &BTreeSet<XorName>,
+        signed: DkgFailureSig,
     ) -> Option<DkgCommand> {
         self.sessions
             .get_mut(dkg_key)?
-            .process_failure(dkg_key, non_participants, signed)
+            .process_failure(dkg_key, failed_participants, signed)
     }
 }

--- a/src/routing/error.rs
+++ b/src/routing/error.rs
@@ -68,8 +68,8 @@ pub enum Error {
     ProposalError(#[from] ProposalError),
     #[error("create error: {0}")]
     CreateError(#[from] CreateError),
-    #[error("extend signed error: {0}")]
-    ExtendSignedError(#[from] ExtendSignedChainError),
+    #[error("extend signed chain error: {0}")]
+    ExtendSignedChainError(#[from] ExtendSignedChainError),
     #[error("invalid payload")]
     InvalidPayload,
     #[error("Routing is set to not allow taking any new node")]

--- a/src/routing/event.rs
+++ b/src/routing/event.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::{client::ClientMsg, node::Signed, DstLocation, EndUser, SrcLocation};
+use crate::messaging::{client::ClientMsg, node::KeyedSig, DstLocation, EndUser, SrcLocation};
 use bytes::Bytes;
 use ed25519_dalek::Keypair;
 use hex_fmt::HexFmt;
@@ -63,8 +63,8 @@ pub enum Event {
         src: SrcLocation,
         /// The destination location that receives the message.
         dst: DstLocation,
-        /// The signed if the message was set to be aggregated at source.
-        signed: Option<Signed>,
+        /// The signature if the message was set to be aggregated at source.
+        sig: Option<KeyedSig>,
         /// The Sender's Section PK.
         section_pk: bls::PublicKey,
     },

--- a/src/routing/routing_api/command.rs
+++ b/src/routing/routing_api/command.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    node::{DkgFailureSignedSet, Proposal, RoutingMsg, Section, Signed},
+    node::{DkgFailureSigSet, KeyedSig, Proposal, RoutingMsg, Section},
     section_info::SectionInfoMsg,
     DstInfo, Itinerary, MessageType, SectionAuthorityProvider,
 };
@@ -45,7 +45,7 @@ pub(crate) enum Command {
     /// Handle peer that's been detected as lost.
     HandlePeerLost(SocketAddr),
     /// Handle agreement on a proposal.
-    HandleAgreement { proposal: Proposal, signed: Signed },
+    HandleAgreement { proposal: Proposal, sig: KeyedSig },
     /// Handle the outcome of a DKG session where we are one of the participants (that is, one of
     /// the proposed new elders).
     HandleDkgOutcome {
@@ -53,7 +53,7 @@ pub(crate) enum Command {
         outcome: SectionKeyShare,
     },
     /// Handle a DKG failure that was observed by a majority of the DKG participants.
-    HandleDkgFailure(DkgFailureSignedSet),
+    HandleDkgFailure(DkgFailureSigSet),
     /// Send a message to `delivery_group_size` peers out of the given `recipients`.
     SendMessage {
         recipients: Vec<(XorName, SocketAddr)>,
@@ -148,10 +148,10 @@ impl Debug for Command {
                 f.debug_tuple("HandleConnectionLost").field(addr).finish()
             }
             Self::HandlePeerLost(addr) => f.debug_tuple("HandlePeerLost").field(addr).finish(),
-            Self::HandleAgreement { proposal, signed } => f
+            Self::HandleAgreement { proposal, sig } => f
                 .debug_struct("HandleAgreement")
                 .field("proposal", proposal)
-                .field("signed.public_key", &signed.public_key)
+                .field("sig.public_key", &sig.public_key)
                 .finish(),
             Self::HandleDkgOutcome {
                 section_auth,

--- a/src/routing/routing_api/core/messaging/handling/decisions.rs
+++ b/src/routing/routing_api/core/messaging/handling/decisions.rs
@@ -9,7 +9,7 @@
 use super::Core;
 use crate::messaging::{
     node::{
-        JoinAsRelocatedResponse, JoinResponse, Proposal, RelocatePromise, RoutingMsg, SignedShare,
+        JoinAsRelocatedResponse, JoinResponse, Proposal, RelocatePromise, RoutingMsg, SigShare,
         Variant,
     },
     DstLocation,
@@ -88,12 +88,10 @@ impl Core {
                 }
             }
             Variant::Propose {
-                content,
-                signed_share,
-                ..
+                content, sig_share, ..
             } => {
                 if let Some(status) =
-                    self.decide_propose_status(&msg.src.name(), content, signed_share)
+                    self.decide_propose_status(&msg.src.name(), content, sig_share)
                 {
                     return Ok(status);
                 }
@@ -123,7 +121,7 @@ impl Core {
         &self,
         sender: &XorName,
         proposal: &Proposal,
-        signed_share: &SignedShare,
+        sig_share: &SigShare,
     ) -> Option<MessageStatus> {
         match proposal {
             Proposal::SectionInfo(section_auth)
@@ -144,7 +142,7 @@ impl Core {
                 if self
                     .section
                     .chain()
-                    .has_key(&signed_share.public_key_set.public_key())
+                    .has_key(&sig_share.public_key_set.public_key())
                 {
                     None
                 } else {

--- a/src/routing/routing_api/core/messaging/mod.rs
+++ b/src/routing/routing_api/core/messaging/mod.rs
@@ -15,7 +15,7 @@ use crate::messaging::{
     DstLocation,
 };
 use crate::routing::{
-    dkg::{ProposalUtils, SignedShare},
+    dkg::{ProposalUtils, SigShare},
     error::Result,
     messages::RoutingMsgUtils,
     routing_api::command::Command,
@@ -57,7 +57,7 @@ impl Core {
             recipients,
         );
 
-        let signed_share = proposal.prove(
+        let sig_share = proposal.prove(
             key_share.public_key_set.clone(),
             key_share.index,
             &key_share.secret_key_share,
@@ -66,7 +66,7 @@ impl Core {
         // Broadcast the proposal to the rest of the section elders.
         let variant = Variant::Propose {
             content: proposal,
-            signed_share,
+            sig_share,
         };
         let message = RoutingMsg::single_src(
             &self.node,
@@ -84,9 +84,9 @@ impl Core {
     pub(crate) fn check_lagging(
         &self,
         peer: (XorName, SocketAddr),
-        signed_share: &SignedShare,
+        sig_share: &SigShare,
     ) -> Result<Option<Command>> {
-        let public_key = signed_share.public_key_set.public_key();
+        let public_key = sig_share.public_key_set.public_key();
 
         if self.section.chain().has_key(&public_key)
             && public_key != *self.section.chain().last_key()
@@ -100,7 +100,7 @@ impl Core {
                     section: self.section.clone(),
                     network: self.network.clone(),
                 },
-                signed_share.public_key_set.public_key(),
+                sig_share.public_key_set.public_key(),
             )?))
         } else {
             Ok(None)

--- a/src/routing/routing_api/dispatcher.rs
+++ b/src/routing/routing_api/dispatcher.rs
@@ -166,11 +166,11 @@ impl Dispatcher {
                 .handle_section_info_msg(sender, message, dst_info)
                 .await),
             Command::HandleTimeout(token) => self.core.write().await.handle_timeout(token),
-            Command::HandleAgreement { proposal, signed } => {
+            Command::HandleAgreement { proposal, sig } => {
                 self.core
                     .write()
                     .await
-                    .handle_agreement(proposal, signed)
+                    .handle_agreement(proposal, sig)
                     .await
             }
             Command::HandleConnectionLost(addr) => {

--- a/src/routing/routing_api/split_barrier.rs
+++ b/src/routing/routing_api/split_barrier.rs
@@ -9,10 +9,10 @@
 use std::mem;
 
 use crate::messaging::{node::SectionSigned, SectionAuthorityProvider};
-use crate::routing::dkg::Signed;
+use crate::routing::dkg::KeyedSig;
 use xor_name::Prefix;
 
-type Entry = (SectionSigned<SectionAuthorityProvider>, Signed);
+type Entry = (SectionSigned<SectionAuthorityProvider>, KeyedSig);
 
 // Helper structure to make sure we process a split by updating info about both our section and the
 // sibling section at the same time.
@@ -33,11 +33,11 @@ impl SplitBarrier {
         &mut self,
         our_prefix: &Prefix,
         section_auth: SectionSigned<SectionAuthorityProvider>,
-        key_signed: Signed,
+        keyed_sig: KeyedSig,
     ) -> Vec<Entry> {
         if !section_auth.value.prefix.is_extension_of(our_prefix) {
             // Not a split, no need to cache.
-            return vec![(section_auth, key_signed)];
+            return vec![(section_auth, keyed_sig)];
         }
 
         // Split detected. Find all cached siblings.
@@ -51,11 +51,11 @@ impl SplitBarrier {
 
         if give.is_empty() {
             // No sibling found. Cache this update until we see the sibling update.
-            self.0.push((section_auth, key_signed));
+            self.0.push((section_auth, keyed_sig));
             vec![]
         } else {
             // Sibling found. We can proceed with the update.
-            give.push((section_auth, key_signed));
+            give.push((section_auth, keyed_sig));
             give
         }
     }

--- a/src/routing/section/mod.rs
+++ b/src/routing/section/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
 };
 
 use crate::messaging::{
-    node::{ElderCandidates, NodeState, Peer, Section, SectionPeers, SectionSigned, Signed},
+    node::{ElderCandidates, KeyedSig, NodeState, Peer, Section, SectionPeers, SectionSigned},
     SectionAuthorityProvider,
 };
 use crate::routing::{
@@ -64,7 +64,7 @@ pub trait SectionUtils {
     fn update_elders(
         &mut self,
         new_section_auth: SectionSigned<SectionAuthorityProvider>,
-        new_key_signed: Signed,
+        new_key_sig: KeyedSig,
     ) -> bool;
 
     /// Update the member. Returns whether it actually changed anything.
@@ -125,7 +125,7 @@ impl SectionUtils for Section {
         chain: SecuredLinkedList,
         section_auth: SectionSigned<SectionAuthorityProvider>,
     ) -> Result<Self, Error> {
-        if section_auth.signed.public_key != *chain.last_key() {
+        if section_auth.sig.public_key != *chain.last_key() {
             error!("can't create section: section_auth signed with incorrect key");
             // TODO: consider more specific error here.
             return Err(Error::InvalidMessage);
@@ -149,17 +149,17 @@ impl SectionUtils for Section {
             create_first_section_authority_provider(&public_key_set, &secret_key_share, peer)?;
 
         let mut section = Section::new(
-            section_auth.signed.public_key,
-            SecuredLinkedList::new(section_auth.signed.public_key),
+            section_auth.sig.public_key,
+            SecuredLinkedList::new(section_auth.sig.public_key),
             section_auth,
         )?;
 
         for peer in section.section_auth.value.peers() {
             let node_state = NodeState::joined(peer);
-            let signed = create_first_signed(&public_key_set, &secret_key_share, &node_state)?;
+            let sig = create_first_sig(&public_key_set, &secret_key_share, &node_state)?;
             let _ = section.members.update(SectionSigned {
                 value: node_state,
-                signed,
+                sig,
             });
         }
 
@@ -183,7 +183,7 @@ impl SectionUtils for Section {
             error!("can't merge sections: other section_auth failed self-verification");
             return Err(Error::InvalidMessage);
         }
-        if &other.section_auth.signed.public_key != other.chain.last_key() {
+        if &other.section_auth.sig.public_key != other.chain.last_key() {
             // TODO: use more specific error variant.
             error!("can't merge sections: other section_auth signed with incorrect key");
             return Err(Error::InvalidMessage);
@@ -191,7 +191,7 @@ impl SectionUtils for Section {
 
         self.chain.merge(other.chain.clone())?;
 
-        if &other.section_auth.signed.public_key == self.chain.last_key() {
+        if &other.section_auth.sig.public_key == self.chain.last_key() {
             self.section_auth = other.section_auth;
         }
 
@@ -209,7 +209,7 @@ impl SectionUtils for Section {
     fn update_elders(
         &mut self,
         new_section_auth: SectionSigned<SectionAuthorityProvider>,
-        new_key_signed: Signed,
+        new_key_sig: KeyedSig,
     ) -> bool {
         if new_section_auth.value.prefix() != *self.prefix()
             && !new_section_auth
@@ -225,18 +225,18 @@ impl SectionUtils for Section {
         }
 
         if let Err(error) = self.chain.insert(
-            &new_key_signed.public_key,
-            new_section_auth.signed.public_key,
-            new_key_signed.signature,
+            &new_key_sig.public_key,
+            new_section_auth.sig.public_key,
+            new_key_sig.signature,
         ) {
             error!(
                 "failed to insert key {:?} (signed with {:?}) into the section chain: {}",
-                new_section_auth.signed.public_key, new_key_signed.public_key, error,
+                new_section_auth.sig.public_key, new_key_sig.public_key, error,
             );
             return false;
         }
 
-        if &new_section_auth.signed.public_key == self.chain.last_key() {
+        if &new_section_auth.sig.public_key == self.chain.last_key() {
             self.section_auth = new_section_auth;
         }
 
@@ -434,22 +434,22 @@ fn create_first_section_authority_provider(
     peer.set_reachable(true);
     let section_auth =
         SectionAuthorityProvider::new(iter::once(peer), Prefix::default(), pk_set.clone());
-    let signed = create_first_signed(pk_set, sk_share, &section_auth)?;
-    Ok(SectionSigned::new(section_auth, signed))
+    let sig = create_first_sig(pk_set, sk_share, &section_auth)?;
+    Ok(SectionSigned::new(section_auth, sig))
 }
 
-fn create_first_signed<T: Serialize>(
+fn create_first_sig<T: Serialize>(
     pk_set: &bls::PublicKeySet,
     sk_share: &bls::SecretKeyShare,
     payload: &T,
-) -> Result<Signed> {
+) -> Result<KeyedSig> {
     let bytes = bincode::serialize(payload).map_err(|_| Error::InvalidPayload)?;
     let signature_share = sk_share.sign(&bytes);
     let signature = pk_set
         .combine_signatures(iter::once((0, &signature_share)))
         .map_err(|_| Error::InvalidSignatureShare)?;
 
-    Ok(Signed {
+    Ok(KeyedSig {
         public_key: pk_set.public_key(),
         signature,
     })

--- a/src/routing/section/section_peers.rs
+++ b/src/routing/section/section_peers.rs
@@ -228,7 +228,7 @@ fn cmp_elder_candidates(
                 _ => Ordering::Equal,
             }
         })
-        .then_with(|| lhs.signed.signature.cmp(&rhs.signed.signature))
+        .then_with(|| lhs.sig.signature.cmp(&rhs.sig.signature))
 }
 
 // Compare candidates for the next elders according to their peer state. The one comparing `Less`

--- a/src/routing/tests/messages.rs
+++ b/src/routing/tests/messages.rs
@@ -14,7 +14,7 @@ use qp2p::QuicP2p;
 use sn_data_types::Keypair;
 use crate::messaging::client::ProcessMsg;
 use crate::messaging::{
-    client::{ClientMsg, ClientSigned, Query, TransferQuery},
+    client::{ClientMsg, ClientSig, Query, TransferQuery},
     location::{Aggregation, Itinerary},
     DstLocation, MessageId, SrcLocation,
 };
@@ -36,7 +36,7 @@ async fn test_messages_client_node() -> Result<()> {
     let mut rng = rand::thread_rng();
     let keypair = Keypair::new_ed25519(&mut rng);
     let pk = keypair.public_key();
-    let client_signed = ClientSigned {
+    let client_sig = ClientSig {
         public_key: pk,
         signature: keypair.sign(b"the msg"),
     };
@@ -60,7 +60,7 @@ async fn test_messages_client_node() -> Result<()> {
     let query = ClientMsg::Process(ProcessMsg::Query {
         id,
         query: Query::Transfer(TransferQuery::GetBalance(pk)),
-        client_signed,
+        client_sig,
     });
     let query_clone = query.clone();
 


### PR DESCRIPTION
The struct `Signed` wraps a signature that we've supplemented with the corresponding key. Therefore, simple and straight forward way is to call it `KeyedSig`.

### Background
"Signed" means the object we're speaking of, that we created a signature over. It's not the sig itself (not even if coupled with the pubkey).
So for example, this struct below is (eh, more or less, still programming..) grammatically correctly named:

```
pub struct SectionSigned<T: Serialize> {
    /// some value to be agreed upon by elders
    pub value: T,
    /// signature over the value
    pub signed: Signed,
}
```
.. as we have a _value_ that is _signed_ (signed is a **property** of the value, not an object),
but then the second member cannot also be _signed_, rather it is _signature_.



Additional updates across the code to align with this language convention.