### PR TITLE
Tidy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,16 +8,11 @@
 
 //! Implementation of the "Node" node for the SAFE Network.
 
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
-    html_favicon_url = "https://maidsafe.net/img/favicon.ico",
-    test(attr(deny(warnings)))
-)]
 // For quick_error
 #![recursion_limit = "256"]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
-    html_favicon_url = "https://maidsafe.net/img/favicon.ico",
+    html_favicon_url = "https://maidsafe.net/favicon.ico",
     test(attr(deny(warnings)))
 )]
 // Forbid some very bad patterns. Forbid is stronger than `deny`, preventing us from suppressing the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 #![recursion_limit = "256"]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
-    html_favicon_url = "https://maidsafe.net/favicon.ico",
+    html_favicon_url = "https://maidsafe.net/img/favicon.ico",
     test(attr(deny(warnings)))
 )]
 // Forbid some very bad patterns. Forbid is stronger than `deny`, preventing us from suppressing the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@
     html_favicon_url = "https://maidsafe.net/img/favicon.ico",
     test(attr(deny(warnings)))
 )]
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
+// Forbid some very bad patterns. Forbid is stronger than `deny`, preventing us from suppressing the
+// lint with `#[allow(...)]` et-all.
 #![forbid(
     arithmetic_overflow,
     mutable_transmutes,
@@ -29,7 +29,7 @@
     unknown_crate_types,
     unsafe_code
 )]
-// For explanation of lint checks, run `rustc -W help`.
+// Turn on some additional warnings to encourage good style.
 #![warn(
     missing_debug_implementations,
     missing_docs,
@@ -39,24 +39,7 @@
     unused_import_braces,
     unused_qualifications,
     unused_results,
-    bad_style,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true,
-    clippy::unicode_not_nfc,
-    clippy::wrong_pub_self_convention,
-    deprecated
+    clippy::unicode_not_nfc
 )]
 
 #[macro_use]


### PR DESCRIPTION
- 8dc76bbff **chore: Remove redundant lint configuration**

  Many of the lints specified for `#[warn(...)]` are warn-by-default and
  have been removed. Additionally:
  
  - `clippy::wrong_pub_self_convention` is deprecated and is now a no-op.
  - comments have been updated to describe the purpose of the
    configuration, on the assumption that folk can discover lint meanings
    themselves (whereas why we're using them can't be Googled).

- 67bf67d58 **chore: Remove duplicate attributes from crate root**

  These were presumably duplicated when the crates were merged.

- 7e02bf3d0 **chore: Update favicon URL**

  The old URL no longer exists. The new URL was taken from the
  https://maidsafe.net site.
