### PR TITLE
refactor(messaging): Remove message info from data write ops

### DIFF
--- a/src/messaging/data/map.rs
+++ b/src/messaging/data/map.rs
@@ -94,14 +94,10 @@ pub enum MapRead {
 pub struct MapCmd {
     /// The operation to perform.
     pub write: MapWrite,
-    /// The ID of the message from which the operation originated, used to send error responses.
-    pub msg_id: crate::messaging::MessageId,
     /// A signature carrying authority to perform the operation.
     ///
     /// This will be verified against the map's owner and permissions.
     pub client_sig: crate::messaging::ClientSigned,
-    /// The origin of the request, used to send error responses.
-    pub origin: crate::messaging::EndUser,
 }
 
 /// [`Map`] write operations.

--- a/src/messaging/data/register.rs
+++ b/src/messaging/data/register.rs
@@ -60,14 +60,10 @@ pub enum RegisterRead {
 pub struct RegisterCmd {
     /// The operation to perform.
     pub write: RegisterWrite,
-    /// The ID of the message from which the operation originated, used to send error responses.
-    pub msg_id: crate::messaging::MessageId,
     /// A signature carrying authority to perform the operation.
     ///
     /// This will be verified against the register's owner and permissions.
     pub client_sig: crate::messaging::ClientSigned,
-    /// The origin of the request, used to send error responses.
-    pub origin: crate::messaging::EndUser,
 }
 
 /// [`Register`] write operations.

--- a/src/messaging/data/sequence.rs
+++ b/src/messaging/data/sequence.rs
@@ -115,14 +115,10 @@ pub enum SequenceRead {
 pub struct SequenceCmd {
     /// The operation to perform.
     pub write: SequenceWrite,
-    /// The ID of the message from which the operation originated, used to send error responses.
-    pub msg_id: crate::messaging::MessageId,
     /// A signature carrying authority to perform the operation.
     ///
     /// This will be verified against the sequence's owner and permissions.
     pub client_sig: crate::messaging::ClientSigned,
-    /// The origin of the request, used to send error responses.
-    pub origin: crate::messaging::EndUser,
 }
 
 /// [`Sequence`] write operations.

--- a/src/node/metadata/elder_stores.rs
+++ b/src/node/metadata/elder_stores.rs
@@ -84,34 +84,19 @@ impl ElderStores {
             DataCmd::Map(write) => {
                 info!("Writing Map");
                 self.map_storage
-                    .write(MapCmd {
-                        write,
-                        msg_id,
-                        client_sig,
-                        origin,
-                    })
+                    .write(msg_id, origin, MapCmd { write, client_sig })
                     .await
             }
             DataCmd::Sequence(write) => {
                 info!("Writing Sequence");
                 self.sequence_storage
-                    .write(SequenceCmd {
-                        write,
-                        msg_id,
-                        client_sig,
-                        origin,
-                    })
+                    .write(msg_id, origin, SequenceCmd { write, client_sig })
                     .await
             }
             DataCmd::Register(write) => {
                 info!("Writing Register");
                 self.register_storage
-                    .write(RegisterCmd {
-                        write,
-                        msg_id,
-                        client_sig,
-                        origin,
-                    })
+                    .write(msg_id, origin, RegisterCmd { write, client_sig })
                     .await
             }
         }

--- a/src/node/metadata/map_storage.rs
+++ b/src/node/metadata/map_storage.rs
@@ -76,9 +76,12 @@ impl MapStorage {
 
     /// --- Writing ---
 
-    pub(super) async fn write(&mut self, op: MapCmd) -> Result<NodeDuty> {
-        let msg_id = op.msg_id;
-        let origin = op.origin;
+    pub(super) async fn write(
+        &mut self,
+        msg_id: MessageId,
+        origin: EndUser,
+        op: MapCmd,
+    ) -> Result<NodeDuty> {
         let write_result = self.apply(op).await;
         self.ok_or_error(write_result, msg_id, origin).await
     }


### PR DESCRIPTION
- 557994ab6 **refactor(messaging): Remove message info from data write ops**

  The `*Write` structs contain the information needed to replay a cmd, the
  `write` op itself, and the `client_sig` authorising it. They also
  contained message info, the `msg_id` and `origin` of the message that
  contained the op.
  
  The message info is used in the initial call to `store.write` to
  construct `CmdError` replies for the origin. It was largely unused in
  the replication logic, except to add the message ID to some logged
  errors (specifically when trying to delete a public register or
  sequence). It therefore makes sense to remove these fields from the
  replicated ops.
