### PR TITLE
Turn on `unreachable_pub` lints in messaging, node, and routing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
+    unreachable_pub,
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
@@ -40,18 +41,11 @@
 #[macro_use]
 extern crate tracing;
 
-#[warn(unreachable_pub)]
 pub mod client;
-#[warn(unreachable_pub)]
 mod dbs;
 /// The messaging interface to the network. Messages sent and serialised in line with this module should be acted upon by the network.
-#[warn(unreachable_pub)]
 pub mod messaging;
-#[warn(unreachable_pub)]
 pub mod node;
-#[warn(unreachable_pub)]
 pub mod routing;
-#[warn(unreachable_pub)]
 pub mod types;
-#[warn(unreachable_pub)]
 pub mod url;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ mod dbs;
 /// The messaging interface to the network. Messages sent and serialised in line with this module should be acted upon by the network.
 #[warn(unreachable_pub)]
 pub mod messaging;
+#[warn(unreachable_pub)]
 pub mod node;
 #[warn(unreachable_pub)]
 pub mod routing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod client;
 #[warn(unreachable_pub)]
 mod dbs;
 /// The messaging interface to the network. Messages sent and serialised in line with this module should be acted upon by the network.
+#[warn(unreachable_pub)]
 pub mod messaging;
 pub mod node;
 #[warn(unreachable_pub)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ mod dbs;
 /// The messaging interface to the network. Messages sent and serialised in line with this module should be acted upon by the network.
 pub mod messaging;
 pub mod node;
+#[warn(unreachable_pub)]
 pub mod routing;
 #[warn(unreachable_pub)]
 pub mod types;

--- a/src/messaging/client/mod.rs
+++ b/src/messaging/client/mod.rs
@@ -291,7 +291,7 @@ mod tests {
         ]
     }
 
-    pub fn gen_keys() -> Vec<PublicKey> {
+    pub(crate) fn gen_keys() -> Vec<PublicKey> {
         gen_keypairs().iter().map(PublicKey::from).collect()
     }
 

--- a/src/messaging/node/agreement.rs
+++ b/src/messaging/node/agreement.rs
@@ -20,7 +20,7 @@ use std::{
 use xor_name::{Prefix, XorName};
 
 /// SHA3-256 hash digest.
-pub type Digest256 = [u8; 32];
+type Digest256 = [u8; 32];
 
 /// Unique identifier of a DKG session.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]

--- a/src/messaging/node/mod.rs
+++ b/src/messaging/node/mod.rs
@@ -26,7 +26,11 @@ pub use node_msgs::{
 };
 pub use prefix_map::PrefixMap;
 pub use relocation::{RelocateDetails, RelocatePayload, RelocatePromise};
-pub use section::{ElderCandidates, MembershipState, NodeState, Peer, Section, SectionPeers};
+pub use section::ElderCandidates;
+pub use section::MembershipState;
+pub use section::NodeState;
+pub use section::Peer;
+pub use section::{Section, SectionPeers};
 pub use signed::{KeyedSig, SigShare};
 
 use crate::messaging::{

--- a/src/messaging/node/relocation.rs
+++ b/src/messaging/node/relocation.rs
@@ -11,7 +11,7 @@
 use super::NodeMsg;
 use crate::messaging::SectionSigned;
 use bls::PublicKey as BlsPublicKey;
-pub use ed25519_dalek::{Keypair, Signature, Verifier};
+use ed25519_dalek::Signature;
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 

--- a/src/messaging/node/section/mod.rs
+++ b/src/messaging/node/section/mod.rs
@@ -11,7 +11,8 @@ mod node_state;
 mod peer;
 
 pub use candidates::ElderCandidates;
-pub use node_state::{MembershipState, NodeState};
+pub use node_state::MembershipState;
+pub use node_state::NodeState;
 pub use peer::Peer;
 
 use crate::messaging::{node::agreement::SectionSigned, SectionAuthorityProvider};

--- a/src/node/capacity/adult_storage_info.rs
+++ b/src/node/capacity/adult_storage_info.rs
@@ -12,13 +12,13 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 #[derive(Clone, Default)]
-pub struct AdultsStorageInfo {
-    pub full_adults: Arc<RwLock<BTreeSet<XorName>>>,
+pub(crate) struct AdultsStorageInfo {
+    pub(crate) full_adults: Arc<RwLock<BTreeSet<XorName>>>,
 }
 
 impl AdultsStorageInfo {
     ///
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let full_adults = Arc::new(RwLock::new(BTreeSet::new()));
         Self { full_adults }
     }

--- a/src/node/event_mapping/client_msg.rs
+++ b/src/node/event_mapping/client_msg.rs
@@ -18,7 +18,7 @@ use crate::node::{
 };
 use tracing::warn;
 
-pub fn map_client_msg(
+pub(super) fn map_client_msg(
     msg_id: MessageId,
     msg: ClientMsg,
     client_signed: ClientSigned,

--- a/src/node/event_mapping/mod.rs
+++ b/src/node/event_mapping/mod.rs
@@ -19,13 +19,13 @@ use std::{thread::sleep, time::Duration};
 use tracing::{debug, error, info, trace};
 
 #[derive(Debug)]
-pub struct Mapping {
-    pub op: NodeDuty,
-    pub ctx: Option<MsgContext>,
+pub(super) struct Mapping {
+    pub(super) op: NodeDuty,
+    pub(super) ctx: Option<MsgContext>,
 }
 
 #[derive(Debug, Clone)]
-pub enum MsgContext {
+pub(super) enum MsgContext {
     Node {
         msg: MessageReceived,
         src: SrcLocation,
@@ -37,7 +37,7 @@ pub enum MsgContext {
 }
 
 // Process any routing event
-pub async fn map_routing_event(event: RoutingEvent, network_api: &Network) -> Mapping {
+pub(super) async fn map_routing_event(event: RoutingEvent, network_api: &Network) -> Mapping {
     info!("Handling RoutingEvent: {:?}", event);
     match event {
         RoutingEvent::MessageReceived {
@@ -226,7 +226,7 @@ pub async fn map_routing_event(event: RoutingEvent, network_api: &Network) -> Ma
     }
 }
 
-pub async fn log_network_stats(network_api: &Network) {
+pub(super) async fn log_network_stats(network_api: &Network) {
     let adults = network_api.our_adults().await.len();
     let elders = network_api.our_elder_names().await.len();
     let prefix = network_api.our_prefix().await;

--- a/src/node/event_mapping/node_msg.rs
+++ b/src/node/event_mapping/node_msg.rs
@@ -23,7 +23,7 @@ use crate::node::{
 use crate::routing::MessageReceived;
 use tracing::debug;
 
-pub fn map_node_msg(
+pub(super) fn map_node_msg(
     msg_id: MessageId,
     src: SrcLocation,
     dst: DstLocation,

--- a/src/node/logging/log_ctx.rs
+++ b/src/node/logging/log_ctx.rs
@@ -10,16 +10,16 @@ use crate::node::network::Network;
 use xor_name::Prefix;
 
 #[derive(Debug)]
-pub struct LogCtx {
+pub(crate) struct LogCtx {
     network: Network,
 }
 
 impl LogCtx {
-    pub fn new(network: Network) -> Self {
+    pub(crate) fn new(network: Network) -> Self {
         Self { network }
     }
 
-    pub async fn prefix(&self) -> Prefix {
+    pub(crate) async fn prefix(&self) -> Prefix {
         self.network.our_prefix().await
     }
 }

--- a/src/node/logging/mod.rs
+++ b/src/node/logging/mod.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-pub mod log_ctx;
+pub(super) mod log_ctx;
 mod system;
 
 use self::log_ctx::LogCtx;
@@ -19,7 +19,7 @@ use tracing::trace;
 
 const LOG_INTERVAL: Duration = std::time::Duration::from_secs(30);
 
-pub async fn run_system_logger(ctx: LogCtx, print_resources_usage: bool) {
+pub(super) async fn run_system_logger(ctx: LogCtx, print_resources_usage: bool) {
     let mut system = System::new_all();
     initial_log(&mut system, &ctx).await;
 

--- a/src/node/logging/system.rs
+++ b/src/node/logging/system.rs
@@ -10,15 +10,15 @@ use sysinfo::{DiskUsage, ProcessExt};
 
 /// Struct containing a process' information.
 #[derive(Debug)]
-pub struct Process {
-    pub memory: u64,
-    pub virtual_memory: u64,
-    pub cpu_usage: f32,
-    pub disk_usage: DiskUsage,
+pub(super) struct Process {
+    pub(super) memory: u64,
+    pub(super) virtual_memory: u64,
+    pub(super) cpu_usage: f32,
+    pub(super) disk_usage: DiskUsage,
 }
 
 impl Process {
-    pub fn map(process: &sysinfo::Process, processors: usize) -> Process {
+    pub(super) fn map(process: &sysinfo::Process, processors: usize) -> Process {
         let usage = process.disk_usage();
         Process {
             memory: process.memory(),

--- a/src/node/metadata/adult_liveness.rs
+++ b/src/node/metadata/adult_liveness.rs
@@ -29,14 +29,14 @@ struct ReadOperation {
     responded_with_success: bool,
 }
 
-pub struct AdultLiveness {
+pub(crate) struct AdultLiveness {
     ops: DashMap<MessageId, ReadOperation>,
     pending_ops: DashMap<XorName, usize>,
     closest_adults: DashMap<XorName, Vec<XorName>>,
 }
 
 impl AdultLiveness {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             ops: DashMap::new(),
             pending_ops: DashMap::new(),
@@ -46,7 +46,7 @@ impl AdultLiveness {
 
     // Inserts a new read operation
     // Returns false if the operation already existed.
-    pub fn new_read(
+    pub(crate) fn new_read(
         &self,
         msg_id: MessageId,
         head_address: ChunkAddress,
@@ -72,7 +72,7 @@ impl AdultLiveness {
         new_operation
     }
 
-    pub fn retain_members_only(&self, current_members: BTreeSet<XorName>) {
+    pub(crate) fn retain_members_only(&self, current_members: BTreeSet<XorName>) {
         let all_keys: Vec<_> = self
             .closest_adults
             .iter()
@@ -108,7 +108,7 @@ impl AdultLiveness {
         self.recompute_closest_adults();
     }
 
-    pub fn remove_target(&self, msg_id: &MessageId, name: &XorName) {
+    pub(crate) fn remove_target(&self, msg_id: &MessageId, name: &XorName) {
         if let Some(mut count) = self.pending_ops.get_mut(name) {
             let counter = *count;
             if counter > 0 {
@@ -128,7 +128,7 @@ impl AdultLiveness {
         }
     }
 
-    pub fn record_adult_read_liveness(
+    pub(crate) fn record_adult_read_liveness(
         &self,
         correlation_id: &MessageId,
         src: &XorName,
@@ -175,7 +175,7 @@ impl AdultLiveness {
         }
     }
 
-    pub fn recompute_closest_adults(&self) {
+    pub(crate) fn recompute_closest_adults(&self) {
         let all_keys: Vec<_> = self
             .closest_adults
             .iter()
@@ -193,7 +193,7 @@ impl AdultLiveness {
     }
 
     // this is not an exact definition, thus has tolerance for variance due to concurrency
-    pub fn find_unresponsive_adults(&self) -> Vec<(XorName, usize)> {
+    pub(crate) fn find_unresponsive_adults(&self) -> Vec<(XorName, usize)> {
         let mut unresponsive_adults = Vec::new();
         for entry in &self.closest_adults {
             let (adult, neighbours) = entry.pair();

--- a/src/node/metadata/adult_reader.rs
+++ b/src/node/metadata/adult_reader.rs
@@ -13,23 +13,23 @@ use crate::routing::{Prefix, XorName};
 use crate::node::network::Network;
 
 #[derive(Clone)]
-pub struct AdultReader {
+pub(crate) struct AdultReader {
     network: Network,
 }
 
 impl AdultReader {
     /// Access to the current state of our adult constellation
-    pub fn new(network: Network) -> Self {
+    pub(crate) fn new(network: Network) -> Self {
         Self { network }
     }
 
     /// Get the sections's current Prefix
-    pub async fn our_prefix(&self) -> Prefix {
+    pub(crate) async fn our_prefix(&self) -> Prefix {
         self.network.our_prefix().await
     }
 
     /// Dynamic state
-    pub async fn non_full_adults_closest_to(
+    pub(crate) async fn non_full_adults_closest_to(
         &self,
         name: &XorName,
         full_adults: &BTreeSet<XorName>,

--- a/src/node/metadata/chunk_records.rs
+++ b/src/node/metadata/chunk_records.rs
@@ -46,20 +46,20 @@ impl ChunkRecords {
         }
     }
 
-    pub async fn get_data_of(&self, prefix: Prefix) -> ChunkDataExchange {
+    pub(super) async fn get_data_of(&self, prefix: Prefix) -> ChunkDataExchange {
         // Prepare full_adult details
         let full_adults = self.capacity.full_adults_matching(prefix).await;
         ChunkDataExchange { full_adults }
     }
 
-    pub async fn update(&self, chunk_data: ChunkDataExchange) {
+    pub(super) async fn update(&self, chunk_data: ChunkDataExchange) {
         let ChunkDataExchange { full_adults } = chunk_data;
         self.capacity.insert_full_adults(full_adults).await
     }
 
     /// Registered holders not present in provided list of members
     /// will be removed from adult_storage_info and no longer tracked for liveness.
-    pub async fn retain_members_only(&self, members: BTreeSet<XorName>) -> Result<()> {
+    pub(super) async fn retain_members_only(&self, members: BTreeSet<XorName>) -> Result<()> {
         // full adults
         self.capacity.retain_members_only(&members).await;
 
@@ -84,7 +84,7 @@ impl ChunkRecords {
     }
 
     /// Adds a given node to the list of full nodes.
-    pub async fn increase_full_node_count(&self, node_id: PublicKey) {
+    pub(super) async fn increase_full_node_count(&self, node_id: PublicKey) {
         let full_adults = self.capacity.full_adults_count().await;
         info!("No. of full Adults: {:?}", full_adults);
         info!("Increasing full Adults count");
@@ -142,7 +142,7 @@ impl ChunkRecords {
     }
 
     /// Needs attention!
-    pub async fn record_adult_read_liveness(
+    pub(super) async fn record_adult_read_liveness(
         &self,
         correlation_id: MessageId,
         response: QueryResponse,

--- a/src/node/metadata/elder_stores.rs
+++ b/src/node/metadata/elder_stores.rs
@@ -29,7 +29,7 @@ pub(super) struct ElderStores {
 }
 
 impl ElderStores {
-    pub fn new(
+    pub(super) fn new(
         chunk_records: ChunkRecords,
         map_storage: MapStorage,
         sequence_storage: SequenceStorage,
@@ -43,7 +43,7 @@ impl ElderStores {
         }
     }
 
-    pub async fn read(
+    pub(super) async fn read(
         &self,
         query: DataQuery,
         msg_id: MessageId,
@@ -66,7 +66,7 @@ impl ElderStores {
         }
     }
 
-    pub async fn write(
+    pub(super) async fn write(
         &mut self,
         cmd: DataCmd,
         msg_id: MessageId,
@@ -117,12 +117,12 @@ impl ElderStores {
         }
     }
 
-    pub fn chunk_records(&self) -> &ChunkRecords {
+    pub(super) fn chunk_records(&self) -> &ChunkRecords {
         &self.chunk_records
     }
 
     // NB: Not yet including Register metadata.
-    pub async fn get_data_of(&self, prefix: Prefix) -> Result<DataExchange> {
+    pub(super) async fn get_data_of(&self, prefix: Prefix) -> Result<DataExchange> {
         // Prepare chunk_records, map and sequence data
         let chunk_data = self.chunk_records.get_data_of(prefix).await;
         let map_data = self.map_storage.get_data_of(prefix).await?;
@@ -137,7 +137,7 @@ impl ElderStores {
         })
     }
 
-    pub async fn update(&mut self, data: DataExchange) -> Result<(), Error> {
+    pub(super) async fn update(&mut self, data: DataExchange) -> Result<(), Error> {
         // todo: all this can be done in parallel
         self.map_storage.update(data.map_data).await?;
         self.register_storage.update(data.reg_data).await?;

--- a/src/node/metadata/map_storage.rs
+++ b/src/node/metadata/map_storage.rs
@@ -60,7 +60,7 @@ impl MapStorage {
     }
 
     /// On receiving data from Elders when promoted.
-    pub async fn update(&mut self, map_data: MapDataExchange) -> Result<()> {
+    pub(super) async fn update(&mut self, map_data: MapDataExchange) -> Result<()> {
         debug!("Updating Map DataStore");
 
         let MapDataExchange(data) = map_data;

--- a/src/node/metadata/mod.rs
+++ b/src/node/metadata/mod.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 mod adult_liveness;
-pub mod adult_reader;
+pub(crate) mod adult_reader;
 mod chunk_records;
 mod elder_stores;
 mod map_storage;
@@ -44,7 +44,7 @@ use xor_name::XorName;
 /// has been implemented; where the data types are all simply
 /// the structures + their metadata - handled at `Elders` - with
 /// all underlying data being chunks stored at `Adults`.
-pub struct Metadata {
+pub(crate) struct Metadata {
     elder_stores: ElderStores,
 }
 
@@ -67,7 +67,7 @@ impl Metadata {
         Ok(Self { elder_stores })
     }
 
-    pub async fn read(
+    pub(crate) async fn read(
         &self,
         query: DataQuery,
         id: MessageId,
@@ -80,7 +80,7 @@ impl Metadata {
         }
     }
 
-    pub async fn record_adult_read_liveness(
+    pub(crate) async fn record_adult_read_liveness(
         &self,
         correlation_id: MessageId,
         result: QueryResponse,
@@ -92,7 +92,7 @@ impl Metadata {
             .await
     }
 
-    pub async fn retain_members_only(&self, members: BTreeSet<XorName>) -> Result<()> {
+    pub(crate) async fn retain_members_only(&self, members: BTreeSet<XorName>) -> Result<()> {
         self.elder_stores
             .chunk_records()
             .retain_members_only(members)
@@ -100,7 +100,7 @@ impl Metadata {
         Ok(())
     }
 
-    pub async fn write(
+    pub(crate) async fn write(
         &mut self,
         cmd: DataCmd,
         id: MessageId,
@@ -113,7 +113,7 @@ impl Metadata {
     }
 
     /// Adds a given node to the list of full nodes.
-    pub async fn increase_full_node_count(&self, node_id: PublicKey) {
+    pub(crate) async fn increase_full_node_count(&self, node_id: PublicKey) {
         self.elder_stores
             .chunk_records()
             .increase_full_node_count(node_id)
@@ -121,18 +121,18 @@ impl Metadata {
     }
 
     // When receiving the chunk from remaining holders, we ask new holders to store it.
-    pub async fn republish_chunk(&self, chunk: Chunk) -> Result<NodeDuty> {
+    pub(crate) async fn republish_chunk(&self, chunk: Chunk) -> Result<NodeDuty> {
         self.elder_stores
             .chunk_records()
             .republish_chunk(chunk)
             .await
     }
 
-    pub async fn get_data_exchange_packet(&self, prefix: Prefix) -> Result<DataExchange> {
+    pub(crate) async fn get_data_exchange_packet(&self, prefix: Prefix) -> Result<DataExchange> {
         self.elder_stores.get_data_of(prefix).await
     }
 
-    pub async fn update(&mut self, data: DataExchange) -> Result<()> {
+    pub(crate) async fn update(&mut self, data: DataExchange) -> Result<()> {
         self.elder_stores.update(data).await
     }
 }

--- a/src/node/metadata/register_storage.rs
+++ b/src/node/metadata/register_storage.rs
@@ -73,7 +73,7 @@ impl RegisterStorage {
     }
 
     /// On receiving data from Elders when promoted.
-    pub async fn update(&self, reg_data: RegisterDataExchange) -> Result<()> {
+    pub(super) async fn update(&self, reg_data: RegisterDataExchange) -> Result<()> {
         debug!("Updating Register store");
 
         let RegisterDataExchange(data) = reg_data;

--- a/src/node/metadata/sequence_storage.rs
+++ b/src/node/metadata/sequence_storage.rs
@@ -63,7 +63,7 @@ impl SequenceStorage {
     }
 
     /// On receiving data from Elders when promoted.
-    pub async fn update(&mut self, seq_data: SequenceDataExchange) -> Result<()> {
+    pub(super) async fn update(&mut self, seq_data: SequenceDataExchange) -> Result<()> {
         debug!("Updating Sequence store");
 
         let SequenceDataExchange(data) = seq_data;

--- a/src/node/network.rs
+++ b/src/node/network.rs
@@ -21,13 +21,13 @@ use xor_name::{Prefix, XorName};
 
 ///
 #[derive(Clone, Debug)]
-pub struct Network {
+pub(crate) struct Network {
     routing: Arc<RoutingNode>,
 }
 
 #[allow(missing_docs)]
 impl Network {
-    pub async fn new(root_dir: &Path, config: &NodeConfig) -> Result<(Self, EventStream)> {
+    pub(crate) async fn new(root_dir: &Path, config: &NodeConfig) -> Result<(Self, EventStream)> {
         let routing_config = RoutingConfig {
             first: config.is_first(),
             transport_config: config.network_config().clone(),
@@ -46,15 +46,15 @@ impl Network {
         ))
     }
 
-    pub async fn age(&self) -> u8 {
+    pub(crate) async fn age(&self) -> u8 {
         self.routing.age().await
     }
 
-    pub async fn public_key(&self) -> Ed25519PublicKey {
+    pub(crate) async fn public_key(&self) -> Ed25519PublicKey {
         self.routing.public_key().await
     }
 
-    pub async fn propose_offline(&self, name: XorName) -> Result<()> {
+    pub(crate) async fn propose_offline(&self, name: XorName) -> Result<()> {
         // Notify the entire section to test connectivity to this node
         self.routing.start_connectivity_test(name).await?;
         self.routing
@@ -64,7 +64,7 @@ impl Network {
     }
 
     /// Returns public key of our section public key set.
-    pub async fn section_public_key(&self) -> Result<PublicKey> {
+    pub(crate) async fn section_public_key(&self) -> Result<PublicKey> {
         Ok(PublicKey::Bls(
             self.routing
                 .public_key_set()
@@ -75,16 +75,16 @@ impl Network {
     }
 
     /// Returns our section's public key.
-    pub async fn our_section_public_key(&self) -> BlsPublicKey {
+    pub(crate) async fn our_section_public_key(&self) -> BlsPublicKey {
         self.routing.our_section().await.public_key_set.public_key()
     }
 
-    pub async fn our_public_key_set(&self) -> Result<PublicKeySet> {
+    pub(crate) async fn our_public_key_set(&self) -> Result<PublicKeySet> {
         let pk_set = self.routing.public_key_set().await?;
         Ok(pk_set)
     }
 
-    pub async fn get_section_pk_by_name(&self, name: &XorName) -> Result<PublicKey> {
+    pub(crate) async fn get_section_pk_by_name(&self, name: &XorName) -> Result<PublicKey> {
         self.routing
             .matching_section(name)
             .await
@@ -92,37 +92,37 @@ impl Network {
             .map_err(From::from)
     }
 
-    pub async fn our_name(&self) -> XorName {
+    pub(crate) async fn our_name(&self) -> XorName {
         self.routing.name().await
     }
 
-    pub async fn our_connection_info(&self) -> SocketAddr {
+    pub(crate) async fn our_connection_info(&self) -> SocketAddr {
         self.routing.our_connection_info().await
     }
 
-    pub async fn our_prefix(&self) -> Prefix {
+    pub(crate) async fn our_prefix(&self) -> Prefix {
         self.routing.our_prefix().await
     }
 
-    pub async fn section_chain(&self) -> SecuredLinkedList {
+    pub(crate) async fn section_chain(&self) -> SecuredLinkedList {
         self.routing.section_chain().await
     }
 
-    pub async fn send_message(&self, wire_msg: WireMsg) -> Result<(), RoutingError> {
+    pub(crate) async fn send_message(&self, wire_msg: WireMsg) -> Result<(), RoutingError> {
         self.routing.send_message(wire_msg).await
     }
 
-    pub async fn set_joins_allowed(&mut self, joins_allowed: bool) -> Result<()> {
+    pub(crate) async fn set_joins_allowed(&mut self, joins_allowed: bool) -> Result<()> {
         self.routing.set_joins_allowed(joins_allowed).await?;
         Ok(())
     }
 
     // Returns whether the node is Elder.
-    pub async fn is_elder(&self) -> bool {
+    pub(crate) async fn is_elder(&self) -> bool {
         self.routing.is_elder().await
     }
 
-    pub async fn our_elder_names(&self) -> BTreeSet<XorName> {
+    pub(crate) async fn our_elder_names(&self) -> BTreeSet<XorName> {
         self.routing
             .our_elders()
             .await
@@ -131,7 +131,7 @@ impl Network {
             .collect::<BTreeSet<_>>()
     }
 
-    pub async fn our_adults(&self) -> BTreeSet<XorName> {
+    pub(crate) async fn our_adults(&self) -> BTreeSet<XorName> {
         self.routing
             .our_adults()
             .await
@@ -140,7 +140,7 @@ impl Network {
             .collect::<BTreeSet<_>>()
     }
 
-    pub async fn our_adults_sorted_by_distance_to(&self, name: &XorName) -> Vec<XorName> {
+    pub(crate) async fn our_adults_sorted_by_distance_to(&self, name: &XorName) -> Vec<XorName> {
         self.routing
             .our_adults_sorted_by_distance_to(name)
             .await
@@ -149,7 +149,7 @@ impl Network {
             .collect::<Vec<_>>()
     }
 
-    pub async fn sign_msg_for_dst_accumulation(
+    pub(crate) async fn sign_msg_for_dst_accumulation(
         &self,
         node_msg: NodeMsg,
         dst: DstLocation,
@@ -161,7 +161,7 @@ impl Network {
         Ok(wire_msg)
     }
 
-    pub async fn sign_single_src_msg(
+    pub(crate) async fn sign_single_src_msg(
         &self,
         node_msg: NodeMsg,
         dst: DstLocation,

--- a/src/node/node_api/handle.rs
+++ b/src/node/node_api/handle.rs
@@ -25,7 +25,7 @@ use tracing::{debug, info};
 use xor_name::XorName;
 
 #[derive(Debug)]
-pub enum NodeTask {
+pub(super) enum NodeTask {
     None,
     Result(Box<(NodeDuties, Option<MsgContext>)>),
     Thread(JoinHandle<Result<NodeTask>>),
@@ -39,7 +39,7 @@ impl From<NodeDuties> for NodeTask {
 
 impl Node {
     ///
-    pub async fn handle(&self, duty: NodeDuty) -> Result<NodeTask> {
+    pub(super) async fn handle(&self, duty: NodeDuty) -> Result<NodeTask> {
         if !matches!(duty, NodeDuty::NoOp) {
             debug!("Handling NodeDuty: {:?}", duty);
         }

--- a/src/node/node_api/mod.rs
+++ b/src/node/node_api/mod.rs
@@ -49,16 +49,16 @@ const JOINING_TIMEOUT: u64 = 180; // 180 seconds
 
 /// Static info about the node.
 #[derive(Clone, Debug)]
-pub struct NodeInfo {
+struct NodeInfo {
     ///
-    pub root_dir: PathBuf,
+    root_dir: PathBuf,
     /// The key used by the node to receive earned rewards.
-    pub reward_key: PublicKey,
+    reward_key: PublicKey,
 }
 
 impl NodeInfo {
     ///
-    pub fn path(&self) -> &Path {
+    fn path(&self) -> &Path {
         self.root_dir.as_path()
     }
 }

--- a/src/node/node_api/role/adult_role.rs
+++ b/src/node/node_api/role/adult_role.rs
@@ -26,11 +26,11 @@ use tracing::{info, trace, warn};
 #[derive(Clone)]
 pub(crate) struct AdultRole {
     // immutable chunks
-    pub chunks: Arc<ChunkStore>,
+    pub(crate) chunks: Arc<ChunkStore>,
 }
 
 impl AdultRole {
-    pub async fn reorganize_chunks(
+    pub(crate) async fn reorganize_chunks(
         &self,
         our_name: XorName,
         new_adults: BTreeSet<XorName>,

--- a/src/node/node_api/role/elder_role.rs
+++ b/src/node/node_api/role/elder_role.rs
@@ -13,13 +13,13 @@ use tokio::sync::RwLock;
 #[derive(Clone)]
 pub(crate) struct ElderRole {
     // data operations
-    pub meta_data: Arc<RwLock<Metadata>>,
+    pub(crate) meta_data: Arc<RwLock<Metadata>>,
     // denotes if we received initial sync
-    pub received_initial_sync: Arc<RwLock<bool>>,
+    pub(crate) received_initial_sync: Arc<RwLock<bool>>,
 }
 
 impl ElderRole {
-    pub fn new(meta_data: Metadata, received_initial_sync: bool) -> Self {
+    pub(crate) fn new(meta_data: Metadata, received_initial_sync: bool) -> Self {
         ElderRole {
             meta_data: Arc::new(RwLock::new(meta_data)),
             received_initial_sync: Arc::new(RwLock::new(received_initial_sync)),

--- a/src/node/node_api/role/mod.rs
+++ b/src/node/node_api/role/mod.rs
@@ -33,14 +33,14 @@ impl Debug for Role {
 }
 
 impl Role {
-    pub fn as_adult(&self) -> Result<&AdultRole> {
+    pub(crate) fn as_adult(&self) -> Result<&AdultRole> {
         match self {
             Self::Adult(adult) => Ok(adult),
             _ => Err(Error::NotAnAdult),
         }
     }
 
-    pub fn as_elder(&self) -> Result<&ElderRole> {
+    pub(crate) fn as_elder(&self) -> Result<&ElderRole> {
         match self {
             Self::Elder(elder) => Ok(elder),
             _ => Err(Error::NotAnElder),

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -36,7 +36,7 @@ use xor_name::XorName;
 /// and is sent on the wire to some other dst(s) on the network.
 
 /// Vec of NodeDuty
-pub type NodeDuties = Vec<NodeDuty>;
+pub(super) type NodeDuties = Vec<NodeDuty>;
 
 /// Common duties run by all nodes.
 #[allow(clippy::large_enum_variant)]

--- a/src/routing/core/bootstrap/join.rs
+++ b/src/routing/core/bootstrap/join.rs
@@ -21,8 +21,8 @@ use crate::routing::{
     node::Node,
     peer::PeerUtils,
     routing_api::command::Command,
-    section::{SectionAuthorityProviderUtils, SectionUtils},
-    FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
+    section::SectionUtils,
+    SectionAuthorityProviderUtils, FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
 };
 use bls::PublicKey as BlsPublicKey;
 use futures::future;
@@ -465,12 +465,9 @@ mod tests {
     use super::*;
     use crate::messaging::{node::NodeState, SectionAuthorityProvider};
     use crate::routing::{
-        dkg::test_utils::*,
-        error::Error as RoutingError,
-        messages::WireMsgUtils,
-        section::test_utils::*,
-        section::{NodeStateUtils, SectionAuthorityProviderUtils},
-        ELDER_SIZE, MIN_ADULT_AGE, MIN_AGE,
+        dkg::test_utils::*, error::Error as RoutingError, messages::WireMsgUtils,
+        section::test_utils::*, section::NodeStateUtils, SectionAuthorityProviderUtils, ELDER_SIZE,
+        MIN_ADULT_AGE, MIN_AGE,
     };
     use anyhow::{anyhow, Error, Result};
     use assert_matches::assert_matches;

--- a/src/routing/core/bootstrap/relocate.rs
+++ b/src/routing/core/bootstrap/relocate.rs
@@ -22,7 +22,8 @@ use crate::routing::{
     peer::PeerUtils,
     relocation::RelocatePayloadUtils,
     routing_api::command::Command,
-    section::{SectionAuthorityProviderUtils, SectionUtils},
+    section::SectionUtils,
+    SectionAuthorityProviderUtils,
 };
 use crate::types::PublicKey;
 use bls::PublicKey as BlsPublicKey;
@@ -43,7 +44,7 @@ pub(crate) struct JoiningAsRelocated {
 }
 
 impl JoiningAsRelocated {
-    pub fn new(
+    pub(crate) fn new(
         node: Node,
         genesis_key: BlsPublicKey,
         relocate_details: RelocateDetails,
@@ -66,7 +67,7 @@ impl JoiningAsRelocated {
 
     // Generates the first command to send a `JoinAsRelocatedRequest`, responses
     // shall be fed back with `handle_join_response` function.
-    pub fn start(&mut self, bootstrap_addrs: Vec<SocketAddr>) -> Result<Command> {
+    pub(crate) fn start(&mut self, bootstrap_addrs: Vec<SocketAddr>) -> Result<Command> {
         let dst_xorname = self.relocate_details.dst;
         let recipients: Vec<(XorName, SocketAddr)> = bootstrap_addrs
             .iter()
@@ -87,7 +88,7 @@ impl JoiningAsRelocated {
     // - `Redirect`: repeat join request with the new set of addresses.
     // - `Approval`: returns the `Section` to use by this node, completing the relocation.
     // - `NodeNotReachable`: returns an error, completing the relocation attempt.
-    pub async fn handle_join_response(
+    pub(crate) async fn handle_join_response(
         &mut self,
         join_response: JoinAsRelocatedResponse,
         sender: SocketAddr,

--- a/src/routing/core/comm.rs
+++ b/src/routing/core/comm.rs
@@ -34,7 +34,7 @@ pub(crate) struct Comm {
 }
 
 impl Comm {
-    pub async fn new(
+    pub(crate) async fn new(
         transport_config: qp2p::Config,
         event_tx: mpsc::Sender<ConnectionEvent>,
     ) -> Result<Self> {
@@ -67,7 +67,7 @@ impl Comm {
         })
     }
 
-    pub async fn async_clone(&self) -> Self {
+    pub(crate) async fn async_clone(&self) -> Self {
         Self {
             quic_p2p: self.quic_p2p.clone(),
             endpoint: self.endpoint.clone(),
@@ -75,7 +75,7 @@ impl Comm {
         }
     }
 
-    pub async fn bootstrap(
+    pub(crate) async fn bootstrap(
         transport_config: qp2p::Config,
         event_tx: mpsc::Sender<ConnectionEvent>,
     ) -> Result<(Self, SocketAddr)> {
@@ -111,17 +111,17 @@ impl Comm {
     }
 
     // Close all existing connections and stop accepting new ones.
-    pub async fn terminate(&self) {
+    pub(crate) async fn terminate(&self) {
         self.endpoint.close();
         let _ = self.event_tx.write().await.take();
     }
 
-    pub fn our_connection_info(&self) -> SocketAddr {
+    pub(crate) fn our_connection_info(&self) -> SocketAddr {
         self.endpoint.socket_addr()
     }
 
     /// Sends a message on an existing connection. If no such connection exists, returns an error.
-    pub async fn send_on_existing_connection(
+    pub(crate) async fn send_on_existing_connection(
         &self,
         recipients: &[(XorName, SocketAddr)],
         mut wire_msg: WireMsg,
@@ -146,7 +146,7 @@ impl Comm {
     }
 
     /// Tests whether the peer is reachable.
-    pub async fn is_reachable(&self, peer: &SocketAddr) -> Result<(), Error> {
+    pub(crate) async fn is_reachable(&self, peer: &SocketAddr) -> Result<(), Error> {
         let qp2p_config = qp2p::Config {
             local_ip: Some(self.endpoint.local_addr().ip()),
             local_port: Some(0),
@@ -184,7 +184,7 @@ impl Comm {
     /// `SendStatus::MinDeliveryGroupSizeReached` or `SendStatus::MinDeliveryGroupSizeFailed` depending
     /// on if the minimum delivery group size is met or not. The failed recipients are sent along
     /// with the status. It returns a `SendStatus::AllRecipients` if message is sent to all the recipients.
-    pub async fn send(
+    pub(crate) async fn send(
         &self,
         recipients: &[(XorName, SocketAddr)],
         delivery_group_size: usize,
@@ -334,7 +334,7 @@ async fn handle_incoming_messages(
 
 /// Returns the status of the send operation.
 #[derive(Debug, Clone)]
-pub enum SendStatus {
+pub(crate) enum SendStatus {
     AllRecipients,
     MinDeliveryGroupSizeReached(Vec<SocketAddr>),
     MinDeliveryGroupSizeFailed(Vec<SocketAddr>),

--- a/src/routing/core/connectivity.rs
+++ b/src/routing/core/connectivity.rs
@@ -12,13 +12,14 @@ use crate::routing::{
     error::Result,
     peer::PeerUtils,
     routing_api::command::Command,
-    section::{NodeStateUtils, SectionAuthorityProviderUtils, SectionPeersUtils, SectionUtils},
+    section::{NodeStateUtils, SectionPeersUtils, SectionUtils},
+    SectionAuthorityProviderUtils,
 };
 use std::{collections::BTreeSet, iter, net::SocketAddr};
 use xor_name::XorName;
 
 impl Core {
-    pub fn handle_connection_lost(&self, addr: SocketAddr) -> Result<Vec<Command>> {
+    pub(crate) fn handle_connection_lost(&self, addr: SocketAddr) -> Result<Vec<Command>> {
         if let Some(peer) = self.section.find_joined_member_by_addr(&addr) {
             debug!(
                 "Possible connection loss detected with known peer {:?}",
@@ -35,7 +36,7 @@ impl Core {
         Ok(vec![])
     }
 
-    pub fn handle_peer_lost(&self, addr: &SocketAddr) -> Result<Vec<Command>> {
+    pub(crate) fn handle_peer_lost(&self, addr: &SocketAddr) -> Result<Vec<Command>> {
         let name = if let Some(peer) = self.section.find_joined_member_by_addr(addr) {
             debug!("Lost known peer {}", peer);
             *peer.name()
@@ -54,11 +55,11 @@ impl Core {
         Ok(commands)
     }
 
-    pub fn propose_offline(&self, name: XorName) -> Result<Vec<Command>> {
+    pub(crate) fn propose_offline(&self, name: XorName) -> Result<Vec<Command>> {
         self.cast_offline_proposals(&iter::once(name).collect())
     }
 
-    pub fn cast_offline_proposals(&self, names: &BTreeSet<XorName>) -> Result<Vec<Command>> {
+    pub(crate) fn cast_offline_proposals(&self, names: &BTreeSet<XorName>) -> Result<Vec<Command>> {
         // Don't send the `Offline` proposal to the peer being lost as that send would fail,
         // triggering a chain of further `Offline` proposals.
         let elders: Vec<_> = self

--- a/src/routing/core/delivery_group.rs
+++ b/src/routing/core/delivery_group.rs
@@ -14,8 +14,8 @@ use crate::routing::{
     error::{Error, Result},
     network::NetworkUtils,
     peer::PeerUtils,
-    section::{SectionAuthorityProviderUtils, SectionPeersUtils, SectionUtils},
-    supermajority, ELDER_SIZE,
+    section::{SectionPeersUtils, SectionUtils},
+    supermajority, SectionAuthorityProviderUtils, ELDER_SIZE,
 };
 use itertools::Itertools;
 use std::{cmp, iter};
@@ -167,8 +167,9 @@ mod tests {
         ed25519,
         section::{
             test_utils::{gen_addr, gen_section_authority_provider},
-            NodeStateUtils, SectionAuthorityProviderUtils, MIN_ADULT_AGE,
+            NodeStateUtils,
         },
+        SectionAuthorityProviderUtils, MIN_ADULT_AGE,
     };
     use anyhow::{Context, Result};
     use rand::seq::IteratorRandom;

--- a/src/routing/core/enduser_registry.rs
+++ b/src/routing/core/enduser_registry.rs
@@ -20,22 +20,26 @@ pub(crate) struct EndUserRegistry {
 }
 
 impl EndUserRegistry {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             clients: BTreeMap::default(),
             socket_id_mapping: BTreeMap::default(),
         }
     }
 
-    pub fn get_enduser_by_addr(&self, socketaddr: &SocketAddr) -> Option<&EndUser> {
+    pub(crate) fn get_enduser_by_addr(&self, socketaddr: &SocketAddr) -> Option<&EndUser> {
         self.clients.get(socketaddr)
     }
 
-    pub fn get_socket_addr(&self, socket_id: SocketId) -> Option<&SocketAddr> {
+    pub(crate) fn get_socket_addr(&self, socket_id: SocketId) -> Option<&SocketAddr> {
         self.socket_id_mapping.get(&socket_id)
     }
 
-    pub fn try_add(&mut self, sender: SocketAddr, section_prefix: &Prefix) -> Result<EndUser> {
+    pub(crate) fn try_add(
+        &mut self,
+        sender: SocketAddr,
+        section_prefix: &Prefix,
+    ) -> Result<EndUser> {
         // create a unique socket id from client socket addr
         let socket_id = XorName::from_content(&[
             &bincode::serialize(&sender).map_err(|_| Error::FailedSignature)?

--- a/src/routing/core/messaging.rs
+++ b/src/routing/core/messaging.rs
@@ -22,7 +22,8 @@ use crate::routing::{
     peer::PeerUtils,
     relocation::RelocateState,
     routing_api::command::Command,
-    section::{ElderCandidatesUtils, SectionAuthorityProviderUtils, SectionKeyShare, SectionUtils},
+    section::{ElderCandidatesUtils, SectionKeyShare, SectionUtils},
+    SectionAuthorityProviderUtils,
 };
 use bls::PublicKey as BlsPublicKey;
 use std::{net::SocketAddr, slice};

--- a/src/routing/core/mod.rs
+++ b/src/routing/core/mod.rs
@@ -20,7 +20,8 @@ mod split_barrier;
 
 pub(crate) use bootstrap::{join_network, JoiningAsRelocated};
 pub(crate) use comm::{Comm, ConnectionEvent, SendStatus};
-pub(crate) use signature_aggregator::{Error as AggregatorError, SignatureAggregator};
+pub use signature_aggregator::Error as AggregatorError;
+pub(crate) use signature_aggregator::SignatureAggregator;
 
 use self::{
     enduser_registry::EndUserRegistry, message_filter::MessageFilter, split_barrier::SplitBarrier,
@@ -37,8 +38,8 @@ use crate::routing::{
     peer::PeerUtils,
     relocation::RelocateState,
     routing_api::command::Command,
-    section::{SectionAuthorityProviderUtils, SectionKeyShare, SectionKeysProvider, SectionUtils},
-    Elders, Event, NodeElderChange,
+    section::{SectionKeyShare, SectionKeysProvider, SectionUtils},
+    Elders, Event, NodeElderChange, SectionAuthorityProviderUtils,
 };
 use itertools::Itertools;
 use resource_proof::ResourceProof;
@@ -47,8 +48,8 @@ use std::collections::BTreeSet;
 use tokio::sync::mpsc;
 use xor_name::{Prefix, XorName};
 
-pub const RESOURCE_PROOF_DATA_SIZE: usize = 64;
-pub const RESOURCE_PROOF_DIFFICULTY: u8 = 2;
+pub(super) const RESOURCE_PROOF_DATA_SIZE: usize = 64;
+pub(super) const RESOURCE_PROOF_DIFFICULTY: u8 = 2;
 const KEY_CACHE_SIZE: u8 = 5;
 
 // State + logic of a routing node.
@@ -73,7 +74,7 @@ pub(crate) struct Core {
 
 impl Core {
     // Creates `Core` for a regular node.
-    pub fn new(
+    pub(crate) fn new(
         comm: Comm,
         mut node: Node,
         section: Section,

--- a/src/routing/core/msg_handling/agreement.rs
+++ b/src/routing/core/msg_handling/agreement.rs
@@ -18,10 +18,8 @@ use crate::routing::{
     network::NetworkUtils,
     peer::PeerUtils,
     routing_api::command::Command,
-    section::{
-        ElderCandidatesUtils, SectionAuthorityProviderUtils, SectionPeersUtils, SectionUtils,
-    },
-    Event, MIN_AGE,
+    section::{ElderCandidatesUtils, SectionPeersUtils, SectionUtils},
+    Event, SectionAuthorityProviderUtils, MIN_AGE,
 };
 use xor_name::XorName;
 

--- a/src/routing/core/msg_handling/anti_entropy.rs
+++ b/src/routing/core/msg_handling/anti_entropy.rs
@@ -17,13 +17,14 @@ use crate::routing::{
     network::NetworkUtils,
     node::Node,
     routing_api::command::Command,
-    section::{SectionAuthorityProviderUtils, SectionUtils},
+    section::SectionUtils,
+    SectionAuthorityProviderUtils,
 };
 use bls::PublicKey as BlsPublicKey;
 use std::{cmp::Ordering, net::SocketAddr};
 
 impl Core {
-    pub async fn check_for_entropy(
+    pub(crate) async fn check_for_entropy(
         &self,
         node_msg: &NodeMsg,
         msg_authority: &NodeMsgAuthority,

--- a/src/routing/core/msg_handling/dkg.rs
+++ b/src/routing/core/msg_handling/dkg.rs
@@ -15,7 +15,8 @@ use crate::routing::{
     dkg::{commands::DkgCommands, DkgFailureSigSetUtils},
     error::{Error, Result},
     routing_api::command::Command,
-    section::{SectionAuthorityProviderUtils, SectionKeyShare, SectionPeersUtils, SectionUtils},
+    section::{SectionKeyShare, SectionPeersUtils, SectionUtils},
+    SectionAuthorityProviderUtils,
 };
 use bls_dkg::key_gen::message::Message as DkgMessage;
 use std::{collections::BTreeSet, slice};

--- a/src/routing/core/msg_handling/end_user.rs
+++ b/src/routing/core/msg_handling/end_user.rs
@@ -12,10 +12,8 @@ use crate::messaging::{
     WireMsg,
 };
 use crate::routing::{
-    error::Result,
-    messages::WireMsgUtils,
-    routing_api::{command::Command, Event},
-    section::{SectionAuthorityProviderUtils, SectionUtils},
+    error::Result, messages::WireMsgUtils, routing_api::command::Command, section::SectionUtils,
+    Event, SectionAuthorityProviderUtils,
 };
 use bytes::Bytes;
 use std::net::SocketAddr;

--- a/src/routing/core/msg_handling/join.rs
+++ b/src/routing/core/msg_handling/join.rs
@@ -19,10 +19,8 @@ use crate::routing::{
     peer::PeerUtils,
     relocation::RelocatePayloadUtils,
     routing_api::command::Command,
-    section::{
-        SectionPeersUtils, SectionUtils, FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE,
-        MIN_ADULT_AGE,
-    },
+    section::{SectionPeersUtils, SectionUtils},
+    FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
 };
 use bls::PublicKey as BlsPublicKey;
 

--- a/src/routing/core/msg_handling/mod.rs
+++ b/src/routing/core/msg_handling/mod.rs
@@ -30,8 +30,8 @@ use crate::routing::{
     network::NetworkUtils,
     relocation::RelocateState,
     routing_api::command::Command,
-    section::{SectionAuthorityProviderUtils, SectionUtils},
-    Event, MessageReceived,
+    section::SectionUtils,
+    Event, MessageReceived, SectionAuthorityProviderUtils,
 };
 use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;

--- a/src/routing/core/msg_handling/relocation.rs
+++ b/src/routing/core/msg_handling/relocation.rs
@@ -17,8 +17,8 @@ use crate::routing::{
     peer::PeerUtils,
     relocation::{self, RelocateAction, RelocateDetailsUtils, RelocateState},
     routing_api::command::Command,
-    section::{NodeStateUtils, SectionAuthorityProviderUtils, SectionPeersUtils, SectionUtils},
-    Event, ELDER_SIZE,
+    section::{NodeStateUtils, SectionPeersUtils, SectionUtils},
+    Event, SectionAuthorityProviderUtils, ELDER_SIZE,
 };
 use xor_name::XorName;
 

--- a/src/routing/core/msg_handling/section_info.rs
+++ b/src/routing/core/msg_handling/section_info.rs
@@ -13,11 +13,8 @@ use crate::messaging::{
     DstLocation, SectionAuthorityProvider, WireMsg,
 };
 use crate::routing::{
-    error::Result,
-    network::NetworkUtils,
-    peer::PeerUtils,
-    routing_api::command::Command,
-    section::{SectionAuthorityProviderUtils, SectionUtils},
+    error::Result, network::NetworkUtils, peer::PeerUtils, routing_api::command::Command,
+    section::SectionUtils, SectionAuthorityProviderUtils,
 };
 use std::net::SocketAddr;
 use xor_name::XorName;

--- a/src/routing/core/signature_aggregator.rs
+++ b/src/routing/core/signature_aggregator.rs
@@ -33,19 +33,19 @@ type Digest256 = [u8; 32];
 /// otherwise lead to invalid signature to be produced even though all the shares are valid.
 ///
 #[allow(missing_debug_implementations)]
-pub struct SignatureAggregator {
+pub(crate) struct SignatureAggregator {
     map: HashMap<Digest256, State>,
     expiration: Duration,
 }
 
 impl SignatureAggregator {
     /// Create new aggregator with default expiration.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::with_expiration(DEFAULT_EXPIRATION)
     }
 
     /// Create new aggregator with the given expiration.
-    pub fn with_expiration(expiration: Duration) -> Self {
+    pub(crate) fn with_expiration(expiration: Duration) -> Self {
         Self {
             map: Default::default(),
             expiration,
@@ -60,7 +60,7 @@ impl SignatureAggregator {
     /// shares still need to be added for that particular payload. This error could be safely
     /// ignored (it might still be useful perhaps for debugging). The other error variants, however,
     /// indicate failures and should be treated a such. See [Error] for more info.
-    pub fn add(&mut self, payload: &[u8], sig_share: SigShare) -> Result<KeyedSig, Error> {
+    pub(crate) fn add(&mut self, payload: &[u8], sig_share: SigShare) -> Result<KeyedSig, Error> {
         self.remove_expired();
 
         if !sig_share.verify(payload) {

--- a/src/routing/core/split_barrier.rs
+++ b/src/routing/core/split_barrier.rs
@@ -19,7 +19,7 @@ type Entry = (SectionSigned<SectionAuthorityProvider>, KeyedSig);
 pub(crate) struct SplitBarrier(Vec<Entry>);
 
 impl SplitBarrier {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self(Vec::new())
     }
 
@@ -29,7 +29,7 @@ impl SplitBarrier {
     //
     // Note: in case of a fork, it can return more than two proposals. In that case one of the
     // proposals will be for one subsection and all the others for the other subsection.
-    pub fn process(
+    pub(crate) fn process(
         &mut self,
         our_prefix: &Prefix,
         section_auth: SectionSigned<SectionAuthorityProvider>,

--- a/src/routing/dkg/dkg_msgs_utils.rs
+++ b/src/routing/dkg/dkg_msgs_utils.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeSet;
 use tiny_keccak::{Hasher, Sha3};
 use xor_name::XorName;
 
-pub trait DkgKeyUtils {
+pub(crate) trait DkgKeyUtils {
     fn new(elder_candidates: &ElderCandidates, generation: u64) -> Self;
 }
 
@@ -39,7 +39,7 @@ impl DkgKeyUtils for DkgKey {
     }
 }
 
-pub trait DkgFailureSigUtils {
+pub(crate) trait DkgFailureSigUtils {
     fn new(keypair: &Keypair, failed_participants: &BTreeSet<XorName>, dkg_key: &DkgKey) -> Self;
 
     fn verify(&self, dkg_key: &DkgKey, failed_participants: &BTreeSet<XorName>) -> bool;
@@ -59,7 +59,7 @@ impl DkgFailureSigUtils for DkgFailureSig {
     }
 }
 
-pub trait DkgFailureSigSetUtils {
+pub(crate) trait DkgFailureSigSetUtils {
     fn insert(&mut self, sig: DkgFailureSig, failed_participants: &BTreeSet<XorName>) -> bool;
 
     fn has_agreement(&self, elder_candidates: &ElderCandidates) -> bool;

--- a/src/routing/dkg/mod.rs
+++ b/src/routing/dkg/mod.rs
@@ -8,11 +8,11 @@
 
 pub(crate) mod commands;
 mod dkg_msgs_utils;
-mod proposal;
+pub(super) mod proposal;
 mod section_signed;
 mod session;
 #[cfg(test)]
-pub mod test_utils;
+pub(crate) mod test_utils;
 mod voter;
 
 pub(crate) use self::{
@@ -21,7 +21,7 @@ pub(crate) use self::{
     voter::DkgVoter,
 };
 pub(crate) use crate::messaging::node::{KeyedSig, SigShare};
-pub use section_signed::SectionSignedUtils;
+pub(super) use section_signed::SectionSignedUtils;
 use serde::Serialize;
 
 // Verify the integrity of `message` against `sig`.

--- a/src/routing/dkg/section_signed.rs
+++ b/src/routing/dkg/section_signed.rs
@@ -11,7 +11,7 @@ use crate::messaging::node::SectionSigned;
 use secured_linked_list::SecuredLinkedList;
 use serde::Serialize;
 
-pub trait SectionSignedUtils<T: Serialize> {
+pub(crate) trait SectionSignedUtils<T: Serialize> {
     fn new(value: T, sig: KeyedSig) -> Self;
 
     fn verify(&self, section_chain: &SecuredLinkedList) -> bool;

--- a/src/routing/dkg/session.rs
+++ b/src/routing/dkg/session.rs
@@ -17,7 +17,8 @@ use crate::routing::{
     },
     ed25519::{self, Keypair},
     routing_api::command,
-    section::{SectionAuthorityProviderUtils, SectionKeyShare},
+    section::SectionKeyShare,
+    SectionAuthorityProviderUtils,
 };
 use bls_dkg::key_gen::{message::Message as DkgMessage, KeyGen};
 use itertools::Itertools;
@@ -295,7 +296,7 @@ impl Backlog {
         Self(VecDeque::with_capacity(BACKLOG_CAPACITY))
     }
 
-    pub fn push(&mut self, dkg_key: DkgKey, message: DkgMessage) {
+    pub(crate) fn push(&mut self, dkg_key: DkgKey, message: DkgMessage) {
         if self.0.len() == self.0.capacity() {
             let _ = self.0.pop_front();
         }

--- a/src/routing/dkg/test_utils.rs
+++ b/src/routing/dkg/test_utils.rs
@@ -12,7 +12,7 @@ use crate::routing::{Error, Result};
 use serde::Serialize;
 
 // Create signature for the given payload using the given secret key.
-pub fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<KeyedSig> {
+pub(crate) fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<KeyedSig> {
     let bytes = bincode::serialize(payload).map_err(|_| Error::InvalidPayload)?;
     Ok(KeyedSig {
         public_key: secret_key.public_key(),
@@ -21,7 +21,7 @@ pub fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<K
 }
 
 // Wrap the given payload in `SectionSigned`
-pub fn section_signed<T: Serialize>(
+pub(crate) fn section_signed<T: Serialize>(
     secret_key: &bls::SecretKey,
     payload: T,
 ) -> Result<SectionSigned<T>> {

--- a/src/routing/dkg/voter.rs
+++ b/src/routing/dkg/voter.rs
@@ -13,8 +13,8 @@ use crate::messaging::{
 use crate::routing::{
     dkg::session::{Backlog, Session},
     ed25519::{self, Keypair},
-    section::{ElderCandidatesUtils, SectionAuthorityProviderUtils, SectionKeyShare},
-    supermajority,
+    section::{ElderCandidatesUtils, SectionKeyShare},
+    supermajority, SectionAuthorityProviderUtils,
 };
 use bls_dkg::key_gen::{message::Message as DkgMessage, KeyGen};
 use std::collections::{BTreeSet, HashMap};
@@ -58,7 +58,7 @@ impl Default for DkgVoter {
 
 impl DkgVoter {
     // Starts a new DKG session.
-    pub fn start(
+    pub(crate) fn start(
         &mut self,
         keypair: &Keypair,
         dkg_key: DkgKey,
@@ -141,7 +141,11 @@ impl DkgVoter {
     }
 
     // Make key generator progress with timed phase.
-    pub fn handle_timeout(&mut self, keypair: &Keypair, timer_token: u64) -> Vec<DkgCommand> {
+    pub(crate) fn handle_timeout(
+        &mut self,
+        keypair: &Keypair,
+        timer_token: u64,
+    ) -> Vec<DkgCommand> {
         if let Some((dkg_key, session)) = self
             .sessions
             .iter_mut()
@@ -154,7 +158,7 @@ impl DkgVoter {
     }
 
     // Handle a received DkgMessage.
-    pub fn process_message(
+    pub(crate) fn process_message(
         &mut self,
         keypair: &Keypair,
         dkg_key: &DkgKey,
@@ -168,7 +172,7 @@ impl DkgVoter {
         }
     }
 
-    pub fn process_failure(
+    pub(crate) fn process_failure(
         &mut self,
         dkg_key: &DkgKey,
         failed_participants: &BTreeSet<XorName>,

--- a/src/routing/ed25519.rs
+++ b/src/routing/ed25519.rs
@@ -8,33 +8,31 @@
 
 //! Cryptographic primitives.
 
-pub use ed25519_dalek::{
-    Keypair, PublicKey, SecretKey, Signature, Verifier, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH,
-};
+pub(super) use ed25519_dalek::{Keypair, PublicKey, Signature, Verifier};
 
 use ed25519_dalek::ExpandedSecretKey;
 use std::ops::RangeInclusive;
 use xor_name::{XorName, XOR_NAME_LEN};
 
 /// SHA3-256 hash digest.
-pub type Digest256 = [u8; 32];
+pub(super) type Digest256 = [u8; 32];
 
-pub fn sign(msg: &[u8], keypair: &Keypair) -> Signature {
+pub(super) fn sign(msg: &[u8], keypair: &Keypair) -> Signature {
     let expanded_secret_key = ExpandedSecretKey::from(&keypair.secret);
     expanded_secret_key.sign(msg, &keypair.public)
 }
 
-pub fn pub_key(name: &XorName) -> Result<PublicKey, ed25519_dalek::SignatureError> {
+pub(super) fn pub_key(name: &XorName) -> Result<PublicKey, ed25519_dalek::SignatureError> {
     PublicKey::from_bytes(&name.0)
 }
 
-pub fn name(public_key: &PublicKey) -> XorName {
+pub(super) fn name(public_key: &PublicKey) -> XorName {
     XorName(public_key.to_bytes())
 }
 
 #[cfg(test)]
 /// Construct a random `XorName` whose last byte represents the targeted age.
-pub fn gen_name_with_age(age: u8) -> XorName {
+pub(super) fn gen_name_with_age(age: u8) -> XorName {
     loop {
         let name = XorName::random();
         if age == name[XOR_NAME_LEN - 1] {
@@ -45,7 +43,7 @@ pub fn gen_name_with_age(age: u8) -> XorName {
 
 /// Construct a `Keypair` whose name is in the interval [start, end] (both endpoints inclusive).
 /// And the last byte equals to the targeted age.
-pub fn gen_keypair(range: &RangeInclusive<XorName>, age: u8) -> Keypair {
+pub(super) fn gen_keypair(range: &RangeInclusive<XorName>, age: u8) -> Keypair {
     let mut rng = rand::thread_rng();
 
     loop {
@@ -60,7 +58,7 @@ pub fn gen_keypair(range: &RangeInclusive<XorName>, age: u8) -> Keypair {
 #[cfg(test)]
 pub(crate) mod test_utils {
     use super::*;
-    use ed25519_dalek::SECRET_KEY_LENGTH;
+    use ed25519_dalek::{SecretKey, SECRET_KEY_LENGTH};
     use proptest::prelude::*;
 
     pub(crate) fn arbitrary_keypair() -> impl Strategy<Value = Keypair> {

--- a/src/routing/error.rs
+++ b/src/routing/error.rs
@@ -6,7 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::routing::dkg::ProposalError;
+pub use crate::routing::core::AggregatorError;
+pub use crate::routing::dkg::proposal::ProposalError;
 use qp2p::Error as Qp2pError;
 use secured_linked_list::error::Error as SecuredLinkedListError;
 use std::net::SocketAddr;

--- a/src/routing/messages/mod.rs
+++ b/src/routing/messages/mod.rs
@@ -8,7 +8,7 @@
 
 mod msg_authority;
 
-pub use self::msg_authority::NodeMsgAuthorityUtils;
+pub(super) use self::msg_authority::NodeMsgAuthorityUtils;
 use crate::messaging::{
     node::{NodeMsg, SigShare},
     BlsShareSigned, ClientSigned, DstLocation, MessageId, MsgKind, NodeMsgAuthority, NodeSigned,
@@ -25,7 +25,7 @@ use bytes::Bytes;
 use xor_name::XorName;
 
 // Utilities for WireMsg.
-pub trait WireMsgUtils {
+pub(crate) trait WireMsgUtils {
     /// Verify this message is properly signed.
     fn check_signature(&self) -> Result<()>;
 

--- a/src/routing/messages/msg_authority.rs
+++ b/src/routing/messages/msg_authority.rs
@@ -18,7 +18,7 @@ use bls::PublicKey as BlsPublicKey;
 use std::net::SocketAddr;
 use xor_name::XorName;
 
-pub trait NodeMsgAuthorityUtils {
+pub(crate) trait NodeMsgAuthorityUtils {
     fn src_location(&self) -> SrcLocation;
 
     fn name(&self) -> XorName;

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -23,19 +23,24 @@
 // ############################################################################
 // Public API
 // ############################################################################
+pub use self::error::AggregatorError;
+pub use self::error::ProposalError;
 pub use self::{
     cache::Cache,
     error::{Error, Result},
     peer::PeerUtils,
     routing_api::{
-        Config, Elders, Event, EventStream, MessageReceived, NodeElderChange, Routing, SendStream,
+        config::Config,
+        event::{Elders, Event, MessageReceived, NodeElderChange},
+        event_stream::EventStream,
+        Routing,
     },
     section::{
-        SectionAuthorityProviderUtils, FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
-        MIN_AGE,
+        node_state::{FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE, MIN_AGE},
+        section_authority_provider::SectionAuthorityProviderUtils,
     },
 };
-pub use qp2p::Config as TransportConfig;
+pub use qp2p::{Config as TransportConfig, SendStream};
 
 pub use xor_name::{Prefix, XorName, XOR_NAME_LEN}; // TODO remove pub on API update
 

--- a/src/routing/network/mod.rs
+++ b/src/routing/network/mod.rs
@@ -14,8 +14,7 @@ use self::stats::NetworkStats;
 use crate::routing::{
     dkg::{verify_sig, KeyedSig, SectionSignedUtils},
     peer::PeerUtils,
-    section::SectionAuthorityProviderUtils,
-    Error, Result,
+    Error, Result, SectionAuthorityProviderUtils,
 };
 
 use crate::messaging::{
@@ -26,7 +25,7 @@ use secured_linked_list::SecuredLinkedList;
 use std::iter;
 use xor_name::{Prefix, XorName};
 
-pub trait NetworkUtils {
+pub(super) trait NetworkUtils {
     fn new() -> Self;
 
     fn closest(&self, name: &XorName) -> Option<&SectionAuthorityProvider>;
@@ -266,7 +265,7 @@ impl NetworkUtils for Network {
     }
 }
 
-pub trait OtherSectionUtils {
+pub(super) trait OtherSectionUtils {
     fn verify(&self, section_chain: &SecuredLinkedList) -> bool;
 
     fn self_verify(&self) -> bool;

--- a/src/routing/network/stats.rs
+++ b/src/routing/network/stats.rs
@@ -6,14 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-pub struct NetworkStats {
+pub(crate) struct NetworkStats {
     pub(super) known_elders: u64,
     pub(super) total_elders: u64,
     pub(super) total_elders_exact: bool,
 }
 
 impl NetworkStats {
-    pub fn print(&self) {
+    pub(crate) fn print(&self) {
         if self.total_elders_exact {
             info!("*** Exact total network elders: {} ***", self.known_elders)
         } else {

--- a/src/routing/node.rs
+++ b/src/routing/node.rs
@@ -19,32 +19,32 @@ use xor_name::{XorName, XOR_NAME_LEN};
 
 /// Information and state of our node
 #[derive(Clone)]
-pub struct Node {
+pub(crate) struct Node {
     // Keep the secret key in Arc to allow Clone while also preventing multiple copies to exist in
     // memory which might be insecure.
     // TODO: find a way to not require `Clone`.
-    pub keypair: Arc<Keypair>,
-    pub addr: SocketAddr,
+    pub(crate) keypair: Arc<Keypair>,
+    pub(crate) addr: SocketAddr,
 }
 
 impl Node {
-    pub fn new(keypair: Keypair, addr: SocketAddr) -> Self {
+    pub(crate) fn new(keypair: Keypair, addr: SocketAddr) -> Self {
         Self {
             keypair: Arc::new(keypair),
             addr,
         }
     }
 
-    pub fn peer(&self) -> Peer {
+    pub(crate) fn peer(&self) -> Peer {
         Peer::new(self.name(), self.addr)
     }
 
-    pub fn name(&self) -> XorName {
+    pub(crate) fn name(&self) -> XorName {
         XorName::from(PublicKey::from(self.keypair.public))
     }
 
     // Last byte of the name represents the age.
-    pub fn age(&self) -> u8 {
+    pub(crate) fn age(&self) -> u8 {
         self.name()[XOR_NAME_LEN - 1]
     }
 }

--- a/src/routing/relocation.rs
+++ b/src/routing/relocation.rs
@@ -60,7 +60,7 @@ pub(crate) fn actions(
 
 /// Details of a relocation: which node to relocate, where to relocate it to and what age it should
 /// get once relocated.
-pub trait RelocateDetailsUtils {
+pub(super) trait RelocateDetailsUtils {
     fn new(section: &Section, network: &Network, peer: &Peer, dst: XorName) -> Self;
 
     fn with_age(
@@ -97,7 +97,7 @@ impl RelocateDetailsUtils for RelocateDetails {
     }
 }
 
-pub trait RelocatePayloadUtils {
+pub(super) trait RelocatePayloadUtils {
     fn new(
         details: NodeMsg,
         section_signed: SectionSigned,
@@ -174,7 +174,12 @@ pub(crate) enum RelocateAction {
 }
 
 impl RelocateAction {
-    pub fn new(section: &Section, network: &Network, peer: &Peer, churn_name: &XorName) -> Self {
+    pub(crate) fn new(
+        section: &Section,
+        network: &Network,
+        peer: &Peer,
+        churn_name: &XorName,
+    ) -> Self {
         let dst = dst(peer.name(), churn_name);
 
         if section.is_elder(peer.name()) {
@@ -187,7 +192,7 @@ impl RelocateAction {
         }
     }
 
-    pub fn dst(&self) -> &XorName {
+    pub(crate) fn dst(&self) -> &XorName {
         match self {
             Self::Instant(details) => &details.dst,
             Self::Delayed(promise) => &promise.dst,
@@ -195,7 +200,7 @@ impl RelocateAction {
     }
 
     #[cfg(test)]
-    pub fn name(&self) -> &XorName {
+    pub(crate) fn name(&self) -> &XorName {
         match self {
             Self::Instant(details) => &details.pub_id,
             Self::Delayed(promise) => &promise.name,
@@ -238,10 +243,8 @@ mod tests {
     use super::*;
     use crate::messaging::SectionAuthorityProvider;
     use crate::routing::{
-        dkg::test_utils::section_signed,
-        peer::test_utils::arbitrary_unique_peers,
-        routing_api::tests::SecretKeySet,
-        section::{NodeStateUtils, SectionAuthorityProviderUtils},
+        dkg::test_utils::section_signed, peer::test_utils::arbitrary_unique_peers,
+        routing_api::tests::SecretKeySet, section::NodeStateUtils, SectionAuthorityProviderUtils,
         ELDER_SIZE, MIN_AGE,
     };
     use anyhow::Result;

--- a/src/routing/routing_api/dispatcher.rs
+++ b/src/routing/routing_api/dispatcher.rs
@@ -30,7 +30,7 @@ use tokio::{
 use tracing::Instrument;
 
 // `Command` Dispatcher.
-pub(crate) struct Dispatcher {
+pub(super) struct Dispatcher {
     pub(super) core: RwLock<Core>,
 
     cancel_timer_tx: watch::Sender<bool>,
@@ -38,7 +38,7 @@ pub(crate) struct Dispatcher {
 }
 
 impl Dispatcher {
-    pub fn new(core: Core) -> Self {
+    pub(super) fn new(core: Core) -> Self {
         let (cancel_timer_tx, cancel_timer_rx) = watch::channel(false);
         Self {
             core: RwLock::new(core),
@@ -49,14 +49,14 @@ impl Dispatcher {
 
     // Terminate this routing instance - cancel all scheduled timers including any future ones,
     // close all network connections and stop accepting new connections.
-    pub async fn terminate(&self) {
+    pub(super) async fn terminate(&self) {
         let _ = self.cancel_timer_tx.send(true);
         self.core.read().await.comm.terminate().await;
     }
 
     /// Handles the given command and transitively any new commands that are produced during its
     /// handling.
-    pub async fn handle_commands(self: Arc<Self>, command: Command) -> Result<()> {
+    pub(super) async fn handle_commands(self: Arc<Self>, command: Command) -> Result<()> {
         let commands = self.handle_command(command).await?;
         for command in commands {
             self.clone().spawn_handle_commands(command)
@@ -72,7 +72,7 @@ impl Dispatcher {
     }
 
     /// Handles a single command.
-    pub async fn handle_command(&self, command: Command) -> Result<Vec<Command>> {
+    pub(super) async fn handle_command(&self, command: Command) -> Result<Vec<Command>> {
         // Create a tracing span containing info about the current node. This is very useful when
         // analyzing logs produced by running multiple nodes within the same process, for example
         // from integration tests.

--- a/src/routing/routing_api/event.rs
+++ b/src/routing/routing_api/event.rs
@@ -13,7 +13,6 @@ use crate::messaging::{
 };
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Keypair;
-pub use qp2p::{RecvStream, SendStream};
 use std::{
     collections::BTreeSet,
     fmt::{self, Debug, Formatter},

--- a/src/routing/routing_api/mod.rs
+++ b/src/routing/routing_api/mod.rs
@@ -11,18 +11,18 @@ pub(crate) mod tests;
 
 pub(crate) mod command;
 
-mod config;
+pub(super) mod config;
 mod dispatcher;
-mod event;
-mod event_stream;
+pub(super) mod event;
+pub(super) mod event_stream;
 
-pub use self::{
+use self::{
+    command::Command,
     config::Config,
-    event::{Elders, Event, MessageReceived, NodeElderChange, SendStream},
+    dispatcher::Dispatcher,
+    event::{Elders, Event, NodeElderChange},
     event_stream::EventStream,
 };
-
-use self::{command::Command, dispatcher::Dispatcher};
 use crate::messaging::{
     node::{NodeMsg, Peer},
     DstLocation, EndUser, SectionAuthorityProvider, WireMsg,
@@ -35,8 +35,8 @@ use crate::routing::{
     network::NetworkUtils,
     node::Node,
     peer::PeerUtils,
-    section::{SectionAuthorityProviderUtils, SectionUtils},
-    Error, MIN_ADULT_AGE,
+    section::SectionUtils,
+    Error, SectionAuthorityProviderUtils, MIN_ADULT_AGE,
 };
 use ed25519_dalek::{PublicKey, Signature, Signer, KEYPAIR_LENGTH};
 use itertools::Itertools;

--- a/src/routing/routing_api/tests/mod.rs
+++ b/src/routing/routing_api/tests/mod.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#![allow(dead_code, unused_imports)]
+
 use super::{Comm, Command, Core, Dispatcher};
 use crate::messaging::{
     node::{
@@ -30,11 +32,11 @@ use crate::routing::{
     peer::PeerUtils,
     relocation::{self, RelocatePayloadUtils},
     section::{
-        test_utils::*, ElderCandidatesUtils, NodeStateUtils, SectionAuthorityProviderUtils,
-        SectionKeyShare, SectionPeersUtils, SectionUtils, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
-        MIN_AGE,
+        test_utils::*, ElderCandidatesUtils, NodeStateUtils, SectionKeyShare, SectionPeersUtils,
+        SectionUtils,
     },
-    supermajority, Event, ELDER_SIZE,
+    supermajority, Event, SectionAuthorityProviderUtils, ELDER_SIZE, FIRST_SECTION_MIN_AGE,
+    MIN_ADULT_AGE, MIN_AGE,
 };
 use crate::types::{Keypair, PublicKey};
 use anyhow::{anyhow, Result};
@@ -1900,7 +1902,7 @@ pub(crate) struct SecretKeySet {
 }
 
 impl SecretKeySet {
-    pub fn random() -> Self {
+    pub(crate) fn random() -> Self {
         let poly = bls::poly::Poly::random(THRESHOLD, &mut rand::thread_rng());
         let key = bls::SecretKey::from_mut(&mut poly.evaluate(0));
         let set = bls::SecretKeySet::from(poly);
@@ -1908,7 +1910,7 @@ impl SecretKeySet {
         Self { set, key }
     }
 
-    pub fn secret_key(&self) -> &bls::SecretKey {
+    pub(crate) fn secret_key(&self) -> &bls::SecretKey {
         &self.key
     }
 }

--- a/src/routing/section/mod.rs
+++ b/src/routing/section/mod.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-mod node_state;
+pub(super) mod node_state;
 pub(crate) mod section_authority_provider;
 mod section_keys;
 mod section_peers;
@@ -14,14 +14,7 @@ mod section_peers;
 #[cfg(test)]
 pub(crate) use self::section_authority_provider::test_utils;
 
-pub use self::{
-    node_state::{
-        NodeStateUtils, FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE, MIN_AGE,
-    },
-    section_authority_provider::{ElderCandidatesUtils, SectionAuthorityProviderUtils},
-    section_keys::{SectionKeyShare, SectionKeysProvider},
-    section_peers::SectionPeersUtils,
-};
+pub(super) use self::section_keys::{SectionKeyShare, SectionKeysProvider};
 
 use crate::messaging::{
     node::{ElderCandidates, KeyedSig, NodeState, Peer, Section, SectionPeers, SectionSigned},
@@ -33,12 +26,16 @@ use crate::routing::{
     peer::PeerUtils,
     ELDER_SIZE, RECOMMENDED_SECTION_SIZE,
 };
+pub(crate) use node_state::NodeStateUtils;
+pub(crate) use section_authority_provider::ElderCandidatesUtils;
+use section_authority_provider::SectionAuthorityProviderUtils;
+pub(super) use section_peers::SectionPeersUtils;
 use secured_linked_list::{error::Error as SecuredLinkedListError, SecuredLinkedList};
 use serde::Serialize;
 use std::{collections::BTreeSet, convert::TryInto, iter, marker::Sized, net::SocketAddr};
 use xor_name::{Prefix, XorName};
 
-pub trait SectionUtils {
+pub(super) trait SectionUtils {
     /// Creates a minimal `Section` initially containing only info about our elders
     /// (`section_auth`).
     ///

--- a/src/routing/section/node_state.rs
+++ b/src/routing/section/node_state.rs
@@ -25,7 +25,7 @@ pub const FIRST_SECTION_MIN_AGE: u8 = MIN_ADULT_AGE + 1;
 pub const FIRST_SECTION_MAX_AGE: u8 = 100;
 
 /// Information about a member of our section.
-pub trait NodeStateUtils {
+pub(crate) trait NodeStateUtils {
     // Creates a `NodeState` in the `Joined` state.
     fn joined(peer: Peer) -> NodeState;
 

--- a/src/routing/section/section_authority_provider.rs
+++ b/src/routing/section/section_authority_provider.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 /// The information about elder candidates in a DKG round.
-pub trait ElderCandidatesUtils {
+pub(crate) trait ElderCandidatesUtils {
     /// Creates a new `ElderCandidates` with the given members and prefix.
     fn new<I: IntoIterator<Item = Peer>>(elders: I, prefix: Prefix) -> Self;
 

--- a/src/routing/section/section_peers.rs
+++ b/src/routing/section/section_peers.rs
@@ -6,18 +6,18 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::SectionAuthorityProviderUtils;
+use super::node_state::NodeStateUtils;
 use crate::messaging::{
     node::{MembershipState, NodeState, Peer, SectionPeers, SectionSigned},
     SectionAuthorityProvider,
 };
-use crate::routing::{peer::PeerUtils, section::NodeStateUtils};
+use crate::routing::{peer::PeerUtils, SectionAuthorityProviderUtils};
 use itertools::Itertools;
 use std::{cmp::Ordering, collections::btree_map::Entry, mem};
 use xor_name::{Prefix, XorName};
 
 /// Container for storing information about members of our section.
-pub trait SectionPeersUtils {
+pub(crate) trait SectionPeersUtils {
     /// Returns an iterator over all current (joined) and past (left) members.
     fn all(&self) -> Box<dyn Iterator<Item = &NodeState> + '_>;
 


### PR DESCRIPTION
- 48e60dc8b **fix(routing): Enable `unreachable_pub` lints**

  As with the previous 'fix `unreachable_pub`' commit, this was mostly a
  mix of re-exporting from nested paths and updating method visibility to
  match their host types. In some cases this has fixed legitimate issues
  of unreachable public types (`AggregateError` and `ProposalError`).

- 6e3dd11c8 **chore(messaging): Enable `unreachable_pub` lints**


- 4556ea25e **chore(node): Enable `unreachable_pub` lints**


- d872b022b **chore: Enable `unreachable_pub` lint for whole crate**

  Now that all the lint errors have been fixed in all sub-modules, we can
  simply enable the lint for the whole crate.
