### PR TITLE
feat: use tracing instead of log

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,5 +99,5 @@ jobs:
       - name: Node Logs
         run: |
           ls $HOME/.safe/node/local-test-network
-          cat $HOME/.safe/node/local-test-network/sn-node-genesis/sn_node_rCURRENT.log
+          cat $HOME/.safe/node/local-test-network/sn-node-genesis/sn_node.log*
         if: failure()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,58 +535,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -862,23 +814,6 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flexi_logger"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba2265890613939b533fa11c3728651531419ac549ccf527896201581f23991"
-dependencies = [
- "atty",
- "chrono",
- "crossbeam",
- "glob",
- "lazy_static",
- "log",
- "regex",
- "thiserror",
- "yansi",
 ]
 
 [[package]]
@@ -1478,15 +1413,6 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
-
-[[package]]
-name = "memoffset"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -2373,8 +2299,6 @@ dependencies = [
  "dirs-next 2.0.0",
  "ed25519",
  "ed25519-dalek",
- "env_logger 0.8.4",
- "flexi_logger",
  "futures",
  "futures-util",
  "fxhash",
@@ -2382,7 +2306,6 @@ dependencies = [
  "hex_fmt",
  "itertools 0.10.1",
  "lazy_static",
- "log",
  "lru",
  "miscreant",
  "multibase",
@@ -2412,6 +2335,7 @@ dependencies = [
  "tokio-util 0.6.7",
  "tracing",
  "tracing-appender",
+ "tracing-futures",
  "tracing-subscriber",
  "uhttp_uri",
  "url",
@@ -2425,12 +2349,6 @@ name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,10 +58,8 @@ anyhow = "1.0.40"
 bincode = "1.3.1"
 crdts = "6.3.3"
 dirs-next = "2.0.0"
-env_logger = "~0.8.3"
 futures = "~0.3.13"
 futures-util = "~0.3.13"
-log = "~0.4.14"
 regex = "1.4.3"
 rmp-serde = "~0.15.4"
 self_encryption = "~0.24.1"
@@ -70,15 +68,11 @@ urlencoding = "1.1.1"
 url = "2.2.0"
 dashmap = "~4.0.2"
 lru="0.6.5"
+tracing-appender = "~0.1.2"
+tracing-subscriber = "~0.2.15"
+tracing-futures = "~0.2.5"
+tracing= "~0.1.26"
 
-  [dependencies.flexi_logger]
-  version = "0.18"
-  features = [ "async" ]
-
-  [dependencies.tracing]
-  version = "~0.1.22"
-  default-features = false
-  features = [ "log", "std" ]
 
   [dependencies.ed25519-dalek]
   version = "1.0.0"
@@ -129,8 +123,6 @@ proptest = "0.10.1"
 rand_xorshift = "~0.2.0"
 structopt = "~0.3.17"
 tempdir = "~0.3.7"
-tracing-appender = "~0.1.2"
-tracing-subscriber = "~0.2.15"
 yansi = "~0.5.0"
 
   [dev-dependencies.rand]

--- a/examples/client_blob.rs
+++ b/examples/client_blob.rs
@@ -16,8 +16,6 @@ use std::{
     time::Duration,
 };
 use tokio::time::sleep;
-use tracing::{debug, error, info, span, warn, Level};
-use tracing_subscriber;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/examples/client_blob.rs
+++ b/examples/client_blob.rs
@@ -16,10 +16,12 @@ use std::{
     time::Duration,
 };
 use tokio::time::sleep;
+use tracing::{debug, error, info, span, warn, Level};
+use tracing_subscriber;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     println!("Reading network bootstrap information...");
     let bootstrap_contacts = read_network_conn_info()?;

--- a/src/client/client_api/blob_apis.rs
+++ b/src/client/client_api/blob_apis.rs
@@ -14,9 +14,9 @@ use crate::client::Error;
 use crate::messaging::client::{ChunkRead, ChunkWrite, DataCmd, DataQuery, Query, QueryResponse};
 use crate::types::{Chunk, ChunkAddress, PrivateChunk, PublicChunk, PublicKey};
 use bincode::{deserialize, serialize};
-use log::{info, trace};
 use self_encryption::{DataMap, SelfEncryptor};
 use serde::{Deserialize, Serialize};
+use tracing::{info, trace};
 
 #[derive(Serialize, Deserialize)]
 enum DataMapLevel {

--- a/src/client/client_api/blob_storage.rs
+++ b/src/client/client_api/blob_storage.rs
@@ -9,8 +9,8 @@
 use super::Client;
 use crate::types::{Chunk, ChunkAddress, PrivateChunk, PublicChunk, PublicKey};
 use async_trait::async_trait;
-use log::trace;
 use self_encryption::{SelfEncryptionError, Storage};
+use tracing::trace;
 use xor_name::{XorName, XOR_NAME_LEN};
 
 /// Network storage is the concrete type which self_encryption crate will use

--- a/src/client/client_api/commands.rs
+++ b/src/client/client_api/commands.rs
@@ -10,8 +10,8 @@ use super::Client;
 use crate::client::Error;
 use crate::messaging::client::{ClientSig, Cmd};
 use crate::types::{PublicKey, Signature};
-use log::debug;
 use std::net::SocketAddr;
+use tracing::debug;
 
 impl Client {
     /// Send a signed Cmd to the network

--- a/src/client/client_api/map_apis.rs
+++ b/src/client/client_api/map_apis.rs
@@ -8,7 +8,7 @@
 
 use super::Client;
 use crate::client::Error;
-use log::trace;
+use tracing::trace;
 
 use crate::types::{
     Map, MapAddress, MapEntries, MapEntryActions, MapPermissionSet, MapSeqEntries,

--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -20,7 +20,6 @@ use crate::messaging::client::{Cmd, CmdError, DataCmd, Error as ErrorMessage, Tr
 use crate::transfers::TransferActor;
 use crate::types::{Chunk, ChunkAddress, Keypair, PublicKey, SectionElders, Token};
 use crdts::Dot;
-use log::{debug, info, trace, warn};
 use lru::LruCache;
 use rand::rngs::OsRng;
 use std::{
@@ -31,6 +30,7 @@ use std::{
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::Duration;
+use tracing::{debug, info, trace, warn};
 
 // Number of attempts to make when trying to bootstrap to the network
 const NUM_OF_BOOTSTRAPPING_ATTEMPTS: u8 = 1;

--- a/src/client/client_api/queries.rs
+++ b/src/client/client_api/queries.rs
@@ -10,7 +10,7 @@ use super::Client;
 use crate::client::{connections::QueryResult, errors::Error};
 use crate::messaging::client::{ClientSig, Query};
 use crate::types::{PublicKey, Signature};
-use log::debug;
+use tracing::debug;
 
 impl Client {
     /// Send a Query to the network and await a response

--- a/src/client/client_api/register_apis.rs
+++ b/src/client/client_api/register_apis.rs
@@ -18,8 +18,8 @@ use crate::types::{
     },
     PublicKey,
 };
-use log::{debug, trace};
 use std::collections::{BTreeMap, BTreeSet};
+use tracing::{debug, trace};
 use xor_name::XorName;
 
 impl Client {

--- a/src/client/client_api/sequence_apis.rs
+++ b/src/client/client_api/sequence_apis.rs
@@ -16,8 +16,8 @@ use crate::types::{
     SequencePermissions, SequencePrivatePermissions, SequencePrivatePolicy,
     SequencePublicPermissions, SequencePublicPolicy, SequenceUser,
 };
-use log::{debug, trace};
 use std::collections::BTreeMap;
+use tracing::{debug, trace};
 use xor_name::XorName;
 
 fn wrap_seq_read(read: SequenceRead) -> Query {

--- a/src/client/client_api/transfers/balance_management.rs
+++ b/src/client/client_api/transfers/balance_management.rs
@@ -12,7 +12,7 @@ use crate::types::{PublicKey, SignedTransfer, Token, TransferAgreementProof};
 
 use crate::client::{Client, Error};
 
-use log::{debug, info, trace};
+use tracing::{debug, info, trace};
 
 /// Handle all token transfers and Write API requests for a given ClientId.
 impl Client {

--- a/src/client/client_api/transfers/mod.rs
+++ b/src/client/client_api/transfers/mod.rs
@@ -22,8 +22,8 @@ use crate::types::{
     DebitId, PublicKey, SignedTransfer, Token, TransferAgreementProof, TransferValidated,
 };
 use bincode::serialize;
-use log::{debug, error, info, trace, warn};
 use tokio::sync::mpsc::channel;
+use tracing::{debug, error, info, trace, warn};
 
 impl Client {
     /// Get the client's current coin balance from the network

--- a/src/client/client_api/transfers/simulated_payouts.rs
+++ b/src/client/client_api/transfers/simulated_payouts.rs
@@ -13,7 +13,7 @@ use crate::types::Transfer;
 use crate::messaging::client::{Cmd, TransferCmd};
 
 #[cfg(feature = "simulated-payouts")]
-use log::info;
+use tracing::info;
 
 use crate::client::{Client, Error};
 use crate::types::Token;

--- a/src/client/config_handler.rs
+++ b/src/client/config_handler.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::client::Error;
-use log::{debug, warn};
 use qp2p::Config as QuicP2pConfig;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -17,6 +16,7 @@ use std::{
     net::SocketAddr,
     path::Path,
 };
+use tracing::{debug, warn};
 
 /// Configuration for sn_client.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]

--- a/src/client/connections/listeners.rs
+++ b/src/client/connections/listeners.rs
@@ -14,12 +14,12 @@ use crate::messaging::{
     MessageId, MessageType, SectionAuthorityProvider, WireMsg,
 };
 use crate::types::PublicKey;
-use log::{debug, error, info, trace, warn};
 use qp2p::IncomingMessages;
 use std::{
     collections::{BTreeMap, BTreeSet},
     net::SocketAddr,
 };
+use tracing::{debug, error, info, trace, warn};
 
 impl Session {
     /// Remove a pending transfer sender from the listener map

--- a/src/client/connections/messaging.rs
+++ b/src/client/connections/messaging.rs
@@ -16,13 +16,13 @@ use crate::messaging::{
 use crate::types::{Chunk, PrivateChunk, PublicChunk, PublicKey, TransferValidated};
 use futures::{future::join_all, stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
-use log::{debug, error, info, trace, warn};
 use std::{collections::BTreeSet, net::SocketAddr, time::Duration};
 use tokio::{
     sync::mpsc::{channel, Sender},
     task::JoinHandle,
     time::timeout,
 };
+use tracing::{debug, error, info, trace, warn};
 use xor_name::XorName;
 
 // Number of attemps when retrying to send a message to a node

--- a/src/client/connections/mod.rs
+++ b/src/client/connections/mod.rs
@@ -14,7 +14,6 @@ use crate::messaging::client::CmdError;
 use crate::messaging::{client::Error as ErrorMessage, client::QueryResponse, MessageId};
 use crate::types::{PublicKey, TransferValidated};
 use bls::PublicKeySet;
-use log::{debug, trace};
 use qp2p::{Config as QuicP2pConfig, Endpoint, QuicP2p};
 use std::{
     borrow::Borrow,
@@ -24,6 +23,7 @@ use std::{
 };
 use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
+use tracing::{debug, trace};
 use xor_name::{Prefix, XorName};
 
 // Channel for sending result of transfer validation

--- a/src/node/bin/launch_network.rs
+++ b/src/node/bin/launch_network.rs
@@ -28,7 +28,6 @@
 )]
 
 use dirs_next::home_dir;
-use log::{debug, info};
 use sn_launch_tool::run_with;
 use std::{
     fs::{create_dir_all, remove_dir_all},
@@ -36,6 +35,7 @@ use std::{
     process::{Command, Stdio},
 };
 use tokio::time::{sleep, Duration};
+use tracing::{debug, info};
 
 #[cfg(not(target_os = "windows"))]
 const SAFE_NODE_EXECUTABLE: &str = "sn_node";

--- a/src/node/bin/sn_node.rs
+++ b/src/node/bin/sn_node.rs
@@ -106,10 +106,7 @@ async fn run_node() -> Result<()> {
         }
     };
 
-    // Guard (if we're writing to a file) should be kept in scope until end of main and therefore should not be _optional_guard
-    // https://tracing.rs/tracing_appender/non_blocking/index.html1
-    #[allow(unused)]
-    let optional_guard = if let Some(log_dir) = config.log_dir() {
+    let _optional_guard = if let Some(log_dir) = config.log_dir() {
         println!("Starting logging to file");
         let file_appender = tracing_appender::rolling::hourly(log_dir, "sn_node.log");
 

--- a/src/node/capacity/store_cost.rs
+++ b/src/node/capacity/store_cost.rs
@@ -9,7 +9,7 @@
 use super::{CapacityReader, CHUNK_COPY_COUNT, MAX_CHUNK_SIZE, MAX_SUPPLY};
 use crate::node::{network::Network, Error, Result};
 use crate::types::Token;
-use log::debug;
+use tracing::debug;
 
 /// Calculation of rate limit for writes.
 #[derive(Clone)]

--- a/src/node/chaos.rs
+++ b/src/node/chaos.rs
@@ -12,9 +12,9 @@ macro_rules! with_chaos {
     ( $x:expr) => {{
         #[cfg(feature = "chaos")]
         {
-            use log::{debug, warn};
             use rand::distributions::{Distribution, Uniform};
             use std::env;
+            use tracing::{debug, warn};
 
             let mut rng = rand::thread_rng();
             // 20% chance of happening

--- a/src/node/chunks/chunk_storage.rs
+++ b/src/node/chunks/chunk_storage.rs
@@ -18,11 +18,11 @@ use crate::node::{
     Error, Result,
 };
 use crate::types::{Chunk, ChunkAddress, DataAddress, PublicKey};
-use log::{error, info};
 use std::{
     fmt::{self, Display, Formatter},
     path::Path,
 };
+use tracing::{error, info};
 
 /// Storage of data chunks.
 pub(crate) struct ChunkStorage {

--- a/src/node/chunks/mod.rs
+++ b/src/node/chunks/mod.rs
@@ -18,11 +18,11 @@ use crate::node::{
 };
 use crate::types::{Chunk, ChunkAddress, PublicKey};
 use chunk_storage::ChunkStorage;
-use log::info;
 use std::{
     fmt::{self, Display, Formatter},
     path::Path,
 };
+use tracing::info;
 
 /// At 50% full, the node will report that it's reaching full capacity.
 pub const MAX_STORAGE_USAGE_RATIO: f64 = 0.5;

--- a/src/node/config_handler.rs
+++ b/src/node/config_handler.rs
@@ -10,7 +10,6 @@
                                  // beep
 use crate::node::{Error, Result};
 use crate::routing::TransportConfig as NetworkConfig;
-use log::{debug, Level};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
@@ -20,6 +19,7 @@ use std::{
     path::PathBuf,
 };
 use structopt::StructOpt;
+use tracing::{debug, Level};
 
 const CONFIG_FILE: &str = "node.config";
 const CONNECTION_INFO_FILE: &str = "node_connection_info.config";
@@ -149,7 +149,7 @@ impl Config {
         config.merge(command_line_args);
 
         config.clear_data_from_disk().unwrap_or_else(|_| {
-            log::error!("Error deleting data file from disk");
+            tracing::error!("Error deleting data file from disk");
         });
 
         Ok(config)
@@ -286,11 +286,11 @@ impl Config {
     /// Get the log level.
     pub fn verbose(&self) -> Level {
         match self.verbose {
-            0 => Level::Error,
-            1 => Level::Warn,
-            2 => Level::Info,
-            3 => Level::Debug,
-            _ => Level::Trace,
+            0 => Level::ERROR,
+            1 => Level::WARN,
+            2 => Level::INFO,
+            3 => Level::DEBUG,
+            _ => Level::TRACE,
         }
     }
 

--- a/src/node/error.rs
+++ b/src/node/error.rs
@@ -22,9 +22,6 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[non_exhaustive]
 /// Node error variants.
 pub enum Error {
-    /// FlexiLogger error
-    #[error("Failed to start logging :: {0}")]
-    FlexiLoggerError(#[from] flexi_logger::FlexiLoggerError),
     /// Attempted to perform an operation meant only for Adults when we are not one.
     #[error("Attempted Adult operation when not an Adult")]
     NotAnAdult,

--- a/src/node/event_mapping/client_msg.rs
+++ b/src/node/event_mapping/client_msg.rs
@@ -16,7 +16,7 @@ use crate::node::{
     node_ops::{MsgType, NodeDuty, OutgoingMsg},
     Error,
 };
-use log::warn;
+use tracing::warn;
 
 pub fn map_client_msg(msg: &ClientMsg, user: EndUser) -> Mapping {
     match msg {

--- a/src/node/event_mapping/mod.rs
+++ b/src/node/event_mapping/mod.rs
@@ -22,9 +22,9 @@ use crate::routing::XorName;
 use crate::routing::{Event as RoutingEvent, NodeElderChange, MIN_AGE};
 use crate::types::PublicKey;
 use client_msg::map_client_msg;
-use log::{debug, error, info, trace, warn};
 use node_msg::map_node_msg;
 use std::{thread::sleep, time::Duration};
+use tracing::{debug, error, info, trace, warn};
 
 #[derive(Debug)]
 pub struct Mapping {
@@ -245,10 +245,8 @@ pub async fn map_routing_event(event: RoutingEvent, network_api: &Network) -> Ma
 }
 
 pub async fn log_network_stats(network_api: &Network) {
-    debug!(
-        "{:?}: {:?} Elders, {:?} Adults.",
-        network_api.our_prefix().await,
-        network_api.our_elder_names().await.len(),
-        network_api.our_adults().await.len()
-    );
+    let adults = network_api.our_adults().await.len();
+    let elders = network_api.our_elder_names().await.len();
+    let prefix = network_api.our_prefix().await;
+    debug!("{:?}: {:?} Elders, {:?} Adults.", prefix, elders, adults);
 }

--- a/src/node/event_mapping/node_msg.rs
+++ b/src/node/event_mapping/node_msg.rs
@@ -20,7 +20,7 @@ use crate::node::{
     node_ops::{MsgType, NodeDuty, OutgoingMsg},
     Error,
 };
-use log::debug;
+use tracing::debug;
 
 pub fn map_node_msg(msg: NodeMsg, src: SrcLocation, dst: DstLocation) -> Mapping {
     debug!(
@@ -45,7 +45,7 @@ pub fn map_node_msg(msg: NodeMsg, src: SrcLocation, dst: DstLocation) -> Mapping
             ));
 
             if let SrcLocation::EndUser(_) = src {
-                log::error!("Logic error! EndUser cannot send NodeMsgs. ({:?})", msg);
+                tracing::error!("Logic error! EndUser cannot send NodeMsgs. ({:?})", msg);
                 return Mapping {
                     op: NodeDuty::NoOp,
                     ctx: None,

--- a/src/node/metadata/adult_liveness.rs
+++ b/src/node/metadata/adult_liveness.rs
@@ -173,7 +173,7 @@ impl AdultLiveness {
                     && adult_pending_ops as f64 * PENDING_OP_TOLERANCE_RATIO
                         > *max_pending_by_neighbours as f64
                 {
-                    log::info!(
+                    tracing::info!(
                         "Pending ops for {}: {} Neighbour max: {}",
                         adult,
                         adult_pending_ops,

--- a/src/node/metadata/chunk_records.rs
+++ b/src/node/metadata/chunk_records.rs
@@ -20,7 +20,7 @@ use crate::node::{
 };
 use crate::routing::Prefix;
 use crate::types::{Chunk, ChunkAddress, PublicKey};
-use log::{info, warn};
+use tracing::{info, warn};
 
 use std::{
     collections::BTreeSet,
@@ -85,10 +85,8 @@ impl ChunkRecords {
 
     /// Adds a given node to the list of full nodes.
     pub async fn increase_full_node_count(&mut self, node_id: PublicKey) {
-        info!(
-            "No. of full Adults: {:?}",
-            self.capacity.full_adults_count().await
-        );
+        let full_adults = self.capacity.full_adults_count().await;
+        info!("No. of full Adults: {:?}", full_adults);
         info!("Increasing full Adults count");
         self.capacity
             .insert_full_adults(btree_set!(XorName::from(node_id)))

--- a/src/node/metadata/elder_stores.rs
+++ b/src/node/metadata/elder_stores.rs
@@ -17,7 +17,7 @@ use crate::messaging::{
 use crate::node::{node_ops::NodeDuty, Error, Result};
 use crate::routing::Prefix;
 use crate::types::PublicKey;
-use log::info;
+use tracing::info;
 
 /// The various data type stores,
 /// that are only managed at Elders.

--- a/src/node/metadata/map_storage.rs
+++ b/src/node/metadata/map_storage.rs
@@ -19,12 +19,12 @@ use crate::types::{
     Error as DtError, Map, MapAction, MapAddress, MapEntryActions, MapPermissionSet, MapValue,
     PublicKey, Result as NdResult,
 };
-use log::{debug, info};
 use std::{
     collections::BTreeMap,
     fmt::{self, Display, Formatter},
     path::Path,
 };
+use tracing::{debug, info};
 
 /// Operations over the data type Map.
 pub(super) struct MapStorage {

--- a/src/node/metadata/register_storage.rs
+++ b/src/node/metadata/register_storage.rs
@@ -19,11 +19,11 @@ use crate::types::{
     register::{Action, Address, Entry, Register, RegisterOp, User},
     PublicKey,
 };
-use log::info;
 use std::{
     fmt::{self, Display, Formatter},
     path::Path,
 };
+use tracing::info;
 
 /// Operations over the data type Register.
 pub(super) struct RegisterStorage {

--- a/src/node/metadata/sequence_storage.rs
+++ b/src/node/metadata/sequence_storage.rs
@@ -20,12 +20,12 @@ use crate::types::{
     Error as DtError, PublicKey, Sequence, SequenceAction, SequenceAddress, SequenceEntry,
     SequenceIndex, SequenceOp, SequenceUser,
 };
-use log::{debug, info};
 use std::{
     collections::BTreeMap,
     fmt::{self, Display, Formatter},
     path::Path,
 };
+use tracing::{debug, info};
 
 /// Operations over the data type Sequence.
 pub(super) struct SequenceStorage {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -11,7 +11,8 @@
 mod capacity;
 mod chaos;
 mod chunks;
-mod config_handler;
+/// Configuration handling
+pub mod config_handler;
 mod data_store;
 mod error;
 mod event_mapping;

--- a/src/node/node_api/handle.rs
+++ b/src/node/node_api/handle.rs
@@ -24,9 +24,9 @@ use crate::node::{
     Error, Node, Result,
 };
 use crate::routing::ELDER_SIZE;
-use log::{debug, info};
 use std::sync::Arc;
 use tokio::{sync::RwLock, task::JoinHandle};
+use tracing::{debug, info};
 use xor_name::XorName;
 
 const DATA_SECTION_TARGET_COUNT: usize = 3;
@@ -228,11 +228,11 @@ impl Node {
                             .set_node_wallet(node_id, wallet_id, *age);
                         Ok(vec![])
                     } else {
+                        let our_prefix = network_api.our_prefix().await;
+
                         debug!(
                             "{:?}: Couldn't find node id {} when adding wallet {}",
-                            network_api.our_prefix().await,
-                            node_id,
-                            wallet_id
+                            our_prefix, node_id, wallet_id
                         );
                         Err(Error::NodeNotFoundForReward)
                     }?;
@@ -249,10 +249,10 @@ impl Node {
                         let _wallet = elder.section_funds.read().await.get_node_wallet(&node_name);
                         Ok(vec![]) // not yet implemented
                     } else {
+                        let our_prefix = network_api.our_prefix().await;
                         debug!(
                             "{:?}: Couldn't find node {} when getting wallet.",
-                            network_api.our_prefix().await,
-                            node_name,
+                            our_prefix, node_name,
                         );
                         Err(Error::NodeNotFoundForReward)
                     }?;

--- a/src/node/node_api/member_churn.rs
+++ b/src/node/node_api/member_churn.rs
@@ -22,8 +22,8 @@ use crate::node::{
 };
 use crate::routing::XorName;
 use crate::types::{ActorHistory, NodeAge, PublicKey};
-use log::info;
 use std::collections::BTreeMap;
+use tracing::info;
 
 impl Node {
     /// If we are an oldie we'll have a transfer instance,

--- a/src/node/node_api/messaging.rs
+++ b/src/node/node_api/messaging.rs
@@ -16,8 +16,8 @@ use crate::node::{
     Error, Result,
 };
 use crate::routing::XorName;
-use log::{error, trace};
 use std::collections::BTreeSet;
+use tracing::{error, trace};
 
 pub(crate) async fn send(msg: OutgoingMsg, network: &Network) -> Result<()> {
     let our_prefix = network.our_prefix().await;

--- a/src/node/node_api/mod.rs
+++ b/src/node/node_api/mod.rs
@@ -30,7 +30,6 @@ use crate::routing::{
 use crate::types::PublicKey;
 use futures::{future::BoxFuture, lock::Mutex, stream::FuturesUnordered, FutureExt, StreamExt};
 use handle::NodeTask;
-use log::{error, warn};
 use rand::rngs::OsRng;
 use role::{AdultRole, Role};
 use std::sync::Arc;
@@ -42,6 +41,7 @@ use std::{
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
+use tracing::{error, warn};
 
 const JOINING_TIMEOUT: u64 = 180; // 180 seconds
 

--- a/src/node/node_api/role/adult_role.rs
+++ b/src/node/node_api/role/adult_role.rs
@@ -19,10 +19,10 @@ use crate::node::{
 use crate::routing::XorName;
 use crate::types::{Chunk, ChunkAddress};
 use itertools::Itertools;
-use log::{info, trace, warn};
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tracing::{info, trace, warn};
 
 #[derive(Clone)]
 pub(crate) struct AdultRole {

--- a/src/node/node_api/split.rs
+++ b/src/node/node_api/split.rs
@@ -18,13 +18,13 @@ use crate::node::{
 };
 use crate::routing::{Prefix, XorName};
 use crate::types::{NodeAge, PublicKey, Token};
-use log::debug;
 use section_funds::{
     elder_signing::ElderSigning,
     reward_process::{OurSection, RewardProcess},
     reward_wallets::RewardWallets,
 };
 use std::collections::{BTreeMap, BTreeSet};
+use tracing::debug;
 
 impl Node {
     /// Called on split reported from routing layer.

--- a/src/node/section_funds/mod.rs
+++ b/src/node/section_funds/mod.rs
@@ -17,8 +17,8 @@ use crate::node::{Error, Result};
 use crate::routing::{Prefix, XorName};
 use crate::types::{CreditAgreementProof, CreditId, NodeAge, PublicKey, Token};
 use dashmap::DashMap;
-use log::info;
 use std::collections::BTreeMap;
+use tracing::info;
 
 /// The management of section funds,
 /// via the usage of a distributed AT2 Actor.

--- a/src/node/section_funds/reward_process.rs
+++ b/src/node/section_funds/reward_process.rs
@@ -26,8 +26,8 @@ use crate::node::{
 use crate::types::{
     Credit, NodeAge, PublicKey, RewardAccumulation, RewardProposal, Signature, Signing, Token,
 };
-use log::{debug, info};
 use std::collections::BTreeMap;
+use tracing::{debug, info};
 use xor_name::{Prefix, XorName};
 
 ///

--- a/src/node/section_funds/reward_stage.rs
+++ b/src/node/section_funds/reward_stage.rs
@@ -11,8 +11,8 @@ use crate::types::{
     Credit, CreditAgreementProof, CreditId, PublicKey, ReplicaPublicKeySet, SignatureShare,
     SignedCredit, SignedCreditShare,
 };
-use log::{debug, warn};
 use std::collections::BTreeMap;
+use tracing::{debug, warn};
 
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]

--- a/src/node/section_funds/reward_wallets.rs
+++ b/src/node/section_funds/reward_wallets.rs
@@ -9,8 +9,8 @@
 use crate::routing::Prefix;
 use crate::types::{NodeAge, PublicKey};
 use dashmap::DashMap;
-use log::debug;
 use std::collections::BTreeMap;
+use tracing::debug;
 use xor_name::XorName;
 
 /// The accumulation and paying

--- a/src/node/transfers/mod.rs
+++ b/src/node/transfers/mod.rs
@@ -37,11 +37,11 @@ use crate::types::{
     TransferAgreementProof,
 };
 use futures::lock::Mutex;
-use log::{debug, error, info, trace, warn};
 use replica_signing::ReplicaSigningImpl;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
+use tracing::{debug, error, info, trace, warn};
 use xor_name::Prefix;
 
 /*
@@ -229,10 +229,8 @@ impl Transfers {
                     ),
                 };
                 info!("Payment: registration and propagation succeeded. (Store cost: {}, paid amount: {}.)", total_cost, payment.amount());
-                info!(
-                    "Section balance: {}",
-                    self.replicas.balance(payment.recipient()).await?
-                );
+                let section_balance = self.replicas.balance(payment.recipient()).await?;
+                info!("Section balance: {}", section_balance);
                 if let Some(e) = error {
                     let origin = SrcLocation::EndUser(origin);
                     return Ok(vec![NodeDuty::Send(OutgoingMsg {

--- a/src/node/transfers/replicas.rs
+++ b/src/node/transfers/replicas.rs
@@ -15,10 +15,10 @@ use crate::types::{
 };
 use bls::PublicKeySet;
 use dashmap::DashMap;
-use log::info;
 use secured_linked_list::SecuredLinkedList;
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
+use tracing::info;
 use xor_name::Prefix;
 
 #[cfg(feature = "simulated-payouts")]
@@ -26,8 +26,8 @@ use {
     crate::node::node_ops::NodeDuty,
     crate::types::{Signature, SignedCredit, SignedDebit, Transfer},
     bls::{SecretKey, SecretKeySet},
-    log::debug,
     rand::thread_rng,
+    tracing::debug,
 };
 
 type Stores = DashMap<PublicKey, Arc<RwLock<TransferStore<ReplicaEvent>>>>;

--- a/src/node/utils.rs
+++ b/src/node/utils.rs
@@ -8,19 +8,13 @@
 
 //! Utilities
 
-use crate::node::{config_handler::Config, Error, Result};
+use crate::node::{Error, Result};
 use bytes::Bytes;
-use flexi_logger::{
-    Cleanup, Criterion, DeferredNow, FileSpec, Logger, LoggerHandle, Naming, WriteMode,
-};
-use log::{Log, Metadata, Record};
+
 use pickledb::{PickleDb, PickleDbDumpPolicy};
 use rand::{distributions::Standard, CryptoRng, Rng};
 use serde::{de::DeserializeOwned, Serialize};
-use std::io::Write;
 use std::{fs, path::Path};
-
-const MODULE_NAME: &str = "safe_network";
 
 /// Easily create a `BTreeSet`.
 #[macro_export]
@@ -90,62 +84,6 @@ pub(crate) fn serialise<T: Serialize>(data: &T) -> Result<Bytes> {
 #[allow(unused)]
 pub(crate) fn deserialise<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
     bincode::deserialize(bytes).map_err(Error::Bincode)
-}
-
-/// Initialize logging
-pub fn init_logging(config: &Config) -> Result<LoggerHandle> {
-    // Custom formatter for logs
-    let do_format = move |writer: &mut dyn Write, clock: &mut DeferredNow, record: &Record| {
-        let handle = std::thread::current();
-        write!(
-            writer,
-            "[{}] {} {} [{}:{}] {}",
-            handle
-                .name()
-                .unwrap_or(&format!("Thread-{:?}", handle.id())),
-            record.level(),
-            clock.now().to_rfc3339(),
-            record.file().unwrap_or_default(),
-            record.line().unwrap_or_default(),
-            record.args()
-        )
-    };
-
-    let level_filter = config.verbose().to_level_filter();
-    let module_log_filter = format!("{}={}", MODULE_NAME, level_filter.to_string());
-    let logger = Logger::try_with_env_or_str(module_log_filter)
-        .map_err(|e| Error::Configuration(format!("{:?}", e)))?
-        .format(do_format)
-        .write_mode(WriteMode::Async)
-        .rotate(
-            Criterion::Size(1024 * 1024), // 1 mb
-            Naming::Numbers,
-            Cleanup::Never,
-        );
-
-    let logger = if let Some(log_dir) = config.log_dir() {
-        logger.log_to_file(FileSpec::default().directory(log_dir).suppress_timestamp())
-    } else {
-        logger
-    };
-
-    logger.start().map_err(Error::from)
-}
-
-struct LoggerWrapper(Box<dyn Log>);
-
-impl Log for LoggerWrapper {
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        self.0.enabled(metadata)
-    }
-
-    fn log(&self, record: &Record) {
-        self.0.log(record)
-    }
-
-    fn flush(&self) {
-        self.0.flush();
-    }
 }
 
 /// Command that the user can send to a running node to control its execution.

--- a/src/transfers/actor.rs
+++ b/src/transfers/actor.rs
@@ -19,9 +19,9 @@ use crate::types::{
 use bls::PublicKeySet;
 use crdts::Dot;
 use itertools::Itertools;
-use log::debug;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
+use tracing::debug;
 
 /// The Actor is the part of an AT2 system
 /// that initiates transfers, by requesting Replicas

--- a/src/transfers/wallet.rs
+++ b/src/transfers/wallet.rs
@@ -8,8 +8,8 @@
 
 use super::{Error, Result};
 use crate::types::{Credit, CreditId, Debit, OwnerType, Token};
-use log::debug;
 use std::collections::HashSet;
+use tracing::debug;
 
 #[derive(Debug, Clone)]
 pub struct WalletSnapshot {

--- a/src/transfers/wallet_replica.rs
+++ b/src/transfers/wallet_replica.rs
@@ -18,9 +18,9 @@ use crate::types::{
     TransferValidationProposed,
 };
 use bls::{PublicKeySet, PublicKeyShare};
-use log::{debug, error};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
+use tracing::{debug, error};
 
 macro_rules! hashmap {
     ($( $key: expr => $val: expr ),*) => {{

--- a/src/url/mod.rs
+++ b/src/url/mod.rs
@@ -15,10 +15,10 @@ mod xorurl_media_types;
 
 use crate::types::register;
 pub use errors::{Error, Result};
-use log::{info, trace, warn};
 use multibase::{decode as base_decode, encode as base_encode, Base};
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use tracing::{info, trace, warn};
 use url::Url;
 use url_parts::SafeUrlParts;
 use xor_name::{XorName, XOR_NAME_LEN};

--- a/src/url/url_parts.rs
+++ b/src/url/url_parts.rs
@@ -8,7 +8,7 @@
 // Software.
 
 use super::{Error, Result};
-use log::debug;
+use tracing::debug;
 use uhttp_uri::HttpUri;
 use url::Url;
 


### PR DESCRIPTION
- adds `tracing` https://tracing.rs/
- removes log / flexi / env
- sets up hourly log rotation
- logs are async, but will exert backpressure so we dont lose logs atm
- logging code moved to main so we can maintain the WriterGuard (which has to be in main func as the type isnt exported so we cant return it from another func afaik)