### PR TITLE
chore(dbs): bring back the generic event store

### DIFF
--- a/src/dbs/event_store.rs
+++ b/src/dbs/event_store.rs
@@ -7,29 +7,36 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Error, Result, ToDbKey};
-use crate::{
-    messaging::data::RegisterCmd,
-    types::utils::{deserialise, serialise},
-};
+use crate::types::utils::{deserialise, serialise};
+use serde::{de::DeserializeOwned, Serialize};
 use sled::{Db, Tree};
+use std::{fmt::Debug, marker::PhantomData};
 use xor_name::XorName;
 
-/// Disk storage for Registers.
+/// Disk storage for events and similar.
 #[derive(Clone, Debug)]
-pub(crate) struct RegisterOpStore {
+pub(crate) struct EventStore<TEvent: Debug + Serialize + DeserializeOwned> {
     tree: Tree,
     db_name: String,
+    _phantom: PhantomData<TEvent>,
 }
 
-impl RegisterOpStore {
+impl<'a, TEvent: Debug + Serialize + DeserializeOwned> EventStore<TEvent>
+where
+    TEvent: 'a,
+{
     pub(crate) fn new(id: XorName, db: Db) -> Result<Self> {
         let db_name = id.to_db_key()?;
         let tree = db.open_tree(&db_name)?;
-        Ok(Self { tree, db_name })
+        Ok(Self {
+            tree,
+            db_name,
+            _phantom: PhantomData::default(),
+        })
     }
 
     /// Get all events stored in db
-    pub(crate) fn get_all(&self) -> Result<Vec<RegisterCmd>> {
+    pub(crate) fn get_all(&self) -> Result<Vec<TEvent>> {
         let iter = self.tree.iter();
 
         let mut events = vec![];
@@ -38,19 +45,19 @@ impl RegisterOpStore {
             let db_key = String::from_utf8(key.to_vec())
                 .map_err(|_| Error::CouldNotParseDbKey(key.to_vec()))?;
 
-            let value: RegisterCmd = deserialise(&val)?;
+            let value: TEvent = deserialise(&val)?;
             events.push((db_key, value))
         }
 
         events.sort_by(|(key_a, _), (key_b, _)| key_a.partial_cmp(key_b).unwrap());
 
-        let events: Vec<RegisterCmd> = events.into_iter().map(|(_, val)| val).collect();
+        let events: Vec<TEvent> = events.into_iter().map(|(_, val)| val).collect();
 
         Ok(events)
     }
 
-    /// add a new register cmd
-    pub(crate) fn append(&mut self, event: RegisterCmd) -> Result<()> {
+    /// append a new entry
+    pub(crate) fn append(&mut self, event: TEvent) -> Result<()> {
         let key = &self.tree.len().to_string();
         if self.tree.get(key)?.is_some() {
             return Err(Error::InvalidOperation(format!(
@@ -68,69 +75,30 @@ impl RegisterOpStore {
 
 #[cfg(test)]
 mod test {
-    use super::RegisterOpStore;
-    use crate::messaging::data::{RegisterCmd, RegisterWrite};
-    use crate::messaging::DataSigned;
-    use crate::node::Result;
-
-    use crate::node::Error;
-    use crate::types::{
-        register::{PublicPermissions, PublicPolicy, Register, User},
-        Keypair,
-    };
-    use rand::rngs::OsRng;
-    use std::collections::BTreeMap;
+    use super::EventStore;
+    use crate::node::{Error, Result};
+    use crate::types::Token;
     use std::path::Path;
     use tempfile::tempdir;
-    use xor_name::XorName;
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn history_of_register() -> Result<()> {
+    #[tokio::test]
+    async fn history() -> Result<()> {
         let id = xor_name::XorName::random();
         let tmp_dir = tempdir()?;
-        let db_dir = tmp_dir.into_path().join(Path::new(&"db".to_string()));
+        let db_dir = tmp_dir.into_path().join(Path::new(&"Token".to_string()));
         let db = sled::open(db_dir).map_err(|error| {
             trace!("Sled Error: {:?}", error);
             Error::Sled(error)
         })?;
-        let mut store = RegisterOpStore::new(id, db)?;
+        let mut store = EventStore::<Token>::new(id, db)?;
 
-        let authority_keypair1 = Keypair::new_ed25519(&mut OsRng);
-        let pk = authority_keypair1.public_key();
-
-        let register_name: XorName = rand::random();
-        let register_tag = 43_000u64;
-
-        let mut permissions = BTreeMap::default();
-        let user_perms = PublicPermissions::new(true);
-        let _ = permissions.insert(User::Key(pk), user_perms);
-
-        let replica1 = Register::new_public(
-            pk,
-            register_name,
-            register_tag,
-            Some(PublicPolicy {
-                owner: pk,
-                permissions,
-            }),
-        );
-
-        let write = RegisterWrite::New(replica1);
-
-        let client_sig = DataSigned {
-            public_key: pk,
-            signature: authority_keypair1.sign(b""),
-        };
-
-        let cmd = RegisterCmd { write, client_sig };
-
-        store.append(cmd.clone())?;
+        store.append(Token::from_nano(10))?;
 
         let events = store.get_all()?;
         assert_eq!(events.len(), 1);
 
         match events.get(0) {
-            Some(found_cmd) => assert_eq!(found_cmd, &cmd),
+            Some(token) => assert_eq!(token.as_nano(), 10),
             None => unreachable!(),
         }
 

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -9,7 +9,7 @@
 mod data_store;
 mod encoding;
 mod errors;
-mod register_op_store;
+mod event_store;
 
 use data_store::to_db_key::ToDbKey;
 pub use data_store::used_space::UsedSpace;
@@ -19,4 +19,4 @@ pub(crate) use data_store::{
 };
 pub(crate) use errors::Result;
 pub(crate) use errors::{convert_to_error_message, Error};
-pub(crate) use register_op_store::RegisterOpStore;
+pub(crate) use event_store::EventStore;

--- a/src/node/metadata/register_storage.rs
+++ b/src/node/metadata/register_storage.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::dbs::{convert_to_error_message, Error, RegisterOpStore, Result, UsedSpace};
+use crate::dbs::{convert_to_error_message, Error, EventStore, Result, UsedSpace};
 use crate::types::{
     register::{Action, Address, Register, User},
     PublicKey,
@@ -32,6 +32,8 @@ use tracing::info;
 use xor_name::{Prefix, XorName};
 
 const DATABASE_NAME: &str = "register";
+
+type RegisterOpStore = EventStore<RegisterCmd>;
 
 /// Operations over the data type Register.
 // TODO: dont expose this
@@ -383,5 +385,77 @@ fn to_reg_key(address: &Address) -> Result<XorName> {
 impl Display for RegisterStorage {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(formatter, "RegisterStorage")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::RegisterOpStore;
+    use crate::messaging::data::{RegisterCmd, RegisterWrite};
+    use crate::messaging::DataSigned;
+    use crate::node::Result;
+
+    use crate::node::Error;
+    use crate::types::{
+        register::{PublicPermissions, PublicPolicy, Register, User},
+        Keypair,
+    };
+    use rand::rngs::OsRng;
+    use std::collections::BTreeMap;
+    use std::path::Path;
+    use tempfile::tempdir;
+    use xor_name::XorName;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn appends_and_reads_from_store() -> Result<()> {
+        let id = xor_name::XorName::random();
+        let tmp_dir = tempdir()?;
+        let db_dir = tmp_dir.into_path().join(Path::new(&"db".to_string()));
+        let db = sled::open(db_dir).map_err(|error| {
+            trace!("Sled Error: {:?}", error);
+            Error::Sled(error)
+        })?;
+        let mut store = RegisterOpStore::new(id, db)?;
+
+        let authority_keypair1 = Keypair::new_ed25519(&mut OsRng);
+        let pk = authority_keypair1.public_key();
+
+        let register_name: XorName = rand::random();
+        let register_tag = 43_000u64;
+
+        let mut permissions = BTreeMap::default();
+        let user_perms = PublicPermissions::new(true);
+        let _ = permissions.insert(User::Key(pk), user_perms);
+
+        let replica1 = Register::new_public(
+            pk,
+            register_name,
+            register_tag,
+            Some(PublicPolicy {
+                owner: pk,
+                permissions,
+            }),
+        );
+
+        let write = RegisterWrite::New(replica1);
+
+        let client_sig = DataSigned {
+            public_key: pk,
+            signature: authority_keypair1.sign(b""),
+        };
+
+        let cmd = RegisterCmd { write, client_sig };
+
+        store.append(cmd.clone())?;
+
+        let events = store.get_all()?;
+        assert_eq!(events.len(), 1);
+
+        match events.get(0) {
+            Some(found_cmd) => assert_eq!(found_cmd, &cmd),
+            None => unreachable!(),
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This was removed recently, and replaced with an impl limited to register cmds.
But the limitation is unnecessary, and the abstraction will be reused.