### PR TITLE
fix(ci): win cmd to remove node dir

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Remove node dir and logs fo next test
         if: matrix.os == 'windows-latest'
-        run: rd /s /q ~/.safe/node
+        run: rd /s /q %USERPROFILE%\.safe\node
         shell: cmd
 
       - name: Remove node dir and logs fo next test


### PR DESCRIPTION
Previously did not recognise the cmd.
Now uses backslash and win equivalent of ´~´.