### PR TITLE
Rename `Client{Signed,Authority}` -> `Data{Signed,Authority}`

### DIFF
--- a/src/client/client_api/commands.rs
+++ b/src/client/client_api/commands.rs
@@ -10,7 +10,7 @@ use super::Client;
 use crate::client::Error;
 use crate::messaging::{
     data::{DataCmd, DataMsg, ProcessMsg},
-    ClientSigned, WireMsg,
+    DataSigned, WireMsg,
 };
 use crate::types::{PublicKey, Signature};
 use bytes::Bytes;
@@ -28,13 +28,13 @@ impl Client {
         signature: Signature,
     ) -> Result<(), Error> {
         debug!("Sending DataCmd: {:?}", cmd);
-        let client_signed = ClientSigned {
+        let data_signed = DataSigned {
             public_key: client_pk,
             signature,
         };
 
         self.session
-            .send_cmd(cmd, client_signed, serialised_cmd)
+            .send_cmd(cmd, data_signed, serialised_cmd)
             .await
     }
 

--- a/src/client/client_api/queries.rs
+++ b/src/client/client_api/queries.rs
@@ -10,7 +10,7 @@ use super::Client;
 use crate::client::{connections::QueryResult, errors::Error};
 use crate::messaging::{
     data::{DataMsg, DataQuery, ProcessMsg},
-    ClientSigned, WireMsg,
+    DataSigned, WireMsg,
 };
 use crate::types::{PublicKey, Signature};
 use bytes::Bytes;
@@ -28,13 +28,13 @@ impl Client {
         signature: Signature,
     ) -> Result<QueryResult, Error> {
         debug!("Sending Query: {:?}", query);
-        let client_signed = ClientSigned {
+        let data_signed = DataSigned {
             public_key: client_pk,
             signature,
         };
 
         self.session
-            .send_query(query, client_signed, serialised_query)
+            .send_query(query, data_signed, serialised_query)
             .await
     }
 

--- a/src/client/connections/messaging.rs
+++ b/src/client/connections/messaging.rs
@@ -11,7 +11,7 @@ use crate::client::Error;
 use crate::messaging::{
     data::{ChunkRead, DataCmd, DataQuery, QueryResponse},
     section_info::SectionInfoMsg,
-    ClientSigned, MessageId, WireMsg,
+    DataSigned, MessageId, WireMsg,
 };
 use crate::messaging::{DstLocation, MsgKind};
 use crate::types::{Chunk, PrivateChunk, PublicChunk, PublicKey};
@@ -112,7 +112,7 @@ impl Session {
     pub(crate) async fn send_cmd(
         &self,
         cmd: DataCmd,
-        client_signed: ClientSigned,
+        data_signed: DataSigned,
         payload: Bytes,
     ) -> Result<(), Error> {
         let endpoint = self.endpoint()?.clone();
@@ -151,7 +151,7 @@ impl Session {
             name: dst_section_name,
             section_pk,
         };
-        let msg_kind = MsgKind::DataMsg(client_signed);
+        let msg_kind = MsgKind::DataMsg(data_signed);
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
 
         let msg_bytes = wire_msg.serialize()?;
@@ -195,7 +195,7 @@ impl Session {
     pub(crate) async fn send_query(
         &self,
         query: DataQuery,
-        client_signed: ClientSigned,
+        data_signed: DataSigned,
         payload: Bytes,
     ) -> Result<QueryResult, Error> {
         let endpoint = self.endpoint()?.clone();
@@ -219,7 +219,7 @@ impl Session {
             section_pk,
         };
         let msg_id = MessageId::new();
-        let msg_kind = MsgKind::DataMsg(client_signed);
+        let msg_kind = MsgKind::DataMsg(data_signed);
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
 
         let msg_bytes = wire_msg.serialize()?;

--- a/src/messaging/authority.rs
+++ b/src/messaging/authority.rs
@@ -22,14 +22,14 @@ impl DataSigned {
     /// The returned `Ok` variant represents a proof that the owner of `public_key` indeed signed
     /// `payload`, and so bears their authority. Note however that it may still be necessary to
     /// confirm that `public_key` is who you expect!
-    pub fn verify(self, payload: &impl AsRef<[u8]>) -> Result<ClientAuthority> {
-        ClientAuthority::verify(self.public_key, self.signature, payload)
+    pub fn verify(self, payload: &impl AsRef<[u8]>) -> Result<DataAuthority> {
+        DataAuthority::verify(self.public_key, self.signature, payload)
     }
 }
 
-/// A [`ClientAuthority`] can be converted back to a [`DataSigned`], losing the 'proof' of validity.
-impl From<ClientAuthority> for DataSigned {
-    fn from(signed: ClientAuthority) -> Self {
+/// A [`DataAuthority`] can be converted back to a [`DataSigned`], losing the 'proof' of validity.
+impl From<DataAuthority> for DataSigned {
+    fn from(signed: DataAuthority) -> Self {
         Self {
             public_key: signed.public_key,
             signature: signed.signature,
@@ -37,22 +37,22 @@ impl From<ClientAuthority> for DataSigned {
     }
 }
 
-/// Verified authority of a client.
+/// Verified authority of a network peer.
 ///
 /// Values of this type constitute a proof that the signature is valid for a particular payload.
 /// This is made possible by performing verification in all possible constructors of the type.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ClientAuthority {
+pub struct DataAuthority {
     public_key: PublicKey,
     signature: Signature,
 }
 
-impl ClientAuthority {
-    /// Verify that `payload` has client's authority.
+impl DataAuthority {
+    /// Verify that `payload` has requester's authority.
     ///
     /// This verifies that the owner of `public_key` (e.g. the holder of the corresponding private
     /// key) created the `signature` by signing the `payload` with theor private key. When this is
-    /// true, we say the payload has client authority.
+    /// true, we say the payload has data authority.
     pub fn verify(
         public_key: PublicKey,
         signature: Signature,
@@ -74,11 +74,11 @@ impl ClientAuthority {
 
     /// Create a [`DataSigned`] from this authority by cloning the fields.
     ///
-    /// Since [`ClientAuthority`] cannot be serialized, it's sometimes necessary to convert back to
+    /// Since [`DataAuthority`] cannot be serialized, it's sometimes necessary to convert back to
     /// an unverified signature. Prefer [`DataSigned::from`][1] if you don't need to retain the
-    /// `ClientAuthority`, as this won't clone the fields.
+    /// `DataAuthority`, as this won't clone the fields.
     ///
-    /// [1]: DataSigned#impl-From<ClientAuthority>
+    /// [1]: DataSigned#impl-From<DataAuthority>
     pub fn to_signed(&self) -> DataSigned {
         DataSigned {
             public_key: self.public_key,

--- a/src/messaging/authority.rs
+++ b/src/messaging/authority.rs
@@ -7,16 +7,16 @@ use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::{PublicKey as EdPublicKey, Signature as EdSignature};
 use xor_name::XorName;
 
-/// Authority of a client
+/// Authority of a network peer.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ClientSigned {
-    /// Client public key.
+pub struct DataSigned {
+    /// Peer's public key.
     pub public_key: PublicKey,
-    /// Client signature.
+    /// Peer's signature.
     pub signature: Signature,
 }
 
-impl ClientSigned {
+impl DataSigned {
     /// Verify that the pair of `public_key` created `signature` over `payload`.
     ///
     /// The returned `Ok` variant represents a proof that the owner of `public_key` indeed signed
@@ -27,8 +27,8 @@ impl ClientSigned {
     }
 }
 
-/// A [`ClientAuthority`] can be converted back to a [`ClientSigned`], losing the 'proof' of validity.
-impl From<ClientAuthority> for ClientSigned {
+/// A [`ClientAuthority`] can be converted back to a [`DataSigned`], losing the 'proof' of validity.
+impl From<ClientAuthority> for DataSigned {
     fn from(signed: ClientAuthority) -> Self {
         Self {
             public_key: signed.public_key,
@@ -72,15 +72,15 @@ impl ClientAuthority {
         &self.public_key
     }
 
-    /// Create a [`ClientSigned`] from this authority by cloning the fields.
+    /// Create a [`DataSigned`] from this authority by cloning the fields.
     ///
     /// Since [`ClientAuthority`] cannot be serialized, it's sometimes necessary to convert back to
-    /// an unverified signature. Prefer [`ClientSigned::from`][1] if you don't need to retain the
+    /// an unverified signature. Prefer [`DataSigned::from`][1] if you don't need to retain the
     /// `ClientAuthority`, as this won't clone the fields.
     ///
-    /// [1]: ClientSigned#impl-From<ClientAuthority>
-    pub fn to_signed(&self) -> ClientSigned {
-        ClientSigned {
+    /// [1]: DataSigned#impl-From<ClientAuthority>
+    pub fn to_signed(&self) -> DataSigned {
+        DataSigned {
             public_key: self.public_key,
             signature: self.signature.clone(),
         }

--- a/src/messaging/data/register.rs
+++ b/src/messaging/data/register.rs
@@ -63,7 +63,7 @@ pub struct RegisterCmd {
     /// A signature carrying authority to perform the operation.
     ///
     /// This will be verified against the register's owner and permissions.
-    pub client_sig: crate::messaging::ClientSigned,
+    pub client_sig: crate::messaging::DataSigned,
 }
 
 /// [`Register`] write operations.

--- a/src/messaging/data/sequence.rs
+++ b/src/messaging/data/sequence.rs
@@ -118,7 +118,7 @@ pub struct SequenceCmd {
     /// A signature carrying authority to perform the operation.
     ///
     /// This will be verified against the sequence's owner and permissions.
-    pub client_sig: crate::messaging::ClientSigned,
+    pub client_sig: crate::messaging::DataSigned,
 }
 
 /// [`Sequence`] write operations.

--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -41,7 +41,7 @@ mod msg_kind;
 mod sap;
 
 pub use self::{
-    authority::{BlsShareSigned, ClientAuthority, DataSigned, NodeSigned, SectionSigned},
+    authority::{BlsShareSigned, DataAuthority, DataSigned, NodeSigned, SectionSigned},
     errors::{Error, Result},
     location::{DstLocation, EndUser, SocketId, SrcLocation},
     msg_id::{MessageId, MESSAGE_ID_LEN},

--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -41,7 +41,7 @@ mod msg_kind;
 mod sap;
 
 pub use self::{
-    authority::{BlsShareSigned, ClientAuthority, ClientSigned, NodeSigned, SectionSigned},
+    authority::{BlsShareSigned, ClientAuthority, DataSigned, NodeSigned, SectionSigned},
     errors::{Error, Result},
     location::{DstLocation, EndUser, SocketId, SrcLocation},
     msg_id::{MessageId, MESSAGE_ID_LEN},

--- a/src/messaging/msg_kind.rs
+++ b/src/messaging/msg_kind.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{BlsShareSigned, ClientSigned, NodeSigned, SectionSigned};
+use super::{BlsShareSigned, DataSigned, NodeSigned, SectionSigned};
 use serde::{Deserialize, Serialize};
 
 /// Source authority of a message.
@@ -25,11 +25,10 @@ pub enum MsgKind {
     /// read-only, and section information is public across the network.
     SectionInfoMsg,
 
-    /// A data message, with their authority.
+    /// A data message, with the requesting peer's authority.
     ///
-    /// Client authority is needed to access private data, such as reading or writing a private
-    /// file.
-    DataMsg(ClientSigned),
+    /// Authority is needed to access private data, such as reading or writing a private file.
+    DataMsg(DataSigned),
 
     /// A message from a Node with its own independent authority.
     ///

--- a/src/messaging/node/mod.rs
+++ b/src/messaging/node/mod.rs
@@ -33,7 +33,7 @@ pub use section::Peer;
 pub use section::{Section, SectionPeers};
 pub use signed::{KeyedSig, SigShare};
 
-use crate::messaging::{data::DataMsg, ClientSigned, EndUser, MessageId, SectionAuthorityProvider};
+use crate::messaging::{data::DataMsg, DataSigned, EndUser, MessageId, SectionAuthorityProvider};
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::message::Message as DkgMessage;
 use itertools::Itertools;
@@ -46,14 +46,14 @@ use xor_name::XorName;
 #[allow(clippy::large_enum_variant)]
 /// Message sent over the among nodes
 pub enum NodeMsg {
-    /// Forward a client msg
+    /// Forward a data message.
     ForwardDataMsg {
         /// The msg
         msg: DataMsg,
         /// The origin
         user: EndUser,
-        /// Signature provided by the client
-        client_signed: ClientSigned,
+        /// Signature provided by the requester.
+        data_signed: DataSigned,
     },
     /// Inform other sections about our section or vice-versa.
     SectionKnowledge {

--- a/src/messaging/node/node_msgs.rs
+++ b/src/messaging/node/node_msgs.rs
@@ -11,7 +11,7 @@ use crate::messaging::{
         ChunkRead, ChunkWrite, CmdError, DataCmd as NodeDataCmd, DataExchange,
         DataQuery as NodeDataQuery, Error, Result,
     },
-    ClientSigned, EndUser,
+    DataSigned, EndUser,
 };
 use crate::types::{Chunk, ChunkAddress, PublicKey, SectionElders, Signature};
 use serde::{Deserialize, Serialize};
@@ -25,8 +25,8 @@ pub enum NodeCmd {
     Metadata {
         /// The contianed command
         cmd: NodeDataCmd,
-        /// Client pk and signature
-        client_signed: ClientSigned,
+        /// Requester pk and signature
+        data_signed: DataSigned,
         /// Message source
         origin: EndUser,
     },
@@ -34,8 +34,8 @@ pub enum NodeCmd {
     Chunks {
         /// The contianed command
         cmd: ChunkWrite,
-        /// Client pk and signature
-        client_signed: ClientSigned,
+        /// Requester pk and signature
+        data_signed: DataSigned,
         /// Message source
         origin: EndUser,
     },
@@ -94,7 +94,7 @@ pub enum NodeQuery {
         /// The actual query message
         query: NodeDataQuery,
         /// Client signature
-        client_signed: ClientSigned,
+        data_signed: DataSigned,
         /// The user that has initiated this query
         origin: EndUser,
     },

--- a/src/messaging/serialisation/mod.rs
+++ b/src/messaging/serialisation/mod.rs
@@ -11,7 +11,7 @@ mod wire_msg_header;
 
 pub use self::wire_msg::WireMsg;
 use super::{
-    data::DataMsg, node::NodeMsg, section_info::SectionInfoMsg, BlsShareSigned, ClientAuthority,
+    data::DataMsg, node::NodeMsg, section_info::SectionInfoMsg, BlsShareSigned, DataAuthority,
     DstLocation, MessageId, NodeSigned, SectionSigned,
 };
 
@@ -34,8 +34,8 @@ pub enum MessageType {
     Client {
         /// Message ID
         msg_id: MessageId,
-        /// Client authority over this message
-        client_auth: ClientAuthority,
+        /// Requester's authority over this message
+        data_auth: DataAuthority,
         /// Message destination location
         dst_location: DstLocation,
         /// the message

--- a/src/messaging/serialisation/wire_msg.rs
+++ b/src/messaging/serialisation/wire_msg.rs
@@ -125,14 +125,14 @@ impl WireMsg {
                     msg,
                 })
             }
-            MsgKind::DataMsg(client_signed) => {
+            MsgKind::DataMsg(data_signed) => {
                 let msg: DataMsg = rmp_serde::from_slice(&self.payload).map_err(|err| {
-                    Error::FailedToParse(format!("Client message payload as Msgpack: {}", err))
+                    Error::FailedToParse(format!("Data message payload as Msgpack: {}", err))
                 })?;
 
                 Ok(MessageType::Client {
                     msg_id: self.header.msg_envelope.msg_id,
-                    client_auth: client_signed.verify(&self.payload)?,
+                    client_auth: data_signed.verify(&self.payload)?,
                     dst_location: self.header.msg_envelope.dst_location,
                     msg,
                 })
@@ -242,7 +242,7 @@ mod tests {
         messaging::{
             data::{ChunkRead, DataMsg, DataQuery, ProcessMsg},
             node::{NodeCmd, NodeMsg, NodeSystemCmd},
-            ClientSigned, MessageId, NodeSigned,
+            DataSigned, MessageId, NodeSigned,
         },
         types::{ChunkAddress, Keypair},
     };
@@ -410,13 +410,13 @@ mod tests {
         ))));
 
         let payload = WireMsg::serialize_msg_payload(&client_msg)?;
-        let client_signed = ClientSigned {
+        let data_signed = DataSigned {
             public_key: src_client_keypair.public_key(),
             signature: src_client_keypair.sign(&payload),
         };
-        let client_auth = client_signed.clone().verify(&payload).unwrap();
+        let client_auth = data_signed.clone().verify(&payload).unwrap();
 
-        let msg_kind = MsgKind::DataMsg(client_signed);
+        let msg_kind = MsgKind::DataMsg(data_signed);
 
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
         let serialized = wire_msg.serialize()?;

--- a/src/messaging/serialisation/wire_msg.rs
+++ b/src/messaging/serialisation/wire_msg.rs
@@ -132,7 +132,7 @@ impl WireMsg {
 
                 Ok(MessageType::Client {
                     msg_id: self.header.msg_envelope.msg_id,
-                    client_auth: data_signed.verify(&self.payload)?,
+                    data_auth: data_signed.verify(&self.payload)?,
                     dst_location: self.header.msg_envelope.dst_location,
                     msg,
                 })
@@ -414,7 +414,7 @@ mod tests {
             public_key: src_client_keypair.public_key(),
             signature: src_client_keypair.sign(&payload),
         };
-        let client_auth = data_signed.clone().verify(&payload).unwrap();
+        let data_auth = data_signed.clone().verify(&payload).unwrap();
 
         let msg_kind = MsgKind::DataMsg(data_signed);
 
@@ -434,7 +434,7 @@ mod tests {
             deserialized.into_message()?,
             MessageType::Client {
                 msg_id: wire_msg.msg_id(),
-                client_auth,
+                data_auth,
                 dst_location,
                 msg: client_msg,
             }

--- a/src/node/event_mapping/client_msg.rs
+++ b/src/node/event_mapping/client_msg.rs
@@ -9,7 +9,7 @@
 use super::{Mapping, MsgContext};
 use crate::messaging::{
     data::{DataMsg, ProcessMsg, ProcessingError},
-    ClientAuthority, EndUser, MessageId, SrcLocation,
+    DataAuthority, EndUser, MessageId, SrcLocation,
 };
 use crate::node::{
     error::convert_to_error_message,
@@ -21,13 +21,13 @@ use tracing::warn;
 pub(super) fn map_client_msg(
     msg_id: MessageId,
     msg: DataMsg,
-    client_auth: ClientAuthority,
+    data_auth: DataAuthority,
     user: EndUser,
 ) -> Mapping {
     match &msg {
         DataMsg::Process(process_msg) => {
             // Signature has already been validated by the routing layer
-            let op = map_client_process_msg(msg_id, process_msg.clone(), user, client_auth);
+            let op = map_client_process_msg(msg_id, process_msg.clone(), user, data_auth);
 
             let ctx = Some(MsgContext::Client {
                 msg,
@@ -54,19 +54,19 @@ fn map_client_process_msg(
     msg_id: MessageId,
     process_msg: ProcessMsg,
     origin: EndUser,
-    client_auth: ClientAuthority,
+    data_auth: DataAuthority,
 ) -> NodeDuty {
     match process_msg {
         ProcessMsg::Query(query) => NodeDuty::ProcessRead {
             query,
             msg_id,
-            client_auth,
+            data_auth,
             origin,
         },
         ProcessMsg::Cmd(cmd) => NodeDuty::ProcessWrite {
             cmd,
             msg_id,
-            client_auth,
+            data_auth,
             origin,
         },
         _ => {

--- a/src/node/event_mapping/mod.rs
+++ b/src/node/event_mapping/mod.rs
@@ -49,9 +49,9 @@ pub(super) async fn map_routing_event(event: RoutingEvent, network_api: &Network
         RoutingEvent::DataMsgReceived {
             msg_id,
             msg,
-            client_auth,
+            data_auth,
             user,
-        } => map_client_msg(msg_id, *msg, client_auth, user),
+        } => map_client_msg(msg_id, *msg, data_auth, user),
         RoutingEvent::SectionSplit {
             elders,
             sibling_elders,

--- a/src/node/metadata/chunk_records.rs
+++ b/src/node/metadata/chunk_records.rs
@@ -10,7 +10,7 @@ use crate::btree_set;
 use crate::messaging::{
     data::{ChunkDataExchange, ChunkRead, ChunkWrite, CmdError, QueryResponse},
     node::{NodeCmd, NodeMsg, NodeQuery, NodeSystemCmd},
-    ClientAuthority, EndUser, MessageId,
+    DataAuthority, EndUser, MessageId,
 };
 use crate::node::{
     capacity::{Capacity, CHUNK_COPY_COUNT},
@@ -73,13 +73,13 @@ impl ChunkRecords {
         &self,
         write: ChunkWrite,
         msg_id: MessageId,
-        client_auth: ClientAuthority,
+        data_auth: DataAuthority,
         origin: EndUser,
     ) -> Result<NodeDuty> {
         use ChunkWrite::*;
         match write {
-            New(data) => self.store(data, msg_id, client_auth, origin).await,
-            DeletePrivate(address) => self.delete(address, client_auth, origin).await,
+            New(data) => self.store(data, msg_id, data_auth, origin).await,
+            DeletePrivate(address) => self.delete(address, data_auth, origin).await,
         }
     }
 
@@ -108,10 +108,10 @@ impl ChunkRecords {
         &self,
         chunk: Chunk,
         msg_id: MessageId,
-        client_auth: ClientAuthority,
+        data_auth: DataAuthority,
         origin: EndUser,
     ) -> Result<NodeDuty> {
-        if let Err(error) = validate_chunk_owner(&chunk, client_auth.public_key()) {
+        if let Err(error) = validate_chunk_owner(&chunk, data_auth.public_key()) {
             return self.send_error(error, msg_id, origin).await;
         }
 
@@ -133,7 +133,7 @@ impl ChunkRecords {
             msg_id: MessageId::new(),
             msg: NodeMsg::NodeCmd(NodeCmd::Chunks {
                 cmd: ChunkWrite::New(chunk),
-                data_signed: client_auth.into(),
+                data_signed: data_auth.into(),
                 origin,
             }),
             targets: target_holders,
@@ -215,7 +215,7 @@ impl ChunkRecords {
     async fn delete(
         &self,
         address: ChunkAddress,
-        client_auth: ClientAuthority,
+        data_auth: DataAuthority,
         origin: EndUser,
     ) -> Result<NodeDuty> {
         let targets = self.capacity.get_chunk_holder_adults(address.name()).await;
@@ -224,7 +224,7 @@ impl ChunkRecords {
             msg_id: MessageId::new(),
             msg: NodeMsg::NodeCmd(NodeCmd::Chunks {
                 cmd: ChunkWrite::DeletePrivate(address),
-                data_signed: client_auth.into(),
+                data_signed: data_auth.into(),
                 origin,
             }),
             targets,

--- a/src/node/metadata/chunk_records.rs
+++ b/src/node/metadata/chunk_records.rs
@@ -133,7 +133,7 @@ impl ChunkRecords {
             msg_id: MessageId::new(),
             msg: NodeMsg::NodeCmd(NodeCmd::Chunks {
                 cmd: ChunkWrite::New(chunk),
-                client_signed: client_auth.into(),
+                data_signed: client_auth.into(),
                 origin,
             }),
             targets: target_holders,
@@ -224,7 +224,7 @@ impl ChunkRecords {
             msg_id: MessageId::new(),
             msg: NodeMsg::NodeCmd(NodeCmd::Chunks {
                 cmd: ChunkWrite::DeletePrivate(address),
-                client_signed: client_auth.into(),
+                data_signed: client_auth.into(),
                 origin,
             }),
             targets,

--- a/src/node/metadata/elder_stores.rs
+++ b/src/node/metadata/elder_stores.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::messaging::{
     data::{DataCmd, DataExchange, DataQuery},
-    ClientAuthority, EndUser, MessageId,
+    DataAuthority, EndUser, MessageId,
 };
 use crate::node::{node_ops::NodeDuty, Error, Result};
 use crate::routing::Prefix;
@@ -66,7 +66,7 @@ impl ElderStores {
         &mut self,
         cmd: DataCmd,
         msg_id: MessageId,
-        client_auth: ClientAuthority,
+        data_auth: DataAuthority,
         origin: EndUser,
     ) -> Result<NodeDuty> {
         info!("Writing Data");
@@ -74,19 +74,19 @@ impl ElderStores {
             DataCmd::Chunk(write) => {
                 info!("Writing Blob");
                 self.chunk_records
-                    .write(write, msg_id, client_auth, origin)
+                    .write(write, msg_id, data_auth, origin)
                     .await
             }
             DataCmd::Sequence(write) => {
                 info!("Writing Sequence");
                 self.sequence_storage
-                    .write(msg_id, origin, write, client_auth)
+                    .write(msg_id, origin, write, data_auth)
                     .await
             }
             DataCmd::Register(write) => {
                 info!("Writing Register");
                 self.register_storage
-                    .write(msg_id, origin, write, client_auth)
+                    .write(msg_id, origin, write, data_auth)
                     .await
             }
         }

--- a/src/node/metadata/mod.rs
+++ b/src/node/metadata/mod.rs
@@ -16,7 +16,7 @@ mod sequence_storage;
 use crate::dbs::UsedSpace;
 use crate::messaging::{
     data::{CmdError, DataCmd, DataExchange, DataMsg, DataQuery, ProcessMsg, QueryResponse},
-    ClientAuthority, DataSigned, DstLocation, EndUser, MessageId, WireMsg,
+    DataAuthority, DataSigned, DstLocation, EndUser, MessageId, WireMsg,
 };
 use crate::node::{
     capacity::Capacity,
@@ -96,10 +96,10 @@ impl Metadata {
         &mut self,
         cmd: DataCmd,
         id: MessageId,
-        client_auth: ClientAuthority,
+        data_auth: DataAuthority,
         origin: EndUser,
     ) -> Result<NodeDuty> {
-        self.elder_stores.write(cmd, id, client_auth, origin).await
+        self.elder_stores.write(cmd, id, data_auth, origin).await
     }
 
     /// Adds a given node to the list of full nodes.
@@ -162,7 +162,7 @@ fn build_client_error_response(error: CmdError, msg_id: MessageId, origin: EndUs
 }
 
 // TODO: verify earlier so that this isn't needed
-fn verify_op(data_signed: DataSigned, cmd: DataCmd) -> Result<ClientAuthority> {
+fn verify_op(data_signed: DataSigned, cmd: DataCmd) -> Result<DataAuthority> {
     let message = DataMsg::Process(ProcessMsg::Cmd(cmd));
     let payload = WireMsg::serialize_msg_payload(&message)?;
     Ok(data_signed.verify(&payload)?)

--- a/src/node/metadata/mod.rs
+++ b/src/node/metadata/mod.rs
@@ -16,7 +16,7 @@ mod sequence_storage;
 use crate::dbs::UsedSpace;
 use crate::messaging::{
     data::{CmdError, DataCmd, DataExchange, DataMsg, DataQuery, ProcessMsg, QueryResponse},
-    ClientAuthority, ClientSigned, DstLocation, EndUser, MessageId, WireMsg,
+    ClientAuthority, DataSigned, DstLocation, EndUser, MessageId, WireMsg,
 };
 use crate::node::{
     capacity::Capacity,
@@ -162,8 +162,8 @@ fn build_client_error_response(error: CmdError, msg_id: MessageId, origin: EndUs
 }
 
 // TODO: verify earlier so that this isn't needed
-fn verify_op(client_signed: ClientSigned, cmd: DataCmd) -> Result<ClientAuthority> {
+fn verify_op(data_signed: DataSigned, cmd: DataCmd) -> Result<ClientAuthority> {
     let message = DataMsg::Process(ProcessMsg::Cmd(cmd));
     let payload = WireMsg::serialize_msg_payload(&message)?;
-    Ok(client_signed.verify(&payload)?)
+    Ok(data_signed.verify(&payload)?)
 }

--- a/src/node/node_api/handle.rs
+++ b/src/node/node_api/handle.rs
@@ -213,14 +213,14 @@ impl Node {
             NodeDuty::WriteChunk {
                 write,
                 msg_id,
-                client_auth,
+                data_auth,
             } => {
                 let adult = self.as_adult().await?;
                 let handle = tokio::spawn(async move {
                     let mut ops = vec![
                         adult
                             .chunks
-                            .write(&write, msg_id, *client_auth.public_key())
+                            .write(&write, msg_id, *data_auth.public_key())
                             .await?,
                     ];
                     ops.extend(adult.chunks.check_storage().await?);
@@ -307,7 +307,7 @@ impl Node {
             NodeDuty::ProcessRead {
                 query,
                 msg_id,
-                client_auth,
+                data_auth,
                 origin,
             } => {
                 let elder = self.as_elder().await?;
@@ -318,7 +318,7 @@ impl Node {
                             .meta_data
                             .write()
                             .await
-                            .read(query, msg_id, *client_auth.public_key(), origin)
+                            .read(query, msg_id, *data_auth.public_key(), origin)
                             .await?,
                     ];
                     Ok(NodeTask::from(duties))
@@ -329,7 +329,7 @@ impl Node {
                 cmd,
                 msg_id,
                 origin,
-                client_auth,
+                data_auth,
             } => {
                 let elder = self.as_elder().await?;
                 let handle = tokio::spawn(async move {
@@ -338,7 +338,7 @@ impl Node {
                             .meta_data
                             .write()
                             .await
-                            .write(cmd, msg_id, client_auth, origin)
+                            .write(cmd, msg_id, data_auth, origin)
                             .await?,
                     ]))
                 });

--- a/src/node/node_api/messaging.rs
+++ b/src/node/node_api/messaging.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    data::DataMsg, node::NodeMsg, ClientSigned, DstLocation, MessageId, MsgKind, WireMsg,
+    data::DataMsg, node::NodeMsg, DataSigned, DstLocation, MessageId, MsgKind, WireMsg,
 };
 use crate::node::{
     network::Network,
@@ -129,7 +129,7 @@ fn random_client_signature(client_msg: &DataMsg) -> Result<(MsgKind, Bytes)> {
     let payload = WireMsg::serialize_msg_payload(client_msg)?;
     let signature = keypair.sign(&payload);
 
-    let msg_kind = MsgKind::DataMsg(ClientSigned {
+    let msg_kind = MsgKind::DataMsg(DataSigned {
         public_key: keypair.public_key(),
         signature,
     });

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -12,7 +12,7 @@ use crate::messaging::{
         QueryResponse,
     },
     node::NodeMsg,
-    ClientAuthority, DstLocation, EndUser, MessageId, SrcLocation,
+    DataAuthority, DstLocation, EndUser, MessageId, SrcLocation,
 };
 use crate::routing::Prefix;
 use crate::types::{Chunk, PublicKey};
@@ -46,7 +46,7 @@ pub enum NodeDuty {
     WriteChunk {
         msg_id: MessageId,
         write: ChunkWrite,
-        client_auth: ClientAuthority,
+        data_auth: DataAuthority,
     },
     ProcessRepublish {
         msg_id: MessageId,
@@ -136,14 +136,14 @@ pub enum NodeDuty {
     ProcessRead {
         msg_id: MessageId,
         query: DataQuery,
-        client_auth: ClientAuthority,
+        data_auth: DataAuthority,
         origin: EndUser,
     },
     /// Process write of data
     ProcessWrite {
         msg_id: MessageId,
         cmd: DataCmd,
-        client_auth: ClientAuthority,
+        data_auth: DataAuthority,
         origin: EndUser,
     },
     /// Receive a chunk that is being replicated.

--- a/src/routing/core/msg_handling/end_user.rs
+++ b/src/routing/core/msg_handling/end_user.rs
@@ -112,7 +112,7 @@ impl Core {
             let node_msg = NodeMsg::ForwardDataMsg {
                 msg,
                 user,
-                client_signed: client_auth.into(),
+                data_signed: client_auth.into(),
             };
 
             let wire_msg = match WireMsg::single_src(

--- a/src/routing/core/msg_handling/end_user.rs
+++ b/src/routing/core/msg_handling/end_user.rs
@@ -8,8 +8,7 @@
 
 use super::Core;
 use crate::messaging::{
-    data::DataMsg, node::NodeMsg, ClientAuthority, DstLocation, EndUser, MessageId, MsgKind,
-    WireMsg,
+    data::DataMsg, node::NodeMsg, DataAuthority, DstLocation, EndUser, MessageId, MsgKind, WireMsg,
 };
 use crate::routing::{
     error::Result, messages::WireMsgUtils, routing_api::command::Command, section::SectionUtils,
@@ -24,13 +23,13 @@ impl Core {
         msg_id: MessageId,
         msg: DataMsg,
         user: EndUser,
-        client_auth: ClientAuthority,
+        data_auth: DataAuthority,
     ) -> Result<Vec<Command>> {
         self.send_event(Event::DataMsgReceived {
             msg_id,
             msg: Box::new(msg),
             user,
-            client_auth,
+            data_auth,
         })
         .await;
 
@@ -41,7 +40,7 @@ impl Core {
         &mut self,
         sender: SocketAddr,
         msg_id: MessageId,
-        client_auth: ClientAuthority,
+        data_auth: DataAuthority,
         msg: DataMsg,
         dst_location: DstLocation,
         payload: Bytes,
@@ -55,7 +54,7 @@ impl Core {
                             let wire_msg = WireMsg::new_msg(
                                 msg_id,
                                 payload,
-                                MsgKind::DataMsg(client_auth.into()),
+                                MsgKind::DataMsg(data_auth.into()),
                                 dst_location,
                             )?;
 
@@ -105,14 +104,14 @@ impl Core {
         if is_in_destination {
             // We send this message to be handled by the upper Node layer
             // through the public event stream API
-            self.handle_client_msg_received(msg_id, msg, user, client_auth)
+            self.handle_client_msg_received(msg_id, msg, user, data_auth)
                 .await
         } else {
             // Let's relay the client message then
             let node_msg = NodeMsg::ForwardDataMsg {
                 msg,
                 user,
-                data_signed: client_auth.into(),
+                data_signed: data_auth.into(),
             };
 
             let wire_msg = match WireMsg::single_src(

--- a/src/routing/core/msg_handling/mod.rs
+++ b/src/routing/core/msg_handling/mod.rs
@@ -208,7 +208,7 @@ impl Core {
             NodeMsg::ForwardDataMsg {
                 msg,
                 user,
-                client_signed,
+                data_signed,
             } => {
                 // If elder, always handle Forward
                 if self.is_not_elder() {
@@ -219,7 +219,7 @@ impl Core {
                 // TODO: preserve the source bytes so we don't need to serialize again here, or else
                 // verify earlier.
                 let payload = WireMsg::serialize_msg_payload(&msg)?;
-                let client_auth = client_signed.verify(&payload)?;
+                let client_auth = data_signed.verify(&payload)?;
 
                 self.handle_client_msg_received(msg_id, msg, user, client_auth)
                     .await

--- a/src/routing/core/msg_handling/mod.rs
+++ b/src/routing/core/msg_handling/mod.rs
@@ -99,19 +99,12 @@ impl Core {
             }
             MessageType::Client {
                 msg_id,
-                client_auth,
+                data_auth,
                 msg,
                 dst_location,
             } => {
-                self.handle_end_user_message(
-                    sender,
-                    msg_id,
-                    client_auth,
-                    msg,
-                    dst_location,
-                    payload,
-                )
-                .await
+                self.handle_end_user_message(sender, msg_id, data_auth, msg, dst_location, payload)
+                    .await
             }
         }
     }
@@ -219,9 +212,9 @@ impl Core {
                 // TODO: preserve the source bytes so we don't need to serialize again here, or else
                 // verify earlier.
                 let payload = WireMsg::serialize_msg_payload(&msg)?;
-                let client_auth = data_signed.verify(&payload)?;
+                let data_auth = data_signed.verify(&payload)?;
 
-                self.handle_client_msg_received(msg_id, msg, user, client_auth)
+                self.handle_client_msg_received(msg_id, msg, user, data_auth)
                     .await
             }
             NodeMsg::SectionKnowledge {

--- a/src/routing/messages/mod.rs
+++ b/src/routing/messages/mod.rs
@@ -11,7 +11,7 @@ mod msg_authority;
 pub(super) use self::msg_authority::NodeMsgAuthorityUtils;
 use crate::messaging::{
     node::{NodeMsg, SigShare},
-    BlsShareSigned, ClientSigned, DstLocation, MessageId, MsgKind, NodeMsgAuthority, NodeSigned,
+    BlsShareSigned, DataSigned, DstLocation, MessageId, MsgKind, NodeMsgAuthority, NodeSigned,
     SectionSigned, WireMsg,
 };
 use crate::routing::{
@@ -62,7 +62,7 @@ impl WireMsgUtils for WireMsg {
     fn check_signature(&self) -> Result<()> {
         match self.msg_kind() {
             MsgKind::SectionInfoMsg => {}
-            MsgKind::DataMsg(ClientSigned {
+            MsgKind::DataMsg(DataSigned {
                 public_key,
                 signature,
             }) => {

--- a/src/routing/routing_api/event.rs
+++ b/src/routing/routing_api/event.rs
@@ -9,7 +9,7 @@
 use crate::messaging::{
     data::DataMsg,
     node::{NodeCmd, NodeCmdError, NodeEvent, NodeQuery, NodeQueryResponse},
-    ClientAuthority, DstLocation, EndUser, MessageId, SrcLocation,
+    DataAuthority, DstLocation, EndUser, MessageId, SrcLocation,
 };
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Keypair;
@@ -110,14 +110,14 @@ pub enum Event {
         #[debug(skip)]
         new_keypair: Arc<Keypair>,
     },
-    /// Received a message from a client node.
+    /// Received a message from a peer.
     DataMsgReceived {
         /// The message ID
         msg_id: MessageId,
         /// The content of the message.
         msg: Box<DataMsg>,
-        /// Client authority
-        client_auth: ClientAuthority,
+        /// Data authority
+        data_auth: DataAuthority,
         /// The end user that sent the message.
         /// Its xorname is derived from the client public key,
         /// and the socket_id maps against the actual socketaddr


### PR DESCRIPTION
- e25a2878a **chore(messaging)!: Rename `ClientSigned` -> `DataSigned`**

  This follows from 7dabc4ff3, since these signatures now cover 'data'
  messages, which may not necessarily be signed by a client.
  
  BREAKING_CHANGE: The `ClientSigned` struct is now called `DataSigned`,
  and `client_signed` fields have been renamed `data_signed`.

- 015817edb **refactor(messaging)!: Rename `ClientAuthority` -> `DataAuthority`**

  This follows from 7dabc4ff3, since these signatures now cover 'data'
  messages, which may not necessarily be signed by a client.
  
  BREAKING_CHANGE: The `ClientAuthority` struct is now calle
  `DataAuthority`, and `client_auth` fields have been renamed `data_auth`.
