### PR TITLE
refactor(msgs): rename datamsg to servicemsg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.3",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -93,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -142,7 +147,7 @@ dependencies = [
  "instant",
  "pin-project",
  "rand 0.8.4",
- "tokio 1.8.1",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -272,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "blsttc"
-version = "2.0.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731c2cd7030d34eb735f27f803508c34e03456222733fe6660467cd00e8c6b72"
+checksum = "ba6c2136f0f0b7d99f0a2a722a776d3f40e78bae15cfddc15c4fa590d6d4d53f"
 dependencies = [
  "blst",
  "byteorder",
@@ -488,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
@@ -510,18 +515,18 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
- "tokio 1.8.1",
+ "tokio 1.9.0",
  "walkdir",
 ]
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.9.0",
+ "itertools 0.10.1",
 ]
 
 [[package]]
@@ -903,9 +908,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -918,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -928,15 +933,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -945,15 +950,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -964,21 +969,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -1087,7 +1092,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.8.1",
+ "tokio 1.9.0",
  "tokio-util 0.6.7",
  "tracing",
 ]
@@ -1100,18 +1105,12 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -1225,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -1240,8 +1239,8 @@ dependencies = [
  "httpdate 1.0.1",
  "itoa",
  "pin-project-lite 0.2.7",
- "socket2 0.4.0",
- "tokio 1.8.1",
+ "socket2 0.4.1",
+ "tokio 1.9.0",
  "tower-service",
  "tracing",
  "want",
@@ -1301,10 +1300,10 @@ dependencies = [
  "bytes 1.0.1",
  "futures",
  "http",
- "hyper 0.14.10",
+ "hyper 0.14.11",
  "log",
  "rand 0.8.4",
- "tokio 1.8.1",
+ "tokio 1.9.0",
  "url",
  "xmltree",
 ]
@@ -1316,7 +1315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1436,11 +1435,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
+checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
 dependencies = [
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1775,18 +1774,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1883,9 +1882,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -1930,7 +1929,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "thiserror",
- "tokio 1.8.1",
+ "tokio 1.9.0",
  "tracing",
  "webpki",
 ]
@@ -1977,7 +1976,7 @@ dependencies = [
  "rustls 0.19.1",
  "socket2 0.3.19",
  "thiserror",
- "tokio 1.8.1",
+ "tokio 1.9.0",
  "tracing",
  "webpki",
 ]
@@ -2450,7 +2449,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tiny-keccak 2.0.2",
- "tokio 1.8.1",
+ "tokio 1.9.0",
  "tokio-util 0.6.7",
  "tracing",
  "tracing-appender",
@@ -2495,9 +2494,9 @@ dependencies = [
 
 [[package]]
 name = "secured_linked_list"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1194adb1e3a2641b89cbc5a7e44ac3b64aa7a824fc822d46b0f6c626129cf2bc"
+checksum = "1ff13e1ff37d93307cf79a60ecaf2644cddde08050261a0c71360acc951fee48"
 dependencies = [
  "bincode",
  "blsttc",
@@ -2608,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -2711,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2763,9 +2762,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2786,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68b8aff80646f09ec11e59b56091a5278ee527d5baeca938f1a5dbd9a15a859"
+checksum = "9e7de153d0438a648bb71e06e300e54fc641685e96af96d49b843f43172d341c"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -2943,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2976,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -3040,7 +3039,7 @@ dependencies = [
  "log",
  "pin-project-lite 0.2.7",
  "slab",
- "tokio 1.8.1",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -3463,9 +3462,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xmltree"
@@ -3505,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/examples/routing_minimal.rs
+++ b/examples/routing_minimal.rs
@@ -277,7 +277,7 @@ async fn handle_event(index: usize, node: &mut Routing, event: Event) -> bool {
                 index, previous_name, new_name,
             );
         }
-        Event::DataMsgReceived { msg, user, .. } => info!(
+        Event::ServiceMsgReceived { msg, user, .. } => info!(
             "Node #{} received message from user: {:?}, msg: {:?}",
             index, user, msg
         ),

--- a/src/client/client_api/commands.rs
+++ b/src/client/client_api/commands.rs
@@ -10,7 +10,7 @@ use super::Client;
 use crate::client::Error;
 use crate::messaging::{
     data::{DataCmd, ServiceMsg},
-    ServiceOpSig, WireMsg,
+    ServiceAuth, WireMsg,
 };
 use crate::types::{PublicKey, Signature};
 use bytes::Bytes;
@@ -28,14 +28,12 @@ impl Client {
         signature: Signature,
     ) -> Result<(), Error> {
         debug!("Sending DataCmd: {:?}", cmd);
-        let data_signed = ServiceOpSig {
+        let auth = ServiceAuth {
             public_key: client_pk,
             signature,
         };
 
-        self.session
-            .send_cmd(cmd, data_signed, serialised_cmd)
-            .await
+        self.session.send_cmd(cmd, auth, serialised_cmd).await
     }
 
     // Send a DataCmd to the network without awaiting for a response.

--- a/src/client/client_api/commands.rs
+++ b/src/client/client_api/commands.rs
@@ -9,8 +9,8 @@
 use super::Client;
 use crate::client::Error;
 use crate::messaging::{
-    data::{DataCmd, DataMsg, ProcessMsg},
-    DataSigned, WireMsg,
+    data::{DataCmd, ServiceMsg},
+    ServiceOpSig, WireMsg,
 };
 use crate::types::{PublicKey, Signature};
 use bytes::Bytes;
@@ -28,7 +28,7 @@ impl Client {
         signature: Signature,
     ) -> Result<(), Error> {
         debug!("Sending DataCmd: {:?}", cmd);
-        let data_signed = DataSigned {
+        let data_signed = ServiceOpSig {
             public_key: client_pk,
             signature,
         };
@@ -42,7 +42,7 @@ impl Client {
     // This function is a helper private to this module.
     pub(crate) async fn send_cmd(&self, cmd: DataCmd) -> Result<(), Error> {
         let client_pk = self.public_key();
-        let msg = DataMsg::Process(ProcessMsg::Cmd(cmd.clone()));
+        let msg = ServiceMsg::Cmd(cmd.clone());
         let serialised_cmd = WireMsg::serialize_msg_payload(&msg)?;
         let signature = self.keypair.sign(&serialised_cmd);
 

--- a/src/client/client_api/queries.rs
+++ b/src/client/client_api/queries.rs
@@ -9,8 +9,8 @@
 use super::Client;
 use crate::client::{connections::QueryResult, errors::Error};
 use crate::messaging::{
-    data::{DataMsg, DataQuery, ProcessMsg},
-    DataSigned, WireMsg,
+    data::{DataQuery, ServiceMsg},
+    ServiceOpSig, WireMsg,
 };
 use crate::types::{PublicKey, Signature};
 use bytes::Bytes;
@@ -28,7 +28,7 @@ impl Client {
         signature: Signature,
     ) -> Result<QueryResult, Error> {
         debug!("Sending Query: {:?}", query);
-        let data_signed = DataSigned {
+        let data_signed = ServiceOpSig {
             public_key: client_pk,
             signature,
         };
@@ -42,7 +42,7 @@ impl Client {
     // This function is a helper private to this module.
     pub(crate) async fn send_query(&self, query: DataQuery) -> Result<QueryResult, Error> {
         let client_pk = self.public_key();
-        let msg = DataMsg::Process(ProcessMsg::Query(query.clone()));
+        let msg = ServiceMsg::Query(query.clone());
         let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
         let signature = self.keypair.sign(&serialised_query);
 

--- a/src/client/client_api/queries.rs
+++ b/src/client/client_api/queries.rs
@@ -10,7 +10,7 @@ use super::Client;
 use crate::client::{connections::QueryResult, errors::Error};
 use crate::messaging::{
     data::{DataQuery, ServiceMsg},
-    ServiceOpSig, WireMsg,
+    ServiceAuth, WireMsg,
 };
 use crate::types::{PublicKey, Signature};
 use bytes::Bytes;
@@ -28,14 +28,12 @@ impl Client {
         signature: Signature,
     ) -> Result<QueryResult, Error> {
         debug!("Sending Query: {:?}", query);
-        let data_signed = ServiceOpSig {
+        let auth = ServiceAuth {
             public_key: client_pk,
             signature,
         };
 
-        self.session
-            .send_query(query, data_signed, serialised_query)
-            .await
+        self.session.send_query(query, auth, serialised_query).await
     }
 
     // Send a Query to the network and await a response.

--- a/src/client/connections/messaging.rs
+++ b/src/client/connections/messaging.rs
@@ -11,7 +11,7 @@ use crate::client::Error;
 use crate::messaging::{
     data::{ChunkRead, DataCmd, DataQuery, QueryResponse},
     section_info::SectionInfoMsg,
-    DataSigned, MessageId, WireMsg,
+    MessageId, ServiceOpSig, WireMsg,
 };
 use crate::messaging::{DstLocation, MsgKind};
 use crate::types::{Chunk, PrivateChunk, PublicChunk, PublicKey};
@@ -108,11 +108,11 @@ impl Session {
         Ok(())
     }
 
-    /// Send a `DataMsg` to the network without awaiting for a response.
+    /// Send a `ServiceMsg` to the network without awaiting for a response.
     pub(crate) async fn send_cmd(
         &self,
         cmd: DataCmd,
-        data_signed: DataSigned,
+        data_signed: ServiceOpSig,
         payload: Bytes,
     ) -> Result<(), Error> {
         let endpoint = self.endpoint()?.clone();
@@ -151,7 +151,7 @@ impl Session {
             name: dst_section_name,
             section_pk,
         };
-        let msg_kind = MsgKind::DataMsg(data_signed);
+        let msg_kind = MsgKind::ServiceMsg(data_signed);
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
 
         let msg_bytes = wire_msg.serialize()?;
@@ -191,11 +191,11 @@ impl Session {
         Ok(())
     }
 
-    /// Send a `DataMsg` to the network awaiting for the response.
+    /// Send a `ServiceMsg` to the network awaiting for the response.
     pub(crate) async fn send_query(
         &self,
         query: DataQuery,
-        data_signed: DataSigned,
+        data_signed: ServiceOpSig,
         payload: Bytes,
     ) -> Result<QueryResult, Error> {
         let endpoint = self.endpoint()?.clone();
@@ -219,7 +219,7 @@ impl Session {
             section_pk,
         };
         let msg_id = MessageId::new();
-        let msg_kind = MsgKind::DataMsg(data_signed);
+        let msg_kind = MsgKind::ServiceMsg(data_signed);
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
 
         let msg_bytes = wire_msg.serialize()?;
@@ -297,7 +297,7 @@ impl Session {
                             tokio::time::sleep(std::time::Duration::from_millis(millis)).await
                         }
                     } else {
-                        trace!("DataMsg with id: {:?}, sent to {}", &msg_id, &socket);
+                        trace!("ServiceMsg with id: {:?}, sent to {}", &msg_id, &socket);
                         result = Ok(());
                         break;
                     }

--- a/src/client/connections/messaging.rs
+++ b/src/client/connections/messaging.rs
@@ -11,7 +11,7 @@ use crate::client::Error;
 use crate::messaging::{
     data::{ChunkRead, DataCmd, DataQuery, QueryResponse},
     section_info::SectionInfoMsg,
-    MessageId, ServiceOpSig, WireMsg,
+    MessageId, ServiceAuth, WireMsg,
 };
 use crate::messaging::{DstLocation, MsgKind};
 use crate::types::{Chunk, PrivateChunk, PublicChunk, PublicKey};
@@ -112,7 +112,7 @@ impl Session {
     pub(crate) async fn send_cmd(
         &self,
         cmd: DataCmd,
-        data_signed: ServiceOpSig,
+        auth: ServiceAuth,
         payload: Bytes,
     ) -> Result<(), Error> {
         let endpoint = self.endpoint()?.clone();
@@ -151,7 +151,7 @@ impl Session {
             name: dst_section_name,
             section_pk,
         };
-        let msg_kind = MsgKind::ServiceMsg(data_signed);
+        let msg_kind = MsgKind::ServiceMsg(auth);
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
 
         let msg_bytes = wire_msg.serialize()?;
@@ -195,7 +195,7 @@ impl Session {
     pub(crate) async fn send_query(
         &self,
         query: DataQuery,
-        data_signed: ServiceOpSig,
+        auth: ServiceAuth,
         payload: Bytes,
     ) -> Result<QueryResult, Error> {
         let endpoint = self.endpoint()?.clone();
@@ -219,7 +219,7 @@ impl Session {
             section_pk,
         };
         let msg_id = MessageId::new();
-        let msg_kind = MsgKind::ServiceMsg(data_signed);
+        let msg_kind = MsgKind::ServiceMsg(auth);
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
 
         let msg_bytes = wire_msg.serialize()?;

--- a/src/messaging/authority.rs
+++ b/src/messaging/authority.rs
@@ -15,7 +15,7 @@ use xor_name::XorName;
 
 /// Authority of a network peer.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DataSigned {
+pub struct ServiceOpSig {
     /// Peer's public key.
     pub public_key: PublicKey,
     /// Peer's signature.
@@ -161,7 +161,7 @@ pub trait VerifyAuthority: Sized + sealed::Sealed {
     fn verify_authority(self, payload: impl AsRef<[u8]>) -> Result<Self>;
 }
 
-impl VerifyAuthority for DataSigned {
+impl VerifyAuthority for ServiceOpSig {
     fn verify_authority(self, payload: impl AsRef<[u8]>) -> Result<Self> {
         self.public_key
             .verify(&self.signature, payload)
@@ -169,7 +169,7 @@ impl VerifyAuthority for DataSigned {
         Ok(self)
     }
 }
-impl sealed::Sealed for DataSigned {}
+impl sealed::Sealed for ServiceOpSig {}
 
 impl VerifyAuthority for NodeSigned {
     fn verify_authority(self, payload: impl AsRef<[u8]>) -> Result<Self> {

--- a/src/messaging/data/register.rs
+++ b/src/messaging/data/register.rs
@@ -63,7 +63,7 @@ pub struct RegisterCmd {
     /// A signature carrying authority to perform the operation.
     ///
     /// This will be verified against the register's owner and permissions.
-    pub client_sig: crate::messaging::ServiceOpSig,
+    pub auth: crate::messaging::ServiceAuth,
 }
 
 /// [`Register`] write operations.

--- a/src/messaging/data/register.rs
+++ b/src/messaging/data/register.rs
@@ -63,7 +63,7 @@ pub struct RegisterCmd {
     /// A signature carrying authority to perform the operation.
     ///
     /// This will be verified against the register's owner and permissions.
-    pub client_sig: crate::messaging::DataSigned,
+    pub client_sig: crate::messaging::ServiceOpSig,
 }
 
 /// [`Register`] write operations.

--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -42,7 +42,7 @@ mod sap;
 
 pub use self::{
     authority::{
-        Authority, BlsShareSigned, DataSigned, NodeSigned, SectionSigned, VerifyAuthority,
+        Authority, BlsShareSigned, NodeSigned, SectionSigned, ServiceOpSig, VerifyAuthority,
     },
     errors::{Error, Result},
     location::{DstLocation, EndUser, SocketId, SrcLocation},

--- a/src/messaging/mod.rs
+++ b/src/messaging/mod.rs
@@ -42,7 +42,7 @@ mod sap;
 
 pub use self::{
     authority::{
-        Authority, BlsShareSigned, NodeSigned, SectionSigned, ServiceOpSig, VerifyAuthority,
+        AuthorityProof, BlsShareAuth, NodeAuth, SectionAuth, ServiceAuth, VerifyAuthority,
     },
     errors::{Error, Result},
     location::{DstLocation, EndUser, SocketId, SrcLocation},

--- a/src/messaging/msg_kind.rs
+++ b/src/messaging/msg_kind.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{BlsShareSigned, DataSigned, NodeSigned, SectionSigned};
+use super::{BlsShareSigned, NodeSigned, SectionSigned, ServiceOpSig};
 use serde::{Deserialize, Serialize};
 
 /// Source authority of a message.
@@ -28,7 +28,7 @@ pub enum MsgKind {
     /// A data message, with the requesting peer's authority.
     ///
     /// Authority is needed to access private data, such as reading or writing a private file.
-    DataMsg(DataSigned),
+    ServiceMsg(ServiceOpSig),
 
     /// A message from a Node with its own independent authority.
     ///

--- a/src/messaging/msg_kind.rs
+++ b/src/messaging/msg_kind.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{BlsShareSigned, NodeSigned, SectionSigned, ServiceOpSig};
+use super::{BlsShareAuth, NodeAuth, SectionAuth, ServiceAuth};
 use serde::{Deserialize, Serialize};
 
 /// Source authority of a message.
@@ -28,21 +28,21 @@ pub enum MsgKind {
     /// A data message, with the requesting peer's authority.
     ///
     /// Authority is needed to access private data, such as reading or writing a private file.
-    ServiceMsg(ServiceOpSig),
+    ServiceMsg(ServiceAuth),
 
     /// A message from a Node with its own independent authority.
     ///
     /// Node authority is needed when nodes send messages directly to other nodes.
     // FIXME: is the above true? What does is the recieving node validating against?
-    NodeSignedMsg(NodeSigned),
+    NodeAuthMsg(NodeAuth),
 
     /// A message from an Elder node with its share of the section authority.
     ///
     /// Section share authority is needed for messages related to section administration, such as
     /// DKG and relocation.
-    NodeBlsShareSignedMsg(BlsShareSigned),
+    NodeBlsShareAuthMsg(BlsShareAuth),
 
     /// A message from an Elder node with authority of its whole section.
     // FIXME: find an example.
-    SectionSignedMsg(SectionSigned),
+    SectionAuthMsg(SectionAuth),
 }

--- a/src/messaging/node/agreement.rs
+++ b/src/messaging/node/agreement.rs
@@ -56,14 +56,14 @@ pub struct DkgFailureSigSet {
 
 /// A value together with the signature that it was agreed on by the majority of the section elders.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
-pub struct SectionSigned<T: Serialize> {
+pub struct SectionAuth<T: Serialize> {
     /// some value to be agreed upon by elders
     pub value: T,
     /// signature over the value
     pub sig: KeyedSig,
 }
 
-impl<T> Borrow<Prefix> for SectionSigned<T>
+impl<T> Borrow<Prefix> for SectionAuth<T>
 where
     T: Borrow<Prefix> + Serialize,
 {
@@ -105,7 +105,7 @@ pub enum Proposal {
     ///   4. the signature of the new key using the current key
     /// Which we can use to update the section section authority provider and the section chain at
     /// the same time as a single atomic operation without needing to cache anything.
-    OurElders(SectionSigned<SectionAuthorityProvider>),
+    OurElders(SectionAuth<SectionAuthorityProvider>),
     /// Proposal to change whether new nodes are allowed to join our section.
     JoinsAllowed((MessageId, bool)),
 }

--- a/src/messaging/node/join.rs
+++ b/src/messaging/node/join.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{agreement::SectionSigned, section::NodeState};
+use super::{agreement::SectionAuth, section::NodeState};
 use crate::messaging::SectionAuthorityProvider;
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Signature;
@@ -66,9 +66,9 @@ pub enum JoinResponse {
         /// Network genesis key (needed to validate) section_chain
         genesis_key: BlsPublicKey,
         /// SectionAuthorityProvider Signed by (current section)
-        section_auth: SectionSigned<SectionAuthorityProvider>,
+        section_auth: SectionAuth<SectionAuthorityProvider>,
         /// Current node's state
-        node_state: SectionSigned<NodeState>,
+        node_state: SectionAuth<NodeState>,
         /// Full verifiable section chain
         section_chain: SecuredLinkedList,
     },

--- a/src/messaging/node/join_as_relocated.rs
+++ b/src/messaging/node/join_as_relocated.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{agreement::SectionSigned, relocation::RelocatePayload, section::NodeState};
+use super::{agreement::SectionAuth, relocation::RelocatePayload, section::NodeState};
 use crate::messaging::SectionAuthorityProvider;
 use bls::PublicKey as BlsPublicKey;
 use secured_linked_list::SecuredLinkedList;
@@ -36,9 +36,9 @@ pub enum JoinAsRelocatedResponse {
     /// info to become a member of the section.
     Approval {
         /// Section Authority over this message for validation
-        section_auth: SectionSigned<SectionAuthorityProvider>,
+        section_auth: SectionAuth<SectionAuthorityProvider>,
         /// info on current members of the section
-        node_state: SectionSigned<NodeState>,
+        node_state: SectionAuth<NodeState>,
         /// The secured (signed) and verifiable section chain
         section_chain: SecuredLinkedList,
     },

--- a/src/messaging/node/mod.rs
+++ b/src/messaging/node/mod.rs
@@ -15,7 +15,7 @@ mod relocation;
 mod section;
 mod signed;
 
-pub use agreement::{DkgFailureSig, DkgFailureSigSet, DkgKey, Proposal, SectionSigned};
+pub use agreement::{DkgFailureSig, DkgFailureSigSet, DkgKey, Proposal, SectionAuth};
 pub use join::{JoinRejectionReason, JoinRequest, JoinResponse, ResourceProofResponse};
 pub use join_as_relocated::{JoinAsRelocatedRequest, JoinAsRelocatedResponse};
 pub use network::{Network, OtherSection};
@@ -29,7 +29,7 @@ pub use section::{Section, SectionPeers};
 pub use signed::{KeyedSig, SigShare};
 
 use crate::messaging::{
-    data::ServiceMsg, EndUser, MessageId, SectionAuthorityProvider, ServiceOpSig,
+    data::ServiceMsg, EndUser, MessageId, SectionAuthorityProvider, ServiceAuth,
 };
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::message::Message as DkgMessage;
@@ -50,12 +50,12 @@ pub enum NodeMsg {
         /// The origin
         user: EndUser,
         /// Signature provided by the requester.
-        data_signed: ServiceOpSig,
+        auth: ServiceAuth,
     },
     /// Inform other sections about our section or vice-versa.
     SectionKnowledge {
         /// `SectionAuthorityProvider` and `SecuredLinkedList` of the sender's section, with the proof chain.
-        src_info: (SectionSigned<SectionAuthorityProvider>, SecuredLinkedList),
+        src_info: (SectionAuth<SectionAuthorityProvider>, SecuredLinkedList),
         /// Message
         msg: Option<Box<NodeMsg>>,
     },

--- a/src/messaging/node/mod.rs
+++ b/src/messaging/node/mod.rs
@@ -28,7 +28,9 @@ pub use section::Peer;
 pub use section::{Section, SectionPeers};
 pub use signed::{KeyedSig, SigShare};
 
-use crate::messaging::{data::DataMsg, DataSigned, EndUser, MessageId, SectionAuthorityProvider};
+use crate::messaging::{
+    data::ServiceMsg, EndUser, MessageId, SectionAuthorityProvider, ServiceOpSig,
+};
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::message::Message as DkgMessage;
 use itertools::Itertools;
@@ -42,13 +44,13 @@ use xor_name::XorName;
 /// Message sent over the among nodes
 pub enum NodeMsg {
     /// Forward a data message.
-    ForwardDataMsg {
+    ForwardServiceMsg {
         /// The msg
-        msg: DataMsg,
+        msg: ServiceMsg,
         /// The origin
         user: EndUser,
         /// Signature provided by the requester.
-        data_signed: DataSigned,
+        data_signed: ServiceOpSig,
     },
     /// Inform other sections about our section or vice-versa.
     SectionKnowledge {

--- a/src/messaging/node/network.rs
+++ b/src/messaging/node/network.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{agreement::SectionSigned, signed::KeyedSig};
+use super::{agreement::SectionAuth, signed::KeyedSig};
 use crate::{messaging::SectionAuthorityProvider, types::PrefixMap};
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
@@ -23,7 +23,7 @@ pub struct Network {
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 pub struct OtherSection {
     /// Section authority so we know this info was valid
-    pub section_auth: SectionSigned<SectionAuthorityProvider>,
+    pub section_auth: SectionAuth<SectionAuthorityProvider>,
     /// If this is signed by our section, then `key_sig` is `None`. If this is signed by our
     /// sibling section, then `key_sig` contains the proof of the signing key itself signed by our
     /// section.

--- a/src/messaging/node/node_msgs.rs
+++ b/src/messaging/node/node_msgs.rs
@@ -8,7 +8,7 @@
 
 use crate::messaging::{
     data::{ChunkRead, ChunkWrite, DataCmd, DataExchange, DataQuery, Result},
-    EndUser, ServiceOpSig,
+    EndUser, ServiceAuth,
 };
 use crate::types::{Chunk, PublicKey};
 use serde::{Deserialize, Serialize};
@@ -23,7 +23,7 @@ pub enum NodeCmd {
         /// The contianed command
         cmd: DataCmd,
         /// Requester pk and signature
-        data_signed: ServiceOpSig,
+        auth: ServiceAuth,
         /// Message source
         origin: EndUser,
     },
@@ -32,7 +32,7 @@ pub enum NodeCmd {
         /// The contianed command
         cmd: ChunkWrite,
         /// Requester pk and signature
-        data_signed: ServiceOpSig,
+        auth: ServiceAuth,
         /// Message source
         origin: EndUser,
     },
@@ -63,7 +63,7 @@ pub enum NodeQuery {
         /// The actual query message
         query: DataQuery,
         /// Client signature
-        data_signed: ServiceOpSig,
+        auth: ServiceAuth,
         /// The user that has initiated this query
         origin: EndUser,
     },

--- a/src/messaging/node/node_msgs.rs
+++ b/src/messaging/node/node_msgs.rs
@@ -8,7 +8,7 @@
 
 use crate::messaging::{
     data::{ChunkRead, ChunkWrite, DataCmd, DataExchange, DataQuery, Result},
-    DataSigned, EndUser,
+    EndUser, ServiceOpSig,
 };
 use crate::types::{Chunk, PublicKey};
 use serde::{Deserialize, Serialize};
@@ -23,7 +23,7 @@ pub enum NodeCmd {
         /// The contianed command
         cmd: DataCmd,
         /// Requester pk and signature
-        data_signed: DataSigned,
+        data_signed: ServiceOpSig,
         /// Message source
         origin: EndUser,
     },
@@ -32,7 +32,7 @@ pub enum NodeCmd {
         /// The contianed command
         cmd: ChunkWrite,
         /// Requester pk and signature
-        data_signed: DataSigned,
+        data_signed: ServiceOpSig,
         /// Message source
         origin: EndUser,
     },
@@ -63,7 +63,7 @@ pub enum NodeQuery {
         /// The actual query message
         query: DataQuery,
         /// Client signature
-        data_signed: DataSigned,
+        data_signed: ServiceOpSig,
         /// The user that has initiated this query
         origin: EndUser,
     },

--- a/src/messaging/node/relocation.rs
+++ b/src/messaging/node/relocation.rs
@@ -9,7 +9,7 @@
 //! Relocation related messages.
 
 use super::NodeMsg;
-use crate::messaging::SectionSigned;
+use crate::messaging::SectionAuth;
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Signature;
 use serde::{Deserialize, Serialize};
@@ -36,7 +36,7 @@ pub struct RelocatePayload {
     /// Message whose content is Variant::Relocate
     pub details: NodeMsg,
     /// Section authority for the details
-    pub section_signed: SectionSigned,
+    pub section_signed: SectionAuth,
     /// The new name of the node signed using its old public_key, to prove the node identity.
     pub signature_of_new_name_with_old_key: Signature,
 }

--- a/src/messaging/node/section/mod.rs
+++ b/src/messaging/node/section/mod.rs
@@ -15,7 +15,7 @@ pub use node_state::MembershipState;
 pub use node_state::NodeState;
 pub use peer::Peer;
 
-use crate::messaging::{node::agreement::SectionSigned, SectionAuthorityProvider};
+use crate::messaging::{node::agreement::SectionAuth, SectionAuthorityProvider};
 use bls::PublicKey as BlsPublicKey;
 use secured_linked_list::SecuredLinkedList;
 use serde::{Deserialize, Serialize};
@@ -34,7 +34,7 @@ pub struct Section {
     /// The secured linked list of previous section keys
     pub chain: SecuredLinkedList,
     /// Signed section authority
-    pub section_auth: SectionSigned<SectionAuthorityProvider>,
+    pub section_auth: SectionAuth<SectionAuthorityProvider>,
     /// memebers of the section
     pub members: SectionPeers,
 }
@@ -43,7 +43,7 @@ pub struct Section {
 #[derive(Clone, Default, Debug, Eq, Serialize, Deserialize)]
 pub struct SectionPeers {
     /// memebers of the section
-    pub members: BTreeMap<XorName, SectionSigned<NodeState>>,
+    pub members: BTreeMap<XorName, SectionAuth<NodeState>>,
 }
 
 impl PartialEq for SectionPeers {
@@ -59,10 +59,10 @@ impl Hash for SectionPeers {
 }
 
 #[derive(Debug)]
-pub struct IntoIter(btree_map::IntoIter<XorName, SectionSigned<NodeState>>);
+pub struct IntoIter(btree_map::IntoIter<XorName, SectionAuth<NodeState>>);
 
 impl Iterator for IntoIter {
-    type Item = SectionSigned<NodeState>;
+    type Item = SectionAuth<NodeState>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|(_, info)| info)

--- a/src/messaging/serialisation/mod.rs
+++ b/src/messaging/serialisation/mod.rs
@@ -11,8 +11,8 @@ mod wire_msg_header;
 
 pub use self::wire_msg::WireMsg;
 use super::{
-    data::ServiceMsg, node::NodeMsg, section_info::SectionInfoMsg, Authority, BlsShareSigned,
-    DstLocation, MessageId, NodeSigned, SectionSigned, ServiceOpSig,
+    data::ServiceMsg, node::NodeMsg, section_info::SectionInfoMsg, AuthorityProof, BlsShareAuth,
+    DstLocation, MessageId, NodeAuth, SectionAuth, ServiceAuth,
 };
 
 /// Type of message.
@@ -35,7 +35,7 @@ pub enum MessageType {
         /// Message ID
         msg_id: MessageId,
         /// Requester's authority over this message
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
         /// Message destination location
         dst_location: DstLocation,
         /// the message
@@ -59,9 +59,9 @@ pub enum MessageType {
 #[derive(PartialEq, Debug, Clone)]
 pub enum NodeMsgAuthority {
     /// Authority of a single peer.
-    Node(Authority<NodeSigned>),
+    Node(AuthorityProof<NodeAuth>),
     /// Authority of a single peer that uses it's BLS Keyshare to sign the message.
-    BlsShare(Authority<BlsShareSigned>),
+    BlsShare(AuthorityProof<BlsShareAuth>),
     /// Authority of a whole section.
-    Section(Authority<SectionSigned>),
+    Section(AuthorityProof<SectionAuth>),
 }

--- a/src/messaging/serialisation/mod.rs
+++ b/src/messaging/serialisation/mod.rs
@@ -11,8 +11,8 @@ mod wire_msg_header;
 
 pub use self::wire_msg::WireMsg;
 use super::{
-    data::DataMsg, node::NodeMsg, section_info::SectionInfoMsg, Authority, BlsShareSigned,
-    DataSigned, DstLocation, MessageId, NodeSigned, SectionSigned,
+    data::ServiceMsg, node::NodeMsg, section_info::SectionInfoMsg, Authority, BlsShareSigned,
+    DstLocation, MessageId, NodeSigned, SectionSigned, ServiceOpSig,
 };
 
 /// Type of message.
@@ -30,16 +30,16 @@ pub enum MessageType {
         /// the message
         msg: SectionInfoMsg,
     },
-    /// Data message
-    Data {
+    /// Service message
+    Service {
         /// Message ID
         msg_id: MessageId,
         /// Requester's authority over this message
-        data_auth: Authority<DataSigned>,
+        auth: Authority<ServiceOpSig>,
         /// Message destination location
         dst_location: DstLocation,
         /// the message
-        msg: DataMsg,
+        msg: ServiceMsg,
     },
     /// Node to node message
     Node {

--- a/src/node/error.rs
+++ b/src/node/error.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::dbs;
-use crate::messaging::{data::Error as ErrorMessage, MessageId, WireMsg};
+use crate::messaging::{data::Error as ErrorMessage, MessageId};
 use crate::routing::Prefix;
 use crate::types::{convert_dt_error_to_error_message, DataAddress, PublicKey};
 use std::io;
@@ -34,84 +34,21 @@ pub enum Error {
     /// Database error.
     #[error("Database error:: {0}")]
     Database(#[from] dbs::Error),
-    /// Not enough storage available on the network.
-    #[error("Not enough storage available on the network")]
-    NetworkFull,
-    /// No source message provided for ProcessingError
-    #[error("No source message for ProcessingError")]
-    NoSourceMessageForProcessingError,
-    /// Unexpected Process msg. A ProcessingError was expected here...
-    #[error("Unexpected Process msg. A ProcessingError was expected here...")]
-    UnexpectedProcessMsg,
-    /// Node does not manage any section funds.
-    #[error("Node does not currently manage any section funds")]
-    NoSectionFunds,
-    /// Node does not manage any metadata, so is likely not a fully prepared elder yet.
-    #[error("Node does not currently manage any section metadata")]
-    NoSectionMetaData,
-    /// Node does not manage any immutable chunks.
-    #[error("Node does not currently manage any immutable chunks")]
-    NoImmutableChunks,
-    /// Node is currently churning so cannot perform the request.
-    #[error("Cannot complete request due to churning of funds")]
-    NodeChurningFunds,
-    /// Node is currently churning, but failed to sign a message.
-    #[error("Error signing message during churn")]
-    ChurnSignError,
-    /// Genesis node not in genesis stage.
-    #[error("Not in genesis stage")]
-    NotInGenesis,
-    /// Target xorname could not be determined from DstLocation
-    #[error("No destination name found")]
-    NoDestinationName,
-    /// Failed to activate a node, due to it being active already
-    #[error("Cannot activate node: Node is already active")]
-    NodeAlreadyActive,
     /// Not Section PublicKey.
     #[error("Not section public key returned from routing")]
     NoSectionPublicKey,
-    /// Unknown as a Section PublicKey.
-    #[error("PublicKey provided was not identified as a section {0}")]
-    UnknownSectionKey(PublicKey),
-    /// Nodes cannot send direct messages
-    #[error("Node cannot send direct messages. This functionality will be deprecated in routing.")]
-    CannotDirectMessage,
-    /// Node cannot be updated, message cannot be resent
-    #[error("Process error could not be handled. We cannot update the erroring node.")]
-    CannotUpdateProcessErrorNode,
-    /// Not a Section PublicKeyShare.
-    #[error("PublicKey provided for signing as elder is not a BLS PublicKeyShare")]
-    ProvidedPkIsNotBlsShare,
-    /// Not a Section PublicKey.
-    #[error("PublicKey provided for signing as elder is not a BLS")]
-    ProvidedPkIsNotBls,
     /// Not Section PublicKeySet.
     #[error("Not section public key set returned from routing")]
     NoSectionPublicKeySet,
     /// Not Section PublicKey.
     #[error("Not section public key returned from routing for xorname {0}")]
     NoSectionPublicKeyKnown(XorName),
-    /// Unable to parse reward proposal.
-    #[error("Cannot parse reward proposal at this stage")]
-    InvalidRewardStage,
-    /// Node not found for rewarding
-    #[error("Node not found for rewards")]
-    NodeNotFoundForReward,
     /// Key, Value pair not found.
     #[error("No such data: {0:?}")]
     NoSuchData(DataAddress),
-    /// Unable to process fund churn message.
-    #[error("Cannot process fund churn message")]
-    NotChurningFunds,
     /// Creating temp directory failed.
     #[error("Could not create temp store: {0}")]
     TempDirCreationFailed(String),
-    // /// Chunk Store Id could not be found
-    // #[error("Could not fetch StoreId")]
-    // NoStoreId,
-    /// Threshold crypto combine signatures error
-    #[error("Could not combine signatures")]
-    CouldNotCombineSignatures,
     /// Chunk already exists for this node
     #[error("Data already exists at this node")]
     DataExists,
@@ -124,16 +61,16 @@ pub enum Error {
     /// Bincode error.
     #[error("Bincode error:: {0}")]
     Bincode(#[from] bincode::Error),
-    /// Network message error.
-    #[error("Client message error:: {0}")]
-    DataMsg(#[from] crate::messaging::data::Error),
-    /// Network processing error message.
-    #[error("Procesing error:: {0:?}")]
-    ProcessingError(crate::messaging::data::ProcessingError),
+    /// Network service message error.
+    #[error("Network service message error:: {0}")]
+    ServiceMsg(#[from] crate::messaging::data::Error),
+    /// Network service error.
+    #[error("Service error:: {0:?}")]
+    ServiceError(crate::messaging::data::ServiceError),
     /// Network message error.
     #[error("Network message error:: {0}")]
     Message(#[from] crate::messaging::Error),
-    /// NetworkData error.
+    /// Network data error.
     #[error("Network data error:: {0}")]
     NetworkData(#[from] crate::types::Error),
     /// Routing error.
@@ -160,9 +97,6 @@ pub enum Error {
     /// Configuration error.
     #[error("Configuration error: {0}")]
     Configuration(String),
-    /// Failed to send message to connection.
-    #[error("Failed to send message to connection: {{0.0}}")]
-    UnableToSend(WireMsg),
     /// Sled error.
     #[error("Sled error:: {0}")]
     Sled(#[from] sled::Error),

--- a/src/node/event_mapping/client_msg.rs
+++ b/src/node/event_mapping/client_msg.rs
@@ -9,7 +9,7 @@
 use super::{Mapping, MsgContext};
 use crate::messaging::{
     data::{ServiceError, ServiceMsg},
-    Authority, DstLocation, EndUser, MessageId, ServiceOpSig, SrcLocation,
+    AuthorityProof, DstLocation, EndUser, MessageId, ServiceAuth, SrcLocation,
 };
 use crate::node::{
     error::convert_to_error_message,
@@ -20,7 +20,7 @@ use crate::node::{
 pub(super) fn map_client_msg(
     msg_id: MessageId,
     msg: ServiceMsg,
-    auth: Authority<ServiceOpSig>,
+    auth: AuthorityProof<ServiceAuth>,
     user: EndUser,
 ) -> Mapping {
     // Signature has already been validated by the routing layer
@@ -38,7 +38,7 @@ fn map_client_service_msg(
     msg_id: MessageId,
     service_msg: ServiceMsg,
     origin: EndUser,
-    auth: Authority<ServiceOpSig>,
+    auth: AuthorityProof<ServiceAuth>,
 ) -> NodeDuty {
     match service_msg {
         ServiceMsg::Query(query) => NodeDuty::ProcessRead {

--- a/src/node/event_mapping/mod.rs
+++ b/src/node/event_mapping/mod.rs
@@ -9,7 +9,7 @@
 mod client_msg;
 mod node_msg;
 
-use crate::messaging::{data::DataMsg, SrcLocation};
+use crate::messaging::{data::ServiceMsg, SrcLocation};
 use crate::node::{network::Network, node_ops::NodeDuty};
 use crate::routing::{Event as RoutingEvent, MessageReceived, NodeElderChange, XorName, MIN_AGE};
 use crate::types::PublicKey;
@@ -31,7 +31,7 @@ pub(super) enum MsgContext {
         src: SrcLocation,
     },
     Client {
-        msg: DataMsg,
+        msg: ServiceMsg,
         src: SrcLocation,
     },
 }
@@ -46,12 +46,12 @@ pub(super) async fn map_routing_event(event: RoutingEvent, network_api: &Network
             dst,
             msg,
         } => map_node_msg(msg_id, src, dst, *msg),
-        RoutingEvent::DataMsgReceived {
+        RoutingEvent::ServiceMsgReceived {
             msg_id,
             msg,
-            data_auth,
+            auth,
             user,
-        } => map_client_msg(msg_id, *msg, data_auth, user),
+        } => map_client_msg(msg_id, *msg, auth, user),
         RoutingEvent::SectionSplit {
             elders,
             sibling_elders,

--- a/src/node/metadata/elder_stores.rs
+++ b/src/node/metadata/elder_stores.rs
@@ -9,7 +9,7 @@
 use super::chunk_records::ChunkRecords;
 use crate::messaging::{
     data::{DataCmd, DataExchange, DataQuery},
-    Authority, EndUser, MessageId, ServiceOpSig,
+    AuthorityProof, EndUser, MessageId, ServiceAuth,
 };
 use crate::node::{network::Network, node_ops::NodeDuty, Error, Result};
 use crate::routing::Prefix;
@@ -53,7 +53,7 @@ impl ElderStores {
         &mut self,
         cmd: DataCmd,
         msg_id: MessageId,
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
         origin: EndUser,
     ) -> Result<NodeDuty> {
         info!("Writing Data");

--- a/src/node/metadata/elder_stores.rs
+++ b/src/node/metadata/elder_stores.rs
@@ -9,7 +9,7 @@
 use super::chunk_records::ChunkRecords;
 use crate::messaging::{
     data::{DataCmd, DataExchange, DataQuery},
-    Authority, DataSigned, EndUser, MessageId,
+    Authority, EndUser, MessageId, ServiceOpSig,
 };
 use crate::node::{network::Network, node_ops::NodeDuty, Error, Result};
 use crate::routing::Prefix;
@@ -53,16 +53,14 @@ impl ElderStores {
         &mut self,
         cmd: DataCmd,
         msg_id: MessageId,
-        data_auth: Authority<DataSigned>,
+        auth: Authority<ServiceOpSig>,
         origin: EndUser,
     ) -> Result<NodeDuty> {
         info!("Writing Data");
         match cmd {
             DataCmd::Chunk(write) => {
                 info!("Writing Blob");
-                self.chunk_records
-                    .write(write, msg_id, data_auth, origin)
-                    .await
+                self.chunk_records.write(write, msg_id, auth, origin).await
             }
             DataCmd::Register(_write) => {
                 // This has been moved to routing/core/msg_handling

--- a/src/node/metadata/register_storage.rs
+++ b/src/node/metadata/register_storage.rs
@@ -16,7 +16,7 @@ use crate::{
         data::{
             DataCmd, QueryResponse, RegisterCmd, RegisterDataExchange, RegisterRead, RegisterWrite,
         },
-        Authority, DataSigned,
+        Authority, ServiceOpSig,
     },
     types::DataAddress,
 };
@@ -102,14 +102,14 @@ impl RegisterStorage {
         // todo: make outer loop parallel
         for (_, history) in data {
             for op in history {
-                let data_auth =
+                let auth =
                     super::verify_op(op.client_sig.clone(), DataCmd::Register(op.write.clone()))
                         .map_err(|_| {
                             Error::Logic(
                                 "Received register operation signature is invalid".to_string(),
                             )
                         })?;
-                let _ = self.apply(op, data_auth)?;
+                let _ = self.apply(op, auth)?;
             }
         }
 
@@ -121,7 +121,7 @@ impl RegisterStorage {
     pub(crate) async fn write(
         &self,
         write: RegisterWrite,
-        data_auth: Authority<DataSigned>,
+        auth: Authority<ServiceOpSig>,
     ) -> Result<()> {
         let required_space = std::mem::size_of::<RegisterCmd>() as u64;
         if !self.used_space.can_consume(required_space).await {
@@ -129,12 +129,12 @@ impl RegisterStorage {
         }
         let op = RegisterCmd {
             write,
-            client_sig: data_auth.clone().into_inner(),
+            client_sig: auth.clone().into_inner(),
         };
-        self.apply(op, data_auth)
+        self.apply(op, auth)
     }
 
-    fn apply(&self, op: RegisterCmd, data_auth: Authority<DataSigned>) -> Result<()> {
+    fn apply(&self, op: RegisterCmd, auth: Authority<ServiceOpSig>) -> Result<()> {
         let RegisterCmd { write, .. } = op.clone();
 
         let address = *write.address();
@@ -172,8 +172,8 @@ impl RegisterStorage {
                             }
                             // TODO - Register::check_permission() doesn't support Delete yet in safe-nd
                             // register.check_permission(action, Some(client_sig.public_key))?;
-                            if data_auth.public_key != entry.state.owner() {
-                                Err(Error::InvalidOwner(data_auth.public_key))
+                            if auth.public_key != entry.state.owner() {
+                                Err(Error::InvalidOwner(auth.public_key))
                             } else {
                                 info!("Deleting Register");
                                 let _ = self.db.drop_tree(key)?;
@@ -215,7 +215,7 @@ impl RegisterStorage {
                 info!("Editing Register");
                 entry
                     .state
-                    .check_permissions(Action::Write, Some(data_auth.public_key))?;
+                    .check_permissions(Action::Write, Some(auth.public_key))?;
                 let result = entry.state.apply_op(reg_op).map_err(Error::NetworkData);
 
                 if result.is_ok() {
@@ -392,7 +392,7 @@ impl Display for RegisterStorage {
 mod test {
     use super::RegisterOpStore;
     use crate::messaging::data::{RegisterCmd, RegisterWrite};
-    use crate::messaging::DataSigned;
+    use crate::messaging::ServiceOpSig;
     use crate::node::Result;
 
     use crate::node::Error;
@@ -439,7 +439,7 @@ mod test {
 
         let write = RegisterWrite::New(replica1);
 
-        let client_sig = DataSigned {
+        let client_sig = ServiceOpSig {
             public_key: pk,
             signature: authority_keypair1.sign(b""),
         };

--- a/src/node/node_api/handle.rs
+++ b/src/node/node_api/handle.rs
@@ -203,16 +203,11 @@ impl Node {
             NodeDuty::WriteChunk {
                 write,
                 msg_id,
-                data_auth,
+                auth,
             } => {
                 let adult = self.as_adult().await?;
                 let handle = tokio::spawn(async move {
-                    let mut ops = vec![
-                        adult
-                            .chunks
-                            .write(&write, msg_id, data_auth.public_key)
-                            .await?,
-                    ];
+                    let mut ops = vec![adult.chunks.write(&write, msg_id, auth.public_key).await?];
                     ops.extend(adult.chunks.check_storage().await?);
                     Ok(NodeTask::from(ops))
                 });
@@ -297,7 +292,7 @@ impl Node {
             NodeDuty::ProcessRead {
                 query,
                 msg_id,
-                data_auth,
+                auth,
                 origin,
             } => {
                 let elder = self.as_elder().await?;
@@ -308,7 +303,7 @@ impl Node {
                             .meta_data
                             .write()
                             .await
-                            .read(query, msg_id, data_auth.public_key, origin)
+                            .read(query, msg_id, auth.public_key, origin)
                             .await?,
                     ];
                     Ok(NodeTask::from(duties))
@@ -319,7 +314,7 @@ impl Node {
                 cmd,
                 msg_id,
                 origin,
-                data_auth,
+                auth,
             } => {
                 let elder = self.as_elder().await?;
                 let handle = tokio::spawn(async move {
@@ -328,7 +323,7 @@ impl Node {
                             .meta_data
                             .write()
                             .await
-                            .write(cmd, msg_id, data_auth, origin)
+                            .write(cmd, msg_id, auth, origin)
                             .await?,
                     ]))
                 });

--- a/src/node/node_api/messaging.rs
+++ b/src/node/node_api/messaging.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    data::DataMsg, node::NodeMsg, DataSigned, DstLocation, MessageId, MsgKind, WireMsg,
+    data::ServiceMsg, node::NodeMsg, DstLocation, MessageId, MsgKind, ServiceOpSig, WireMsg,
 };
 use crate::node::{
     network::Network,
@@ -57,7 +57,7 @@ pub(crate) async fn send_error(msg: OutgoingLazyError, network: &Network) -> Res
     // FIXME: define which signature/authority this message should really carry,
     // perhaps it needs to carry Node signature on a NodeMsg::QueryResponse msg type.
     // Giving a random sig temporarily
-    let (msg_kind, payload) = random_client_signature(&DataMsg::ProcessingError(msg.msg))?;
+    let (msg_kind, payload) = random_client_signature(&ServiceMsg::ServiceError(msg.msg))?;
 
     let wire_msg = WireMsg::new_msg(MessageId::new(), payload, msg_kind, msg.dst)?;
 
@@ -123,13 +123,13 @@ pub(crate) async fn send_to_nodes(
     Ok(())
 }
 
-fn random_client_signature(client_msg: &DataMsg) -> Result<(MsgKind, Bytes)> {
+fn random_client_signature(client_msg: &ServiceMsg) -> Result<(MsgKind, Bytes)> {
     let mut rng = OsRng;
     let keypair = Keypair::new_ed25519(&mut rng);
     let payload = WireMsg::serialize_msg_payload(client_msg)?;
     let signature = keypair.sign(&payload);
 
-    let msg_kind = MsgKind::DataMsg(DataSigned {
+    let msg_kind = MsgKind::ServiceMsg(ServiceOpSig {
         public_key: keypair.public_key(),
         signature,
     });

--- a/src/node/node_api/messaging.rs
+++ b/src/node/node_api/messaging.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    data::ServiceMsg, node::NodeMsg, DstLocation, MessageId, MsgKind, ServiceOpSig, WireMsg,
+    data::ServiceMsg, node::NodeMsg, DstLocation, MessageId, MsgKind, ServiceAuth, WireMsg,
 };
 use crate::node::{
     network::Network,
@@ -129,7 +129,7 @@ fn random_client_signature(client_msg: &ServiceMsg) -> Result<(MsgKind, Bytes)> 
     let payload = WireMsg::serialize_msg_payload(client_msg)?;
     let signature = keypair.sign(&payload);
 
-    let msg_kind = MsgKind::ServiceMsg(ServiceOpSig {
+    let msg_kind = MsgKind::ServiceMsg(ServiceAuth {
         public_key: keypair.public_key(),
         signature,
     });

--- a/src/node/node_api/mod.rs
+++ b/src/node/node_api/mod.rs
@@ -14,7 +14,7 @@ mod role;
 mod split;
 
 use crate::dbs::UsedSpace;
-use crate::messaging::data::{DataMsg, ProcessingError};
+use crate::messaging::data::ServiceError;
 use crate::node::logging::log_ctx::LogCtx;
 use crate::node::logging::run_system_logger;
 use crate::node::{
@@ -246,13 +246,10 @@ fn try_handle_error(err: Error, ctx: Option<MsgContext>) -> NodeDuty {
                 );
             NodeDuty::NoOp
         }
-        Some(MsgContext::Client {
-            msg: DataMsg::Process(msg),
-            src,
-        }) => {
+        Some(MsgContext::Client { msg, src }) => {
             warn!("Sending in response to a message: {:?}", msg);
-            let err_msg = ProcessingError {
-                source_message: Some(msg),
+            let err_msg = ServiceError {
+                source_message: Some(Box::new(msg)),
                 reason: Some(convert_to_error_message(err)),
             };
 

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -12,7 +12,7 @@ use crate::messaging::{
         ServiceMsg,
     },
     node::NodeMsg,
-    Authority, DstLocation, EndUser, MessageId, ServiceOpSig,
+    AuthorityProof, DstLocation, EndUser, MessageId, ServiceAuth,
 };
 use crate::routing::Prefix;
 use crate::types::{Chunk, PublicKey};
@@ -46,7 +46,7 @@ pub enum NodeDuty {
     WriteChunk {
         msg_id: MessageId,
         write: ChunkWrite,
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
     },
     ProcessRepublish {
         msg_id: MessageId,
@@ -131,14 +131,14 @@ pub enum NodeDuty {
     ProcessRead {
         msg_id: MessageId,
         query: DataQuery,
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
         origin: EndUser,
     },
     /// Process write of data
     ProcessWrite {
         msg_id: MessageId,
         cmd: DataCmd,
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
         origin: EndUser,
     },
     /// Receive a chunk that is being replicated.

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -8,11 +8,11 @@
 
 use crate::messaging::{
     data::{
-        ChunkRead, ChunkWrite, DataCmd, DataExchange, DataMsg, DataQuery, ProcessingError,
-        QueryResponse,
+        ChunkRead, ChunkWrite, DataCmd, DataExchange, DataQuery, QueryResponse, ServiceError,
+        ServiceMsg,
     },
     node::NodeMsg,
-    Authority, DataSigned, DstLocation, EndUser, MessageId,
+    Authority, DstLocation, EndUser, MessageId, ServiceOpSig,
 };
 use crate::routing::Prefix;
 use crate::types::{Chunk, PublicKey};
@@ -46,7 +46,7 @@ pub enum NodeDuty {
     WriteChunk {
         msg_id: MessageId,
         write: ChunkWrite,
-        data_auth: Authority<DataSigned>,
+        auth: Authority<ServiceOpSig>,
     },
     ProcessRepublish {
         msg_id: MessageId,
@@ -131,14 +131,14 @@ pub enum NodeDuty {
     ProcessRead {
         msg_id: MessageId,
         query: DataQuery,
-        data_auth: Authority<DataSigned>,
+        auth: Authority<ServiceOpSig>,
         origin: EndUser,
     },
     /// Process write of data
     ProcessWrite {
         msg_id: MessageId,
         cmd: DataCmd,
-        data_auth: Authority<DataSigned>,
+        auth: Authority<ServiceOpSig>,
         origin: EndUser,
     },
     /// Receive a chunk that is being replicated.
@@ -176,11 +176,11 @@ pub struct OutgoingMsg {
 #[allow(clippy::large_enum_variant)]
 pub enum MsgType {
     Node(NodeMsg),
-    Client(DataMsg),
+    Client(ServiceMsg),
 }
 
 #[derive(Debug, Clone)]
 pub struct OutgoingLazyError {
-    pub msg: ProcessingError,
+    pub msg: ServiceError,
     pub dst: DstLocation,
 }

--- a/src/routing/core/bootstrap/join.rs
+++ b/src/routing/core/bootstrap/join.rs
@@ -300,7 +300,7 @@ impl<'a> Join<'a> {
             let (join_response, sender, src_name) = match event {
                 ConnectionEvent::Received((sender, bytes)) => match WireMsg::from(bytes) {
                     Ok(wire_msg) => match wire_msg.msg_kind() {
-                        MsgKind::DataMsg(_) | MsgKind::SectionInfoMsg => continue,
+                        MsgKind::ServiceMsg(_) | MsgKind::SectionInfoMsg => continue,
                         MsgKind::NodeBlsShareSignedMsg(_) | MsgKind::SectionSignedMsg(_) => {
                             trace!(
                                 "Bootstrap message discarded: sender: {:?} wire_msg: {:?}",
@@ -317,7 +317,7 @@ impl<'a> Join<'a> {
                                     ..
                                 }) => (*resp, sender, msg_authority.src_location().name()),
                                 Ok(
-                                    MessageType::Data { msg_id, .. }
+                                    MessageType::Service { msg_id, .. }
                                     | MessageType::SectionInfo { msg_id, .. }
                                     | MessageType::Node { msg_id, .. },
                                 ) => {

--- a/src/routing/core/bootstrap/relocate.rs
+++ b/src/routing/core/bootstrap/relocate.rs
@@ -11,10 +11,10 @@ use crate::messaging::{
         JoinAsRelocatedRequest, JoinAsRelocatedResponse, NodeMsg, RelocateDetails, RelocatePayload,
         Section,
     },
-    Authority, DstLocation, SectionAuthorityProvider, SectionSigned, WireMsg,
+    AuthorityProof, DstLocation, SectionAuth, SectionAuthorityProvider, WireMsg,
 };
 use crate::routing::{
-    dkg::SectionSignedUtils,
+    dkg::SectionAuthUtils,
     ed25519,
     error::{Error, Result},
     messages::WireMsgUtils,
@@ -37,7 +37,7 @@ pub(crate) struct JoiningAsRelocated {
     dst_section_key: BlsPublicKey,
     relocate_details: RelocateDetails,
     node_msg: NodeMsg,
-    node_msg_auth: Authority<SectionSigned>,
+    node_msg_auth: AuthorityProof<SectionAuth>,
     // Avoid sending more than one request to the same peer.
     used_recipients: HashSet<SocketAddr>,
     relocate_payload: Option<RelocatePayload>,
@@ -49,7 +49,7 @@ impl JoiningAsRelocated {
         genesis_key: BlsPublicKey,
         relocate_details: RelocateDetails,
         node_msg: NodeMsg,
-        section_auth: Authority<SectionSigned>,
+        section_auth: AuthorityProof<SectionAuth>,
     ) -> Result<Self> {
         let dst_section_key = relocate_details.dst_key;
 

--- a/src/routing/core/messaging.rs
+++ b/src/routing/core/messaging.rs
@@ -10,7 +10,7 @@ use super::Core;
 use crate::messaging::{
     node::{
         DkgKey, ElderCandidates, JoinResponse, Network, NodeMsg, NodeState, Peer, Proposal,
-        RelocateDetails, RelocatePromise, Section, SectionSigned,
+        RelocateDetails, RelocatePromise, Section, SectionAuth,
     },
     DstLocation, WireMsg,
 };
@@ -113,10 +113,7 @@ impl Core {
     }
 
     // Send NodeApproval to a joining node which makes them a section member
-    pub(crate) fn send_node_approval(
-        &self,
-        node_state: SectionSigned<NodeState>,
-    ) -> Result<Command> {
+    pub(crate) fn send_node_approval(&self, node_state: SectionAuth<NodeState>) -> Result<Command> {
         info!(
             "Our section with {:?} has approved peer {:?}.",
             self.section.prefix(),

--- a/src/routing/core/mod.rs
+++ b/src/routing/core/mod.rs
@@ -30,7 +30,7 @@ use self::{
     enduser_registry::EndUserRegistry, message_filter::MessageFilter, split_barrier::SplitBarrier,
 };
 use crate::messaging::{
-    node::{Network, NodeMsg, Proposal, Section, SectionSigned},
+    node::{Network, NodeMsg, Proposal, Section, SectionAuth},
     MessageId, SectionAuthorityProvider,
 };
 use crate::routing::{
@@ -133,7 +133,7 @@ impl Core {
 
     pub(crate) fn update_section_knowledge(
         &mut self,
-        section_auth: SectionSigned<SectionAuthorityProvider>,
+        section_auth: SectionAuth<SectionAuthorityProvider>,
         section_chain: SecuredLinkedList,
     ) {
         let prefix = section_auth.value.prefix;

--- a/src/routing/core/msg_handling/agreement.rs
+++ b/src/routing/core/msg_handling/agreement.rs
@@ -9,11 +9,11 @@
 use std::cmp;
 
 use crate::messaging::{
-    node::{KeyedSig, MembershipState, NodeMsg, NodeState, Proposal, SectionSigned},
+    node::{KeyedSig, MembershipState, NodeMsg, NodeState, Proposal, SectionAuth},
     SectionAuthorityProvider,
 };
 use crate::routing::{
-    dkg::SectionSignedUtils,
+    dkg::SectionAuthUtils,
     error::Result,
     network::NetworkUtils,
     peer::PeerUtils,
@@ -85,7 +85,7 @@ impl Core {
             }
         }
 
-        let new_info = SectionSigned {
+        let new_info = SectionAuth {
             value: new_info,
             sig,
         };
@@ -129,7 +129,7 @@ impl Core {
         let age = peer.age();
         let signature = sig.signature.clone();
 
-        if !self.section.update_member(SectionSigned {
+        if !self.section.update_member(SectionAuth {
             value: node_state,
             sig,
         }) {
@@ -165,7 +165,7 @@ impl Core {
         let mut commands = vec![];
         let equal_or_extension = section_auth.prefix() == *self.section.prefix()
             || section_auth.prefix().is_extension_of(self.section.prefix());
-        let section_auth = SectionSigned::new(section_auth, sig.clone());
+        let section_auth = SectionAuth::new(section_auth, sig.clone());
 
         if equal_or_extension {
             // Our section of sub-section
@@ -214,7 +214,7 @@ impl Core {
 
     async fn handle_our_elders_agreement(
         &mut self,
-        section_auth: SectionSigned<SectionAuthorityProvider>,
+        section_auth: SectionAuth<SectionAuthorityProvider>,
         key_sig: KeyedSig,
     ) -> Result<Vec<Command>> {
         let updates = self

--- a/src/routing/core/msg_handling/anti_entropy.rs
+++ b/src/routing/core/msg_handling/anti_entropy.rs
@@ -143,7 +143,7 @@ fn process(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::messaging::{MessageType, NodeSigned};
+    use crate::messaging::{MessageType, NodeAuth};
     use crate::routing::{
         dkg::test_utils::section_signed,
         ed25519,
@@ -300,7 +300,7 @@ mod tests {
             let msg_payload = WireMsg::serialize_msg_payload(&node_msg)
                 .context("Failed to create a test NodeMsg")?;
 
-            let node_msg_authority = NodeMsgAuthority::Node(NodeSigned::authorize(
+            let node_msg_authority = NodeMsgAuthority::Node(NodeAuth::authorize(
                 section_pk,
                 &sender.keypair,
                 &msg_payload,

--- a/src/routing/core/msg_handling/data_msgs.rs
+++ b/src/routing/core/msg_handling/data_msgs.rs
@@ -12,7 +12,7 @@ use crate::messaging::data::ServiceMsg;
 use crate::messaging::{
     data::{CmdError, DataCmd, DataQuery, Error as ErrorMessage, RegisterRead, RegisterWrite},
     node::NodeMsg,
-    Authority, DstLocation, EndUser, MessageId, MsgKind, ServiceOpSig, WireMsg,
+    AuthorityProof, DstLocation, EndUser, MessageId, MsgKind, ServiceAuth, WireMsg,
 };
 use crate::routing::{
     error::Result, messages::WireMsgUtils, routing_api::command::Command, section::SectionUtils,
@@ -55,7 +55,7 @@ impl Core {
         msg_id: MessageId,
         register_cmd: RegisterWrite,
         user: EndUser,
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
     ) -> Result<Vec<Command>> {
         match self.register_storage.write(register_cmd, auth).await {
             Ok(_) => Ok(vec![]),
@@ -72,7 +72,7 @@ impl Core {
         msg_id: MessageId,
         query: RegisterRead,
         user: EndUser,
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
     ) -> Result<Vec<Command>> {
         match self.register_storage.read(&query, auth.public_key) {
             Ok(response) => {
@@ -112,7 +112,7 @@ impl Core {
         msg_id: MessageId,
         msg: ServiceMsg,
         user: EndUser,
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
     ) -> Result<Vec<Command>> {
         match msg {
             ServiceMsg::Cmd(DataCmd::Register(register_cmd)) => {
@@ -142,7 +142,7 @@ impl Core {
         &mut self,
         sender: SocketAddr,
         msg_id: MessageId,
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
         msg: ServiceMsg,
         dst_location: DstLocation,
         payload: Bytes,
@@ -219,7 +219,7 @@ impl Core {
             let node_msg = NodeMsg::ForwardServiceMsg {
                 msg,
                 user,
-                data_signed: auth.into_inner(),
+                auth: auth.into_inner(),
             };
 
             let wire_msg = match WireMsg::single_src(

--- a/src/routing/core/msg_handling/relocation.rs
+++ b/src/routing/core/msg_handling/relocation.rs
@@ -9,7 +9,7 @@
 use super::Core;
 use crate::messaging::{
     node::{NodeMsg, Peer, Proposal, RelocateDetails, RelocatePromise},
-    Authority, SectionSigned,
+    AuthorityProof, SectionAuth,
 };
 use crate::routing::{
     core::bootstrap::JoiningAsRelocated,
@@ -93,7 +93,7 @@ impl Core {
         &mut self,
         relocate_details: RelocateDetails,
         node_msg: NodeMsg,
-        section_auth: Authority<SectionSigned>,
+        section_auth: AuthorityProof<SectionAuth>,
     ) -> Result<Option<Command>> {
         if relocate_details.pub_id != self.node.name() {
             // This `Relocate` message is not for us - it's most likely a duplicate of a previous

--- a/src/routing/core/split_barrier.rs
+++ b/src/routing/core/split_barrier.rs
@@ -8,11 +8,11 @@
 
 use std::mem;
 
-use crate::messaging::{node::SectionSigned, SectionAuthorityProvider};
+use crate::messaging::{node::SectionAuth, SectionAuthorityProvider};
 use crate::routing::dkg::KeyedSig;
 use xor_name::Prefix;
 
-type Entry = (SectionSigned<SectionAuthorityProvider>, KeyedSig);
+type Entry = (SectionAuth<SectionAuthorityProvider>, KeyedSig);
 
 // Helper structure to make sure we process a split by updating info about both our section and the
 // sibling section at the same time.
@@ -32,7 +32,7 @@ impl SplitBarrier {
     pub(crate) fn process(
         &mut self,
         our_prefix: &Prefix,
-        section_auth: SectionSigned<SectionAuthorityProvider>,
+        section_auth: SectionAuth<SectionAuthorityProvider>,
         keyed_sig: KeyedSig,
     ) -> Vec<Entry> {
         if !section_auth.value.prefix.is_extension_of(our_prefix) {

--- a/src/routing/dkg/mod.rs
+++ b/src/routing/dkg/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use self::{
     voter::DkgVoter,
 };
 pub(crate) use crate::messaging::node::{KeyedSig, SigShare};
-pub(super) use section_signed::SectionSignedUtils;
+pub(super) use section_signed::SectionAuthUtils;
 use serde::Serialize;
 
 // Verify the integrity of `message` against `sig`.

--- a/src/routing/dkg/section_signed.rs
+++ b/src/routing/dkg/section_signed.rs
@@ -7,11 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{verify_sig, KeyedSig};
-use crate::messaging::node::SectionSigned;
+use crate::messaging::node::SectionAuth;
 use secured_linked_list::SecuredLinkedList;
 use serde::Serialize;
 
-pub(crate) trait SectionSignedUtils<T: Serialize> {
+pub(crate) trait SectionAuthUtils<T: Serialize> {
     fn new(value: T, sig: KeyedSig) -> Self;
 
     fn verify(&self, section_chain: &SecuredLinkedList) -> bool;
@@ -19,7 +19,7 @@ pub(crate) trait SectionSignedUtils<T: Serialize> {
     fn self_verify(&self) -> bool;
 }
 
-impl<T: Serialize> SectionSignedUtils<T> for SectionSigned<T> {
+impl<T: Serialize> SectionAuthUtils<T> for SectionAuth<T> {
     fn new(value: T, sig: KeyedSig) -> Self {
         Self { value, sig }
     }

--- a/src/routing/dkg/test_utils.rs
+++ b/src/routing/dkg/test_utils.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{KeyedSig, SectionSignedUtils};
-use crate::messaging::node::SectionSigned;
+use super::{KeyedSig, SectionAuthUtils};
+use crate::messaging::node::SectionAuth;
 use crate::routing::{Error, Result};
 use serde::Serialize;
 
@@ -20,11 +20,11 @@ pub(crate) fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> R
     })
 }
 
-// Wrap the given payload in `SectionSigned`
+// Wrap the given payload in `SectionAuth`
 pub(crate) fn section_signed<T: Serialize>(
     secret_key: &bls::SecretKey,
     payload: T,
-) -> Result<SectionSigned<T>> {
+) -> Result<SectionAuth<T>> {
     let sig = prove(secret_key, &payload)?;
-    Ok(SectionSigned::new(payload, sig))
+    Ok(SectionAuth::new(payload, sig))
 }

--- a/src/routing/messages/mod.rs
+++ b/src/routing/messages/mod.rs
@@ -10,7 +10,7 @@ mod msg_authority;
 
 pub(super) use self::msg_authority::NodeMsgAuthorityUtils;
 use crate::messaging::{
-    node::NodeMsg, BlsShareSigned, DstLocation, MessageId, MsgKind, NodeMsgAuthority, NodeSigned,
+    node::NodeMsg, BlsShareAuth, DstLocation, MessageId, MsgKind, NodeAuth, NodeMsgAuthority,
     WireMsg,
 };
 use crate::routing::{
@@ -71,16 +71,16 @@ impl WireMsgUtils for WireMsg {
         let (id, msg_kind) = match node_msg_authority {
             NodeMsgAuthority::Node(node_auth) => (
                 MessageId::from_content(&node_auth.signature).unwrap_or_default(),
-                MsgKind::NodeSignedMsg(node_auth.into_inner()),
+                MsgKind::NodeAuthMsg(node_auth.into_inner()),
             ),
             NodeMsgAuthority::BlsShare(bls_share_auth) => (
                 MessageId::from_content(&bls_share_auth.sig_share.signature_share.0)
                     .unwrap_or_default(),
-                MsgKind::NodeBlsShareSignedMsg(bls_share_auth.into_inner()),
+                MsgKind::NodeBlsShareAuthMsg(bls_share_auth.into_inner()),
             ),
             NodeMsgAuthority::Section(section_auth) => (
                 MessageId::from_content(&section_auth.sig.signature).unwrap_or_default(),
-                MsgKind::SectionSignedMsg(section_auth.into_inner()),
+                MsgKind::SectionAuthMsg(section_auth.into_inner()),
             ),
         };
 
@@ -100,7 +100,7 @@ impl WireMsgUtils for WireMsg {
         let msg_payload =
             WireMsg::serialize_msg_payload(&node_msg).map_err(|_| Error::InvalidMessage)?;
 
-        let msg_authority = NodeMsgAuthority::BlsShare(BlsShareSigned::authorize(
+        let msg_authority = NodeMsgAuthority::BlsShare(BlsShareAuth::authorize(
             src_section_pk,
             src_name,
             key_share,
@@ -120,7 +120,7 @@ impl WireMsgUtils for WireMsg {
         let msg_payload =
             WireMsg::serialize_msg_payload(&node_msg).map_err(|_| Error::InvalidMessage)?;
 
-        let msg_authority = NodeMsgAuthority::Node(NodeSigned::authorize(
+        let msg_authority = NodeMsgAuthority::Node(NodeAuth::authorize(
             src_section_pk,
             &node.keypair,
             &msg_payload,

--- a/src/routing/messages/mod.rs
+++ b/src/routing/messages/mod.rs
@@ -24,7 +24,7 @@ use xor_name::XorName;
 
 // Utilities for WireMsg.
 pub(crate) trait WireMsgUtils {
-    /// Return 'true' if the message kind is MsgKind::DataMsg or MsgKind::SectionInfoMsg
+    /// Return 'true' if the message kind is MsgKind::ServiceMsg or MsgKind::SectionInfoMsg
     fn is_client_msg_kind(&self) -> bool;
 
     /// Creates a signed message where signature is assumed valid.
@@ -53,11 +53,11 @@ pub(crate) trait WireMsgUtils {
 }
 
 impl WireMsgUtils for WireMsg {
-    /// Return 'true' if the message kind is MsgKind::DataMsg or MsgKind::SectionInfoMsg
+    /// Return 'true' if the message kind is MsgKind::ServiceMsg or MsgKind::SectionInfoMsg
     fn is_client_msg_kind(&self) -> bool {
         matches!(
             self.msg_kind(),
-            MsgKind::DataMsg(_) | MsgKind::SectionInfoMsg
+            MsgKind::ServiceMsg(_) | MsgKind::SectionInfoMsg
         )
     }
 

--- a/src/routing/network/mod.rs
+++ b/src/routing/network/mod.rs
@@ -10,13 +10,13 @@ mod stats;
 
 use self::stats::NetworkStats;
 use crate::routing::{
-    dkg::{verify_sig, KeyedSig, SectionSignedUtils},
+    dkg::{verify_sig, KeyedSig, SectionAuthUtils},
     peer::PeerUtils,
     Error, Result, SectionAuthorityProviderUtils,
 };
 
 use crate::messaging::{
-    node::{Network, OtherSection, Peer, SectionSigned},
+    node::{Network, OtherSection, Peer, SectionAuth},
     SectionAuthorityProvider,
 };
 use crate::types::PrefixMap;
@@ -57,7 +57,7 @@ pub(super) trait NetworkUtils {
     /// needed in that case.
     fn update_section(
         &mut self,
-        section_auth: SectionSigned<SectionAuthorityProvider>,
+        section_auth: SectionAuth<SectionAuthorityProvider>,
         key_sig: Option<KeyedSig>,
         section_chain: &SecuredLinkedList,
     ) -> bool;
@@ -151,7 +151,7 @@ impl NetworkUtils for Network {
     /// needed in that case.
     fn update_section(
         &mut self,
-        section_auth: SectionSigned<SectionAuthorityProvider>,
+        section_auth: SectionAuth<SectionAuthorityProvider>,
         key_sig: Option<KeyedSig>,
         section_chain: &SecuredLinkedList,
     ) -> bool {
@@ -321,7 +321,7 @@ mod tests {
     fn gen_section_auth(
         sk: &bls::SecretKey,
         prefix: Prefix,
-    ) -> Result<SectionSigned<SectionAuthorityProvider>> {
+    ) -> Result<SectionAuth<SectionAuthorityProvider>> {
         let (section_auth, _, _) = section::test_utils::gen_section_authority_provider(prefix, 5);
         dkg::test_utils::section_signed(sk, section_auth)
     }

--- a/src/routing/relocation.rs
+++ b/src/routing/relocation.rs
@@ -13,7 +13,7 @@ use crate::messaging::{
         Network, NodeMsg, NodeState, Peer, RelocateDetails, RelocatePayload, RelocatePromise,
         Section,
     },
-    Authority, SectionSigned,
+    AuthorityProof, SectionAuth,
 };
 use crate::routing::{
     core::JoiningAsRelocated,
@@ -100,7 +100,7 @@ impl RelocateDetailsUtils for RelocateDetails {
 pub(super) trait RelocatePayloadUtils {
     fn new(
         details: NodeMsg,
-        section_auth: Authority<SectionSigned>,
+        section_auth: AuthorityProof<SectionAuth>,
         new_name: &XorName,
         old_keypair: &Keypair,
     ) -> Self;
@@ -113,7 +113,7 @@ pub(super) trait RelocatePayloadUtils {
 impl RelocatePayloadUtils for RelocatePayload {
     fn new(
         details: NodeMsg,
-        section_auth: Authority<SectionSigned>,
+        section_auth: AuthorityProof<SectionAuth>,
         new_name: &XorName,
         old_keypair: &Keypair,
     ) -> Self {

--- a/src/routing/routing_api/command.rs
+++ b/src/routing/routing_api/command.rs
@@ -7,9 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    data::DataMsg,
+    data::ServiceMsg,
     node::{DkgFailureSigSet, KeyedSig, Proposal, Section},
-    Authority, DataSigned, EndUser, MessageId, SectionAuthorityProvider, WireMsg,
+    Authority, EndUser, MessageId, SectionAuthorityProvider, ServiceOpSig, WireMsg,
 };
 use crate::routing::{node::Node, routing_api::Peer, section::SectionKeyShare, XorName};
 use std::{
@@ -28,12 +28,12 @@ pub(crate) enum Command {
         sender: SocketAddr,
         wire_msg: WireMsg,
     },
-    /// Handle DataMsg, either directly or notify via event listener
-    HandleDataMessage {
+    /// Handle ServiceMsg, either directly or notify via event listener
+    HandleServiceMessage {
         msg_id: MessageId,
-        msg: DataMsg,
+        msg: ServiceMsg,
         user: EndUser,
-        data_auth: Authority<DataSigned>,
+        auth: Authority<ServiceOpSig>,
     },
     /// Handle a timeout previously scheduled with `ScheduleTimeout`.
     HandleTimeout(u64),

--- a/src/routing/routing_api/command.rs
+++ b/src/routing/routing_api/command.rs
@@ -9,7 +9,7 @@
 use crate::messaging::{
     data::ServiceMsg,
     node::{DkgFailureSigSet, KeyedSig, Proposal, Section},
-    Authority, EndUser, MessageId, SectionAuthorityProvider, ServiceOpSig, WireMsg,
+    AuthorityProof, EndUser, MessageId, SectionAuthorityProvider, ServiceAuth, WireMsg,
 };
 use crate::routing::{node::Node, routing_api::Peer, section::SectionKeyShare, XorName};
 use std::{
@@ -33,7 +33,7 @@ pub(crate) enum Command {
         msg_id: MessageId,
         msg: ServiceMsg,
         user: EndUser,
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
     },
     /// Handle a timeout previously scheduled with `ScheduleTimeout`.
     HandleTimeout(u64),

--- a/src/routing/routing_api/dispatcher.rs
+++ b/src/routing/routing_api/dispatcher.rs
@@ -113,16 +113,16 @@ impl Dispatcher {
                     .handle_message(sender, wire_msg)
                     .await
             }
-            Command::HandleDataMessage {
+            Command::HandleServiceMessage {
                 msg_id,
                 user,
                 msg,
-                data_auth,
+                auth,
             } => {
                 self.core
                     .read()
                     .await
-                    .handle_data_msg_received(msg_id, msg, user, data_auth)
+                    .handle_data_msg_received(msg_id, msg, user, auth)
                     .await
             }
             Command::HandleTimeout(token) => self.core.write().await.handle_timeout(token),
@@ -285,7 +285,7 @@ impl Dispatcher {
                 }
                 .map_err(|e: Error| e)?
             }
-            MsgKind::DataMsg(_) | MsgKind::SectionInfoMsg => {
+            MsgKind::ServiceMsg(_) | MsgKind::SectionInfoMsg => {
                 let _ = self
                     .core
                     .read()

--- a/src/routing/routing_api/dispatcher.rs
+++ b/src/routing/routing_api/dispatcher.rs
@@ -262,9 +262,9 @@ impl Dispatcher {
         wire_msg: WireMsg,
     ) -> Result<Vec<Command>> {
         let cmds = match wire_msg.msg_kind() {
-            MsgKind::NodeSignedMsg(_)
-            | MsgKind::NodeBlsShareSignedMsg(_)
-            | MsgKind::SectionSignedMsg(_) => {
+            MsgKind::NodeAuthMsg(_)
+            | MsgKind::NodeBlsShareAuthMsg(_)
+            | MsgKind::SectionAuthMsg(_) => {
                 let status = self
                     .core
                     .read()

--- a/src/routing/routing_api/event.rs
+++ b/src/routing/routing_api/event.rs
@@ -9,7 +9,7 @@
 use crate::messaging::{
     data::ServiceMsg,
     node::{NodeCmd, NodeQuery, NodeQueryResponse},
-    Authority, DstLocation, EndUser, MessageId, ServiceOpSig, SrcLocation,
+    AuthorityProof, DstLocation, EndUser, MessageId, ServiceAuth, SrcLocation,
 };
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Keypair;
@@ -117,7 +117,7 @@ pub enum Event {
         /// The content of the message.
         msg: Box<ServiceMsg>,
         /// Data authority
-        auth: Authority<ServiceOpSig>,
+        auth: AuthorityProof<ServiceAuth>,
         /// The end user that sent the message.
         /// Its xorname is derived from the client public key,
         /// and the socket_id maps against the actual socketaddr

--- a/src/routing/routing_api/event.rs
+++ b/src/routing/routing_api/event.rs
@@ -7,9 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    data::DataMsg,
+    data::ServiceMsg,
     node::{NodeCmd, NodeQuery, NodeQueryResponse},
-    Authority, DataSigned, DstLocation, EndUser, MessageId, SrcLocation,
+    Authority, DstLocation, EndUser, MessageId, ServiceOpSig, SrcLocation,
 };
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Keypair;
@@ -111,13 +111,13 @@ pub enum Event {
         new_keypair: Arc<Keypair>,
     },
     /// Received a message from a peer.
-    DataMsgReceived {
+    ServiceMsgReceived {
         /// The message ID
         msg_id: MessageId,
         /// The content of the message.
-        msg: Box<DataMsg>,
+        msg: Box<ServiceMsg>,
         /// Data authority
-        data_auth: Authority<DataSigned>,
+        auth: Authority<ServiceOpSig>,
         /// The end user that sent the message.
         /// Its xorname is derived from the client public key,
         /// and the socket_id maps against the actual socketaddr

--- a/src/routing/section/section_peers.rs
+++ b/src/routing/section/section_peers.rs
@@ -8,7 +8,7 @@
 
 use super::node_state::NodeStateUtils;
 use crate::messaging::{
-    node::{MembershipState, NodeState, Peer, SectionPeers, SectionSigned},
+    node::{MembershipState, NodeState, Peer, SectionAuth, SectionPeers},
     SectionAuthorityProvider,
 };
 use crate::routing::{peer::PeerUtils, SectionAuthorityProviderUtils};
@@ -31,7 +31,7 @@ pub(crate) trait SectionPeersUtils {
     fn get(&self, name: &XorName) -> Option<&NodeState>;
 
     /// Get section_signed info for the member with the given name.
-    fn get_section_signed(&self, name: &XorName) -> Option<&SectionSigned<NodeState>>;
+    fn get_section_signed(&self, name: &XorName) -> Option<&SectionAuth<NodeState>>;
 
     /// Returns the candidates for elders out of all the nodes in this section.
     fn elder_candidates(
@@ -56,7 +56,7 @@ pub(crate) trait SectionPeersUtils {
 
     /// Update a member of our section.
     /// Returns whether anything actually changed.
-    fn update(&mut self, new_info: SectionSigned<NodeState>) -> bool;
+    fn update(&mut self, new_info: SectionAuth<NodeState>) -> bool;
 
     /// Remove all members whose name does not match `prefix`.
     fn prune_not_matching(&mut self, prefix: &Prefix);
@@ -93,7 +93,7 @@ impl SectionPeersUtils for SectionPeers {
     }
 
     /// Get section_signed info for the member with the given name.
-    fn get_section_signed(&self, name: &XorName) -> Option<&SectionSigned<NodeState>> {
+    fn get_section_signed(&self, name: &XorName) -> Option<&SectionAuth<NodeState>> {
         self.members.get(name)
     }
 
@@ -148,7 +148,7 @@ impl SectionPeersUtils for SectionPeers {
 
     /// Update a member of our section.
     /// Returns whether anything actually changed.
-    fn update(&mut self, new_info: SectionSigned<NodeState>) -> bool {
+    fn update(&mut self, new_info: SectionAuth<NodeState>) -> bool {
         match self.members.entry(*new_info.value.peer.name()) {
             Entry::Vacant(entry) => {
                 let _ = entry.insert(new_info);
@@ -193,7 +193,7 @@ fn elder_candidates<'a, I>(
     members: I,
 ) -> Vec<Peer>
 where
-    I: IntoIterator<Item = &'a SectionSigned<NodeState>>,
+    I: IntoIterator<Item = &'a SectionAuth<NodeState>>,
 {
     members
         .into_iter()
@@ -205,8 +205,8 @@ where
 
 // Compare candidates for the next elders. The one comparing `Less` wins.
 fn cmp_elder_candidates(
-    lhs: &SectionSigned<NodeState>,
-    rhs: &SectionSigned<NodeState>,
+    lhs: &SectionAuth<NodeState>,
+    rhs: &SectionAuth<NodeState>,
     current_elders: &SectionAuthorityProvider,
 ) -> Ordering {
     // Older nodes are preferred. In case of a tie, prefer current elders. If still a tie, break

--- a/src/routing/tests/messages.rs
+++ b/src/routing/tests/messages.rs
@@ -36,7 +36,7 @@ async fn test_messages_client_node() -> Result<()> {
     let mut rng = rand::thread_rng();
     let keypair = Keypair::new_ed25519(&mut rng);
     let pk = keypair.public_key();
-    let client_sig = ClientSig {
+    let auth = ServiceAuth {
         public_key: pk,
         signature: keypair.sign(b"the msg"),
     };
@@ -60,7 +60,7 @@ async fn test_messages_client_node() -> Result<()> {
     let query = ServiceMsg::Query {
         id,
         query: Query::Transfer(TransferQuery::GetBalance(pk)),
-        client_sig,
+        auth,
     });
     let query_clone = query.clone();
 


### PR DESCRIPTION
The msg type encompasses more than data; in fact all the exposed network services.
Therefore, the name `ServiceMsg` is a better fit.
It also collapses former `DataMsg` and `ProcessMsg` into this one `ServiceMsg`, thereby removing one layer.
Also replaces `Signed` with `Auth`, to denote authority, since that's
what it is described to be in the docs.
`Authority` is then renamed to `AuthorityProof`, since in the docs it is said 
that `Values of this type constitute a proof that the signature is valid for 
a particular payload `.