### PR TITLE
refactor!: Move `PrefixMap` to `types` and simplify impls

### DIFF
--- a/src/messaging/node/mod.rs
+++ b/src/messaging/node/mod.rs
@@ -11,7 +11,6 @@ mod join;
 mod join_as_relocated;
 mod network;
 mod node_msgs;
-mod prefix_map;
 mod relocation;
 mod section;
 mod signed;
@@ -21,7 +20,6 @@ pub use join::{JoinRejectionReason, JoinRequest, JoinResponse, ResourceProofResp
 pub use join_as_relocated::{JoinAsRelocatedRequest, JoinAsRelocatedResponse};
 pub use network::{Network, OtherSection};
 pub use node_msgs::{NodeCmd, NodeQuery, NodeQueryResponse};
-pub use prefix_map::PrefixMap;
 pub use relocation::{RelocateDetails, RelocatePayload, RelocatePromise};
 pub use section::ElderCandidates;
 pub use section::MembershipState;

--- a/src/messaging/node/network.rs
+++ b/src/messaging/node/network.rs
@@ -6,14 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{agreement::SectionSigned, prefix_map::PrefixMap, signed::KeyedSig};
-use crate::messaging::SectionAuthorityProvider;
+use super::{agreement::SectionSigned, signed::KeyedSig};
+use crate::{messaging::SectionAuthorityProvider, types::PrefixMap};
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use xor_name::Prefix;
 
 /// Container for storing information about other sections in the network.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Network {
     /// Other sections: maps section prefixes to their latest signed section authority providers.
     pub sections: PrefixMap<OtherSection>,

--- a/src/routing/network/mod.rs
+++ b/src/routing/network/mod.rs
@@ -18,9 +18,10 @@ use crate::routing::{
 };
 
 use crate::messaging::{
-    node::{Network, OtherSection, Peer, PrefixMap, SectionSigned},
+    node::{Network, OtherSection, Peer, SectionSigned},
     SectionAuthorityProvider,
 };
+use crate::types::PrefixMap;
 use secured_linked_list::SecuredLinkedList;
 use std::iter;
 use xor_name::{Prefix, XorName};

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,6 +17,7 @@ pub mod utils;
 mod chunk;
 mod errors;
 mod keys;
+pub mod prefix_map;
 mod token;
 
 pub use chunk::{
@@ -31,6 +32,7 @@ pub use keys::{
     secret_key::SecretKey,
     signature::{Signature, SignatureShare},
 };
+pub use prefix_map::PrefixMap;
 pub use register::Address as RegisterAddress;
 pub use token::Token;
 


### PR DESCRIPTION
- 104b86894 **refactor!: Move `PrefixMap` to `types` and simplify impls**

  The `PrefixMap` type implements a fully generic map-like structure that
  only depends on `T: Borrow<xor_name::Prefix>`. As such, it's not really
  `messaging`-specific (though it is currently the only call-site).
  
  To keep `messaging` simple, and help with the separation of the
  structure of messages from their API, `PrefixMap` has been moved to
  `types`. Additionally, `Debug` impls are now derived, the `Hash` impl
  has been removed, since it doesn't seem to be used, and serialization is
  now transparent (e.g. `PrefixMap<T>` is serialized exactly like
  `BTreeSet<T>`).
  
  BREAKING CHANGE: `PrefixMap` has moved from `messaging::node` to
  `types`. Additionally, `PrefixMap` and `messaging::node::Network` no
  longer implement `Hash`.
