### PR TITLE
fix(updater): point self_update to new repo name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,7 +2330,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe_network"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/src/node/bin/sn_node.rs
+++ b/src/node/bin/sn_node.rs
@@ -188,7 +188,7 @@ fn update() -> Result<Status, Box<dyn (::std::error::Error)>> {
 
     let releases = self_update::backends::github::ReleaseList::configure()
         .repo_owner("maidsafe")
-        .repo_name("sn_node")
+        .repo_name("safe_network")
         .with_target(&target)
         .build()?
         .fetch()?;
@@ -203,7 +203,7 @@ fn update() -> Result<Status, Box<dyn (::std::error::Error)>> {
         };
         let status = self_update::backends::github::Update::configure()
             .repo_owner("maidsafe")
-            .repo_name("sn_node")
+            .repo_name("safe_network")
             .target(&target)
             .bin_name(&bin_name)
             .show_download_progress(true)


### PR DESCRIPTION
Without this, running `safe node update` will check the now defunct sn_node repo releases, rather than the `safe_network` repo.