### PR TITLE
Remove `client` feature and improve client config API

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,13 +61,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-1-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build launch local network
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --features=always-joinable
+          args: --release --features=always-joinable,testing
       
       - run: ./target/release/testnet
         if: matrix.os != 'windows-latest'
@@ -93,23 +93,23 @@ jobs:
       - name: Initital client tests...
         shell: bash
         # always joinable not actually needed here, but should speed up compilation as we've just built with it
-        run: timeout 25m cargo test --release --features=always-joinable -- client_api --skip client_api::seq --skip client_api::map --skip client_api::reg --skip client_api::blob --skip client_api::transfer && sleep 5
+        run: timeout 25m cargo test --release --features=always-joinable,testing -- client_api --skip client_api::seq --skip client_api::map --skip client_api::reg --skip client_api::blob --skip client_api::transfer && sleep 5
       
       - name: Client map tests against local network
         shell: bash
-        run: timeout 10m cargo test --release --features=always-joinable -- client_api::map && sleep 5
+        run: timeout 10m cargo test --release --features=always-joinable,testing -- client_api::map && sleep 5
       
       - name: Client reg tests against local network
         shell: bash
-        run: timeout 10m cargo test --release --features=always-joinable -- client_api::reg && sleep 5
+        run: timeout 10m cargo test --release --features=always-joinable,testing -- client_api::reg && sleep 5
       
       - name: Client sequence tests against local network
         shell: bash
-        run: timeout 10m cargo test --release --features=always-joinable -- client_api::seq && sleep 5
+        run: timeout 10m cargo test --release --features=always-joinable,testing -- client_api::seq && sleep 5
       
       - name: Client blob tests against local network
         shell: bash
-        run: timeout 15m cargo test --release --features=always-joinable -- client_api::blob && sleep 5
+        run: timeout 15m cargo test --release --features=always-joinable,testing -- client_api::blob && sleep 5
       
       - name: Run example app for Blob API against local network
         shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,13 +61,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-1-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.toolchain.rustc_hash }}-${{ matrix.target }}-cargo-cache-2-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build launch local network
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --features=always-joinable,testing
+          args: --release --features=always-joinable,testing --bins --examples --tests
       
       - run: ./target/release/testnet
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,27 +93,27 @@ jobs:
       - name: Initital client tests...
         shell: bash
         # always joinable not actually needed here, but should speed up compilation as we've just built with it
-        run: timeout 25m cargo test --release --features=always-joinable,client -- client_api --skip client_api::seq --skip client_api::map --skip client_api::reg --skip client_api::blob --skip client_api::transfer && sleep 5
+        run: timeout 25m cargo test --release --features=always-joinable -- client_api --skip client_api::seq --skip client_api::map --skip client_api::reg --skip client_api::blob --skip client_api::transfer && sleep 5
       
       - name: Client map tests against local network
         shell: bash
-        run: timeout 10m cargo test --release --features=always-joinable,client -- client_api::map && sleep 5
+        run: timeout 10m cargo test --release --features=always-joinable -- client_api::map && sleep 5
       
       - name: Client reg tests against local network
         shell: bash
-        run: timeout 10m cargo test --release --features=always-joinable,client -- client_api::reg && sleep 5
+        run: timeout 10m cargo test --release --features=always-joinable -- client_api::reg && sleep 5
       
       - name: Client sequence tests against local network
         shell: bash
-        run: timeout 10m cargo test --release --features=always-joinable,client -- client_api::seq && sleep 5
+        run: timeout 10m cargo test --release --features=always-joinable -- client_api::seq && sleep 5
       
       - name: Client blob tests against local network
         shell: bash
-        run: timeout 15m cargo test --release --features=always-joinable,client -- client_api::blob && sleep 5
+        run: timeout 15m cargo test --release --features=always-joinable -- client_api::blob && sleep 5
       
       - name: Run example app for Blob API against local network
         shell: bash
-        run: timeout 15m cargo run --release  --features=always-joinable,client,testing --example client_blob
+        run: timeout 15m cargo run --release  --features=always-joinable,testing --example client_blob
       
       - name: Kill the current network (next test doesnt need it)
         if: matrix.os != 'windows-latest'
@@ -136,7 +136,7 @@ jobs:
 
       - name: Run example of split and chunk check
         shell: bash
-        run: timeout 15m cargo run --release  --features=always-joinable,client,testing --example network_split
+        run: timeout 15m cargo run --release  --features=always-joinable,testing --example network_split
       
       - name: Was there a section split?
         run: ./scripts/has_split.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ required-features = ["testing"]
 default = []
 always-joinable = []
 chaos = []
-client = ["qp2p/no-igd"]
 testing = []
 
 [dependencies]

--- a/benches/put.rs
+++ b/benches/put.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use criterion::{criterion_group, criterion_main, Criterion};
 use safe_network::client::utils::generate_random_vector;
 use safe_network::client::utils::test_utils::{read_network_conn_info, run_w_backoff_delayed};
-use safe_network::client::{Client, Error, DEFAULT_QUERY_TIMEOUT};
+use safe_network::client::{config_handler::Config, Client, Error, DEFAULT_QUERY_TIMEOUT};
 use tokio::runtime::Runtime;
 
 /// This bench requires a network already set up
@@ -18,7 +18,8 @@ async fn put_kbs(amount: usize) -> Result<(), Error> {
     let contact_info = read_network_conn_info().unwrap();
     let size = 1024 * amount;
     let data = generate_random_vector(size);
-    let client = Client::new(None, None, Some(contact_info), DEFAULT_QUERY_TIMEOUT).await?;
+    let config = Config::new(None, Some(contact_info)).await;
+    let client = Client::new(None, config, DEFAULT_QUERY_TIMEOUT).await?;
     let address = client.store_public_blob(&data).await?;
 
     // let's make sure the public chunk is stored

--- a/benches/put.rs
+++ b/benches/put.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use criterion::{criterion_group, criterion_main, Criterion};
 use safe_network::client::utils::generate_random_vector;
 use safe_network::client::utils::test_utils::{read_network_conn_info, run_w_backoff_delayed};
-use safe_network::client::{Client, Config, Error, DEFAULT_QUERY_TIMEOUT};
+use safe_network::client::{Client, Config, Error};
 use tokio::runtime::Runtime;
 
 /// This bench requires a network already set up
@@ -18,8 +18,8 @@ async fn put_kbs(amount: usize) -> Result<(), Error> {
     let contact_info = read_network_conn_info().unwrap();
     let size = 1024 * amount;
     let data = generate_random_vector(size);
-    let config = Config::new(None, Some(contact_info)).await;
-    let client = Client::new(None, config, DEFAULT_QUERY_TIMEOUT).await?;
+    let config = Config::new(None, Some(contact_info), None).await;
+    let client = Client::new(None, config).await?;
     let address = client.store_public_blob(&data).await?;
 
     // let's make sure the public chunk is stored

--- a/benches/put.rs
+++ b/benches/put.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use criterion::{criterion_group, criterion_main, Criterion};
 use safe_network::client::utils::generate_random_vector;
 use safe_network::client::utils::test_utils::{read_network_conn_info, run_w_backoff_delayed};
-use safe_network::client::{config_handler::Config, Client, Error, DEFAULT_QUERY_TIMEOUT};
+use safe_network::client::{Client, Config, Error, DEFAULT_QUERY_TIMEOUT};
 use tokio::runtime::Runtime;
 
 /// This bench requires a network already set up

--- a/examples/client_blob.rs
+++ b/examples/client_blob.rs
@@ -8,10 +8,7 @@
 
 use anyhow::{Context, Result};
 use safe_network::{
-    client::{
-        config_handler::Config, utils::test_utils::read_network_conn_info, Client,
-        DEFAULT_QUERY_TIMEOUT,
-    },
+    client::{utils::test_utils::read_network_conn_info, Client, Config, DEFAULT_QUERY_TIMEOUT},
     url::{SafeContentType, SafeUrl, DEFAULT_XORURL_BASE},
 };
 use std::{

--- a/examples/client_blob.rs
+++ b/examples/client_blob.rs
@@ -8,7 +8,7 @@
 
 use anyhow::{Context, Result};
 use safe_network::{
-    client::{utils::test_utils::read_network_conn_info, Client, Config, DEFAULT_QUERY_TIMEOUT},
+    client::{utils::test_utils::read_network_conn_info, Client, Config},
     url::{SafeContentType, SafeUrl, DEFAULT_XORURL_BASE},
 };
 use std::{
@@ -25,8 +25,8 @@ async fn main() -> Result<()> {
     let bootstrap_contacts = read_network_conn_info()?;
 
     println!("Creating a Client to connect to {:?}", bootstrap_contacts);
-    let config = Config::new(None, Some(bootstrap_contacts)).await;
-    let client = Client::new(None, config, DEFAULT_QUERY_TIMEOUT).await?;
+    let config = Config::new(None, Some(bootstrap_contacts), None).await;
+    let client = Client::new(None, config).await?;
 
     let pk = client.public_key();
     println!("Client Public Key: {}", pk);

--- a/examples/client_blob.rs
+++ b/examples/client_blob.rs
@@ -8,7 +8,10 @@
 
 use anyhow::{Context, Result};
 use safe_network::{
-    client::{utils::test_utils::read_network_conn_info, Client, DEFAULT_QUERY_TIMEOUT},
+    client::{
+        config_handler::Config, utils::test_utils::read_network_conn_info, Client,
+        DEFAULT_QUERY_TIMEOUT,
+    },
     url::{SafeContentType, SafeUrl, DEFAULT_XORURL_BASE},
 };
 use std::{
@@ -25,7 +28,8 @@ async fn main() -> Result<()> {
     let bootstrap_contacts = read_network_conn_info()?;
 
     println!("Creating a Client to connect to {:?}", bootstrap_contacts);
-    let client = Client::new(None, None, Some(bootstrap_contacts), DEFAULT_QUERY_TIMEOUT).await?;
+    let config = Config::new(None, Some(bootstrap_contacts)).await;
+    let client = Client::new(None, config, DEFAULT_QUERY_TIMEOUT).await?;
 
     let pk = client.public_key();
     println!("Client Public Key: {}", pk);

--- a/examples/network_split.rs
+++ b/examples/network_split.rs
@@ -23,7 +23,10 @@ use tiny_keccak::{Hasher, Sha3};
 
 use anyhow::{anyhow, Context, Result};
 use safe_network::{
-    client::{utils::generate_random_vector, utils::test_utils::read_network_conn_info, Client},
+    client::{
+        config_handler::Config, utils::generate_random_vector,
+        utils::test_utils::read_network_conn_info, Client,
+    },
     types::ChunkAddress,
     url::{SafeContentType, SafeUrl, DEFAULT_XORURL_BASE},
 };
@@ -174,7 +177,8 @@ pub async fn run_split() -> Result<()> {
     let bootstrap_contacts =
         read_network_conn_info().context("Could not read network bootstrap".to_string())?;
 
-    let client = Client::new(None, None, Some(bootstrap_contacts), QUERY_TIMEOUT).await?;
+    let config = Config::new(None, Some(bootstrap_contacts)).await;
+    let client = Client::new(None, config, QUERY_TIMEOUT).await?;
 
     for (address, hash) in all_data_put {
         println!("...fetching Blob at address {:?} ...", address);
@@ -211,7 +215,8 @@ async fn put_data() -> Result<(ChunkAddress, [u8; 32])> {
         read_network_conn_info().context("Could not read network bootstrap".to_string())?;
 
     println!("Creating a Client to connect to {:?}", bootstrap_contacts);
-    let client = Client::new(None, None, Some(bootstrap_contacts), QUERY_TIMEOUT).await?;
+    let config = Config::new(None, Some(bootstrap_contacts)).await;
+    let client = Client::new(None, config, QUERY_TIMEOUT).await?;
 
     let raw_data = generate_random_vector::<u8>(1024 * 1024);
 

--- a/examples/network_split.rs
+++ b/examples/network_split.rs
@@ -24,8 +24,7 @@ use tiny_keccak::{Hasher, Sha3};
 use anyhow::{anyhow, Context, Result};
 use safe_network::{
     client::{
-        config_handler::Config, utils::generate_random_vector,
-        utils::test_utils::read_network_conn_info, Client,
+        utils::generate_random_vector, utils::test_utils::read_network_conn_info, Client, Config,
     },
     types::ChunkAddress,
     url::{SafeContentType, SafeUrl, DEFAULT_XORURL_BASE},

--- a/examples/network_split.rs
+++ b/examples/network_split.rs
@@ -40,7 +40,7 @@ const NODES_DIR: &str = "local-test-network";
 const INTERVAL: &str = "2";
 const RUST_LOG: &str = "RUST_LOG";
 const ADDITIONAL_NODES_TO_SPLIT: u64 = 30;
-const QUERY_TIMEOUT: u64 = 30;
+const QUERY_TIMEOUT: Duration = Duration::from_secs(30);
 #[tokio::main]
 async fn main() -> Result<()> {
     // First lets build the network and testnet launcher, to ensure we're on the latest version
@@ -176,8 +176,8 @@ pub async fn run_split() -> Result<()> {
     let bootstrap_contacts =
         read_network_conn_info().context("Could not read network bootstrap".to_string())?;
 
-    let config = Config::new(None, Some(bootstrap_contacts)).await;
-    let client = Client::new(None, config, QUERY_TIMEOUT).await?;
+    let config = Config::new(None, Some(bootstrap_contacts), Some(QUERY_TIMEOUT)).await;
+    let client = Client::new(None, config).await?;
 
     for (address, hash) in all_data_put {
         println!("...fetching Blob at address {:?} ...", address);
@@ -214,8 +214,8 @@ async fn put_data() -> Result<(ChunkAddress, [u8; 32])> {
         read_network_conn_info().context("Could not read network bootstrap".to_string())?;
 
     println!("Creating a Client to connect to {:?}", bootstrap_contacts);
-    let config = Config::new(None, Some(bootstrap_contacts)).await;
-    let client = Client::new(None, config, QUERY_TIMEOUT).await?;
+    let config = Config::new(None, Some(bootstrap_contacts), Some(QUERY_TIMEOUT)).await;
+    let client = Client::new(None, config).await?;
 
     let raw_data = generate_random_vector::<u8>(1024 * 1024);
 

--- a/examples/network_split.rs
+++ b/examples/network_split.rs
@@ -44,7 +44,7 @@ const QUERY_TIMEOUT: Duration = Duration::from_secs(30);
 #[tokio::main]
 async fn main() -> Result<()> {
     // First lets build the network and testnet launcher, to ensure we're on the latest version
-    let args: Vec<&str> = vec!["build", "--release", "--features=always-joinable"];
+    let args: Vec<&str> = vec!["build", "--release", "--features=always-joinable,testing"];
 
     println!("Building current sn_node");
     let _child = Command::new("cargo")

--- a/src/bin/testnet.rs
+++ b/src/bin/testnet.rs
@@ -65,16 +65,16 @@ async fn main() -> Result<(), String> {
         .await
         .expect("Cannot create nodes directory");
 
-    #[cfg(any(feature = "always-joinable"))]
-    let mut args: Vec<&str> = vec!["build", "--release"];
+    let mut args = vec!["build", "--release"];
 
-    #[cfg(not(feature = "always-joinable"))]
-    let args: Vec<&str> = vec!["build", "--release"];
-
-    #[cfg(any(feature = "always-joinable"))]
-    {
-        println!("Building node bin with always joinable feature set");
-        args.push("--features=always-joinable")
+    // Keep features consistent to avoid recompiling when possible
+    if cfg!(feature = "always-joinable") {
+        args.push("--features");
+        args.push("always-joinable");
+    }
+    if cfg!(feature = "testing") {
+        args.push("--features");
+        args.push("testing");
     }
 
     println!("Building current sn_node");

--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -52,11 +52,7 @@ impl Client {
     ///
     /// TODO: update once data types are crdt compliant
     ///
-    pub async fn new(
-        optional_keypair: Option<Keypair>,
-        config: Config,
-        query_timeout: u64,
-    ) -> Result<Self, Error> {
+    pub async fn new(optional_keypair: Option<Keypair>, config: Config) -> Result<Self, Error> {
         let mut rng = OsRng;
 
         let keypair = match optional_keypair {
@@ -95,7 +91,7 @@ impl Client {
             keypair,
             session,
             incoming_errors: Arc::new(RwLock::new(err_receiver)),
-            query_timeout: Duration::from_secs(query_timeout),
+            query_timeout: config.query_timeout,
             blob_cache: Arc::new(RwLock::new(LruCache::new(BLOB_CACHE_CAP))),
         };
 

--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -12,7 +12,7 @@ mod commands;
 mod queries;
 mod register_apis;
 
-use crate::client::{config_handler::Config, connections::Session, errors::Error};
+use crate::client::{connections::Session, errors::Error, Config};
 use crate::messaging::data::{CmdError, DataCmd};
 use crate::types::{Chunk, ChunkAddress, Keypair, PublicKey};
 use lru::LruCache;

--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -70,15 +70,11 @@ impl Client {
             }
         };
 
-        let mut qp2p_config = config.qp2p;
-        // We use feature `no-igd` so this will use the echo service only
-        qp2p_config.forward_port = true;
-
         // Incoming error notifiers
         let (err_sender, err_receiver) = tokio::sync::mpsc::channel::<CmdError>(10);
 
         // Create the session with the network
-        let mut session = Session::new(qp2p_config, err_sender)?;
+        let mut session = Session::new(config.qp2p, err_sender)?;
 
         let client_pk = keypair.public_key();
 

--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -17,10 +17,7 @@ use crate::messaging::data::{CmdError, DataCmd};
 use crate::types::{Chunk, ChunkAddress, Keypair, PublicKey};
 use lru::LruCache;
 use rand::rngs::OsRng;
-use std::{
-    path::Path,
-    {collections::HashSet, net::SocketAddr, sync::Arc},
-};
+use std::sync::Arc;
 use tokio::{
     sync::{mpsc::Receiver, RwLock},
     time::Duration,
@@ -57,8 +54,7 @@ impl Client {
     ///
     pub async fn new(
         optional_keypair: Option<Keypair>,
-        config_file_path: Option<&Path>,
-        bootstrap_config: Option<HashSet<SocketAddr>>,
+        config: Config,
         query_timeout: u64,
     ) -> Result<Self, Error> {
         let mut rng = OsRng;
@@ -78,7 +74,7 @@ impl Client {
             }
         };
 
-        let mut qp2p_config = Config::new(config_file_path, bootstrap_config).await.qp2p;
+        let mut qp2p_config = config.qp2p;
         // We use feature `no-igd` so this will use the echo service only
         qp2p_config.forward_port = true;
 
@@ -168,7 +164,10 @@ mod tests {
     use super::*;
     use crate::client::utils::test_utils::{create_test_client, create_test_client_with};
     use anyhow::Result;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::{
+        collections::HashSet,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+    };
 
     #[tokio::test(flavor = "multi_thread")]
     async fn client_creation() -> Result<()> {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -26,20 +26,20 @@
 //! TODO: update once data types are crdt compliant
 //!
 
+mod config_handler;
 mod connections;
 mod errors;
 
 // Export public API.
 
 pub use client_api::Client;
+pub use config_handler::Config;
 pub use errors::Error;
 pub use errors::ErrorMessage;
 pub use qp2p::Config as QuicP2pConfig;
 
 /// Client trait and related constants.
 pub mod client_api;
-/// Config file handling.
-pub mod config_handler;
 
 /// Default timeout in
 pub const DEFAULT_QUERY_TIMEOUT: u64 = 20; // 20 seconds

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,16 +33,13 @@ mod errors;
 // Export public API.
 
 pub use client_api::Client;
-pub use config_handler::Config;
+pub use config_handler::{Config, DEFAULT_QUERY_TIMEOUT};
 pub use errors::Error;
 pub use errors::ErrorMessage;
 pub use qp2p::Config as QuicP2pConfig;
 
 /// Client trait and related constants.
 pub mod client_api;
-
-/// Default timeout in
-pub const DEFAULT_QUERY_TIMEOUT: u64 = 20; // 20 seconds
 
 /// Utility functions.
 pub mod utils;

--- a/src/client/utils/test_utils/test_client.rs
+++ b/src/client/utils/test_utils/test_client.rs
@@ -7,10 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::read_network_conn_info;
-use crate::client::{Client, Config, DEFAULT_QUERY_TIMEOUT};
+use crate::client::{Client, Config};
 use crate::types::Keypair;
 use anyhow::Result;
-use std::sync::Once;
+use std::{sync::Once, time::Duration};
 use tracing_subscriber::{fmt, EnvFilter};
 
 static INIT: Once = Once::new();
@@ -41,10 +41,10 @@ pub async fn create_test_client_with(
     timeout: Option<u64>,
 ) -> Result<Client> {
     init_logger();
-    let timeout = timeout.unwrap_or(DEFAULT_QUERY_TIMEOUT);
+    let timeout = timeout.map(Duration::from_secs);
     let contact_info = read_network_conn_info()?;
-    let config = Config::new(None, Some(contact_info)).await;
-    let client = Client::new(optional_keypair.clone(), config, timeout).await?;
+    let config = Config::new(None, Some(contact_info), timeout).await;
+    let client = Client::new(optional_keypair.clone(), config).await?;
 
     Ok(client)
 }

--- a/src/client/utils/test_utils/test_client.rs
+++ b/src/client/utils/test_utils/test_client.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::read_network_conn_info;
-use crate::client::{config_handler::Config, Client, DEFAULT_QUERY_TIMEOUT};
+use crate::client::{Client, Config, DEFAULT_QUERY_TIMEOUT};
 use crate::types::Keypair;
 use anyhow::Result;
 use std::sync::Once;

--- a/src/client/utils/test_utils/test_client.rs
+++ b/src/client/utils/test_utils/test_client.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::read_network_conn_info;
-use crate::client::{Client, DEFAULT_QUERY_TIMEOUT};
+use crate::client::{config_handler::Config, Client, DEFAULT_QUERY_TIMEOUT};
 use crate::types::Keypair;
 use anyhow::Result;
 use std::sync::Once;
@@ -43,7 +43,8 @@ pub async fn create_test_client_with(
     init_logger();
     let timeout = timeout.unwrap_or(DEFAULT_QUERY_TIMEOUT);
     let contact_info = read_network_conn_info()?;
-    let client = Client::new(optional_keypair.clone(), None, Some(contact_info), timeout).await?;
+    let config = Config::new(None, Some(contact_info)).await;
+    let client = Client::new(optional_keypair.clone(), config, timeout).await?;
 
     Ok(client)
 }


### PR DESCRIPTION
I originally thought I'd have to keep the IGD override in some cases, so spend some time tidying up the `client::Config` APIs (first 3 commits), then decided to just remove the override. The changes are still quite nice though so I've left 'em in.

There will be breakage in `sn_api` and/or `sn_cli` which I'll look at.

---

- a51925c55 **refactor(client)!: Construct `Client` with `Config`**

  This changes the signature of `Client::new` to take a `Config` instance
  rather than separate optional `config_file_path` and `bootstrap_config`.
  This is a better separation of concerns (e.g. set up your configuration,
  then constuct a client with that configuration) and will facilitate
  further improvements to this API.
  
  BREAKING CHANGE: The signature for `Client::new` has changed to require
  a `Config`. `Config` itself can be constructed from the arguments that
  used to be supplied to `Client::new`.

- f7f6db927 **refactor(client)!: Re-export `Config` from `client`**

  With `Config` becoming pat of the interface to construct a `Client`, it
  would be nicer for it to be exported at the same point. Furthermore,
  `Config` is the only public item in `client::config_handler`, so that
  module has been made private.
  
  BREAKING CHANGE: Client `Config` now needs to be imported from
  `client::Config`, rather than `client::config_handler::Config`.

- 62c40f88b **refactor(client)!: Move query timeout into `Config`**

  This is another tweak to normalise the client configuration handling.
  Rather than supplying the query timeout as an additional parameter to
  `Client::new`, it's now passed as part of the config.
  
  BREAKING CHANGE: `Client::new` no longer takes a `query_timeout`
  argument, while `Config::new` now requires one.

- 5c67744ab **fix(client): Don't set `forward_port` for clients**

  Clients do not need a reachable public IP, so turning this on just gives
  us (at least) an additional round trip for now benefit.
  
  This will also allow us to drop the `client` feature as it is no longer
  needed.
  
  Note that this could be regarded as a breaking change since clients
  would no longer be reachable by a public IP, but we expect this not to
  be a problem in practice.

- c58886219 **refactor!: Remove `client` feature**

  This was only used to suppress UPnP IGD when running tests. Since this
  is no longer enabled by default, we can drop the feature.
  
  BREAKING CHANGE: The `client` feature has been removed.

- 22e2e37a7 **test: Normalise features in E2Es**

  All compiling in E2E tests now uses both the `always-joinable` and
  `testing` features. In some cases this is adding the `testing` feature,
  which would only introduce extraneous items. Specifically:
  
  - All `cargo` invocations in e2e.yml use the same features.
  - `testnet`, which builds `sn_node`, uses the same features used for it.
  - `network_split`, which is only run from e2e.yml, uses the same
    features as e2e.yml.
  
  This should reduce the amount of compiling we have to do in E2Es. The
  cache key has been tweaked as well to ensure a fresh cache is generated
  with these changes.

- 06c119e16 **ci: Compile everything up-front in E2Es**

  Rather than building only the binaries (default target for `cargo
  build`) we now build the binaries, examples, and tests, which covers
  everything used in the workflow.
  
  The cache key has been tweaked to ensure a fresh one is generated with
  these changes.
