### PR TITLE
Fixmes

### DIFF
--- a/src/client/client_api/blob_apis.rs
+++ b/src/client/client_api/blob_apis.rs
@@ -150,7 +150,7 @@ impl Client {
         &self,
         address: ChunkAddress,
     ) -> Result<(), Error> {
-        let cmd = DataCmd::Blob(ChunkWrite::DeletePrivate(address));
+        let cmd = DataCmd::Chunk(ChunkWrite::DeletePrivate(address));
         self.pay_and_send_data_command(cmd).await?;
 
         Ok(())
@@ -163,7 +163,7 @@ impl Client {
         if !chunk.validate_size() {
             return Err(Error::NetworkDataError(crate::types::Error::ExceededSize));
         }
-        let cmd = DataCmd::Blob(ChunkWrite::New(chunk));
+        let cmd = DataCmd::Chunk(ChunkWrite::New(chunk));
         self.pay_and_send_data_command(cmd).await?;
         Ok(())
     }

--- a/src/client/connections/listeners.rs
+++ b/src/client/connections/listeners.rs
@@ -70,7 +70,6 @@ impl Session {
                             warn!("Processing error received. {:?}", error);
                             // TODO: Handle lazy message errors
                         }
-                        msg => warn!("SupportingInfo received: {:?}", msg),
                     }
                 }
                 msg_type => {

--- a/src/client/connections/listeners.rs
+++ b/src/client/connections/listeners.rs
@@ -217,14 +217,6 @@ impl Session {
                         trace!("No channel found for {:?}", correlation_id);
                     }
                 }
-                ProcessMsg::Event {
-                    event,
-                    correlation_id,
-                    ..
-                } => {
-                    debug!("Event received to be processed: {:?}", correlation_id);
-                    trace!("Event received is: {:?}", event);
-                }
                 ProcessMsg::CmdError {
                     error,
                     correlation_id,

--- a/src/messaging/data/cmd.rs
+++ b/src/messaging/data/cmd.rs
@@ -27,8 +27,7 @@ pub enum DataCmd {
     /// [`Chunk`] write operation.
     ///
     /// [`Chunk`]: crate::types::Chunk
-    // FIXME: Rename `Blob` -> `Chunk`
-    Blob(ChunkWrite),
+    Chunk(ChunkWrite),
     /// [`Map`] write operation.
     ///
     /// [`Map`]: crate::types::Map
@@ -49,7 +48,7 @@ impl DataCmd {
     pub fn error(&self, error: Error) -> CmdError {
         use DataCmd::*;
         match self {
-            Blob(c) => c.error(error),
+            Chunk(c) => c.error(error),
             Map(c) => c.error(error),
             Sequence(c) => c.error(error),
             Register(c) => c.error(error),
@@ -60,7 +59,7 @@ impl DataCmd {
     pub fn dst_address(&self) -> XorName {
         use DataCmd::*;
         match self {
-            Blob(c) => c.dst_address(),
+            Chunk(c) => c.dst_address(),
             Map(c) => c.dst_address(),
             Sequence(c) => c.dst_address(),
             Register(c) => c.dst_address(),
@@ -70,7 +69,7 @@ impl DataCmd {
     /// Returns the owner of the data.
     pub fn owner(&self) -> Option<PublicKey> {
         match self {
-            Self::Blob(write) => write.owner(),
+            Self::Chunk(write) => write.owner(),
             Self::Map(write) => write.owner(),
             Self::Sequence(write) => write.owner(),
             Self::Register(write) => write.owner(),

--- a/src/messaging/data/errors.rs
+++ b/src/messaging/data/errors.rs
@@ -20,32 +20,12 @@ pub type Result<T, E = Error> = result::Result<T, E>;
 #[non_exhaustive]
 #[allow(clippy::large_enum_variant)]
 pub enum Error {
-    /// Message read was built with an unsupported version.
-    // FIXME: unused
-    #[error("Unsupported messaging protocol version: {0}")]
-    UnsupportedVersion(u16),
-    /// Message read contains a payload with an unsupported serialization type.
-    // FIXME: unused
-    #[error("Unsupported payload serialization: {0}")]
-    UnsupportedSerialization(u16),
     /// Access denied for supplied PublicKey
     #[error("Access denied for PublicKey: {0}")]
     AccessDenied(PublicKey),
-    /// Error occurred when atempting to verify signature
-    // FIXME: unused
-    #[error("Signature verification error: {0}")]
-    SignatureVerification(String),
-    /// Serialization error
-    // FIXME: unused
-    #[error("Serialization error: {0}")]
-    Serialization(String),
     /// Requested data not found
     #[error("Requested data not found: {0:?}")]
     DataNotFound(DataAddress),
-    /// No history found for PublicKey
-    // FIXME: unused
-    #[error("No history found for PublicKey: {0}")]
-    NoHistoryForPublicKey(PublicKey),
     /// Failed to write file, likely due to a system Io error
     #[error("Failed to write file")]
     FailedToWriteFile,
@@ -55,142 +35,16 @@ pub enum Error {
     /// Entry could not be found on the data
     #[error("Requested entry not found")]
     NoSuchEntry,
-    /// Exceeds limit on entrites for the given data type
-    // FIXME: unused
-    #[error("Exceeded a limit on a number of entries")]
-    TooManyEntries,
     /// Key does not exist
     #[error("Key does not exist")]
     NoSuchKey,
-    /// Duplicate Entries in this push
-    // FIXME: unused
-    #[error("Duplicate entries provided")]
-    DuplicateEntryKeys,
     /// The list of owner keys is invalid
     #[error("Invalid owner key: {0}")]
     InvalidOwners(PublicKey),
-    /// No Policy has been set to the data
-    // FIXME: unused
-    #[error("No policy has been set for this data")]
-    PolicyNotSet,
-    /// Invalid version for performing a given mutating operation. Contains the
-    /// current data version.
-    // FIXME: unused
-    #[error("Invalid version provided: {0}")]
-    InvalidSuccessor(u64),
-    /// Invalid version for performing a given mutating operation. Contains the
-    /// current owners version.
-    // FIXME: unused
-    #[error("Invalid owners version provided: {0}")]
-    InvalidOwnersSuccessor(u64),
-    /// Invalid mutating operation as it causality dependency is currently not satisfied
-    // FIXME: unused
-    #[error("Operation is not causally ready. Ensure you have the full history of operations.")]
-    OpNotCausallyReady,
-    /// Invalid version for performing a given mutating operation. Contains the
-    /// current permissions version.
-    // FIXME: unused
-    #[error("Invalid permission version provided: {0}")]
-    InvalidPermissionsSuccessor(u64),
     /// Invalid Operation such as a POST on ImmutableData
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
-    /// Mismatch between key type and signature type.
-    // FIXME: unused
-    #[error("Sign key and signature type do not match")]
-    SigningKeyTypeMismatch,
-    /// Failed signature validation.
-    // FIXME: unused
-    #[error("Invalid signature")]
-    InvalidSignature,
-    /// Received a request with a duplicate MessageId
-    // FIXME: unused
-    #[error("Duplicate message id received")]
-    DuplicateMessageId,
-    // /// Network error occurring at Node level which has no bearing on clients, e.g. serialisation
-    // /// failure or database failure
-    // #[error("Network error: {0}")]
-    // NetworkOther(String),
-    /// While parsing, precision would be lost.
-    // FIXME: unused
-    #[error("Lost precision on the number of coins during parsing")]
-    LossOfPrecision,
-    /// The amount would exceed the maximum value for `Token` (u64::MAX).
-    // FIXME: unused
-    #[error("The token amount would exceed the maximum value (u64::MAX)")]
-    ExcessiveValue,
-    /// Transaction ID already exists.
-    // FIXME: unused
-    #[error("Transaction Id already exists")]
-    TransactionIdExists,
-    /// Transfer hsitory missing, operation out of order. <received, expected>
-    // FIXME: unused
-    #[error("Transfer received out of order. Requested transfer operation index was {0}, but {1} was expected" )]
-    MissingTransferHistory(u64, u64),
-    /// Insufficient tokens provided to pay for this operation.
-    // FIXME: unused
-    #[error("Insufficient payment provided to complete this operation")]
-    InsufficientPayment,
-    /// Inexistent balance.
-    // TODO: key/wallet/balance, what's our vocab here?
-    // FIXME: unused
-    #[error("No such key exists")]
-    NoSuchBalance,
-    /// Inexistent sender balance.
-    // FIXME: unused
-    #[error("No such sender key balance")]
-    NoSuchSender,
-    /// Inexistent recipient balance.
-    // TODO: this should not be possible
-    // FIXME: unused
-    #[error("No such recipient key balance")]
-    NoSuchRecipient,
-    /// Coin balance already exists.
-    // FIXME: unused
-    #[error("Key already exists")]
-    BalanceExists,
-    /// Expected data size exceeded.
-    // FIXME: unused
-    #[error("Size of the structure exceeds the limit")]
-    ExceededSize,
-    /// The operation has not been signed by an actor PK and so cannot be validated.
-    // FIXME: unused
-    #[error("CRDT operation missing actor signature")]
-    CrdtMissingOpSignature,
-    /// The data for a given policy could not be located, so CRDT operations cannot be applied.
-    // FIXME: unused
-    #[error("CRDT data is in an unexpected and/or inconsistent state. No data found for current policy.")]
-    CrdtUnexpectedState,
-    /// Entry already exists. Contains the current entry Key.
-    // FIXME: unused
-    #[error("Entry already exists {0}")]
-    EntryExists(u8),
-    /// Problem registering the payment at a node
-    // FIXME: unused
-    #[error("Payment registration failed")]
-    PaymentFailed,
     /// Node failed to delete the requested data for some reason.
-    // FIXME: unused
     #[error("Failed to delete requested data")]
     FailedToDelete,
-    /// Node does not manage any section funds.
-    // FIXME: unused
-    #[error("Node does not currently manage any section funds")]
-    NoSectionFunds,
-    /// Node does not manage any metadata, so is likely not a fully prepared elder yet.
-    // FIXME: unused
-    #[error("Node does not currently manage any section metadata")]
-    NoSectionMetaData,
-    /// Node does not manage any immutable chunks.
-    // FIXME: unused
-    #[error("Node does not currently manage any immutable chunks")]
-    NoImmutableChunks,
-    /// Node is currently churning so cannot perform the request.
-    // FIXME: unused
-    #[error("Cannot complete request due to churning of funds")]
-    NodeChurningFunds,
-    /// The node hasn't left the section, and was not marked for relocation during reward operations
-    // FIXME: unused
-    #[error("Node is not being relocated")]
-    NodeWasNotRelocated,
 }

--- a/src/messaging/data/mod.rs
+++ b/src/messaging/data/mod.rs
@@ -55,37 +55,7 @@ pub enum DataMsg {
 
     /// A response indicating that the recipient was unable to process a client's message.
     ProcessingError(ProcessingError),
-
-    /// A response indicating that the recipient was unable to process a client's message due to out
-    /// of date information.
-    // FIXME: this cannot be constructed due to empty enum in `SupportingInfo`, so it is not being
-    // used.
-    SupportingInfo(SupportingInfo),
 }
-
-/// A response indicating that the recipient was unable to process a client's message due to out
-/// of date information.
-///
-/// This could be returned when a client sends an otherwise valid message containing outdated
-/// information. The response includes up to date information that can be used to re-send the
-/// request such that it should now be valid.
-// FIXME: updates the erroring **node**? Is this not a client message? Is it something that clients
-// would send?
-// FIXME: this cannot be constructed due to empty `SupportingInfoFor` enum field.
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub struct SupportingInfo {
-    /// Supporting information for the `source_message`.
-    pub info: SupportingInfoFor,
-    /// The original message that triggered the error this update should correct.
-    pub source_message: ProcessMsg,
-    /// Correlates to a `ProcessingError`.
-    pub correlation_id: MessageId,
-}
-
-/// Various types of supporting information that can be received and acted upon by a node.
-// FIXME: this cannot be constructed as it is empty.
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub enum SupportingInfoFor {}
 
 /// A response indicating that the recipient was unable to process a client's message.
 #[allow(clippy::large_enum_variant)]

--- a/src/messaging/data/mod.rs
+++ b/src/messaging/data/mod.rs
@@ -87,14 +87,6 @@ pub enum ProcessMsg {
     /// reply.
     /// [`QueryResponse`]: Self::QueryResponse
     Query(DataQuery),
-    /// An Event is a fact about something that happened.
-    // FIXME: this is never constructed, so could perhaps be removed.
-    Event {
-        /// Request.
-        event: Event,
-        /// ID of causing cmd.
-        correlation_id: MessageId,
-    },
     /// The response to a query, containing the query result.
     QueryResponse {
         /// The result of the query.
@@ -124,11 +116,6 @@ pub enum CmdError {
     // FIXME: `Cmd` is not an enum, so should this be?
     Data(Error), // DataError enum for better differentiation?
 }
-
-/// Events from the network that are pushed to the client.
-// FIXME: this cannot be constructed as it is empty.
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub enum Event {}
 
 /// The response to a query, containing the query result.
 #[allow(clippy::large_enum_variant, clippy::type_complexity)]

--- a/src/node/config_handler.rs
+++ b/src/node/config_handler.rs
@@ -6,8 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#![allow(trivial_numeric_casts)] // FIXME
-                                 // beep
 use crate::node::{Error, Result};
 use crate::routing::TransportConfig as NetworkConfig;
 use serde::{Deserialize, Serialize};
@@ -49,7 +47,7 @@ pub struct Config {
     /// Verbose output. `-v` is equivalent to logging with `warn`, `-vv` to `info`, `-vvv` to
     /// `debug`, `-vvvv` to `trace`. This flag overrides RUST_LOG.
     #[structopt(short, long, parse(from_occurrences))]
-    pub verbose: u64,
+    pub verbose: u8,
     /// dump shell completions for: [bash, fish, zsh, powershell, elvish]
     #[structopt(long)]
     pub completions: Option<String>,
@@ -455,7 +453,7 @@ fn smoke() {
     // NOTE: IF this value is being changed due to a change in the config,
     // the change in config also be handled in Config::merge()
     // and in examples/config_handling.rs
-    let expected_size = 504;
+    let expected_size = 496;
 
     assert_eq!(std::mem::size_of::<Config>(), expected_size);
 }

--- a/src/node/event_mapping/client_msg.rs
+++ b/src/node/event_mapping/client_msg.rs
@@ -47,17 +47,6 @@ pub(super) fn map_client_msg(
                 ctx: None,
             }
         }
-        DataMsg::SupportingInfo(msg) => {
-            warn!(
-                "A node should never receive a DataMsg::SupportingInfo {:?}",
-                msg
-            );
-
-            Mapping {
-                op: NodeDuty::NoOp,
-                ctx: None,
-            }
-        }
     }
 }
 

--- a/src/node/metadata/elder_stores.rs
+++ b/src/node/metadata/elder_stores.rs
@@ -75,7 +75,7 @@ impl ElderStores {
     ) -> Result<NodeDuty> {
         info!("Writing Data");
         match cmd {
-            DataCmd::Blob(write) => {
+            DataCmd::Chunk(write) => {
                 info!("Writing Blob");
                 self.chunk_records
                     .write(write, msg_id, client_sig, origin)

--- a/src/node/node_api/handle.rs
+++ b/src/node/node_api/handle.rs
@@ -8,7 +8,7 @@
 
 use super::{
     interaction::push_state,
-    messaging::{send, send_error, send_support, send_to_nodes},
+    messaging::{send, send_error, send_to_nodes},
     role::{AdultRole, ElderRole, Role},
 };
 use crate::messaging::MessageId;
@@ -275,14 +275,6 @@ impl Node {
                 let network_api = self.network_api.clone();
                 let handle = tokio::spawn(async move {
                     send_error(msg, &network_api).await?;
-                    Ok(NodeTask::None)
-                });
-                Ok(NodeTask::Thread(handle))
-            }
-            NodeDuty::SendSupport(msg) => {
-                let network_api = self.network_api.clone();
-                let handle = tokio::spawn(async move {
-                    send_support(msg, &network_api).await?;
                     Ok(NodeTask::None)
                 });
                 Ok(NodeTask::Thread(handle))

--- a/src/node/node_api/messaging.rs
+++ b/src/node/node_api/messaging.rs
@@ -11,7 +11,7 @@ use crate::messaging::{
 };
 use crate::node::{
     network::Network,
-    node_ops::{MsgType, OutgoingLazyError, OutgoingMsg, OutgoingSupportingInfo},
+    node_ops::{MsgType, OutgoingLazyError, OutgoingMsg},
     Error, Result,
 };
 use crate::routing::XorName;
@@ -58,22 +58,6 @@ pub(crate) async fn send_error(msg: OutgoingLazyError, network: &Network) -> Res
     // perhaps it needs to carry Node signature on a NodeMsg::QueryResponse msg type.
     // Giving a random sig temporarily
     let (msg_kind, payload) = random_client_signature(&DataMsg::ProcessingError(msg.msg))?;
-
-    let wire_msg = WireMsg::new_msg(MessageId::new(), payload, msg_kind, msg.dst)?;
-
-    network
-        .send_message(wire_msg)
-        .await
-        .map_err(|err| err.into())
-}
-
-// TODO: Refactor over support/error
-pub(crate) async fn send_support(msg: OutgoingSupportingInfo, network: &Network) -> Result<()> {
-    trace!("Sending support msg: {:?}", msg);
-    // FIXME: define which signature/authority this message should really carry,
-    // perhaps it needs to carry Node signature on a NodeMsg::QueryResponse msg type.
-    // Giving a random sig temporarily
-    let (msg_kind, payload) = random_client_signature(&DataMsg::SupportingInfo(msg.msg))?;
 
     let wire_msg = WireMsg::new_msg(MessageId::new(), payload, msg_kind, msg.dst)?;
 

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -9,7 +9,7 @@
 use crate::messaging::{
     data::{
         ChunkRead, ChunkWrite, DataCmd, DataExchange, DataMsg, DataQuery, ProcessingError,
-        QueryResponse, SupportingInfo,
+        QueryResponse,
     },
     node::NodeMsg,
     ClientSigned, DstLocation, EndUser, MessageId, SrcLocation,
@@ -125,9 +125,6 @@ pub enum NodeDuty {
     /// Send a lazy error as a result of a specific message.
     /// The aim here is for the sender to respond with any missing state
     SendError(OutgoingLazyError),
-    /// Send supporting info for a given processing error.
-    /// This should be any missing state required to proceed at the erring node.
-    SendSupport(OutgoingSupportingInfo),
     /// Send the same request to each individual node.
     SendToNodes {
         msg_id: MessageId,
@@ -190,11 +187,5 @@ pub enum MsgType {
 #[derive(Debug, Clone)]
 pub struct OutgoingLazyError {
     pub msg: ProcessingError,
-    pub dst: DstLocation,
-}
-
-#[derive(Debug, Clone)]
-pub struct OutgoingSupportingInfo {
-    pub msg: SupportingInfo,
     pub dst: DstLocation,
 }


### PR DESCRIPTION
- a2639c707 **chore(messaging): Remove all unused `data::Error` variants**

  The `data::Error` enum has many unused variants. Some may have been used
  for transfers, which have been ripped out for now. It's probably safer
  to do this than to leave them, since they add bloat and may
  inadvertently influence the addition of new variants in future.

- 87cccf094 **chore: Remove unused `DataMsg::SupportingInfo`**

  This variant contained a struct which itself contains an empty enum.
  Empty enums cannot be constructed or matched, so the entire variant is
  redundant. This cascades to the logic for handling and sending those
  messages, which are also non-functional.

- 696d0c32e **chore(messaging): Remove empty `data::Event` enum**

  Empty enums cannot be constructed, so we can remove this and all of its
  references.

- 02f1caab3 **chore(node): Resolve `trivial_numeric_cast` lint**

  This was marked `FIXME` - rather than suppressing the lint we just use a
  smaller sized integer for verbosity (we probably don't need more than
  256 levels...).

- 383e1cdcd **chore: Rename `messaging::data::DataCmd::{Blob,Chunk}`**

  "Blob" was mostly renamed to "chunk" in 0249c7d, however this was
  missed. It seems the same logic from that commit applied here (the
  messages always pertain to a single chunk, rather than a 'blob' of many
  chunks).
