### PR TITLE
Minor test fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,7 +2323,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe_network"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/src/client/client_api/transfers/balance_management.rs
+++ b/src/client/client_api/transfers/balance_management.rs
@@ -270,7 +270,6 @@ mod tests {
                 .checked_sub(amount_to_send)
                 .ok_or_else(|| anyhow!("No more money to send"))?;
 
-            // Initial 10 token on creation from farming simulation minus 1
             // Assert locally
             assert_eq!(client.get_local_balance().await, correct_balance);
 

--- a/src/client/client_api/transfers/balance_management.rs
+++ b/src/client/client_api/transfers/balance_management.rs
@@ -354,10 +354,6 @@ mod tests {
             let _ = receiving_client.get_history().await;
             tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
             receiving_bal = receiving_client.get_balance().await?;
-
-            if receiving_bal > target_tokens {
-                continue;
-            }
         }
 
         assert_eq!(receiving_bal, target_tokens);


### PR DESCRIPTION
Some small issues encountered when looking through the `balance_management` tests.

---

- 4e1e3d6f2 **chore(client): Fix some comments in tests**

  The comments were out of sync with the asserted values.

- 51049baec **test(client): Remove redundant statement**

  The loop will continue as long as `receiving_bal != target_tokens` which
  subsumes the explicit `receiving_bal > target_tokens` test, making the
  latter redundant.
