### PR TITLE
fix: node now uses contact config file when no HCC supplied

### DIFF
--- a/src/node/config_handler.rs
+++ b/src/node/config_handler.rs
@@ -138,8 +138,9 @@ impl Config {
 
         if command_line_args.hard_coded_contacts.is_empty() {
             debug!("Using node connection config file as no hard coded contacts were passed in");
-            let contacts_config = read_conn_info_from_file()?;
-            command_line_args.hard_coded_contacts = contacts_config;
+            if let Ok(info) = read_conn_info_from_file() {
+                command_line_args.hard_coded_contacts = info;
+            }
         }
 
         config.merge(command_line_args);

--- a/src/node/config_handler.rs
+++ b/src/node/config_handler.rs
@@ -136,6 +136,12 @@ impl Config {
             command_line_args.local_addr = Some(socket_addr);
         }
 
+        if command_line_args.hard_coded_contacts.is_empty() {
+            debug!("Using node connection config file as no hard coded contacts were passed in");
+            let contacts_config = read_conn_info_from_file()?;
+            command_line_args.hard_coded_contacts = contacts_config;
+        }
+
         config.merge(command_line_args);
 
         config.clear_data_from_disk().unwrap_or_else(|_| {


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
