### PR TITLE
Remove hand-written debug impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "blsttc"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2cf27c82f62fd876518ea11d7a29120a410efb04d8b291cbec2ac0151d8dbd"
+checksum = "731c2cd7030d34eb735f27f803508c34e03456222733fe6660467cd00e8c6b72"
 dependencies = [
  "blst",
  "byteorder",

--- a/src/messaging/data/mod.rs
+++ b/src/messaging/data/mod.rs
@@ -333,8 +333,7 @@ mod tests {
     fn debug_format_functional() -> Result<()> {
         if let Some(key) = gen_keys().first() {
             let errored_response = QueryResponse::GetSequence(Err(Error::AccessDenied(*key)));
-            assert!(format!("{:?}", errored_response)
-                .contains("GetSequence(Err(AccessDenied(PublicKey::"));
+            assert!(format!("{:?}", errored_response).contains("GetSequence(Err(AccessDenied("));
             Ok(())
         } else {
             Err(anyhow!("Could not generate public key"))

--- a/src/messaging/data/register.rs
+++ b/src/messaging/data/register.rs
@@ -12,7 +12,6 @@ use crate::types::{
     PublicKey,
 };
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use xor_name::XorName;
 
 /// [`Register`] read operations.
@@ -73,7 +72,7 @@ pub struct RegisterCmd {
 
 /// [`Register`] write operations.
 #[allow(clippy::large_enum_variant)]
-#[derive(Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum RegisterWrite {
     /// Create a new [`Register`] on the network.
     New(Register),
@@ -144,19 +143,5 @@ impl RegisterWrite {
             Self::New(data) => Some(data.owner()),
             _ => None,
         }
-    }
-}
-
-impl fmt::Debug for RegisterWrite {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "RegisterWrite::{}",
-            match self {
-                RegisterWrite::New(register) => format!("New({:?})", register.address()),
-                RegisterWrite::Delete(address) => format!("Delete({:?})", address),
-                RegisterWrite::Edit(op) => format!("Edit({:?})", op),
-            }
-        )
     }
 }

--- a/src/messaging/data/sequence.rs
+++ b/src/messaging/data/sequence.rs
@@ -12,7 +12,6 @@ use crate::types::{
     SequenceIndex as Index, SequenceOp, SequenceUser as User,
 };
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use xor_name::XorName;
 
 /// [`Sequence`] read operations.
@@ -128,7 +127,7 @@ pub struct SequenceCmd {
 
 /// [`Sequence`] write operations.
 #[allow(clippy::large_enum_variant)]
-#[derive(Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum SequenceWrite {
     /// Create a new [`Sequence`] on the network.
     New(Sequence),
@@ -202,20 +201,5 @@ impl SequenceWrite {
             Self::New(data) => Some(data.owner()),
             _ => None,
         }
-    }
-}
-
-impl fmt::Debug for SequenceWrite {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        use SequenceWrite::*;
-        write!(
-            formatter,
-            "SequenceWrite::{}",
-            match self {
-                New(seq) => format!("New({:?})", seq.address()),
-                Delete(address) => format!("Delete({:?})", address),
-                Edit(op) => format!("Edit({:?})", op),
-            }
-        )
     }
 }

--- a/src/messaging/msg_id.rs
+++ b/src/messaging/msg_id.rs
@@ -20,7 +20,7 @@ pub const MESSAGE_ID_LEN: usize = 32;
 /// This is used for deduplication: Since the network sends messages redundantly along different
 /// routes, the same message will usually arrive more than once at any given node. A message with
 /// an ID that is already in the cache will be ignored.
-#[derive(Ord, PartialOrd, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Ord, PartialOrd, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct MessageId([u8; MESSAGE_ID_LEN]);
 
 impl MessageId {
@@ -93,11 +93,5 @@ impl fmt::Display for MessageId {
             "{:02x}{:02x}{:02x}{:02x}..",
             self.0[0], self.0[1], self.0[2], self.0[3]
         )
-    }
-}
-
-impl fmt::Debug for MessageId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
     }
 }

--- a/src/messaging/msg_id.rs
+++ b/src/messaging/msg_id.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{Error, Result};
+use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use tiny_keccak::{Hasher, Sha3};
@@ -20,8 +21,10 @@ pub const MESSAGE_ID_LEN: usize = 32;
 /// This is used for deduplication: Since the network sends messages redundantly along different
 /// routes, the same message will usually arrive more than once at any given node. A message with
 /// an ID that is already in the cache will be ignored.
-#[derive(Debug, Ord, PartialOrd, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub struct MessageId([u8; MESSAGE_ID_LEN]);
+#[derive(
+    Ord, PartialOrd, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, custom_debug::Debug,
+)]
+pub struct MessageId(#[debug(with = "Self::fmt_bytes")] [u8; MESSAGE_ID_LEN]);
 
 impl MessageId {
     /// Generates a new `MessageId` with random content.
@@ -71,6 +74,10 @@ impl MessageId {
         hasher.finalize(&mut output);
 
         Self(output)
+    }
+
+    fn fmt_bytes(bytes: &[u8; MESSAGE_ID_LEN], f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:0.10}", HexFmt(bytes))
     }
 }
 

--- a/src/messaging/msg_kind.rs
+++ b/src/messaging/msg_kind.rs
@@ -62,13 +62,15 @@ pub struct ClientSigned {
 }
 
 /// Authority of a single peer.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 pub struct NodeSigned {
     /// Section key of the source.
     pub section_pk: BlsPublicKey,
     /// Public key of the source peer.
+    #[debug(with = "PublicKey::fmt_ed25519")]
     pub public_key: EdPublicKey,
     /// Ed25519 signature of the message corresponding to the public key of the source peer.
+    #[debug(with = "Signature::fmt_ed25519")]
     pub signature: EdSignature,
 }
 

--- a/src/messaging/msg_kind.rs
+++ b/src/messaging/msg_kind.rs
@@ -10,9 +10,7 @@ use super::node::{KeyedSig, SigShare};
 use crate::types::{PublicKey, Signature};
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::{PublicKey as EdPublicKey, Signature as EdSignature};
-use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Debug};
 use xor_name::XorName;
 
 /// Source authority of a message.
@@ -22,7 +20,7 @@ use xor_name::XorName;
 /// against the public key and we know the public key then we are good. If the proof is not
 /// recognised we can ask for a longer chain that can be recognised).
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum MsgKind {
     /// A section information message, which doesn't have any message authority.
     ///
@@ -94,49 +92,4 @@ pub struct SectionSigned {
     pub src_name: XorName,
     /// BLS proof of the message corresponding to the source section.
     pub sig: KeyedSig,
-}
-
-impl Debug for MsgKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::SectionInfoMsg => write!(f, "SectionInfoMsg"),
-            Self::DataMsg(ClientSigned {
-                public_key,
-                signature,
-            }) => write!(
-                f,
-                "DataMsg {{ public_key: {:?}, signature: {:?} }}",
-                public_key, signature
-            ),
-            Self::NodeSignedMsg(NodeSigned {
-                section_pk,
-                public_key,
-                signature,
-            }) => write!(
-                f,
-                "NodeSignedMsg {{ section_pk: {:?}, public_key: {:10?}, signature: {:10?} }}",
-                section_pk,
-                HexFmt(public_key),
-                HexFmt(signature)
-            ),
-            Self::NodeBlsShareSignedMsg(BlsShareSigned {
-                section_pk,
-                src_name,
-                sig_share,
-            }) => write!(
-                f,
-                "NodeBlsShareSignedMsg {{ section_pk: {:?}, src_name: {:?}, sig_share: {:?} ",
-                section_pk, src_name, sig_share
-            ),
-            Self::SectionSignedMsg(SectionSigned {
-                section_pk,
-                src_name,
-                sig,
-            }) => write!(
-                f,
-                "Section {{ section_pk: {:?}, src_name: {:?}, sig: {:?}",
-                section_pk, src_name, sig
-            ),
-        }
-    }
 }

--- a/src/messaging/node/agreement.rs
+++ b/src/messaging/node/agreement.rs
@@ -10,31 +10,20 @@ use super::{section::NodeState, signed::KeyedSig};
 use crate::messaging::{MessageId, SectionAuthorityProvider};
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::{PublicKey, Signature};
-use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
-use std::{
-    borrow::Borrow,
-    collections::BTreeSet,
-    fmt::{self, Debug, Formatter},
-};
+use std::{borrow::Borrow, collections::BTreeSet};
 use xor_name::{Prefix, XorName};
 
 /// SHA3-256 hash digest.
 type Digest256 = [u8; 32];
 
 /// Unique identifier of a DKG session.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct DkgKey {
     /// A hash of the peers and prefix of the specific session.
     pub hash: Digest256,
     /// The generation, as in the length of the section chain main branch.
     pub generation: u64,
-}
-
-impl Debug for DkgKey {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "DkgKey({:10}/{})", HexFmt(&self.hash), self.generation)
-    }
 }
 
 /// One signed failure for a DKG round by a given PublicKey

--- a/src/messaging/node/agreement.rs
+++ b/src/messaging/node/agreement.rs
@@ -35,11 +35,13 @@ impl DkgKey {
 }
 
 /// One signed failure for a DKG round by a given PublicKey
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 pub struct DkgFailureSig {
     #[allow(missing_docs)]
+    #[debug(with = "crate::types::PublicKey::fmt_ed25519")]
     pub public_key: PublicKey,
     #[allow(missing_docs)]
+    #[debug(with = "crate::types::Signature::fmt_ed25519")]
     pub signature: Signature,
 }
 

--- a/src/messaging/node/agreement.rs
+++ b/src/messaging/node/agreement.rs
@@ -10,20 +10,28 @@ use super::{section::NodeState, signed::KeyedSig};
 use crate::messaging::{MessageId, SectionAuthorityProvider};
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::{PublicKey, Signature};
+use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
-use std::{borrow::Borrow, collections::BTreeSet};
+use std::{borrow::Borrow, collections::BTreeSet, fmt};
 use xor_name::{Prefix, XorName};
 
 /// SHA3-256 hash digest.
 type Digest256 = [u8; 32];
 
 /// Unique identifier of a DKG session.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, custom_debug::Debug)]
 pub struct DkgKey {
     /// A hash of the peers and prefix of the specific session.
+    #[debug(with = "Self::fmt_hash")]
     pub hash: Digest256,
     /// The generation, as in the length of the section chain main branch.
     pub generation: u64,
+}
+
+impl DkgKey {
+    fn fmt_hash(hash: &Digest256, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:0.10}", HexFmt(hash))
+    }
 }
 
 /// One signed failure for a DKG round by a given PublicKey

--- a/src/messaging/node/join.rs
+++ b/src/messaging/node/join.rs
@@ -12,35 +12,15 @@ use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Signature;
 use secured_linked_list::SecuredLinkedList;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::VecDeque,
-    fmt::{self, Debug, Formatter},
-    net::SocketAddr,
-};
+use std::{collections::VecDeque, net::SocketAddr};
 
 /// Request to join a section
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct JoinRequest {
     /// The public key of the section to join.
     pub section_key: BlsPublicKey,
     /// Proof of the resouce proofing.
     pub resource_proof_response: Option<ResourceProofResponse>,
-}
-
-impl Debug for JoinRequest {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        formatter
-            .debug_struct("JoinRequest")
-            .field("section_key", &self.section_key)
-            .field(
-                "resource_proof_response",
-                &self
-                    .resource_proof_response
-                    .as_ref()
-                    .map(|proof| proof.solution),
-            )
-            .finish()
-    }
 }
 
 /// Joining peer's proof of resolvement of given resource proofing challenge.
@@ -57,7 +37,7 @@ pub struct ResourceProofResponse {
 }
 
 /// Response to a request to join a section
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum JoinResponse {
     /// Challenge sent from existing elder nodes to the joining peer for resource proofing.
@@ -91,37 +71,6 @@ pub enum JoinResponse {
     },
     /// Join was rejected
     Rejected(JoinRejectionReason),
-}
-
-impl Debug for JoinResponse {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::ResourceChallenge {
-                data_size,
-                difficulty,
-                ..
-            } => f
-                .debug_struct("ResourceChallenge")
-                .field("data_size", data_size)
-                .field("difficulty", difficulty)
-                .finish(),
-            Self::Retry(section_auth) => write!(f, "Retry({:?})", section_auth),
-            Self::Redirect(section_auth) => write!(f, "Redirect({:?})", section_auth),
-            Self::Approval {
-                genesis_key,
-                section_auth,
-                node_state,
-                section_chain,
-            } => f
-                .debug_struct("Approval")
-                .field("genesis_key", genesis_key)
-                .field("section_auth", section_auth)
-                .field("node_state", node_state)
-                .field("section_chain", section_chain)
-                .finish(),
-            Self::Rejected(reason) => write!(f, "Rejected({:?})", reason),
-        }
-    }
 }
 
 /// Reason of a join request being rejected

--- a/src/messaging/node/join.rs
+++ b/src/messaging/node/join.rs
@@ -24,7 +24,7 @@ pub struct JoinRequest {
 }
 
 /// Joining peer's proof of resolvement of given resource proofing challenge.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 pub struct ResourceProofResponse {
     #[allow(missing_docs)]
     pub solution: u64,
@@ -33,6 +33,7 @@ pub struct ResourceProofResponse {
     #[allow(missing_docs)]
     pub nonce: [u8; 32],
     #[allow(missing_docs)]
+    #[debug(with = "crate::types::Signature::fmt_ed25519")]
     pub nonce_signature: Signature,
 }
 

--- a/src/messaging/node/join.rs
+++ b/src/messaging/node/join.rs
@@ -29,8 +29,10 @@ pub struct ResourceProofResponse {
     #[allow(missing_docs)]
     pub solution: u64,
     #[allow(missing_docs)]
+    #[debug(skip)]
     pub data: VecDeque<u8>,
     #[allow(missing_docs)]
+    #[debug(skip)]
     pub nonce: [u8; 32],
     #[allow(missing_docs)]
     #[debug(with = "crate::types::Signature::fmt_ed25519")]

--- a/src/messaging/node/join_as_relocated.rs
+++ b/src/messaging/node/join_as_relocated.rs
@@ -11,13 +11,10 @@ use crate::messaging::SectionAuthorityProvider;
 use bls::PublicKey as BlsPublicKey;
 use secured_linked_list::SecuredLinkedList;
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{self, Debug, Formatter},
-    net::SocketAddr,
-};
+use std::net::SocketAddr;
 
 /// Request to join a section as relocated from another section
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct JoinAsRelocatedRequest {
     /// The public key of the section to join.
     pub section_key: BlsPublicKey,
@@ -25,24 +22,8 @@ pub struct JoinAsRelocatedRequest {
     pub relocate_payload: Option<RelocatePayload>,
 }
 
-impl Debug for JoinAsRelocatedRequest {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        formatter
-            .debug_struct("JoinAsRelocatedRequest")
-            .field("section_key", &self.section_key)
-            .field(
-                "relocate_payload",
-                &self
-                    .relocate_payload
-                    .as_ref()
-                    .map(|payload| &payload.details),
-            )
-            .finish()
-    }
-}
-
 /// Response to a request to join a section as relocated
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum JoinAsRelocatedResponse {
     /// Up to date section information for a joining peer to retry its join request with
@@ -63,24 +44,4 @@ pub enum JoinAsRelocatedResponse {
     },
     /// The requesting node is not externally reachable
     NodeNotReachable(SocketAddr),
-}
-
-impl Debug for JoinAsRelocatedResponse {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::Retry(section_auth) => write!(f, "Retry({:?})", section_auth),
-            Self::Redirect(section_auth) => write!(f, "Redirect({:?})", section_auth),
-            Self::Approval {
-                section_auth,
-                node_state,
-                section_chain,
-            } => f
-                .debug_struct("Approval")
-                .field("section_auth", section_auth)
-                .field("node_state", node_state)
-                .field("section_chain", section_chain)
-                .finish(),
-            Self::NodeNotReachable(addr) => write!(f, "NodeNotReachable({})", addr),
-        }
-    }
 }

--- a/src/messaging/node/mod.rs
+++ b/src/messaging/node/mod.rs
@@ -36,16 +36,12 @@ pub use signed::{KeyedSig, SigShare};
 use crate::messaging::{data::DataMsg, ClientSigned, EndUser, MessageId, SectionAuthorityProvider};
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::message::Message as DkgMessage;
-use itertools::Itertools;
 use secured_linked_list::SecuredLinkedList;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::BTreeSet,
-    fmt::{self, Debug, Formatter},
-};
+use std::collections::BTreeSet;
 use xor_name::XorName;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 /// Message sent over the among nodes
 pub enum NodeMsg {
@@ -171,114 +167,4 @@ pub enum NodeMsg {
         /// ID of causing cmd.
         correlation_id: MessageId,
     },
-}
-
-impl Debug for NodeMsg {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::ForwardDataMsg { .. } => f.debug_struct("ForwardDataMsg").finish(),
-            Self::SectionKnowledge { .. } => f.debug_struct("SectionKnowledge").finish(),
-            Self::Sync { section, network } => f
-                .debug_struct("Sync")
-                .field("section_auth", &section.section_auth.value)
-                .field("section_key", section.chain.last_key())
-                .field(
-                    "other_prefixes",
-                    &format_args!(
-                        "({:b})",
-                        network
-                            .sections
-                            .iter()
-                            .map(|info| &info.section_auth.value.prefix)
-                            .format(", ")
-                    ),
-                )
-                .finish(),
-            Self::Relocate(payload) => write!(f, "Relocate({:?})", payload),
-            Self::StartConnectivityTest(name) => write!(f, "StartConnectivityTest({:?})", name),
-            Self::RelocatePromise(payload) => write!(f, "RelocatePromise({:?})", payload),
-            Self::JoinRequest(payload) => write!(f, "JoinRequest({:?})", payload),
-            Self::JoinResponse(response) => write!(f, "JoinResponse({:?})", response),
-            Self::JoinAsRelocatedRequest(payload) => {
-                write!(f, "JoinAsRelocatedRequest({:?})", payload)
-            }
-            Self::JoinAsRelocatedResponse(response) => {
-                write!(f, "JoinAsRelocatedResponse({:?})", response)
-            }
-            Self::BouncedUntrustedMessage {
-                msg,
-                dst_section_pk,
-            } => f
-                .debug_struct("BouncedUntrustedMessage")
-                .field("message", msg)
-                .field("dst_section_pk", dst_section_pk)
-                .finish(),
-            Self::DkgStart {
-                dkg_key,
-                elder_candidates,
-            } => f
-                .debug_struct("DkgStart")
-                .field("dkg_key", dkg_key)
-                .field("elder_candidates", elder_candidates)
-                .finish(),
-            Self::DkgMessage { dkg_key, message } => f
-                .debug_struct("DkgMessage")
-                .field("dkg_key", &dkg_key)
-                .field("message", message)
-                .finish(),
-            Self::DkgFailureObservation {
-                dkg_key,
-                sig,
-                failed_participants,
-            } => f
-                .debug_struct("DkgFailureObservation")
-                .field("dkg_key", dkg_key)
-                .field("sig", sig)
-                .field("failed_participants", failed_participants)
-                .finish(),
-            Self::DkgFailureAgreement(proofs) => {
-                f.debug_tuple("DkgFailureAgreement").field(proofs).finish()
-            }
-            Self::Propose { content, sig_share } => f
-                .debug_struct("Propose")
-                .field("content", content)
-                .field("sig_share", sig_share)
-                .finish(),
-            Self::SectionKnowledgeQuery { .. } => write!(f, "SectionKnowledgeQuery"),
-            Self::NodeCmd(node_cmd) => write!(f, "NodeCmd({:?})", node_cmd),
-            Self::NodeCmdError {
-                error,
-                correlation_id,
-            } => f
-                .debug_struct("NodeCmdError")
-                .field("error", error)
-                .field("correlation_id", correlation_id)
-                .finish(),
-            Self::NodeEvent {
-                event,
-                correlation_id,
-            } => f
-                .debug_struct("NodeEvent")
-                .field("event", event)
-                .field("correlation_id", correlation_id)
-                .finish(),
-            Self::NodeQuery(node_query) => write!(f, "NodeQuery({:?})", node_query),
-            Self::NodeQueryResponse {
-                response,
-                correlation_id,
-            } => f
-                .debug_struct("NodeQueryResponse")
-                .field("response", response)
-                .field("correlation_id", correlation_id)
-                .finish(),
-            Self::NodeMsgError {
-                error,
-                correlation_id,
-            } => f
-                .debug_struct("NodeMsgError")
-                .field("error", error)
-                .field("correlation_id", correlation_id)
-                .finish(),
-        }
-    }
 }

--- a/src/messaging/node/section/candidates.rs
+++ b/src/messaging/node/section/candidates.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt::Debug, net::SocketAddr};
+use std::{collections::BTreeMap, net::SocketAddr};
 use xor_name::{Prefix, XorName};
 
 /// The information about elder candidates in a DKG round.

--- a/src/messaging/node/signed.rs
+++ b/src/messaging/node/signed.rs
@@ -6,28 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Debug, Formatter};
 
 /// Signature created when a quorum of the section elders has agreed on something.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct KeyedSig {
     /// The BLS public key.
     pub public_key: bls::PublicKey,
     /// The BLS signature corresponding to the public key.
     pub signature: bls::Signature,
-}
-
-impl Debug for KeyedSig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "KeyedSig {{ public_key: {:10?}, signature: {:10?} }}",
-            HexFmt(self.public_key.to_bytes()),
-            HexFmt(self.signature.to_bytes())
-        )
-    }
 }
 
 impl KeyedSig {
@@ -38,7 +25,7 @@ impl KeyedSig {
 }
 
 /// Single share of `KeyedSig`.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct SigShare {
     /// BLS public key set.
     pub public_key_set: bls::PublicKeySet,
@@ -68,17 +55,6 @@ impl SigShare {
         self.public_key_set
             .public_key_share(self.index)
             .verify(&self.signature_share, payload)
-    }
-}
-
-impl Debug for SigShare {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "SigShare {{ public_key: {:?}, index: {}, .. }}",
-            self.public_key_set.public_key(),
-            self.index
-        )
     }
 }
 

--- a/src/messaging/sap.rs
+++ b/src/messaging/sap.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     borrow::Borrow,
     collections::BTreeMap,
-    fmt::{self, Debug, Display, Formatter},
+    fmt::{self, Display, Formatter},
     net::SocketAddr,
 };
 use xor_name::{Prefix, XorName};
@@ -21,7 +21,7 @@ use xor_name::{Prefix, XorName};
 ///
 /// A new `SectionAuthorityProvider` is created whenever the elders change, due to an elder being
 /// added or removed, or the section splitting or merging.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
 pub struct SectionAuthorityProvider {
     /// The section prefix. It matches all the members' names.
     pub prefix: Prefix,
@@ -34,18 +34,6 @@ pub struct SectionAuthorityProvider {
 impl Borrow<Prefix> for SectionAuthorityProvider {
     fn borrow(&self) -> &Prefix {
         &self.prefix
-    }
-}
-
-impl Debug for SectionAuthorityProvider {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "SectionAuthorityProvider {{ prefix: ({:b}), section_key: {:?}, elders: {{{:?}}} }}",
-            self.prefix,
-            self.public_key_set.public_key(),
-            self.elders.iter().format(", "),
-        )
     }
 }
 

--- a/src/messaging/serialisation/mod.rs
+++ b/src/messaging/serialisation/mod.rs
@@ -14,7 +14,6 @@ use super::{
     data::DataMsg, node::NodeMsg, section_info::SectionInfoMsg, BlsShareSigned, ClientSigned,
     DstLocation, MessageId, NodeSigned, SectionSigned,
 };
-use std::fmt::Debug;
 
 /// Type of message.
 /// Note this is part of this crate's public API but this enum is

--- a/src/messaging/serialisation/wire_msg_header.rs
+++ b/src/messaging/serialisation/wire_msg_header.rs
@@ -10,7 +10,7 @@ use crate::messaging::{DstLocation, Error, MessageId, MsgKind, Result};
 use bytes::Bytes;
 use cookie_factory::{bytes::be_u16, combinator::slice, gen, gen_simple};
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, mem::size_of};
+use std::mem::size_of;
 
 // Current version of the messaging protocol.
 // At this point this implementation supports only this version.

--- a/src/node/logging/log_ctx.rs
+++ b/src/node/logging/log_ctx.rs
@@ -9,7 +9,6 @@
 use crate::node::network::Network;
 use xor_name::Prefix;
 
-#[derive(Debug)]
 pub(crate) struct LogCtx {
     network: Network,
 }

--- a/src/node/logging/mod.rs
+++ b/src/node/logging/mod.rs
@@ -46,7 +46,7 @@ fn fmt(string: Option<String>) -> String {
     string.unwrap_or_else(|| "Unknown".to_string())
 }
 
-#[tracing::instrument]
+#[tracing::instrument(skip(ctx))]
 async fn log(system: &mut System, ctx: &LogCtx, print_resources_usage: bool) {
     system.refresh_all();
 

--- a/src/node/network.rs
+++ b/src/node/network.rs
@@ -20,7 +20,7 @@ use std::{collections::BTreeSet, net::SocketAddr, path::Path, sync::Arc};
 use xor_name::{Prefix, XorName};
 
 ///
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct Network {
     routing: Arc<RoutingNode>,
 }

--- a/src/node/node_api/mod.rs
+++ b/src/node/node_api/mod.rs
@@ -64,8 +64,9 @@ impl NodeInfo {
 }
 
 /// Main node struct.
-#[derive(Debug)]
+#[derive(custom_debug::Debug)]
 pub struct Node {
+    #[debug(skip)]
     network_api: Network,
     node_info: NodeInfo,
     used_space: UsedSpace,

--- a/src/node/node_api/role/mod.rs
+++ b/src/node/node_api/role/mod.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{Error, Result};
-use std::fmt::{self, Debug, Formatter};
+use std::fmt::{self, Formatter};
 
 pub(crate) use adult_role::AdultRole;
 pub(crate) use elder_role::ElderRole;
@@ -16,20 +16,10 @@ mod adult_role;
 mod elder_role;
 
 #[allow(clippy::large_enum_variant)]
-
+#[derive(custom_debug::Debug)]
 pub(crate) enum Role {
-    Adult(AdultRole),
-    Elder(ElderRole),
-}
-
-impl Debug for Role {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        let role = match self {
-            Role::Adult(_) => "Adult".to_string(),
-            Role::Elder(_) => "Elder".to_string(),
-        };
-        write!(formatter, "Role is {:?}", role)
-    }
+    Adult(#[debug(skip)] AdultRole),
+    Elder(#[debug(skip)] ElderRole),
 }
 
 impl Role {

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -16,10 +16,7 @@ use crate::messaging::{
 };
 use crate::routing::Prefix;
 use crate::types::{Chunk, PublicKey};
-use std::{
-    collections::BTreeSet,
-    fmt::{Debug, Formatter},
-};
+use std::collections::BTreeSet;
 use xor_name::XorName;
 
 /// Internal messages are what is passed along
@@ -40,6 +37,7 @@ pub(super) type NodeDuties = Vec<NodeDuty>;
 
 /// Common duties run by all nodes.
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
 pub enum NodeDuty {
     ReadChunk {
         msg_id: MessageId,
@@ -168,55 +166,6 @@ impl From<NodeDuty> for NodeDuties {
             vec![]
         } else {
             vec![duty]
-        }
-    }
-}
-
-impl Debug for NodeDuty {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Genesis { .. } => write!(f, "Genesis"),
-            Self::ReadChunk { .. } => write!(f, "ReadChunk"),
-            Self::WriteChunk { .. } => write!(f, "WriteChunk"),
-            Self::ProcessRepublish { .. } => write!(f, "ProcessRepublish"),
-            Self::RecordAdultReadLiveness {
-                correlation_id,
-                response,
-                src,
-            } => write!(
-                f,
-                "RecordAdultReadLiveness {{ correlation_id: {}, response: {:?}, src: {} }}",
-                correlation_id, response, src
-            ),
-            Self::LevelDown => write!(f, "LevelDown"),
-            Self::SynchState { .. } => write!(f, "SynchState"),
-            Self::EldersChanged { .. } => write!(f, "EldersChanged"),
-            Self::AdultsChanged { .. } => write!(f, "AdultsChanged"),
-            Self::SectionSplit { .. } => write!(f, "SectionSplit"),
-            Self::GetSectionElders { .. } => write!(f, "GetSectionElders"),
-            Self::NoOp => write!(f, "No op."),
-            Self::ReachingMaxCapacity => write!(f, "ReachingMaxCapacity"),
-            Self::ProcessLostMember { .. } => write!(f, "ProcessLostMember"),
-            //Self::ProcessRelocatedMember { .. } => write!(f, "ProcessRelocatedMember"),
-            Self::IncrementFullNodeCount { .. } => write!(f, "IncrementFullNodeCount"),
-            Self::SetNodeJoinsAllowed(_) => write!(f, "SetNodeJoinsAllowed"),
-            Self::Send(msg) => write!(f, "Send [ msg: {:?} ]", msg),
-            Self::SendError(msg) => write!(f, "SendError [ msg: {:?} ]", msg),
-            Self::SendSupport(msg) => write!(f, "SendSupport [ msg: {:?} ]", msg),
-            Self::SendToNodes {
-                msg_id,
-                msg,
-                targets,
-                aggregation,
-            } => write!(
-                f,
-                "SendToNodes [ msg_id: {}, msg: {:?}, targets: {:?}, aggregation: {:?} ]",
-                msg_id, msg, targets, aggregation
-            ),
-            Self::ProcessRead { .. } => write!(f, "ProcessRead"),
-            Self::ProcessWrite { .. } => write!(f, "ProcessWrite"),
-            Self::ReplicateChunk { .. } => write!(f, "ReplicateChunk"),
-            Self::ProposeOffline(nodes) => write!(f, "ProposeOffline({:?})", nodes),
         }
     }
 }

--- a/src/routing/core/comm.rs
+++ b/src/routing/core/comm.rs
@@ -10,12 +10,8 @@ use crate::messaging::WireMsg;
 use crate::routing::error::{Error, Result};
 use bytes::Bytes;
 use futures::stream::{FuturesUnordered, StreamExt};
-use hex_fmt::HexFmt;
 use qp2p::{Endpoint, QuicP2p};
-use std::{
-    fmt::{self, Debug, Formatter},
-    net::SocketAddr,
-};
+use std::net::SocketAddr;
 use tokio::{
     sync::{mpsc, RwLock},
     task,
@@ -298,18 +294,10 @@ impl Drop for Comm {
     }
 }
 
+#[derive(Debug)]
 pub(crate) enum ConnectionEvent {
     Received((SocketAddr, Bytes)),
     Disconnected(SocketAddr),
-}
-
-impl Debug for ConnectionEvent {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::Received((src, msg)) => write!(f, "Received(src: {}, msg: {})", src, HexFmt(msg)),
-            Self::Disconnected(addr) => write!(f, "Disconnected({})", addr),
-        }
-    }
 }
 
 async fn handle_disconnection_events(

--- a/src/routing/core/signature_aggregator.rs
+++ b/src/routing/core/signature_aggregator.rs
@@ -9,7 +9,6 @@
 use crate::messaging::node::{KeyedSig, SigShare};
 use std::{
     collections::HashMap,
-    fmt::Debug,
     time::{Duration, Instant},
 };
 use thiserror::Error;

--- a/src/routing/dkg/commands.rs
+++ b/src/routing/dkg/commands.rs
@@ -16,7 +16,7 @@ use crate::routing::{
 };
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::message::Message as DkgMessage;
-use std::{collections::BTreeSet, fmt::Debug, net::SocketAddr, time::Duration};
+use std::{collections::BTreeSet, net::SocketAddr, time::Duration};
 use xor_name::XorName;
 
 #[derive(Debug)]

--- a/src/routing/node.rs
+++ b/src/routing/node.rs
@@ -11,18 +11,19 @@ use crate::routing::peer::PeerUtils;
 use crate::types::PublicKey;
 use ed25519_dalek::Keypair;
 use std::{
-    fmt::{self, Debug, Display, Formatter},
+    fmt::{self, Display, Formatter},
     net::SocketAddr,
     sync::Arc,
 };
 use xor_name::{XorName, XOR_NAME_LEN};
 
 /// Information and state of our node
-#[derive(Clone)]
+#[derive(Clone, custom_debug::Debug)]
 pub(crate) struct Node {
     // Keep the secret key in Arc to allow Clone while also preventing multiple copies to exist in
     // memory which might be insecure.
     // TODO: find a way to not require `Clone`.
+    #[debug(skip)]
     pub(crate) keypair: Arc<Keypair>,
     pub(crate) addr: SocketAddr,
 }
@@ -52,16 +53,6 @@ impl Node {
 impl Display for Node {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.name())
-    }
-}
-
-impl Debug for Node {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_struct("Node")
-            .field("name", &self.name())
-            .field("addr", &self.addr)
-            .field("age", &self.age())
-            .finish()
     }
 }
 

--- a/src/routing/routing_api/command.rs
+++ b/src/routing/routing_api/command.rs
@@ -12,7 +12,6 @@ use crate::messaging::{
 };
 use crate::routing::{node::Node, routing_api::Peer, section::SectionKeyShare, XorName};
 use std::{
-    fmt::{self, Debug, Formatter},
     net::SocketAddr,
     sync::atomic::{AtomicU64, Ordering},
     time::Duration,
@@ -20,6 +19,7 @@ use std::{
 
 /// Command for node.
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
 pub(crate) enum Command {
     /// Handle `message` from `sender`.
     /// holding the WireMsg that has been received from the network,
@@ -78,78 +78,6 @@ pub(crate) enum Command {
     StartConnectivityTest(XorName),
     /// Test Connectivity
     TestConnectivity(XorName),
-}
-
-impl Debug for Command {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::HandleMessage { sender, wire_msg } => f
-                .debug_struct("HandleMessage")
-                .field("sender", sender)
-                .field("wire_msg", wire_msg)
-                .finish(),
-            Self::HandleTimeout(token) => f.debug_tuple("HandleTimeout").field(token).finish(),
-            Self::HandleConnectionLost(addr) => {
-                f.debug_tuple("HandleConnectionLost").field(addr).finish()
-            }
-            Self::HandlePeerLost(addr) => f.debug_tuple("HandlePeerLost").field(addr).finish(),
-            Self::HandleAgreement { proposal, sig } => f
-                .debug_struct("HandleAgreement")
-                .field("proposal", proposal)
-                .field("sig.public_key", &sig.public_key)
-                .finish(),
-            Self::HandleDkgOutcome {
-                section_auth,
-                outcome,
-            } => f
-                .debug_struct("HandleDkgOutcome")
-                .field("section_auth", section_auth)
-                .field("outcome", &outcome.public_key_set.public_key())
-                .finish(),
-            Self::HandleDkgFailure(signeds) => {
-                f.debug_tuple("HandleDkgFailure").field(signeds).finish()
-            }
-            Self::SendMessage {
-                recipients,
-                delivery_group_size,
-                wire_msg,
-            } => f
-                .debug_struct("SendMessage")
-                .field("recipients", recipients)
-                .field("delivery_group_size", delivery_group_size)
-                .field("wire_msg", wire_msg)
-                .finish(),
-            Self::RelayMessage(wire_msg) => f.debug_tuple("RelayMessage").field(wire_msg).finish(),
-            Self::ScheduleTimeout { duration, token } => f
-                .debug_struct("ScheduleTimeout")
-                .field("duration", duration)
-                .field("token", token)
-                .finish(),
-            Self::HandleRelocationComplete { node, section } => f
-                .debug_struct("HandleRelocationComplete")
-                .field("node", node)
-                .field("section", section)
-                .finish(),
-            Self::SetJoinsAllowed(joins_allowed) => f
-                .debug_tuple("SetJoinsAllowed")
-                .field(joins_allowed)
-                .finish(),
-            Self::ProposeOnline {
-                peer,
-                previous_name,
-                ..
-            } => f
-                .debug_struct("ProposeOnline")
-                .field("peer", peer)
-                .field("previous_name", previous_name)
-                .finish(),
-            Self::ProposeOffline(name) => f.debug_tuple("ProposeOffline").field(name).finish(),
-            Self::TestConnectivity(name) => f.debug_tuple("TestConnectivity").field(name).finish(),
-            Self::StartConnectivityTest(name) => {
-                f.debug_tuple("StartConnectivityTest").field(name).finish()
-            }
-        }
-    }
 }
 
 /// Generate unique timer token.

--- a/src/routing/routing_api/event.rs
+++ b/src/routing/routing_api/event.rs
@@ -13,11 +13,7 @@ use crate::messaging::{
 };
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Keypair;
-use std::{
-    collections::BTreeSet,
-    fmt::{self, Debug, Formatter},
-    sync::Arc,
-};
+use std::{collections::BTreeSet, sync::Arc};
 use xor_name::{Prefix, XorName};
 
 /// A flag in EldersChanged event, indicating
@@ -55,6 +51,7 @@ pub struct Elders {
 /// `Request` and `Response` events from section locations are only raised once the majority has
 /// been reached, i.e. enough members of the section have sent the same message.
 #[allow(clippy::large_enum_variant)]
+#[derive(custom_debug::Debug)]
 pub enum Event {
     /// Received a message from another Node.
     MessageReceived {
@@ -110,6 +107,7 @@ pub enum Event {
         /// Old name before the relocation.
         previous_name: XorName,
         /// New keypair to be used after relocation.
+        #[debug(skip)]
         new_keypair: Arc<Keypair>,
     },
     /// Received a message from a client node.
@@ -134,87 +132,6 @@ pub enum Event {
         /// Removed Adults in our section.
         removed: BTreeSet<XorName>,
     },
-}
-
-impl Debug for Event {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::MessageReceived {
-                msg_id,
-                src,
-                dst,
-                msg,
-            } => formatter
-                .debug_struct("MessageReceived")
-                .field("msg_id", msg_id)
-                .field("src", src)
-                .field("dst", dst)
-                .field("msg", msg)
-                .finish(),
-            Self::MemberJoined {
-                name,
-                previous_name,
-                age,
-            } => formatter
-                .debug_struct("MemberJoined")
-                .field("name", name)
-                .field("previous_name", previous_name)
-                .field("age", age)
-                .finish(),
-            Self::MemberLeft { name, age } => formatter
-                .debug_struct("MemberLeft")
-                .field("name", name)
-                .field("age", age)
-                .finish(),
-            Self::SectionSplit {
-                elders,
-                sibling_elders,
-                self_status_change,
-            } => formatter
-                .debug_struct("EldersChanged")
-                .field("elders", elders)
-                .field("sibling_elders", sibling_elders)
-                .field("self_status_change", self_status_change)
-                .finish(),
-            Self::EldersChanged {
-                elders,
-                self_status_change,
-            } => formatter
-                .debug_struct("EldersChanged")
-                .field("elders", elders)
-                .field("self_status_change", self_status_change)
-                .finish(),
-            Self::RelocationStarted { previous_name } => formatter
-                .debug_struct("RelocationStarted")
-                .field("previous_name", previous_name)
-                .finish(),
-            Self::Relocated {
-                previous_name,
-                new_keypair,
-            } => formatter
-                .debug_struct("Relocated")
-                .field("previous_name", previous_name)
-                .field("new_keypair", new_keypair)
-                .finish(),
-            Self::DataMsgReceived {
-                msg_id, msg, user, ..
-            } => write!(
-                formatter,
-                "DataMsgReceived {{ msg_id: {}, msg: {:?}, src: {:?} }}",
-                msg_id, msg, user,
-            ),
-            Self::AdultsChanged {
-                remaining,
-                added,
-                removed,
-            } => formatter
-                .debug_struct("AdultsChanged")
-                .field("remaining", remaining)
-                .field("added", added)
-                .field("removed", removed)
-                .finish(),
-        }
-    }
 }
 
 /// Type of messages that are received from a peer

--- a/src/routing/routing_api/event_stream.rs
+++ b/src/routing/routing_api/event_stream.rs
@@ -7,9 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Event;
-use std::fmt::{self, Debug, Formatter};
 use tokio::sync::mpsc;
+
 /// Stream of routing node events
+#[allow(missing_debug_implementations)]
 pub struct EventStream {
     events_rx: mpsc::Receiver<Event>,
 }
@@ -22,11 +23,5 @@ impl EventStream {
     /// Returns next event
     pub async fn next(&mut self) -> Option<Event> {
         self.events_rx.recv().await
-    }
-}
-
-impl Debug for EventStream {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "EventStream")
     }
 }

--- a/src/routing/routing_api/mod.rs
+++ b/src/routing/routing_api/mod.rs
@@ -41,12 +41,7 @@ use crate::routing::{
 use ed25519_dalek::{PublicKey, Signature, Signer, KEYPAIR_LENGTH};
 use itertools::Itertools;
 use secured_linked_list::SecuredLinkedList;
-use std::{
-    collections::BTreeSet,
-    fmt::{self, Debug, Formatter},
-    net::SocketAddr,
-    sync::Arc,
-};
+use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
 use tokio::{sync::mpsc, task};
 use xor_name::{Prefix, XorName};
 
@@ -57,6 +52,7 @@ use xor_name::{Prefix, XorName};
 /// location. Its methods can be used to send requests and responses as either an individual
 /// `Node` or as a part of a section or group location. Their `src` argument indicates that
 /// role, and can be `crate::messaging::SrcLocation::Node` or `crate::messaging::SrcLocation::Section`.
+#[allow(missing_debug_implementations)]
 pub struct Routing {
     dispatcher: Arc<Dispatcher>,
 }
@@ -431,12 +427,6 @@ impl Routing {
 impl Drop for Routing {
     fn drop(&mut self) {
         futures::executor::block_on(self.dispatcher.terminate());
-    }
-}
-
-impl Debug for Routing {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Routing")
     }
 }
 

--- a/src/routing/section/section_keys.rs
+++ b/src/routing/section/section_keys.rs
@@ -7,30 +7,18 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::routing::error::{Error, Result};
-use std::{
-    collections::{HashMap, VecDeque},
-    fmt::{self, Debug, Formatter},
-};
+use std::collections::{HashMap, VecDeque};
 
 /// All the key material needed to sign or combine signature for our section key.
+#[derive(custom_debug::Debug)]
 pub(crate) struct SectionKeyShare {
     /// Public key set to verify threshold signatures and combine shares.
     pub(crate) public_key_set: bls::PublicKeySet,
     /// Index of the owner of this key share within the set of all section elders.
     pub(crate) index: usize,
     /// Secret Key share.
+    #[debug(skip)]
     pub(crate) secret_key_share: bls::SecretKeyShare,
-}
-
-impl Debug for SectionKeyShare {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "SectionKeyShare {{ public_key: {:?}, index: {}, .. }}",
-            self.public_key_set.public_key(),
-            self.index
-        )
-    }
 }
 
 /// Struct that holds the current section keys and helps with new key generation.

--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -10,22 +10,20 @@
 use super::{utils, Error, PublicKey, XorName};
 use bincode::serialized_size;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::{
-    fmt::{self, Debug, Formatter},
-    u64,
-};
+use std::u64;
 
 /// Maximum allowed size for a serialised Chunk to grow to.
 pub const MAX_CHUNK_SIZE_IN_BYTES: u64 = 1024 * 1024 + 10 * 1024;
 
 /// Private Chunk: an immutable chunk of data which can be deleted. Can only be fetched
 /// by the listed owner.
-#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone)]
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, custom_debug::Debug)]
 pub struct PrivateChunk {
     /// Network address. Omitted when serialising and calculated from the `value` and `owner` when
     /// deserialising.
     address: Address,
     /// Contained chunk.
+    #[debug(skip)]
     value: Vec<u8>,
     /// Contains a set of owners of this chunk.
     owner: PublicKey,
@@ -97,20 +95,14 @@ impl<'de> Deserialize<'de> for PrivateChunk {
     }
 }
 
-impl Debug for PrivateChunk {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        // TODO: Output owners?
-        write!(formatter, "PrivateChunk {:?}", self.name())
-    }
-}
-
 /// Public Chunk: an immutable chunk of data which cannot be deleted.
-#[derive(Hash, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Hash, Clone, Eq, PartialEq, Ord, PartialOrd, custom_debug::Debug)]
 pub struct PublicChunk {
     /// Network address. Omitted when serialising and calculated from the `value` when
     /// deserialising.
     address: Address,
     /// Contained chunk.
+    #[debug(skip)]
     value: Vec<u8>,
 }
 
@@ -164,12 +156,6 @@ impl<'de> Deserialize<'de> for PublicChunk {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let value: Vec<u8> = Deserialize::deserialize(deserializer)?;
         Ok(PublicChunk::new(value))
-    }
-}
-
-impl Debug for PublicChunk {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "PublicChunk {:?}", self.name())
     }
 }
 

--- a/src/types/keys/public_key.rs
+++ b/src/types/keys/public_key.rs
@@ -16,6 +16,7 @@
 use super::super::{utils, Error, Result};
 use super::super::{Keypair, Signature};
 
+use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
 use signature::Verifier;
 use std::{
@@ -28,10 +29,10 @@ use std::{
 use xor_name::{XorName, XOR_NAME_LEN};
 
 /// Wrapper for different public key types.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 pub enum PublicKey {
     /// Ed25519 public key.
-    Ed25519(ed25519_dalek::PublicKey),
+    Ed25519(#[debug(with = "Self::fmt_ed25519")] ed25519_dalek::PublicKey),
     /// BLS public key.
     Bls(bls::PublicKey),
     /// BLS public key share.
@@ -150,6 +151,11 @@ impl PublicKey {
     /// Creates from z-base-32 encoded string.
     pub fn decode_from_zbase32<I: AsRef<str>>(encoded: I) -> Result<Self> {
         utils::decode(encoded)
+    }
+
+    // ed25519_dalek::PublicKey has overly verbose debug output, so we provide our own
+    pub(crate) fn fmt_ed25519(pk: &ed25519_dalek::PublicKey, f: &mut Formatter) -> fmt::Result {
+        write!(f, "PublicKey({:0.10})", HexFmt(pk.as_bytes()))
     }
 }
 

--- a/src/types/keys/public_key.rs
+++ b/src/types/keys/public_key.rs
@@ -28,7 +28,7 @@ use std::{
 use xor_name::{XorName, XOR_NAME_LEN};
 
 /// Wrapper for different public key types.
-#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PublicKey {
     /// Ed25519 public key.
     Ed25519(ed25519_dalek::PublicKey),
@@ -210,31 +210,6 @@ impl From<bls::PublicKeyShare> for PublicKey {
 impl From<&Keypair> for PublicKey {
     fn from(keypair: &Keypair) -> Self {
         keypair.public_key()
-    }
-}
-
-impl Debug for PublicKey {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "PublicKey::")?;
-        match self {
-            Self::Ed25519(pub_key) => {
-                write!(
-                    formatter,
-                    "Ed25519({:<8})",
-                    hex::encode(&pub_key.to_bytes())
-                )
-            }
-            Self::Bls(pub_key) => write!(
-                formatter,
-                "Bls({:<8})",
-                hex::encode(&pub_key.to_bytes()[..XOR_NAME_LEN])
-            ),
-            Self::BlsShare(pub_key) => write!(
-                formatter,
-                "BlsShare({:<8})",
-                hex::encode(&pub_key.to_bytes()[..XOR_NAME_LEN])
-            ),
-        }
     }
 }
 

--- a/src/types/keys/signature.rs
+++ b/src/types/keys/signature.rs
@@ -15,8 +15,12 @@
 
 use super::super::utils;
 
+use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
-use std::hash::{Hash, Hasher};
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+};
 
 /// A signature share, with its index in the combined collection.
 #[derive(Clone, Hash, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
@@ -28,10 +32,11 @@ pub struct SignatureShare {
 }
 
 /// Wrapper for different signature types.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum Signature {
     /// Ed25519 signature.
+    #[debug(with = "Self::fmt_ed25519")]
     Ed25519(ed25519_dalek::Signature),
     /// BLS signature.
     Bls(bls::Signature),
@@ -54,6 +59,14 @@ impl Signature {
             Self::Ed25519(sig) => Some(sig),
             _ => None,
         }
+    }
+
+    // ed25519_dalek::Signature has overly verbose debug output, so we provide our own
+    pub(crate) fn fmt_ed25519(
+        sig: &ed25519_dalek::Signature,
+        f: &mut fmt::Formatter,
+    ) -> fmt::Result {
+        write!(f, "Signature({:0.10})", HexFmt(sig))
     }
 }
 

--- a/src/types/keys/signature.rs
+++ b/src/types/keys/signature.rs
@@ -16,10 +16,7 @@
 use super::super::utils;
 
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{self, Debug, Formatter},
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
 
 /// A signature share, with its index in the combined collection.
 #[derive(Clone, Hash, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
@@ -31,7 +28,7 @@ pub struct SignatureShare {
 }
 
 /// Wrapper for different signature types.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum Signature {
     /// Ed25519 signature.
@@ -89,16 +86,5 @@ impl From<(usize, bls::SignatureShare)> for Signature {
 impl Hash for Signature {
     fn hash<H: Hasher>(&self, state: &mut H) {
         utils::serialise(&self).hash(state)
-    }
-}
-
-impl Debug for Signature {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "Signature::")?;
-        match self {
-            Self::Ed25519(_) => write!(formatter, "Ed25519(..)"),
-            Self::Bls(_) => write!(formatter, "Bls(..)"),
-            Self::BlsShare(_) => write!(formatter, "BlsShare(..)"),
-        }
     }
 }

--- a/src/types/map.rs
+++ b/src/types/map.rs
@@ -19,14 +19,13 @@ use super::{utils, Error, PublicKey, Result};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{btree_map::Entry, BTreeMap, BTreeSet},
-    fmt::{self, Debug, Formatter},
     mem,
 };
 use xor_name::XorName;
 
 /// Map that is unpublished on the network. This data can only be fetched by the owner or
 /// those in the permissions fields with `Permission::Read` access.
-#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+#[derive(Debug, Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 pub struct Map {
     /// Network address.
     address: Address,
@@ -42,25 +41,13 @@ pub struct Map {
     owner: PublicKey,
 }
 
-impl Debug for Map {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "Map {:?}", self.name())
-    }
-}
-
 /// A value in a Map.
-#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+#[derive(Debug, Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 pub struct Value {
     /// Pointer.
     pub pointer: XorName,
     /// Version, incremented sequentially for any change to `data`.
     pub version: u64,
-}
-
-impl Debug for Value {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{:<8} :: {}", hex::encode(&self.pointer), self.version)
-    }
 }
 
 /// Wrapper type for lists of values.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -56,7 +56,6 @@ pub use token::Token;
 
 use register::Register;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 use xor_name::XorName;
 
 /// Object storing a data variant.

--- a/src/types/register/metadata.rs
+++ b/src/types/register/metadata.rs
@@ -9,7 +9,7 @@
 
 use super::super::{utils, Result, XorName};
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, hash::Hash};
+use std::hash::Hash;
 
 /// An action on Register data type.
 #[derive(Clone, Debug, Copy, Eq, PartialEq)]

--- a/src/types/register/mod.rs
+++ b/src/types/register/mod.rs
@@ -21,28 +21,12 @@ use reg_crdt::{CrdtOperation, RegisterCrdt};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fmt::{self, Debug, Formatter},
     hash::Hash,
 };
 use xor_name::XorName;
 
 /// Register mutation operation to apply to Register.
 pub type RegisterOp<T> = CrdtOperation<T>;
-
-impl Debug for RegisterCrdt {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "{} Register {:?}",
-            if self.address().is_public() {
-                "Public"
-            } else {
-                "Private"
-            },
-            self.address().name()
-        )
-    }
-}
 
 /// Object storing the Register
 #[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize, Debug)]

--- a/src/types/register/policy.rs
+++ b/src/types/register/policy.rs
@@ -10,7 +10,7 @@
 use super::super::{Error, PublicKey, Result};
 use super::Action;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt::Debug, hash::Hash};
+use std::{collections::BTreeMap, hash::Hash};
 
 /// Wrapper type for permissions, which can be public or private.
 #[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]

--- a/src/types/register/reg_crdt.rs
+++ b/src/types/register/reg_crdt.rs
@@ -37,7 +37,7 @@ pub struct CrdtOperation<T> {
 }
 
 /// Register data type as a CRDT with Access Control
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd)]
 pub(super) struct RegisterCrdt {
     /// Address on the network of this piece of data
     address: Address,

--- a/src/types/sequence/metadata.rs
+++ b/src/types/sequence/metadata.rs
@@ -9,7 +9,7 @@
 
 use super::super::{utils, Error, PublicKey, Result, XorName};
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt::Debug, hash::Hash};
+use std::{collections::BTreeMap, hash::Hash};
 
 /// An action on Sequence data type.
 #[derive(Clone, Debug, Copy, Eq, PartialEq)]

--- a/src/types/sequence/mod.rs
+++ b/src/types/sequence/mod.rs
@@ -18,7 +18,7 @@ use metadata::{
 use seq_crdt::{CrdtOperation, SequenceCrdt};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::{fmt::Debug, hash::Hash};
+use std::hash::Hash;
 use xor_name::XorName;
 
 // Type of data used for the 'Actor' in CRDT vector clocks

--- a/src/types/token.rs
+++ b/src/types/token.rs
@@ -10,7 +10,7 @@
 use super::errors::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::{
-    fmt::{self, Debug, Display, Formatter},
+    fmt::{self, Display, Formatter},
     str::FromStr,
 };
 
@@ -20,7 +20,7 @@ const TOKEN_TO_RAW_POWER_OF_10_CONVERSION: u32 = 9;
 /// The conversion from Token to raw value
 const TOKEN_TO_RAW_CONVERSION: u64 = 1_000_000_000;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 /// Structure representing a Token amount.
 pub struct Token(u64);
 
@@ -85,12 +85,6 @@ impl FromStr for Token {
         };
 
         Ok(Self::from_nano(converted_units + remainder))
-    }
-}
-
-impl Debug for Token {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        Display::fmt(self, formatter)
     }
 }
 


### PR DESCRIPTION
- cb0d94b80 **chore: Remove hand-written `Debug` impls**

  In almost every case, our hand-written `Debug` impls existed exclusively
  to skip/reformat sensitive/overly verbose fields. Recently we added the
  `custom_debug` crate to our dependencies, which allows us to make these
  tweaks as annotations in the type definition, which is a massive
  reduction in boilerplate.
  
  Additionally, this commit takes the somewhat stronger stance that we
  should prefer not to customise `Debug` output, except for security
  reasons (e.g. don't show private keys) or *extremely* verbose fields
  (such as payload or chunk bytes). This is on the basis that, if you are
  looking at a type's `Debug` output, you probably want more information,
  rather than less.
  
  This will probably mean significantly more verbose `Debug` output, which
  is likely to have a detrimental impact on logging clarity. Follow-up
  commits will seek to tackle this with the following interventions:
  
  - Be more specific about what to log. E.g., rather than logging an
    entire `Map` struct, just log its address if that's what we care
    about. The idea here is to handle verbosity at the call-site, rather
    than globally reducing verbosity for the type.
  - Otherwise, apply verbosity reductions as 'far out' as possible. This
    is likely to affect messaging enums, for example, which sometimes
    contain fairly nested structure which could wind up being particularly
    verbose. Again, the principle would be to make the messaging enum
    responsible for setting its desired verbosity, rather than 'infecting'
    all of its members with those concerns.
  
  In both cases, we should be able to achieve a satisfactory level of
  verbosity using `custom_debug`, perhaps with the addition of a couple of
  formatting helpers, so we would ideally still have very few hand-written
  `Debug` impls.

- 7fbfcaddb **chore: Use abbreviated `Debug` format for byte arrays**

  The default `Debug` output for byte arrays is not very readable. The new
  impl uses `HexFmt` to print an abbreviated hexadecimal format.

- fd0e94b31 **chore(types): Short `Debug` output for `{PublicKey,Signature}::Ed25519`**

  `ed25519_dalek` uses the default derived `Debug` output, which is very
  verbose for these types as they contain large byte arrays. It's also
  inconsistent with the other variants, from `blsttc`, which use an
  abbreviated slice of the byte representation. `custom_debug` has been
  used to apply the abbreviated format to the `Ed25519` variants.

- eb15cbac9 **chore: Update blsttc to get new `Debug` impl for `PublicKeySet`**

  This brings down the verbosity of the `Debug` output for types
  containing `PublicKeySet`.

- 221c2b6fd **chore: Exclude verbose fields from `Debug` impls**

  Fields that are byte arrays or other large, opaque types are not very
  useful in `Debug` output and create a lot of clutter. We can skip the
  with `custom_debug`.

- 4e513491c **chore(messaging): Simplify `Debug` format for `NodeMsg::Sync`**

  The `Section` and `Network` types are very large, so their `Debug`
  output is quite verbose. This is not great when we're logging messages
  going through the network. The new format is based on the one removed
  previously.
