### PR TITLE
chore(types): Update `ed25519` to simplify signature serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,11 +711,12 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "ed25519"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "serde",
+ "serde_bytes",
  "signature",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand = "~0.7.3"
 rand_chacha = "~0.2.2"
 serde_json = "1.0.53"
 structopt = "~0.3.17"
-ed25519 = "1.0.1"
+ed25519 = { version = "1.2.0", features = ["serde_bytes"] }
 signature = "1.1.10"
 xor_name = "1.1.10"
 sn_launch_tool = "0.3.2"

--- a/src/messaging/authority.rs
+++ b/src/messaging/authority.rs
@@ -97,8 +97,7 @@ pub struct NodeSigned {
     pub public_key: EdPublicKey,
     /// Ed25519 signature of the message corresponding to the public key of the source peer.
     #[debug(with = "Signature::fmt_ed25519")]
-    #[serde(deserialize_with = "Signature::deserialize_ed25519")]
-    #[serde(serialize_with = "Signature::serialize_ed25519")]
+    #[serde(with = "serde_bytes")]
     pub signature: EdSignature,
 }
 


### PR DESCRIPTION
- a9dcafdb6 **chore(types): Update `ed25519` to simplify signature serialization**

  The upstream `ed25519::Signature` type now implements
  `serde_bytes::{Deserialize,Serialize}`, so we can now delegate their
  serialization entirely to `serde_bytes`.
