### PR TITLE
Aarch64 builds

### DIFF
--- a/.github/workflows/all_prs.yml
+++ b/.github/workflows/all_prs.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf]
+        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf, aarch64-unknown-linux-musl]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,6 +242,27 @@ jobs:
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.zip
           asset_content_type: application/zip
 
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-arm-unknown-linux-musleabi.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.version }}-arm-unknown-linux-musleabi.zip
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-armv7-unknown-linux-musleabihf.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.version }}-armv7-unknown-linux-musleabihf.zip
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-aarch64-unknown-linux-musl.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.version }}-aarch64-unknown-linux-musl.zip
+          asset_content_type: application/zip
+
       # Upload tar files
       - uses: actions/upload-release-asset@v1.0.1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf]
+        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf, aarch64-unknown-linux-musl]
     steps:
       - uses: actions/checkout@v2
 
@@ -172,6 +172,10 @@ jobs:
         with:
           name: sn_node-armv7-unknown-linux-musleabihf-prod
           path: artifacts/prod/armv7-unknown-linux-musleabihf/release
+      - uses: actions/download-artifact@master
+        with:
+          name: sn_node-aarch64-unknown-linux-musl-prod
+          path: artifacts/prod/aarch64-unknown-linux-musl/release
 
       # Get information for the release.
       - shell: bash
@@ -272,6 +276,13 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-armv7-unknown-linux-musleabihf.tar.gz
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-armv7-unknown-linux-musleabihf.tar.gz
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-aarch64-unknown-linux-musl.tar.gz
+          asset_name: sn_node-${{ steps.versioning.outputs.version }}-aarch64-unknown-linux-musl.tar.gz
           asset_content_type: application/zip
 
   # Publish if we're on a `chore(release):` commit

--- a/.github/workflows/pr_client.yml
+++ b/.github/workflows/pr_client.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf]
+        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf, aarch64-unknown-linux-musl]
     steps:
       - uses: actions/checkout@v2
       # test for changes. (dont use baked in GHA pr/paths filter as then job wont run and we can't require itz)

--- a/.github/workflows/pr_messaging.yml
+++ b/.github/workflows/pr_messaging.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf]
+        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf, aarch64-unknown-linux-musl]
     steps:
       - uses: actions/checkout@v2
       # test for changes. (dont use baked in GHA pr/paths filter as then job wont run and we can't require itz)

--- a/.github/workflows/pr_routing.yml
+++ b/.github/workflows/pr_routing.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf]
+        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf, aarch64-unknown-linux-musl]
     steps:
       - uses: actions/checkout@v2
       - uses: dorny/paths-filter@v2

--- a/.github/workflows/pr_url.yml
+++ b/.github/workflows/pr_url.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf]
+        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf, aarch64-unknown-linux-musl]
     steps:
       - uses: actions/checkout@v2
       - uses: dorny/paths-filter@v2

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,25 @@ aarch64-unknown-linux-musl:
 	find target/aarch64-unknown-linux-musl/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 
 .ONESHELL:
+build-artifacts-for-deploy:
+	# This target is just for debugging the packaging process.
+	# Given the zipped artifacts retrieved from Github, it creates the
+	# directory structure that's expected by the packaging target.
+	declare -a architectures=( \
+		"x86_64-unknown-linux-musl" \
+		"x86_64-pc-windows-msvc" \
+		"x86_64-apple-darwin" \
+		"arm-unknown-linux-musleabi" \
+		"armv7-unknown-linux-musleabihf" \
+		"aarch64-unknown-linux-musl")
+	cd artifacts
+	for arch in "$${architectures[@]}" ; do \
+		mkdir -p prod/$$arch/release; \
+		unzip sn_node-$$arch-prod.zip -d prod/$$arch/release; \
+		rm sn_node-$$arch-prod.zip
+	done
+
+.ONESHELL:
 package-version-artifacts-for-deploy:
 	rm -f *.zip *.tar.gz
 	rm -rf ${DEPLOY_PATH}
@@ -67,11 +86,12 @@ package-version-artifacts-for-deploy:
 		"aarch64-unknown-linux-musl")
 
 	for arch in "$${architectures[@]}" ; do \
-		zip -j sn_node-${SN_NODE_VERSION}-$$arch.zip artifacts/prod/$$arch/release/sn_node*; \
-		zip -j sn_node-latest-$$arch.zip artifacts/prod/$$arch/release/sn_node*; \
-		(cd artifacts/prod/$$arch/release && tar -zcvf sn_node-${SN_NODE_VERSION}-$$arch.tar.gz sn_node*); \
-		(cd artifacts/prod/$$arch/release && tar -zcvf sn_node-latest-$$arch.tar.gz sn_node*); \
+		if [[ $$arch == *"windows"* ]]; then bin_name="sn_node.exe"; else bin_name="sn_node"; fi; \
+		zip -j sn_node-${SN_NODE_VERSION}-$$arch.zip artifacts/prod/$$arch/release/$$bin_name; \
+		zip -j sn_node-latest-$$arch.zip artifacts/prod/$$arch/release/$$bin_name; \
+		tar -C artifacts/prod/$$arch/release -zcvf sn_node-${SN_NODE_VERSION}-$$arch.tar.gz $$bin_name; \
+		tar -C artifacts/prod/$$arch/release -zcvf sn_node-latest-$$arch.tar.gz $$bin_name; \
 	done
 
-	find artifacts -name "*.tar.gz" -exec mv {} ${DEPLOY_PROD_PATH} \;
 	mv *.tar.gz ${DEPLOY_PROD_PATH}
+	mv *.zip ${DEPLOY_PROD_PATH}

--- a/Makefile
+++ b/Makefile
@@ -44,53 +44,34 @@ armv7-unknown-linux-musleabihf:
 	cross build --release --target armv7-unknown-linux-musleabihf
 	find target/armv7-unknown-linux-musleabihf/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 
+aarch64-unknown-linux-musl:
+	rm -rf target
+	rm -rf artifacts
+	mkdir artifacts
+	cargo install cross
+	cross build --release --target aarch64-unknown-linux-musl
+	find target/aarch64-unknown-linux-musl/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+
 .ONESHELL:
 package-version-artifacts-for-deploy:
 	rm -f *.zip *.tar.gz
 	rm -rf ${DEPLOY_PATH}
 	mkdir -p ${DEPLOY_PROD_PATH}
 
-	zip -j sn_node-${SN_NODE_VERSION}-x86_64-unknown-linux-musl.zip \
-		artifacts/prod/x86_64-unknown-linux-musl/release/sn_node
-	zip -j sn_node-latest-x86_64-unknown-linux-musl.zip \
-		artifacts/prod/x86_64-unknown-linux-musl/release/sn_node
-	zip -j sn_node-${SN_NODE_VERSION}-x86_64-pc-windows-msvc.zip \
-		artifacts/prod/x86_64-pc-windows-msvc/release/sn_node.exe
-	zip -j sn_node-latest-x86_64-pc-windows-msvc.zip \
-		artifacts/prod/x86_64-pc-windows-msvc/release/sn_node.exe
-	zip -j sn_node-${SN_NODE_VERSION}-x86_64-apple-darwin.zip \
-		artifacts/prod/x86_64-apple-darwin/release/sn_node
-	zip -j sn_node-latest-x86_64-apple-darwin.zip \
-		artifacts/prod/x86_64-apple-darwin/release/sn_node
-	zip -j sn_node-${SN_NODE_VERSION}-arm-unknown-linux-musleabi.zip \
-		artifacts/prod/arm-unknown-linux-musleabi/release/sn_node
-	zip -j sn_node-latest-arm-unknown-linux-musleabi.zip \
-		artifacts/prod/arm-unknown-linux-musleabi/release/sn_node
-	zip -j sn_node-${SN_NODE_VERSION}-armv7-unknown-linux-musleabihf.zip \
-		artifacts/prod/armv7-unknown-linux-musleabihf/release/sn_node
-	zip -j sn_node-latest-armv7-unknown-linux-musleabihf.zip \
-		artifacts/prod/armv7-unknown-linux-musleabihf/release/sn_node
+	declare -a architectures=( \
+		"x86_64-unknown-linux-musl" \
+		"x86_64-pc-windows-msvc" \
+		"x86_64-apple-darwin" \
+		"arm-unknown-linux-musleabi" \
+		"armv7-unknown-linux-musleabihf" \
+		"aarch64-unknown-linux-musl")
 
-	tar -C artifacts/prod/x86_64-unknown-linux-musl/release \
-		-zcvf sn_node-${SN_NODE_VERSION}-x86_64-unknown-linux-musl.tar.gz sn_node
-	tar -C artifacts/prod/x86_64-unknown-linux-musl/release \
-		-zcvf sn_node-latest-x86_64-unknown-linux-musl.tar.gz sn_node
-	tar -C artifacts/prod/x86_64-pc-windows-msvc/release \
-		-zcvf sn_node-${SN_NODE_VERSION}-x86_64-pc-windows-msvc.tar.gz sn_node.exe
-	tar -C artifacts/prod/x86_64-pc-windows-msvc/release \
-		-zcvf sn_node-latest-x86_64-pc-windows-msvc.tar.gz sn_node.exe
-	tar -C artifacts/prod/x86_64-apple-darwin/release \
-		-zcvf sn_node-${SN_NODE_VERSION}-x86_64-apple-darwin.tar.gz sn_node
-	tar -C artifacts/prod/x86_64-apple-darwin/release \
-		-zcvf sn_node-latest-x86_64-apple-darwin.tar.gz sn_node
-	tar -C artifacts/prod/arm-unknown-linux-musleabi/release \
-		-zcvf sn_node-${SN_NODE_VERSION}-arm-unknown-linux-musleabi.tar.gz sn_node
-	tar -C artifacts/prod/arm-unknown-linux-musleabi/release \
-		-zcvf sn_node-latest-arm-unknown-linux-musleabi.tar.gz sn_node
-	tar -C artifacts/prod/armv7-unknown-linux-musleabihf/release \
-		-zcvf sn_node-${SN_NODE_VERSION}-armv7-unknown-linux-musleabihf.tar.gz sn_node
-	tar -C artifacts/prod/armv7-unknown-linux-musleabihf/release \
-		-zcvf sn_node-latest-armv7-unknown-linux-musleabihf.tar.gz sn_node
+	for arch in "$${architectures[@]}" ; do \
+		zip -j sn_node-${SN_NODE_VERSION}-$$arch.zip artifacts/prod/$$arch/release/sn_node*; \
+		zip -j sn_node-latest-$$arch.zip artifacts/prod/$$arch/release/sn_node*; \
+		(cd artifacts/prod/$$arch/release && tar -zcvf sn_node-${SN_NODE_VERSION}-$$arch.tar.gz sn_node*); \
+		(cd artifacts/prod/$$arch/release && tar -zcvf sn_node-latest-$$arch.tar.gz sn_node*); \
+	done
 
-	mv *.zip ${DEPLOY_PROD_PATH}
+	find artifacts -name "*.tar.gz" -exec mv {} ${DEPLOY_PROD_PATH} \;
 	mv *.tar.gz ${DEPLOY_PROD_PATH}

--- a/scripts/get_release_description.sh
+++ b/scripts/get_release_description.sh
@@ -35,6 +35,10 @@ tar.gz: TAR_ARM_CHECKSUM
 ARMv7
 zip: ZIP_ARMv7_CHECKSUM
 tar.gz: TAR_ARMv7_CHECKSUM
+
+Aarch64
+zip: ZIP_AARCH64_CHECKSUM
+tar.gz: TAR_AARCH64_CHECKSUM
 ```
 
 ## Related Links
@@ -59,6 +63,9 @@ zip_arm_checksum=$(sha256sum \
 zip_armv7_checksum=$(sha256sum \
     "./deploy/prod/sn_node-$version-armv7-unknown-linux-musleabihf.zip" | \
     awk '{ print $1 }')
+zip_aarch64_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-aarch64-unknown-linux-musl.zip" | \
+    awk '{ print $1 }')
 tar_linux_checksum=$(sha256sum \
     "./deploy/prod/sn_node-$version-x86_64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
@@ -74,6 +81,9 @@ tar_arm_checksum=$(sha256sum \
 tar_armv7_checksum=$(sha256sum \
     "./deploy/prod/sn_node-$version-armv7-unknown-linux-musleabihf.tar.gz" | \
     awk '{ print $1 }')
+tar_aarch64_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-aarch64-unknown-linux-musl.tar.gz" | \
+    awk '{ print $1 }')
 
 # Need to use something like `=` instead of the usual `\` in the commands below because the changelog has `\` characters`
 release_description=$(sed "s=CHANGELOG_TEXT=$changelog_text=g" <<< "$release_description")
@@ -82,9 +92,11 @@ release_description=$(sed "s=ZIP_MACOS_CHECKSUM=$zip_macos_checksum=g" <<< "$rel
 release_description=$(sed "s=ZIP_WIN_CHECKSUM=$zip_win_checksum=g" <<< "$release_description")
 release_description=$(sed "s=ZIP_ARM_CHECKSUM=$zip_arm_checksum=g" <<< "$release_description")
 release_description=$(sed "s=ZIP_ARMv7_CHECKSUM=$zip_armv7_checksum=g" <<< "$release_description")
+release_description=$(sed "s=ZIP_AARCH64_CHECKSUM=$zip_aarch64_checksum=g" <<< "$release_description")
 release_description=$(sed "s=TAR_LINUX_CHECKSUM=$tar_linux_checksum=g" <<< "$release_description")
 release_description=$(sed "s=TAR_MACOS_CHECKSUM=$tar_macos_checksum=g" <<< "$release_description")
 release_description=$(sed "s=TAR_WIN_CHECKSUM=$tar_win_checksum=g" <<< "$release_description")
 release_description=$(sed "s=TAR_ARM_CHECKSUM=$tar_arm_checksum=g" <<< "$release_description")
 release_description=$(sed "s=TAR_ARMv7_CHECKSUM=$tar_armv7_checksum=g" <<< "$release_description")
+release_description=$(sed "s=TAR_AARCH64_CHECKSUM=$tar_aarch64_checksum=g" <<< "$release_description")
 echo "$release_description"


### PR DESCRIPTION
This target was overlooked when we added the ARM and ARMv7 build and deploy.
    
Everything here is the same, just with the addition of the new aarch64-unknown-linux-musl target.

Also fixed some errors in the deployment process.

I've tested the updated deploy process on my own fork: https://github.com/jacderida/safe_network/releases/tag/v0.7.26

closes #182 
