### PR TITLE
refactor(messaging): Move `*Signed` types into an `authority` module

### DIFF
--- a/src/messaging/authority.rs
+++ b/src/messaging/authority.rs
@@ -1,0 +1,49 @@
+use super::node::{KeyedSig, SigShare};
+use crate::types::{PublicKey, Signature};
+use bls::PublicKey as BlsPublicKey;
+use ed25519_dalek::{PublicKey as EdPublicKey, Signature as EdSignature};
+use xor_name::XorName;
+
+/// Authority of a client
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct ClientSigned {
+    /// Client public key.
+    pub public_key: PublicKey,
+    /// Client signature.
+    pub signature: Signature,
+}
+
+/// Authority of a single peer.
+#[derive(Clone, Eq, PartialEq, custom_debug::Debug, serde::Deserialize, serde::Serialize)]
+pub struct NodeSigned {
+    /// Section key of the source.
+    pub section_pk: BlsPublicKey,
+    /// Public key of the source peer.
+    #[debug(with = "PublicKey::fmt_ed25519")]
+    pub public_key: EdPublicKey,
+    /// Ed25519 signature of the message corresponding to the public key of the source peer.
+    #[debug(with = "Signature::fmt_ed25519")]
+    pub signature: EdSignature,
+}
+
+/// Authority of a single peer that uses it's BLS Keyshare to sign the message.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct BlsShareSigned {
+    /// Section key of the source.
+    pub section_pk: BlsPublicKey,
+    /// Name in the source section.
+    pub src_name: XorName,
+    /// Proof Share signed by the peer's BLS KeyShare.
+    pub sig_share: SigShare,
+}
+
+/// Authority of a whole section.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct SectionSigned {
+    /// Section key of the source.
+    pub section_pk: BlsPublicKey,
+    /// Name in the source section.
+    pub src_name: XorName,
+    /// BLS proof of the message corresponding to the source section.
+    pub sig: KeyedSig,
+}

--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -27,6 +27,8 @@ pub mod section_info;
 /// The wire format and message (de)serialization API.
 pub mod serialisation;
 
+// Message authority - keys and signatures.
+mod authority;
 // Error types definitions
 mod errors;
 // Source and destination structs for messages
@@ -39,10 +41,11 @@ mod msg_kind;
 mod sap;
 
 pub use self::{
+    authority::{BlsShareSigned, ClientSigned, NodeSigned, SectionSigned},
     errors::{Error, Result},
     location::{DstLocation, EndUser, SocketId, SrcLocation},
     msg_id::{MessageId, MESSAGE_ID_LEN},
-    msg_kind::{BlsShareSigned, ClientSigned, MsgKind, NodeSigned, SectionSigned},
+    msg_kind::MsgKind,
     sap::SectionAuthorityProvider,
     serialisation::{MessageType, NodeMsgAuthority, WireMsg},
 };

--- a/src/messaging/msg_kind.rs
+++ b/src/messaging/msg_kind.rs
@@ -6,12 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::node::{KeyedSig, SigShare};
-use crate::types::{PublicKey, Signature};
-use bls::PublicKey as BlsPublicKey;
-use ed25519_dalek::{PublicKey as EdPublicKey, Signature as EdSignature};
+use super::{BlsShareSigned, ClientSigned, NodeSigned, SectionSigned};
 use serde::{Deserialize, Serialize};
-use xor_name::XorName;
 
 /// Source authority of a message.
 ///
@@ -50,48 +46,4 @@ pub enum MsgKind {
     /// A message from an Elder node with authority of its whole section.
     // FIXME: find an example.
     SectionSignedMsg(SectionSigned),
-}
-
-/// Authority of a client
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ClientSigned {
-    /// Client public key.
-    pub public_key: PublicKey,
-    /// Client signature.
-    pub signature: Signature,
-}
-
-/// Authority of a single peer.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
-pub struct NodeSigned {
-    /// Section key of the source.
-    pub section_pk: BlsPublicKey,
-    /// Public key of the source peer.
-    #[debug(with = "PublicKey::fmt_ed25519")]
-    pub public_key: EdPublicKey,
-    /// Ed25519 signature of the message corresponding to the public key of the source peer.
-    #[debug(with = "Signature::fmt_ed25519")]
-    pub signature: EdSignature,
-}
-
-/// Authority of a single peer that uses it's BLS Keyshare to sign the message.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct BlsShareSigned {
-    /// Section key of the source.
-    pub section_pk: BlsPublicKey,
-    /// Name in the source section.
-    pub src_name: XorName,
-    /// Proof Share signed by the peer's BLS KeyShare.
-    pub sig_share: SigShare,
-}
-
-/// Authority of a whole section.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct SectionSigned {
-    /// Section key of the source.
-    pub section_pk: BlsPublicKey,
-    /// Name in the source section.
-    pub src_name: XorName,
-    /// BLS proof of the message corresponding to the source section.
-    pub sig: KeyedSig,
 }


### PR DESCRIPTION
- 54356df4b **refactor(messaging): Move `*Signed` types into an `authority` module**

  This sets up the contained structures for more general use that within
  `MsgKind`.
