### PR TITLE
fix: improved retry loop with max iterations

### DIFF
--- a/src/client/utils/test_utils/mod.rs
+++ b/src/client/utils/test_utils/mod.rs
@@ -108,7 +108,7 @@ macro_rules! retry_loop {
                 Ok(val) => break val,
                 Err(_) if retries > 0 => {
                     retries -= 1;
-                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                    tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
                 }
                 Err(e) => anyhow::bail!("Failed after {} retries: {:?}", $n, e),
             }


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

This is an attempt to fix the hanging tests that use the `retry_loop!` macro which loops indefinitely, making tests hang and hiding the repeating error.
This is my proposal for a fix: it retries a given number of times (defaults to 10 if n is not provided) and `bail`s after retrying those n times.