### PR TITLE
Client authority by construction

### DIFF
--- a/src/messaging/errors.rs
+++ b/src/messaging/errors.rs
@@ -29,6 +29,13 @@ pub enum Error {
     #[error("Failed to parse: {0}")]
     FailedToParse(String),
 
+    /// Signature verification failed.
+    ///
+    /// Wherever possible, signatures are verified when deserialising messages. This error is
+    /// returned when deserialisation succeeded but the signature was invalid.
+    #[error("Invalid signature")]
+    InvalidSignature,
+
     /// Message read was built with an unsupported version.
     #[error("Unsupported messaging protocol version: {0}")]
     UnsupportedVersion(u16),

--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -41,7 +41,7 @@ mod msg_kind;
 mod sap;
 
 pub use self::{
-    authority::{BlsShareSigned, ClientSigned, NodeSigned, SectionSigned},
+    authority::{BlsShareSigned, ClientAuthority, ClientSigned, NodeSigned, SectionSigned},
     errors::{Error, Result},
     location::{DstLocation, EndUser, SocketId, SrcLocation},
     msg_id::{MessageId, MESSAGE_ID_LEN},

--- a/src/messaging/serialisation/mod.rs
+++ b/src/messaging/serialisation/mod.rs
@@ -11,7 +11,7 @@ mod wire_msg_header;
 
 pub use self::wire_msg::WireMsg;
 use super::{
-    data::DataMsg, node::NodeMsg, section_info::SectionInfoMsg, BlsShareSigned, ClientSigned,
+    data::DataMsg, node::NodeMsg, section_info::SectionInfoMsg, BlsShareSigned, ClientAuthority,
     DstLocation, MessageId, NodeSigned, SectionSigned,
 };
 
@@ -35,7 +35,7 @@ pub enum MessageType {
         /// Message ID
         msg_id: MessageId,
         /// Client authority over this message
-        client_signed: ClientSigned,
+        client_auth: ClientAuthority,
         /// Message destination location
         dst_location: DstLocation,
         /// the message

--- a/src/node/event_mapping/client_msg.rs
+++ b/src/node/event_mapping/client_msg.rs
@@ -9,7 +9,7 @@
 use super::{Mapping, MsgContext};
 use crate::messaging::{
     data::{DataMsg, ProcessMsg, ProcessingError},
-    ClientSigned, EndUser, MessageId, SrcLocation,
+    ClientAuthority, EndUser, MessageId, SrcLocation,
 };
 use crate::node::{
     error::convert_to_error_message,
@@ -21,13 +21,13 @@ use tracing::warn;
 pub(super) fn map_client_msg(
     msg_id: MessageId,
     msg: DataMsg,
-    client_signed: ClientSigned,
+    client_auth: ClientAuthority,
     user: EndUser,
 ) -> Mapping {
     match &msg {
         DataMsg::Process(process_msg) => {
             // Signature has already been validated by the routing layer
-            let op = map_client_process_msg(msg_id, process_msg.clone(), user, client_signed);
+            let op = map_client_process_msg(msg_id, process_msg.clone(), user, client_auth);
 
             let ctx = Some(MsgContext::Client {
                 msg,
@@ -54,19 +54,19 @@ fn map_client_process_msg(
     msg_id: MessageId,
     process_msg: ProcessMsg,
     origin: EndUser,
-    client_signed: ClientSigned,
+    client_auth: ClientAuthority,
 ) -> NodeDuty {
     match process_msg {
         ProcessMsg::Query(query) => NodeDuty::ProcessRead {
             query,
             msg_id,
-            client_signed,
+            client_auth,
             origin,
         },
         ProcessMsg::Cmd(cmd) => NodeDuty::ProcessWrite {
             cmd,
             msg_id,
-            client_signed,
+            client_auth,
             origin,
         },
         _ => {

--- a/src/node/event_mapping/mod.rs
+++ b/src/node/event_mapping/mod.rs
@@ -49,9 +49,9 @@ pub(super) async fn map_routing_event(event: RoutingEvent, network_api: &Network
         RoutingEvent::DataMsgReceived {
             msg_id,
             msg,
-            client_signed,
+            client_auth,
             user,
-        } => map_client_msg(msg_id, *msg, client_signed, user),
+        } => map_client_msg(msg_id, *msg, client_auth, user),
         RoutingEvent::SectionSplit {
             elders,
             sibling_elders,

--- a/src/node/metadata/chunk_records.rs
+++ b/src/node/metadata/chunk_records.rs
@@ -7,9 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::btree_set;
-use crate::messaging::ClientSigned;
 use crate::messaging::{
-    data::{ChunkDataExchange, ChunkRead, ChunkWrite, CmdError, DataCmd, QueryResponse},
+    data::{ChunkDataExchange, ChunkRead, ChunkWrite, CmdError, QueryResponse},
     node::{NodeCmd, NodeMsg, NodeQuery, NodeSystemCmd},
     ClientAuthority, EndUser, MessageId,
 };
@@ -74,12 +73,9 @@ impl ChunkRecords {
         &self,
         write: ChunkWrite,
         msg_id: MessageId,
-        client_signed: ClientSigned,
+        client_auth: ClientAuthority,
         origin: EndUser,
     ) -> Result<NodeDuty> {
-        // TODO: move earlier
-        let client_auth = super::verify_op(client_signed, DataCmd::Chunk(write.clone()))?;
-
         use ChunkWrite::*;
         match write {
             New(data) => self.store(data, msg_id, client_auth, origin).await,

--- a/src/node/metadata/elder_stores.rs
+++ b/src/node/metadata/elder_stores.rs
@@ -11,7 +11,7 @@ use super::{
     sequence_storage::SequenceStorage,
 };
 use crate::messaging::{
-    data::{DataCmd, DataExchange, DataQuery, RegisterCmd, SequenceCmd},
+    data::{DataCmd, DataExchange, DataQuery},
     ClientAuthority, EndUser, MessageId,
 };
 use crate::node::{node_ops::NodeDuty, Error, Result};
@@ -80,27 +80,13 @@ impl ElderStores {
             DataCmd::Sequence(write) => {
                 info!("Writing Sequence");
                 self.sequence_storage
-                    .write(
-                        msg_id,
-                        origin,
-                        SequenceCmd {
-                            write,
-                            client_sig: client_auth.into(),
-                        },
-                    )
+                    .write(msg_id, origin, write, client_auth)
                     .await
             }
             DataCmd::Register(write) => {
                 info!("Writing Register");
                 self.register_storage
-                    .write(
-                        msg_id,
-                        origin,
-                        RegisterCmd {
-                            write,
-                            client_sig: client_auth.into(),
-                        },
-                    )
+                    .write(msg_id, origin, write, client_auth)
                     .await
             }
         }

--- a/src/node/metadata/elder_stores.rs
+++ b/src/node/metadata/elder_stores.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::messaging::{
     data::{DataCmd, DataExchange, DataQuery, RegisterCmd, SequenceCmd},
-    ClientSigned, EndUser, MessageId,
+    ClientAuthority, EndUser, MessageId,
 };
 use crate::node::{node_ops::NodeDuty, Error, Result};
 use crate::routing::Prefix;
@@ -66,7 +66,7 @@ impl ElderStores {
         &mut self,
         cmd: DataCmd,
         msg_id: MessageId,
-        client_sig: ClientSigned,
+        client_auth: ClientAuthority,
         origin: EndUser,
     ) -> Result<NodeDuty> {
         info!("Writing Data");
@@ -74,19 +74,33 @@ impl ElderStores {
             DataCmd::Chunk(write) => {
                 info!("Writing Blob");
                 self.chunk_records
-                    .write(write, msg_id, client_sig, origin)
+                    .write(write, msg_id, client_auth, origin)
                     .await
             }
             DataCmd::Sequence(write) => {
                 info!("Writing Sequence");
                 self.sequence_storage
-                    .write(msg_id, origin, SequenceCmd { write, client_sig })
+                    .write(
+                        msg_id,
+                        origin,
+                        SequenceCmd {
+                            write,
+                            client_sig: client_auth.into(),
+                        },
+                    )
                     .await
             }
             DataCmd::Register(write) => {
                 info!("Writing Register");
                 self.register_storage
-                    .write(msg_id, origin, RegisterCmd { write, client_sig })
+                    .write(
+                        msg_id,
+                        origin,
+                        RegisterCmd {
+                            write,
+                            client_sig: client_auth.into(),
+                        },
+                    )
                     .await
             }
         }

--- a/src/node/metadata/mod.rs
+++ b/src/node/metadata/mod.rs
@@ -16,7 +16,7 @@ mod sequence_storage;
 use crate::dbs::UsedSpace;
 use crate::messaging::{
     data::{CmdError, DataCmd, DataExchange, DataMsg, DataQuery, ProcessMsg, QueryResponse},
-    ClientSigned, DstLocation, EndUser, MessageId,
+    ClientAuthority, ClientSigned, DstLocation, EndUser, MessageId, WireMsg,
 };
 use crate::node::{
     capacity::Capacity,
@@ -161,4 +161,11 @@ fn build_client_error_response(error: CmdError, msg_id: MessageId, origin: EndUs
         dst: DstLocation::EndUser(origin),
         aggregation: false,
     }
+}
+
+// TODO: verify earlier so that this isn't needed
+fn verify_op(client_signed: ClientSigned, cmd: DataCmd) -> Result<ClientAuthority> {
+    let message = DataMsg::Process(ProcessMsg::Cmd(cmd));
+    let payload = WireMsg::serialize_msg_payload(&message)?;
+    Ok(client_signed.verify(&payload)?)
 }

--- a/src/node/metadata/mod.rs
+++ b/src/node/metadata/mod.rs
@@ -96,12 +96,10 @@ impl Metadata {
         &mut self,
         cmd: DataCmd,
         id: MessageId,
-        client_signed: ClientSigned,
+        client_auth: ClientAuthority,
         origin: EndUser,
     ) -> Result<NodeDuty> {
-        self.elder_stores
-            .write(cmd, id, client_signed, origin)
-            .await
+        self.elder_stores.write(cmd, id, client_auth, origin).await
     }
 
     /// Adds a given node to the list of full nodes.

--- a/src/node/metadata/sequence_storage.rs
+++ b/src/node/metadata/sequence_storage.rs
@@ -86,11 +86,13 @@ impl SequenceStorage {
         &mut self,
         msg_id: MessageId,
         origin: EndUser,
-        op: SequenceCmd,
+        write: SequenceWrite,
+        client_auth: ClientAuthority,
     ) -> Result<NodeDuty> {
-        // TODO: verify earlier
-        let client_auth =
-            super::verify_op(op.client_sig.clone(), DataCmd::Sequence(op.write.clone()))?;
+        let op = SequenceCmd {
+            write,
+            client_sig: client_auth.to_signed(),
+        };
         let write_result = self.apply(op, client_auth).await;
         self.ok_or_error(write_result, msg_id, origin).await
     }

--- a/src/node/node_api/handle.rs
+++ b/src/node/node_api/handle.rs
@@ -213,14 +213,14 @@ impl Node {
             NodeDuty::WriteChunk {
                 write,
                 msg_id,
-                client_signed,
+                client_auth,
             } => {
                 let adult = self.as_adult().await?;
                 let handle = tokio::spawn(async move {
                     let mut ops = vec![
                         adult
                             .chunks
-                            .write(&write, msg_id, client_signed.public_key)
+                            .write(&write, msg_id, *client_auth.public_key())
                             .await?,
                     ];
                     ops.extend(adult.chunks.check_storage().await?);
@@ -307,7 +307,7 @@ impl Node {
             NodeDuty::ProcessRead {
                 query,
                 msg_id,
-                client_signed,
+                client_auth,
                 origin,
             } => {
                 let elder = self.as_elder().await?;
@@ -318,7 +318,7 @@ impl Node {
                             .meta_data
                             .write()
                             .await
-                            .read(query, msg_id, client_signed.public_key, origin)
+                            .read(query, msg_id, *client_auth.public_key(), origin)
                             .await?,
                     ];
                     Ok(NodeTask::from(duties))
@@ -329,7 +329,7 @@ impl Node {
                 cmd,
                 msg_id,
                 origin,
-                client_signed,
+                client_auth,
             } => {
                 let elder = self.as_elder().await?;
                 let handle = tokio::spawn(async move {
@@ -338,7 +338,7 @@ impl Node {
                             .meta_data
                             .write()
                             .await
-                            .write(cmd, msg_id, client_signed, origin)
+                            .write(cmd, msg_id, client_auth, origin)
                             .await?,
                     ]))
                 });

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -12,7 +12,7 @@ use crate::messaging::{
         QueryResponse,
     },
     node::NodeMsg,
-    ClientSigned, DstLocation, EndUser, MessageId, SrcLocation,
+    ClientAuthority, DstLocation, EndUser, MessageId, SrcLocation,
 };
 use crate::routing::Prefix;
 use crate::types::{Chunk, PublicKey};
@@ -46,7 +46,7 @@ pub enum NodeDuty {
     WriteChunk {
         msg_id: MessageId,
         write: ChunkWrite,
-        client_signed: ClientSigned,
+        client_auth: ClientAuthority,
     },
     ProcessRepublish {
         msg_id: MessageId,
@@ -136,14 +136,14 @@ pub enum NodeDuty {
     ProcessRead {
         msg_id: MessageId,
         query: DataQuery,
-        client_signed: ClientSigned,
+        client_auth: ClientAuthority,
         origin: EndUser,
     },
     /// Process write of data
     ProcessWrite {
         msg_id: MessageId,
         cmd: DataCmd,
-        client_signed: ClientSigned,
+        client_auth: ClientAuthority,
         origin: EndUser,
     },
     /// Receive a chunk that is being replicated.

--- a/src/routing/core/msg_handling/end_user.rs
+++ b/src/routing/core/msg_handling/end_user.rs
@@ -30,7 +30,7 @@ impl Core {
             msg_id,
             msg: Box::new(msg),
             user,
-            client_signed: client_auth.into(),
+            client_auth,
         })
         .await;
 

--- a/src/routing/routing_api/event.rs
+++ b/src/routing/routing_api/event.rs
@@ -9,7 +9,7 @@
 use crate::messaging::{
     data::DataMsg,
     node::{NodeCmd, NodeCmdError, NodeEvent, NodeQuery, NodeQueryResponse},
-    ClientSigned, DstLocation, EndUser, MessageId, SrcLocation,
+    ClientAuthority, DstLocation, EndUser, MessageId, SrcLocation,
 };
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Keypair;
@@ -117,7 +117,7 @@ pub enum Event {
         /// The content of the message.
         msg: Box<DataMsg>,
         /// Client authority
-        client_signed: ClientSigned,
+        client_auth: ClientAuthority,
         /// The end user that sent the message.
         /// Its xorname is derived from the client public key,
         /// and the socket_id maps against the actual socketaddr


### PR DESCRIPTION
- e355f5628 **feat(messaging): Add a `ClientAuthority` 'proof' struct**

  The `ClientAuthority` struct can only be constructed by verifying a
  `ClientSigned` for a particular payload. Thus, instances of
  `ClientAuthority` can be trusted as proof that the payload indeed had a
  valid signature, and was signed by the owner of `public_key` (e.g. a
  holder of the corresponding secret key).
  
  Note that it's important that `ClientAuthority` **does not** implement
  `Deserialize`, or any other trait that could allow unverified
  construction. It therefore cannot be a drop-in replacement for
  `ClientSigned`, which is kind of the point as we can now introduce
  `ClientAuthority` in areas where we expect the signature to be valid,
  then work our way back towards verification. Ideally we should be able
  to verify immediately and use `ClientAuthority` in `MessageType`.

- 412984884 **refactor(messaging)!: Use `ClientAuthority` in `MessageType`**

  This is pretty non-functional currently. In fact, we end up verifying
  the signature *twice*, since we also verify in
  `routing::Core::handle_message`. We should deduplcate this in future.
  
  BREAKING CHANGE: The `MessageType::Client` variant's `client_signed`
  field has been removed, and replaced with `client_auth`.

- 9c11f12e2 **fix(node): Ensure storage write op authority is verified**

  Previously, we would only verify the signatures of the original client
  message, not the signatures of replicated ops. With this change, a
  `ClientAuthority` is now needed to apply an op, meaning the signature
  needs to be verified in order to call those functions.
  
  Currently, verifications happens quite late, inside each individual
  store. This is because the `DataExchange` content is not iterated until
  this point. We really want to do this verification earlier, however.

- b0e8385bd **fix(node): Stores always verify client authority**

  We use `ClientAuthority` in `NodeDuty` to reflect the fact that, by the
  time we have constructed a `NodeDuty`, we expect the client authority to
  be valid. Note that authentication is still a separate step, but the
  public key in the authority can be trusted to have signed the op.
  
  Ultimately, this makes it impossible to call any of the store functions
  without a `ClientAuthority`, which can only be constructed by verifying
  a `ClientSigned` for the op.

- 85a01c19e **refactor(node): Rework storage APIs to avoid double-verifying**

  This doesn't completely remove double-verification (e.g. when dealing
  with the contents of a `MessageType::Client`, which is still verified on
  deserialization and again on conversion).
