### PR TITLE
fix(register): load from disk if not in cache

### DIFF
--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -9,7 +9,7 @@
 mod data_store;
 mod encoding;
 mod errors;
-mod register_cmd_event_store;
+mod register_op_store;
 
 use data_store::to_db_key::ToDbKey;
 pub(crate) use data_store::{
@@ -19,4 +19,4 @@ pub(crate) use data_store::{
 };
 pub(crate) use errors::Error;
 use errors::Result;
-pub(crate) use register_cmd_event_store::RegisterCmdEventStore;
+pub(crate) use register_op_store::RegisterOpStore;

--- a/src/dbs/register_op_store.rs
+++ b/src/dbs/register_op_store.rs
@@ -16,12 +16,12 @@ use xor_name::XorName;
 
 /// Disk storage for Registers.
 #[derive(Clone)]
-pub(crate) struct RegisterCmdEventStore {
+pub(crate) struct RegisterOpStore {
     tree: Tree,
     db_name: String,
 }
 
-impl RegisterCmdEventStore {
+impl RegisterOpStore {
     pub(crate) fn new(id: XorName, db: Db) -> Result<Self> {
         let db_name = id.to_db_key()?;
         let tree = db.open_tree(&db_name)?;
@@ -68,7 +68,7 @@ impl RegisterCmdEventStore {
 
 #[cfg(test)]
 mod test {
-    use super::RegisterCmdEventStore;
+    use super::RegisterOpStore;
     use crate::messaging::data::{RegisterCmd, RegisterWrite};
     use crate::messaging::DataSigned;
     use crate::node::Result;
@@ -93,7 +93,7 @@ mod test {
             trace!("Sled Error: {:?}", error);
             Error::UnableToCreateRegisterDb
         })?;
-        let mut store = RegisterCmdEventStore::new(id, db)?;
+        let mut store = RegisterOpStore::new(id, db)?;
 
         let authority_keypair1 = Keypair::new_ed25519(&mut OsRng);
         let pk = authority_keypair1.public_key();

--- a/src/types/register/metadata.rs
+++ b/src/types/register/metadata.rs
@@ -26,14 +26,14 @@ pub type Entry = Vec<u8>;
 /// Address of a Register.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub enum Address {
-    /// Public sequence namespace.
+    /// Public namespace.
     Public {
         /// Name.
         name: XorName,
         /// Tag.
         tag: u64,
     },
-    /// Private sequence namespace.
+    /// Private namespace.
     Private {
         /// Name.
         name: XorName,


### PR DESCRIPTION
When querying storage for register data, we previously did not handle the case
where the cache was empty.

Now we make sure to load from disk, to populate the returned data exchange
struct.