### PR TITLE
VersionHash replacing the u64 versions

### DIFF
--- a/src/url/mod.rs
+++ b/src/url/mod.rs
@@ -1752,8 +1752,8 @@ mod tests {
     #[test]
     fn test_native_url_to_string() -> Result<()> {
         // These two are equivalent.  ie, the xorurl is the result of nrs.to_xorurl_string()
-        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&name=John+Doe#somefragment";
-        let xorurl = "safe://my.sub.hyryygyynpm7tjdim96rdtz9kkyc758zqth5b3ynzya69njrjshgu7w84k3tomzy/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&name=John+Doe#somefragment";
+        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&v=hyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy&name=John+Doe#somefragment";
+        let xorurl = "safe://my.sub.hyryygyynpm7tjdim96rdtz9kkyc758zqth5b3ynzya69njrjshgu7w84k3tomzy/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&v=hyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy&name=John+Doe#somefragment";
 
         let nrs = NativeUrl::from_url(nrsurl)?;
         let xor = NativeUrl::from_url(xorurl)?;
@@ -1773,8 +1773,8 @@ mod tests {
     #[test]
     fn test_native_url_parts() -> Result<()> {
         // These two are equivalent.  ie, the xorurl is the result of nrs.to_xorurl_string()
-        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&name=John+Doe#somefragment";
-        let xorurl = "safe://my.sub.hnyydyiixsfrqix9aoqg97jebuzc6748uc8rykhdd5hjrtg5o4xso9jmggbqh/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&name=John+Doe#somefragment";
+        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&v=hyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy&name=John+Doe#somefragment";
+        let xorurl = "safe://my.sub.hnyydyiixsfrqix9aoqg97jebuzc6748uc8rykhdd5hjrtg5o4xso9jmggbqh/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&v=hyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy&name=John+Doe#somefragment";
 
         let nrs = NativeUrl::from_url(nrsurl)?;
         let xor = NativeUrl::from_url(xorurl)?;
@@ -1808,15 +1808,18 @@ mod tests {
 
         assert_eq!(
             nrs.query_string(),
-            "this=that&this=other&color=blue&name=John+Doe"
+            "this=that&this=other&color=blue&v=hyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy&name=John+Doe"
         );
         assert_eq!(
             xor.query_string(),
-            "this=that&this=other&color=blue&name=John+Doe"
+            "this=that&this=other&color=blue&v=hyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy&name=John+Doe"
         );
 
         assert_eq!(nrs.fragment(), "somefragment");
         assert_eq!(xor.fragment(), "somefragment");
+
+        assert_eq!(nrs.content_version(), Some(VersionHash::default()));
+        assert_eq!(xor.content_version(), Some(VersionHash::default()));
 
         Ok(())
     }
@@ -1899,7 +1902,7 @@ mod tests {
 
     #[test]
     fn test_native_url_validate() -> Result<()> {
-        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&name=John+Doe#somefragment";
+        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&v=hyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy&name=John+Doe#somefragment";
         let trailing_slash = "safe://my.domain/";
         let double_q = "safe://my.domain/??foo=bar";
 

--- a/src/url/mod.rs
+++ b/src/url/mod.rs
@@ -1421,7 +1421,7 @@ mod tests {
         let xor_name = XorName(*b"12345678901234567890123456789012");
         let type_tag: u64 = 0x0eef;
         let subdirs = "/dir1/dir2";
-        let content_version = 5;
+        let content_version = VersionHash::default();
         let query_string = "k1=v1&k2=v2";
         let query_string_v = format!("{}&v={}", query_string, content_version);
         let fragment = "myfragment";
@@ -1436,7 +1436,7 @@ mod tests {
             Some(vec!["subname".to_string()]),
             Some(query_string),
             Some(fragment),
-            Some(5),
+            Some(content_version),
             XorUrlBase::Base32z,
         )?;
         let native_url = NativeUrl::from_url(&xorurl)?;
@@ -1635,20 +1635,21 @@ mod tests {
         assert_eq!(x.to_string(), "safe://myname?name=&age=25");
 
         // Test setting content version via ?v=61342
-        x.set_query_key(URL_VERSION_QUERY_NAME, Some("61342"))?;
+        let version_hash = VersionHash::default();
+        x.set_query_key(URL_VERSION_QUERY_NAME, Some(&version_hash.to_string()))?;
         assert_eq!(
             x.query_key_last(URL_VERSION_QUERY_NAME),
-            Some("61342".to_string())
+            Some(version_hash.to_string())
         );
-        assert_eq!(x.content_version(), Some(61342));
+        assert_eq!(x.content_version(), Some(version_hash));
 
         // Test unsetting content version via ?v=None
         x.set_query_key(URL_VERSION_QUERY_NAME, None)?;
         assert_eq!(x.query_key_last(URL_VERSION_QUERY_NAME), None);
         assert_eq!(x.content_version(), None);
 
-        // Test parse error for version via ?v=non-integer
-        let result = x.set_query_key(URL_VERSION_QUERY_NAME, Some("non-integer"));
+        // Test parse error for version via ?v=non-hash
+        let result = x.set_query_key(URL_VERSION_QUERY_NAME, Some("non-hash"));
         assert!(result.is_err());
 
         Ok(())
@@ -1656,7 +1657,7 @@ mod tests {
 
     #[test]
     fn test_native_url_set_sub_names() -> Result<()> {
-        let mut x = NativeUrl::from_url("safe://sub1.sub2.myname?v=5")?;
+        let mut x = NativeUrl::from_url("safe://sub1.sub2.myname")?;
         assert_eq!(x.sub_names(), "sub1.sub2");
         assert_eq!(x.sub_names_vec(), ["sub1", "sub2"]);
 
@@ -1664,7 +1665,7 @@ mod tests {
         assert_eq!(x.sub_names(), "s1.s2.s3");
         assert_eq!(x.sub_names_vec(), ["s1", "s2", "s3"]);
 
-        assert_eq!(x.to_string(), "safe://s1.s2.s3.myname?v=5");
+        assert_eq!(x.to_string(), "safe://s1.s2.s3.myname");
         Ok(())
     }
 
@@ -1672,15 +1673,19 @@ mod tests {
     fn test_native_url_set_content_version() -> Result<()> {
         let mut x = NativeUrl::from_url("safe://myname?name=John+Doe&name=Jane%20Doe")?;
 
-        x.set_content_version(Some(234));
+        let version_hash = VersionHash::default();
+        x.set_content_version(Some(version_hash));
         assert_eq!(
             x.query_key_first(URL_VERSION_QUERY_NAME),
-            Some("234".to_string())
+            Some(version_hash.to_string())
         );
-        assert_eq!(x.content_version(), Some(234));
+        assert_eq!(x.content_version(), Some(version_hash));
         assert_eq!(
             x.to_string(),
-            "safe://myname?name=John+Doe&name=Jane+Doe&v=234"
+            format!(
+                "safe://myname?name=John+Doe&name=Jane+Doe&v={}",
+                version_hash
+            )
         );
 
         x.set_content_version(None);
@@ -1696,8 +1701,8 @@ mod tests {
         // Make sure we can read percent-encoded paths, and set them as well.
         // Here we verify that url::Url has the same path encoding behavior
         // as our implementation...for better or worse.
-        let mut x = NativeUrl::from_url("safe://domain/path/to/my%20file.txt?v=1")?;
-        let mut u = Url::parse("safe://domain/path/to/my%20file.txt?v=1").map_err(|e| {
+        let mut x = NativeUrl::from_url("safe://domain/path/to/my%20file.txt")?;
+        let mut u = Url::parse("safe://domain/path/to/my%20file.txt").map_err(|e| {
             Error::InvalidInput(format!(
                 "Unexpectedly failed to parse with third-party Url::parse: {}",
                 e
@@ -1722,14 +1727,14 @@ mod tests {
         u.set_path("no-leading-slash");
         assert_eq!(x.path(), "/no-leading-slash");
         assert_eq!(x.path(), u.path());
-        assert_eq!(x.to_string(), "safe://domain/no-leading-slash?v=1");
+        assert_eq!(x.to_string(), "safe://domain/no-leading-slash");
         assert_eq!(x.to_string(), u.to_string());
 
         x.set_path("");
         u.set_path("");
         assert_eq!(x.path(), ""); // no slash if path is empty.
         assert_eq!(x.path(), u.path());
-        assert_eq!(x.to_string(), "safe://domain?v=1");
+        assert_eq!(x.to_string(), "safe://domain");
         assert_eq!(x.to_string(), u.to_string());
 
         // TODO: url::Url preserves the missing slash, and allows path to
@@ -1738,8 +1743,8 @@ mod tests {
         u.set_path("/");
         assert_eq!(x.path(), "");
         assert_eq!(u.path(), "/"); // slash removed if path otherwise empty.
-        assert_eq!(x.to_string(), "safe://domain?v=1"); // note that slash in path omitted.
-        assert_eq!(u.to_string(), "safe://domain/?v=1");
+        assert_eq!(x.to_string(), "safe://domain"); // note that slash in path omitted.
+        assert_eq!(u.to_string(), "safe://domain/");
 
         Ok(())
     }
@@ -1747,8 +1752,8 @@ mod tests {
     #[test]
     fn test_native_url_to_string() -> Result<()> {
         // These two are equivalent.  ie, the xorurl is the result of nrs.to_xorurl_string()
-        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&v=5&name=John+Doe#somefragment";
-        let xorurl = "safe://my.sub.hyryygyynpm7tjdim96rdtz9kkyc758zqth5b3ynzya69njrjshgu7w84k3tomzy/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&v=5&name=John+Doe#somefragment";
+        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&name=John+Doe#somefragment";
+        let xorurl = "safe://my.sub.hyryygyynpm7tjdim96rdtz9kkyc758zqth5b3ynzya69njrjshgu7w84k3tomzy/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&name=John+Doe#somefragment";
 
         let nrs = NativeUrl::from_url(nrsurl)?;
         let xor = NativeUrl::from_url(xorurl)?;
@@ -1768,8 +1773,8 @@ mod tests {
     #[test]
     fn test_native_url_parts() -> Result<()> {
         // These two are equivalent.  ie, the xorurl is the result of nrs.to_xorurl_string()
-        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&v=5&name=John+Doe#somefragment";
-        let xorurl = "safe://my.sub.hnyydyiixsfrqix9aoqg97jebuzc6748uc8rykhdd5hjrtg5o4xso9jmggbqh/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&v=5&name=John+Doe#somefragment";
+        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&name=John+Doe#somefragment";
+        let xorurl = "safe://my.sub.hnyydyiixsfrqix9aoqg97jebuzc6748uc8rykhdd5hjrtg5o4xso9jmggbqh/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&name=John+Doe#somefragment";
 
         let nrs = NativeUrl::from_url(nrsurl)?;
         let xor = NativeUrl::from_url(xorurl)?;
@@ -1803,11 +1808,11 @@ mod tests {
 
         assert_eq!(
             nrs.query_string(),
-            "this=that&this=other&color=blue&v=5&name=John+Doe"
+            "this=that&this=other&color=blue&name=John+Doe"
         );
         assert_eq!(
             xor.query_string(),
-            "this=that&this=other&color=blue&v=5&name=John+Doe"
+            "this=that&this=other&color=blue&name=John+Doe"
         );
 
         assert_eq!(nrs.fragment(), "somefragment");
@@ -1894,7 +1899,7 @@ mod tests {
 
     #[test]
     fn test_native_url_validate() -> Result<()> {
-        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&v=5&name=John+Doe#somefragment";
+        let nrsurl = "safe://my.sub.domain/path/my%20dir/my%20file.txt?this=that&this=other&color=blue&name=John+Doe#somefragment";
         let trailing_slash = "safe://my.domain/";
         let double_q = "safe://my.domain/??foo=bar";
 

--- a/src/url/version_hash.rs
+++ b/src/url/version_hash.rs
@@ -57,6 +57,13 @@ impl From<&EntryHash> for VersionHash {
     }
 }
 
+impl VersionHash {
+    /// Getter for register the entry hash corresponding to that version
+    pub fn register_entry_hash(&self) -> EntryHash {
+        self.register_entry_hash
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/url/version_hash.rs
+++ b/src/url/version_hash.rs
@@ -9,10 +9,10 @@
 
 use crate::types::register::EntryHash;
 use multibase::Base;
-use std::str::FromStr;
-use std::fmt::{self, Display};
-use std::convert::TryInto;
 use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+use std::fmt::{self, Display};
+use std::str::FromStr;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -25,15 +25,15 @@ pub enum VersionHashError {
     InvalidEncoding,
 }
 
-/// Version Hash corresponding to the register entry hash where the content is stored
+/// Version Hash corresponding to the entry hash where the content is stored
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Default, Copy)]
 pub struct VersionHash {
-    register_entry_hash: EntryHash,
+    entry_hash: EntryHash,
 }
 
 impl Display for VersionHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let base32z = multibase::encode(Base::Base32Z, self.register_entry_hash);
+        let base32z = multibase::encode(Base::Base32Z, self.entry_hash);
         write!(f, "{}", base32z)
     }
 }
@@ -44,30 +44,36 @@ impl FromStr for VersionHash {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (base, data) = multibase::decode(s)?;
         if base != Base::Base32Z {
-            return Err(VersionHashError::InvalidEncoding)
+            return Err(VersionHashError::InvalidEncoding);
         }
-        let entry_hash = data.try_into().map_err(|_| VersionHashError::InvalidHashLength)?;
-        Ok(VersionHash{register_entry_hash: entry_hash})
+        let entry_hash = data
+            .try_into()
+            .map_err(|_| VersionHashError::InvalidHashLength)?;
+        Ok(VersionHash {
+            entry_hash,
+        })
     }
 }
 
 impl From<&EntryHash> for VersionHash {
-    fn from(register_entry_hash: &EntryHash) -> Self {
-        VersionHash{register_entry_hash: register_entry_hash.to_owned()}
+    fn from(entry_hash: &EntryHash) -> Self {
+        VersionHash {
+            entry_hash: entry_hash.to_owned(),
+        }
     }
 }
 
 impl VersionHash {
-    /// Getter for register the entry hash corresponding to that version
-    pub fn register_entry_hash(&self) -> EntryHash {
-        self.register_entry_hash
+    /// Getter for the entry hash corresponding to that version
+    pub fn entry_hash(&self) -> EntryHash {
+        self.entry_hash
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::{Result, bail};
+    use anyhow::{bail, Result};
 
     #[test]
     fn test_version_hash_encode_decode() -> Result<()> {

--- a/src/url/version_hash.rs
+++ b/src/url/version_hash.rs
@@ -1,0 +1,98 @@
+// Copyright 2021 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::types::register::EntryHash;
+use multibase::Base;
+use std::str::FromStr;
+use std::fmt::{self, Display};
+use std::convert::TryInto;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum VersionHashError {
+    #[error("Decoding error")]
+    DecodingError(#[from] multibase::Error),
+    #[error("Invalid hash length")]
+    InvalidHashLength,
+    #[error("Invalid encoding (must be Base32Z)")]
+    InvalidEncoding,
+}
+
+/// Version Hash corresponding to the register entry hash where the content is stored
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Default, Copy)]
+pub struct VersionHash {
+    register_entry_hash: EntryHash,
+}
+
+impl Display for VersionHash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let base32z = multibase::encode(Base::Base32Z, self.register_entry_hash);
+        write!(f, "{}", base32z)
+    }
+}
+
+impl FromStr for VersionHash {
+    type Err = VersionHashError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (base, data) = multibase::decode(s)?;
+        if base != Base::Base32Z {
+            return Err(VersionHashError::InvalidEncoding)
+        }
+        let entry_hash = data.try_into().map_err(|_| VersionHashError::InvalidHashLength)?;
+        Ok(VersionHash{register_entry_hash: entry_hash})
+    }
+}
+
+impl From<&EntryHash> for VersionHash {
+    fn from(register_entry_hash: &EntryHash) -> Self {
+        VersionHash{register_entry_hash: register_entry_hash.to_owned()}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::{Result, bail};
+
+    #[test]
+    fn test_version_hash_encode_decode() -> Result<()> {
+        let string_hash_32bits = "hqt1zg7dwci3ze7dfqp48e3muqt4gkh5wqt1zg7dwci3ze7dfqp4y";
+        let vh = VersionHash::from_str(string_hash_32bits)?;
+        let str_vh = vh.to_string();
+        assert_eq!(&str_vh, string_hash_32bits);
+        Ok(())
+    }
+
+    #[test]
+    fn test_version_hash_decoding_error() -> Result<()> {
+        let string_hash = "hxf1zgedpcfzg1ebbhxf1zgedpcfzg1ebbhxf1zgedpcfzg1ebb";
+        match VersionHash::from_str(string_hash) {
+            Err(VersionHashError::DecodingError(_)) => Ok(()),
+            _ => bail!("Should have triggered a DecodingError"),
+        }
+    }
+
+    #[test]
+    fn test_version_hash_invalid_encoding() -> Result<()> {
+        let string_hash = "900573277761329450583662625";
+        let vh = VersionHash::from_str(string_hash);
+        assert_eq!(vh, Err(VersionHashError::InvalidEncoding));
+        Ok(())
+    }
+
+    #[test]
+    fn test_version_hash_invalid_len() -> Result<()> {
+        let string_hash = "hxf1zgedpcfzg1ebb";
+        let vh = VersionHash::from_str(string_hash);
+        assert_eq!(vh, Err(VersionHashError::InvalidHashLength));
+        Ok(())
+    }
+}

--- a/src/url/version_hash.rs
+++ b/src/url/version_hash.rs
@@ -49,9 +49,7 @@ impl FromStr for VersionHash {
         let entry_hash = data
             .try_into()
             .map_err(|_| VersionHashError::InvalidHashLength)?;
-        Ok(VersionHash {
-            entry_hash,
-        })
+        Ok(VersionHash { entry_hash })
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

Update versions with VersionHash instead of u64
VersionHash is needed by the new NRS and file containers in `sn_api`