### PR TITLE
fix: remove the client timeout

### DIFF
--- a/src/client/connections/messaging.rs
+++ b/src/client/connections/messaging.rs
@@ -387,10 +387,7 @@ impl Session {
 
         let response = loop {
             let mut error_response = None;
-            match (
-                receiver.recv().await,
-                chunk_addr,
-            ) {
+            match (receiver.recv().await, chunk_addr) {
                 (Some(QueryResponse::GetChunk(Ok(blob))), Some(chunk_addr)) => {
                     // We are dealing with Chunk query responses, thus we validate its hash
                     // matches its xorname, if so, we don't need to await for more responses


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

Remove the client timeout (that made many tests fail), and adapt the pattern matching accordingly. 