### PR TITLE
refactor(signing): return index and sig share

### DIFF
--- a/examples/routing_stress.rs
+++ b/examples/routing_stress.rs
@@ -456,15 +456,10 @@ impl Network {
 
         // The message dst is unique so we use it also as its indentifier.
         let bytes = bincode::serialize(&dst)?;
-        let signature_share = node
+        let (index, signature_share) = node
             .sign_as_elder(&bytes, &public_key_set.public_key())
             .await
             .with_context(|| format!("failed to sign probe by {}", src))?;
-
-        let index = node
-            .our_index()
-            .await
-            .with_context(|| format!("failed to retrieve key share index by {}", src))?;
 
         let message = ProbeMessage {
             sig_share: SigShare {

--- a/src/node/network.rs
+++ b/src/node/network.rs
@@ -76,24 +76,20 @@ impl Network {
             .await
             .map_err(|_| Error::NoSectionPublicKey)?
             .public_key();
-        let share = self
+        let (index, share) = self
             .routing
             .sign_as_elder(&utils::serialise(data)?, &bls_pk)
             .await
             .map_err(Error::Routing)?;
-        Ok(SignatureShare {
-            share,
-            index: self
-                .routing
-                .our_index()
-                .await
-                .map_err(|_| Error::NoSectionPublicKey)?,
-        })
+        Ok(SignatureShare { index, share })
     }
 
     /// Sign with our BLS PK Share
     #[allow(unused)]
-    pub async fn sign_as_elder_raw<T: Serialize>(&self, data: &T) -> Result<bls::SignatureShare> {
+    pub async fn sign_as_elder_raw<T: Serialize>(
+        &self,
+        data: &T,
+    ) -> Result<(usize, bls::SignatureShare)> {
         let bls_pk = self
             .routing
             .public_key_set()

--- a/src/routing/core/api.rs
+++ b/src/routing/core/api.rs
@@ -73,7 +73,7 @@ impl Core {
         &self,
         data: &[u8],
         public_key: &bls::PublicKey,
-    ) -> Result<bls::SignatureShare> {
+    ) -> Result<(usize, bls::SignatureShare)> {
         self.section_keys_provider.sign_with(data, public_key)
     }
 

--- a/src/routing/routing_api/mod.rs
+++ b/src/routing/routing_api/mod.rs
@@ -221,7 +221,7 @@ impl Routing {
         &self,
         data: &[u8],
         public_key: &bls::PublicKey,
-    ) -> Result<bls::SignatureShare> {
+    ) -> Result<(usize, bls::SignatureShare)> {
         self.dispatcher
             .core
             .read()

--- a/src/routing/section/section_keys.rs
+++ b/src/routing/section/section_keys.rs
@@ -68,7 +68,7 @@ impl SectionKeysProvider {
         &self,
         data: &[u8],
         public_key: &bls::PublicKey,
-    ) -> Result<bls::SignatureShare> {
+    ) -> Result<(usize, bls::SignatureShare)> {
         self.cache.sign_with(data, public_key)
     }
 
@@ -124,10 +124,13 @@ impl MiniKeyCache {
         &self,
         data: &[u8],
         public_key: &bls::PublicKey,
-    ) -> Result<bls::SignatureShare> {
+    ) -> Result<(usize, bls::SignatureShare)> {
         for (cached_public, section_key_share) in &self.list {
             if public_key == cached_public {
-                return Ok(section_key_share.secret_key_share.sign(data));
+                return Ok((
+                    section_key_share.index,
+                    section_key_share.secret_key_share.sign(data),
+                ));
             }
         }
         Err(Error::MissingSecretKeyShare)


### PR DESCRIPTION
- The index was always quired for separately, a potential racing condition.
