### PR TITLE
fix(types): Fix `Debug` output for `Signature::Ed25519`

### DIFF
--- a/src/types/keys/signature.rs
+++ b/src/types/keys/signature.rs
@@ -36,8 +36,7 @@ pub struct SignatureShare {
 #[allow(clippy::large_enum_variant)]
 pub enum Signature {
     /// Ed25519 signature.
-    #[debug(with = "Self::fmt_ed25519")]
-    Ed25519(ed25519_dalek::Signature),
+    Ed25519(#[debug(with = "Self::fmt_ed25519")] ed25519_dalek::Signature),
     /// BLS signature.
     Bls(bls::Signature),
     /// BLS signature share.


### PR DESCRIPTION
- fca7700fe **fix(types): Fix `Debug` output for `Signature::Ed25519`**

  The `#[debug(...)]` annotation was meant to apply to the field, not the
  variant. It's a shame `custom_debug` does not emit an error in this
  case.
