### PR TITLE
ci: Use the rustc version hash in cache keys

### DIFF
--- a/.github/workflows/all_prs.yml
+++ b/.github/workflows/all_prs.yml
@@ -16,6 +16,7 @@ jobs:
 
       # Install Rust and required components
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         with:
           profile: minimal
           toolchain: stable
@@ -30,7 +31,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Check if the code is formatted correctly.
       - name: Check formatting
@@ -53,6 +54,7 @@ jobs:
 
       # Install Rust and required components
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         with:
           profile: minimal
           toolchain: stable
@@ -67,7 +69,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build launch local network
         uses: actions-rs/cargo@v1
@@ -111,6 +113,7 @@ jobs:
 
       # Install Rust
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         with:
           profile: minimal
           toolchain: stable
@@ -124,7 +127,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Test build scripts.
       - name: Build
@@ -142,6 +145,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         with:
           profile: minimal
           toolchain: stable
@@ -154,7 +158,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cross
         run: cargo install cross

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,7 @@ jobs:
 
       # Install Rust and required components
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         name: Install Rust & required components
         with:
           profile: minimal
@@ -60,7 +61,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build launch local network
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
 
       # Install Rust
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         with:
           profile: minimal
           toolchain: stable
@@ -49,7 +50,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run build.
       - shell: bash
@@ -77,6 +78,7 @@ jobs:
 
       # Install Rust
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         with:
           profile: minimal
           toolchain: stable
@@ -90,7 +92,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run build.
       - shell: bash
@@ -114,6 +116,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         with:
           profile: minimal
           toolchain: stable
@@ -126,7 +129,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       - shell: bash
         run: make ${{ matrix.target }}

--- a/.github/workflows/pr_client.yml
+++ b/.github/workflows/pr_client.yml
@@ -30,6 +30,7 @@ jobs:
 
       # Install Rust
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         if: steps.changes.outputs.src == 'true'
         with:
           profile: minimal
@@ -45,7 +46,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run Doc Tests
         if: steps.changes.outputs.src == 'true'
@@ -74,6 +75,7 @@ jobs:
               - 'src/types/**'
 
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         if: steps.changes.outputs.src == 'true'
         with:
           profile: minimal
@@ -88,7 +90,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cross
         run: cargo install cross

--- a/.github/workflows/pr_data_types.yml
+++ b/.github/workflows/pr_data_types.yml
@@ -34,6 +34,7 @@ jobs:
               
       # Install Rust
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         if: steps.changes.outputs.src == 'true'
         with:
           profile: minimal
@@ -49,7 +50,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run tests.
       - shell: bash

--- a/.github/workflows/pr_messaging.yml
+++ b/.github/workflows/pr_messaging.yml
@@ -33,6 +33,7 @@ jobs:
               - 'src/types/**'
 
       - name: Install Rust
+        id: toolchain
         if: steps.changes.outputs.src == 'true'
         uses: actions-rs/toolchain@v1
         with:
@@ -49,7 +50,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Make sure tests pass.
       - name: Run cargo test
@@ -77,6 +78,7 @@ jobs:
               - 'src/types/**'
 
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         if: steps.changes.outputs.src == 'true'
         with:
           profile: minimal
@@ -91,7 +93,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cross
         run: cargo install cross

--- a/.github/workflows/pr_node.yml
+++ b/.github/workflows/pr_node.yml
@@ -37,6 +37,7 @@ jobs:
 
       # Install Rust
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         if: steps.changes.outputs.src == 'true'
         with:
           profile: minimal
@@ -52,7 +53,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run tests.
       # Currently do not run client tests on mac

--- a/.github/workflows/pr_routing.yml
+++ b/.github/workflows/pr_routing.yml
@@ -35,6 +35,7 @@ jobs:
               
       # Install Rust
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         if: steps.changes.outputs.src == 'true'
         with:
           profile: minimal
@@ -50,7 +51,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run tests.
       - shell: bash
@@ -83,6 +84,7 @@ jobs:
               - 'src/types/**'
               
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         if: steps.changes.outputs.src == 'true'
         with:
           profile: minimal
@@ -97,7 +99,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cross
         run: cargo install cross

--- a/.github/workflows/pr_url.yml
+++ b/.github/workflows/pr_url.yml
@@ -34,6 +34,7 @@ jobs:
               
       # Install Rust
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         if: steps.changes.outputs.src == 'true'
         with:
           profile: minimal
@@ -49,7 +50,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run tests.
       - shell: bash
@@ -80,6 +81,7 @@ jobs:
               - 'src/url/**'
               
       - uses: actions-rs/toolchain@v1
+        id: toolchain
         if: steps.changes.outputs.src == 'true'
         with:
           profile: minimal
@@ -94,7 +96,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cross
         run: cargo install cross


### PR DESCRIPTION
- 8825230fe **ci: Use the rustc version hash in cache keys**

  This prevents issues with reusing intermediate build steps when the rust
  version changes. This is exacerbated by the fact that caches are not
  updated after their first creation, so they would continue to use the
  old results, which could never be used.
