### PR TITLE
Unreachable pub

### DIFF
--- a/src/client/client_api/blob_apis.rs
+++ b/src/client/client_api/blob_apis.rs
@@ -367,7 +367,7 @@ mod tests {
     // Test storing and getting public Blob.
     #[tokio::test]
     #[ignore = "too heavy for CI"]
-    pub async fn parallel_timings() -> Result<()> {
+    async fn parallel_timings() -> Result<()> {
         let client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
 
         let handles = (0..1000_usize)
@@ -399,7 +399,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "too heavy for CI"]
-    pub async fn one_by_one_timings() -> Result<()> {
+    async fn one_by_one_timings() -> Result<()> {
         let client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
 
         for i in 0..1000_usize {
@@ -415,7 +415,7 @@ mod tests {
 
     // Test storing and getting public Blob.
     #[tokio::test]
-    pub async fn public_blob_test() -> Result<()> {
+    async fn public_blob_test() -> Result<()> {
         let client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
         let value = generate_random_vector::<u8>(10);
         let (_, expected_address) = Client::blob_data_map(value.clone(), None).await?;
@@ -440,7 +440,7 @@ mod tests {
 
     // Test storing, getting, and deleting private chunk.
     #[tokio::test]
-    pub async fn private_blob_test() -> Result<()> {
+    async fn private_blob_test() -> Result<()> {
         let mut client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
 
         let value = generate_random_vector::<u8>(10);
@@ -505,7 +505,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn private_delete_large() -> Result<()> {
+    async fn private_delete_large() -> Result<()> {
         let mut client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
 
         let value = generate_random_vector::<u8>(1024 * 1024);
@@ -557,21 +557,21 @@ mod tests {
 
     // Test creating and retrieving a 1kb blob.
     #[tokio::test]
-    pub async fn create_and_retrieve_1kb_pub_unencrypted() -> Result<()> {
+    async fn create_and_retrieve_1kb_pub_unencrypted() -> Result<()> {
         let size = 1024;
         gen_data_then_create_and_retrieve(size, true).await?;
         Ok(())
     }
 
     #[tokio::test]
-    pub async fn create_and_retrieve_1kb_private_unencrypted() -> Result<()> {
+    async fn create_and_retrieve_1kb_private_unencrypted() -> Result<()> {
         let size = 1024;
         gen_data_then_create_and_retrieve(size, false).await?;
         Ok(())
     }
 
     #[tokio::test]
-    pub async fn create_and_retrieve_1kb_put_pub_retrieve_private() -> Result<()> {
+    async fn create_and_retrieve_1kb_put_pub_retrieve_private() -> Result<()> {
         let size = 1024;
         let data = generate_random_vector(size);
 
@@ -591,7 +591,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn create_and_retrieve_1kb_put_private_retrieve_pub() -> Result<()> {
+    async fn create_and_retrieve_1kb_put_private_retrieve_pub() -> Result<()> {
         let size = 1024;
 
         let value = generate_random_vector(size);
@@ -613,14 +613,14 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn create_and_retrieve_1mb_public() -> Result<()> {
+    async fn create_and_retrieve_1mb_public() -> Result<()> {
         let size = 1024 * 1024;
         gen_data_then_create_and_retrieve(size, true).await?;
         Ok(())
     }
 
     #[tokio::test]
-    pub async fn create_and_retrieve_1mb_private() -> Result<()> {
+    async fn create_and_retrieve_1mb_private() -> Result<()> {
         let size = 1024 * 1024;
         gen_data_then_create_and_retrieve(size, false).await?;
         Ok(())
@@ -630,14 +630,14 @@ mod tests {
     // 10mb (ie. more than 1 chunk)
     // ----------------------------------------------------------------
     #[tokio::test]
-    pub async fn create_and_retrieve_10mb_private() -> Result<()> {
+    async fn create_and_retrieve_10mb_private() -> Result<()> {
         let size = 1024 * 1024 * 10;
         gen_data_then_create_and_retrieve(size, false).await?;
         Ok(())
     }
 
     #[tokio::test]
-    pub async fn create_and_retrieve_10mb_public() -> Result<()> {
+    async fn create_and_retrieve_10mb_public() -> Result<()> {
         let size = 1024 * 1024 * 10;
         gen_data_then_create_and_retrieve(size, true).await?;
         Ok(())
@@ -645,14 +645,14 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "too heavy for CI"]
-    pub async fn create_and_retrieve_100mb_public() -> Result<()> {
+    async fn create_and_retrieve_100mb_public() -> Result<()> {
         let size = 1024 * 1024 * 100;
         gen_data_then_create_and_retrieve(size, true).await?;
         Ok(())
     }
 
     #[tokio::test]
-    pub async fn create_and_retrieve_index_based() -> Result<()> {
+    async fn create_and_retrieve_index_based() -> Result<()> {
         create_and_index_based_retrieve(1024).await
     }
 

--- a/src/client/client_api/map_apis.rs
+++ b/src/client/client_api/map_apis.rs
@@ -382,7 +382,7 @@ mod tests {
     // 2. Fetch the shell version, entries, keys, values anv verify them
     // 3. Fetch the entire. data object and verify
     #[tokio::test]
-    pub async fn public_map_test() -> Result<()> {
+    async fn public_map_test() -> Result<()> {
         let client = create_test_client(None).await?;
 
         let name = XorName::random();
@@ -440,7 +440,7 @@ mod tests {
     // 2. Fetch the shell version, entries, keys, values anv verify them
     // 3. Fetch the entire. data object and verify
     #[tokio::test]
-    pub async fn private_map_test() -> Result<()> {
+    async fn private_map_test() -> Result<()> {
         let client = create_test_client(None).await?;
 
         let name = XorName::random();
@@ -500,7 +500,7 @@ mod tests {
     // 1. Put seq. map on the network and then delete it
     // 2. Try getting the data object. It should bail
     #[tokio::test]
-    pub async fn del_private_map_test() -> Result<()> {
+    async fn del_private_map_test() -> Result<()> {
         let mut client = create_test_client(None).await?;
         let name = XorName(rand::random());
         let tag = 15001;
@@ -531,7 +531,7 @@ mod tests {
     // 1. Put unseq. map on the network and then delete it
     // 2. Try getting the data object. It should bail
     #[tokio::test]
-    pub async fn del_public_map_test() -> Result<()> {
+    async fn del_public_map_test() -> Result<()> {
         let mut client = create_test_client(None).await?;
         let name = XorName(rand::random());
         let tag = 15001;
@@ -562,7 +562,7 @@ mod tests {
     // 1. Create a client that PUTs some map on the network
     // 2. Create a different client that tries to delete the data. It should bail.
     #[tokio::test]
-    pub async fn del_public_map_permission_test() -> Result<()> {
+    async fn del_public_map_permission_test() -> Result<()> {
         let name = XorName(rand::random());
         let tag = 15001;
         let mapref = MapAddress::Public { name, tag };
@@ -588,8 +588,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "Has been failing for a long time, fix coming up."]
-    pub async fn map_cannot_initially_put_data_with_another_owner_than_current_client() -> Result<()>
-    {
+    async fn map_cannot_initially_put_data_with_another_owner_than_current_client() -> Result<()> {
         let client = create_test_client(None).await?;
         let mut permissions: BTreeMap<_, _> = Default::default();
         let permission_set = MapPermissionSet::new()
@@ -644,7 +643,7 @@ mod tests {
     // 3. Fetch the list of permissions and verify the edit.
     // 4. Delete a user's permissions from the permission set and verify the deletion.
     #[tokio::test]
-    pub async fn map_can_modify_permissions_test() -> Result<()> {
+    async fn map_can_modify_permissions_test() -> Result<()> {
         let client = create_test_client(None).await?;
         let name = XorName(rand::random());
         let tag = 15001;
@@ -720,7 +719,7 @@ mod tests {
     // 3. List the entries and verify that the mutation was applied.
     // 4. Fetch a value for a particular key and verify
     #[tokio::test]
-    pub async fn map_mutations_test() -> Result<()> {
+    async fn map_mutations_test() -> Result<()> {
         let client = create_test_client(None).await?;
         let name = XorName::random();
         let val_1 = XorName::random();

--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -175,7 +175,7 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     #[tokio::test]
-    pub async fn client_creation() -> Result<()> {
+    async fn client_creation() -> Result<()> {
         let _client = create_test_client(None).await?;
 
         Ok(())
@@ -183,7 +183,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    pub async fn client_nonsense_bootstrap_fails() -> Result<()> {
+    async fn client_nonsense_bootstrap_fails() -> Result<()> {
         let mut nonsense_bootstrap = HashSet::new();
         let _ = nonsense_bootstrap.insert(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
@@ -195,7 +195,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn client_creation_with_existing_keypair() -> Result<()> {
+    async fn client_creation_with_existing_keypair() -> Result<()> {
         let mut rng = OsRng;
         let full_id = Keypair::new_ed25519(&mut rng);
         let pk = full_id.public_key();
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn long_lived_connection_survives() -> Result<()> {
+    async fn long_lived_connection_survives() -> Result<()> {
         let client = create_test_client(None).await?;
         tokio::time::sleep(tokio::time::Duration::from_secs(40)).await;
 

--- a/src/client/client_api/register_apis.rs
+++ b/src/client/client_api/register_apis.rs
@@ -251,7 +251,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "too heavy for CI"]
-    pub async fn measure_upload_times() -> Result<()> {
+    async fn measure_upload_times() -> Result<()> {
         let mut total = 0;
 
         let name = XorName(rand::random());
@@ -289,7 +289,7 @@ mod tests {
     /**** Register data tests ****/
 
     #[tokio::test]
-    pub async fn register_basics() -> Result<()> {
+    async fn register_basics() -> Result<()> {
         let client = create_test_client(None).await?;
 
         let name = XorName(rand::random());
@@ -330,7 +330,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn register_private_permissions() -> Result<()> {
+    async fn register_private_permissions() -> Result<()> {
         let client = create_test_client(None).await?;
         let name = XorName(rand::random());
         let tag = 15000;
@@ -371,7 +371,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn register_public_permissions() -> Result<()> {
+    async fn register_public_permissions() -> Result<()> {
         let client = create_test_client(None).await?;
 
         let name = XorName(rand::random());
@@ -411,7 +411,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn register_write() -> Result<()> {
+    async fn register_write() -> Result<()> {
         let name = XorName(rand::random());
         let tag = 10;
         let client = create_test_client(None).await?;
@@ -473,7 +473,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn register_owner() -> Result<()> {
+    async fn register_owner() -> Result<()> {
         let name = XorName(rand::random());
         let tag = 10;
         let client = create_test_client(None).await?;
@@ -494,7 +494,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn register_can_delete_private() -> Result<()> {
+    async fn register_can_delete_private() -> Result<()> {
         let mut client = create_test_client(None).await?;
         let name = XorName(rand::random());
         let tag = 15000;
@@ -533,7 +533,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn register_cannot_delete_public() -> Result<()> {
+    async fn register_cannot_delete_public() -> Result<()> {
         let client = create_test_client(None).await?;
 
         let name = XorName(rand::random());

--- a/src/client/client_api/sequence_apis.rs
+++ b/src/client/client_api/sequence_apis.rs
@@ -394,7 +394,7 @@ mod tests {
     /// Sequence data tests ///
 
     #[tokio::test]
-    pub async fn sequence_basics() -> Result<()> {
+    async fn sequence_basics() -> Result<()> {
         let client = create_test_client(None).await?;
 
         let name = XorName(rand::random());
@@ -433,7 +433,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn sequence_private_permissions() -> Result<()> {
+    async fn sequence_private_permissions() -> Result<()> {
         let client = create_test_client(None).await?;
         let name = XorName(rand::random());
         let tag = 15000;
@@ -502,7 +502,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn sequence_public_permissions() -> Result<()> {
+    async fn sequence_public_permissions() -> Result<()> {
         let client = create_test_client(None).await?;
 
         let name = XorName(rand::random());
@@ -573,7 +573,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn append_to_sequence() -> Result<()> {
+    async fn append_to_sequence() -> Result<()> {
         let name = XorName(rand::random());
         let tag = 10;
         let client = create_test_client(None).await?;
@@ -656,7 +656,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn sequence_owner() -> Result<()> {
+    async fn sequence_owner() -> Result<()> {
         let name = XorName(rand::random());
         let tag = 10;
         let client = create_test_client(None).await?;
@@ -677,7 +677,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn sequence_can_delete_private() -> Result<()> {
+    async fn sequence_can_delete_private() -> Result<()> {
         let mut client = create_test_client(None).await?;
         let name = XorName(rand::random());
         let tag = 15000;
@@ -718,7 +718,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn sequence_cannot_delete_public() -> Result<()> {
+    async fn sequence_cannot_delete_public() -> Result<()> {
         let mut client = create_test_client(None).await?;
 
         let name = XorName(rand::random());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,11 +40,15 @@
 #[macro_use]
 extern crate tracing;
 
+#[warn(unreachable_pub)]
 pub mod client;
+#[warn(unreachable_pub)]
 mod dbs;
 /// The messaging interface to the network. Messages sent and serialised in line with this module should be acted upon by the network.
 pub mod messaging;
 pub mod node;
 pub mod routing;
+#[warn(unreachable_pub)]
 pub mod types;
+#[warn(unreachable_pub)]
 pub mod url;


### PR DESCRIPTION
- 2d90ec55b **chore: Turn on `unreachable_pub` lint for some modules**

  Some modules have already been updated to fix `unreachable_pub`
  warnings. We should actually turn on the lint for those modules to make
  sure nothing sneaks in.

- 5c0cc3720 **chore(client): Fix `unreachable_pub` in tests**

  These were missed before, due to checking without `--all-targets` 😳
