### PR TITLE
Switch from `anyhow` to `eyre`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --features=always-joinable,testing --bins --examples --tests
+          args: --release --features=always-joinable,test-utils --bins --examples --tests
       
       - run: ./target/release/testnet
         if: matrix.os != 'windows-latest'
@@ -94,19 +94,19 @@ jobs:
       - name: Initital client tests...
         shell: bash
         # always joinable not actually needed here, but should speed up compilation as we've just built with it
-        run: timeout 25m cargo test --release --features=always-joinable,testing -- client_api --skip client_api::seq --skip client_api::map --skip client_api::reg --skip client_api::blob --skip client_api::transfer && sleep 5
-      
+        run: timeout 25m cargo test --release --features=always-joinable,test-utils -- client_api --skip client_api::seq --skip client_api::map --skip client_api::reg --skip client_api::blob --skip client_api::transfer && sleep 5
+
       - name: Client reg tests against local network
         shell: bash
-        run: timeout 10m cargo test --release --features=always-joinable,testing -- client_api::reg && sleep 5
-      
+        run: timeout 10m cargo test --release --features=always-joinable,test-utils -- client_api::reg && sleep 5
+
       - name: Client blob tests against local network
         shell: bash
-        run: timeout 15m cargo test --release --features=always-joinable,testing -- client_api::blob && sleep 5
+        run: timeout 15m cargo test --release --features=always-joinable,test-utils -- client_api::blob && sleep 5
       
       - name: Run example app for Blob API against local network
         shell: bash
-        run: timeout 15m cargo run --release  --features=always-joinable,testing --example client_blob
+        run: timeout 15m cargo run --release  --features=always-joinable,test-utils --example client_blob
       
       - name: Kill the current network (next test doesnt need it)
         if: matrix.os != 'windows-latest'
@@ -129,7 +129,7 @@ jobs:
 
       - name: Run example of split and chunk check
         shell: bash
-        run: timeout 15m cargo run --release  --features=always-joinable,testing --example network_split
+        run: timeout 15m cargo run --release  --features=always-joinable,test-utils --example network_split
       
       - name: Was there a section split?
         run: ./scripts/has_split.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +364,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -471,6 +492,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "futures",
+ "itertools 0.10.1",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio 1.9.0",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools 0.10.1",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +578,28 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "curve25519-dalek"
@@ -1015,6 +1096,12 @@ dependencies = [
  "tokio-util 0.6.7",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
@@ -1614,6 +1701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,6 +1809,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2222,6 +2343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.4",
+]
+
+[[package]]
 name = "rustls"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,6 +2415,7 @@ dependencies = [
  "blsttc",
  "bytes 1.0.1",
  "crdts",
+ "criterion",
  "custom_debug",
  "dashmap",
  "dirs-next 2.0.0",
@@ -2336,6 +2467,15 @@ name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2399,7 +2539,7 @@ dependencies = [
  "quick-xml",
  "regex",
  "reqwest",
- "semver",
+ "semver 0.9.0",
  "serde_json",
  "tar",
  "tempfile",
@@ -2414,6 +2554,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "semver-parser"
@@ -2436,6 +2582,16 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -2776,6 +2932,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,6 +3252,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,12 +74,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
-
-[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,16 +238,14 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bls_dkg"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2c19530d31f5bdf3892ea3647adcdebd72f752a446437aae95c9a2c9fe19fa"
+checksum = "d8c82ee7e80ec22a6ba8f5ac0d6cf3c6a94b790a488a62bc761c2c5ac856a816"
 dependencies = [
  "aes",
- "anyhow",
  "bincode",
  "block-modes",
  "blsttc",
- "itertools 0.9.0",
  "log",
  "rand 0.7.3",
  "rand_core 0.5.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221239d1d5ea86bf5d6f91c9d6bc3646ffe471b08ff9b0f91c44f115ac969d2b"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "ff"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1317,12 @@ dependencies = [
  "url",
  "xmltree",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -2405,7 +2421,6 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 name = "safe_network"
 version = "0.24.2"
 dependencies = [
- "anyhow",
  "assert_matches",
  "async-recursion",
  "async-trait",
@@ -2422,6 +2437,7 @@ dependencies = [
  "ed25519",
  "ed25519-dalek",
  "exponential-backoff",
+ "eyre",
  "futures",
  "hex",
  "hex_fmt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +151,21 @@ dependencies = [
  "pin-project",
  "rand 0.8.4",
  "tokio 1.9.0",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -429,6 +453,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -1042,6 +1093,12 @@ dependencies = [
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "glob"
@@ -1703,6 +1760,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
+name = "object"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1785,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "owo-colors"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "pairing"
@@ -2351,6 +2423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,6 +2499,7 @@ dependencies = [
  "bls_dkg",
  "blsttc",
  "bytes 1.0.1",
+ "color-eyre",
  "crdts",
  "criterion",
  "custom_debug",
@@ -3099,6 +3178,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ chaos = []
 test-utils = []
 
 [dependencies]
-anyhow = "1.0.40"
 async-recursion = "0.3.2"
 async-trait = "0.1.42"
 base64 = "~0.10.1"
@@ -56,6 +55,7 @@ dirs-next = "2.0.0"
 ed25519 = { version = "1.2.0", features = ["serde_bytes"] }
 ed25519-dalek = { version = "1.0.0", features = ["serde"] }
 exponential-backoff = "1.0.0"
+eyre = "0.6.5"
 futures = "~0.3.13"
 hex = "~0.3.2"
 hex_fmt = "~0.3.0"
@@ -81,9 +81,9 @@ sysinfo = "0.19.0"
 tempfile = "3.2.0"
 thiserror = "1.0.23"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
+tracing = "~0.1.26"
 tracing-appender = "~0.1.2"
 tracing-subscriber = "~0.2.15"
-tracing = "~0.1.26"
 uhttp_uri = "~0.5"
 url = "2.2.0"
 urlencoding = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,29 +16,29 @@ incremental = true
 [[bench]]
 name = "put"
 harness = false
-required-features = ["testing"]
+required-features = ["test-utils"]
 
 [[example]]
 name = "client_blob"
-required-features = ["testing"]
+required-features = ["test-utils"]
 
 [[example]]
 name = "network_split"
-required-features = ["testing"]
+required-features = ["test-utils"]
 
 [[example]]
 name = "routing_minimal"
-required-features = ["testing"]
+required-features = ["test-utils"]
 
 [[example]]
 name = "routing_stress"
-required-features = ["testing"]
+required-features = ["test-utils"]
 
 [features]
 default = []
 always-joinable = []
 chaos = []
-testing = []
+test-utils = []
 
 [dependencies]
 anyhow = "1.0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 
 [dev-dependencies]
 assert_matches = "1.3"
+criterion = { version = "0.3", features = ["async_tokio"] }
 proptest = "0.10.1"
 rand = { version = "0.7.3", features = ["small_rng"] }
 rand_xorshift = "~0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,14 @@ required-features = ["testing"]
 name = "network_split"
 required-features = ["testing"]
 
+[[example]]
+name = "routing_minimal"
+required-features = ["testing"]
+
+[[example]]
+name = "routing_stress"
+required-features = ["testing"]
+
 [features]
 default = []
 always-joinable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ bincode = "1.3.1"
 bls = { package = "blsttc", version = "2.0.1" }
 bls_dkg = "~0.5.0"
 bytes = { version = "1.0.1", features = ["serde"] }
+color-eyre = "0.5.11"
 crdts = "~7.0"
 custom_debug = "0.5.0"
 dashmap = "~4.0.2"

--- a/benches/put.rs
+++ b/benches/put.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use anyhow::Result;
 use criterion::{criterion_group, criterion_main, Criterion};
+use eyre::Result;
 use safe_network::client::utils::generate_random_vector;
 use safe_network::client::utils::test_utils::{read_network_conn_info, run_w_backoff_delayed};
 use safe_network::client::{Client, Config, Error};

--- a/examples/client_blob.rs
+++ b/examples/client_blob.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use anyhow::{Context, Result};
+use eyre::{Context, Result};
 use safe_network::{
     client::{utils::test_utils::read_network_conn_info, Client, Config},
     url::{ContentType, NativeUrl, Scope, DEFAULT_XORURL_BASE},

--- a/examples/config_handling.rs
+++ b/examples/config_handling.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use anyhow::Result;
+use eyre::Result;
 use safe_network::node::Config;
 use structopt::StructOpt;
 use tokio::{fs::remove_file, io};

--- a/examples/network_split.rs
+++ b/examples/network_split.rs
@@ -21,7 +21,7 @@ use tracing::{debug, info};
 
 use tiny_keccak::{Hasher, Sha3};
 
-use anyhow::{anyhow, Context, Result};
+use eyre::{eyre, Context, Result};
 use safe_network::{
     client::{
         utils::generate_random_vector, utils::test_utils::read_network_conn_info, Client, Config,
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
         .stderr(Stdio::inherit())
         .output()
         .map_err(|err| {
-            anyhow!(
+            eyre!(
                 "Failed to run build command with args '{:?}': {}",
                 args, err
             )
@@ -77,7 +77,7 @@ fn get_node_bin_path(node_path: Option<PathBuf>) -> Result<PathBuf> {
         Some(p) => Ok(p),
         None => {
             let mut home_dirs =
-                home_dir().ok_or_else(|| anyhow!("Failed to obtain user's home path"))?;
+                home_dir().ok_or_else(|| eyre!("Failed to obtain user's home path"))?;
 
             home_dirs.push(".safe");
             home_dirs.push("node");
@@ -100,7 +100,7 @@ pub async fn run_split() -> Result<()> {
     if !node_log_dir.exists() {
         debug!("Creating '{}' folder", node_log_dir.display());
         create_dir_all(node_log_dir.clone()).await.map_err(|err| {
-            anyhow!(
+            eyre!(
                 "Couldn't create target path to store nodes' generated data: {}",
                 err
             )
@@ -142,7 +142,7 @@ pub async fn run_split() -> Result<()> {
     // We can now call the tool with the args
     info!("Launching local Safe network...");
     run_with(Some(&sn_launch_tool_args))
-        .map_err(|err| anyhow!("Error starting the testnet, {:?}", err))?;
+        .map_err(|err| eyre!("Error starting the testnet, {:?}", err))?;
 
     // leave a longer interval with more nodes to allow for splits if using split amounts
     let interval_duration = Duration::from_secs(interval_as_int * start_node_count);
@@ -169,7 +169,7 @@ pub async fn run_split() -> Result<()> {
     // We can now call the tool with the args
     info!("Adding nodes to the local Safe network...");
     run_with(Some(&sn_launch_tool_args))
-        .map_err(|err| anyhow!("Error adding nodes to the testnet, {:?}", err))?;
+        .map_err(|err| eyre!("Error adding nodes to the testnet, {:?}", err))?;
 
     // leave a longer interval with more nodes to allow for splits if using split amounts
     let interval_duration = Duration::from_secs(interval_as_int * additional_node_count);

--- a/examples/network_split.rs
+++ b/examples/network_split.rs
@@ -44,7 +44,11 @@ const QUERY_TIMEOUT: Duration = Duration::from_secs(30);
 #[tokio::main]
 async fn main() -> Result<()> {
     // First lets build the network and testnet launcher, to ensure we're on the latest version
-    let args: Vec<&str> = vec!["build", "--release", "--features=always-joinable,testing"];
+    let args: Vec<&str> = vec![
+        "build",
+        "--release",
+        "--features=always-joinable,test-utils",
+    ];
 
     println!("Building current sn_node");
     let _child = Command::new("cargo")

--- a/examples/routing_minimal.rs
+++ b/examples/routing_minimal.rs
@@ -33,7 +33,7 @@
 //! command-line option for more details.
 //!
 
-use anyhow::Result;
+use eyre::Result;
 use futures::future::join_all;
 use safe_network::routing::{
     create_test_used_space_and_root_storage, Config, Event, EventStream, Routing, TransportConfig,

--- a/src/bin/sn_node.rs
+++ b/src/bin/sn_node.rs
@@ -27,7 +27,7 @@
     unused_results
 )]
 
-use anyhow::{anyhow, Error as AnyhowError, Result};
+use eyre::{eyre, Result};
 use safe_network::node::{add_connection_info, set_connection_info, Config, Error, Node};
 use self_update::{cargo_crate_version, Status};
 use std::{io::Write, process};
@@ -45,10 +45,10 @@ fn main() {
     let sn_node_thread = std::thread::Builder::new()
         .name("sn_node".to_string())
         .stack_size(16 * 1024 * 1024)
-        .spawn(move || {
+        .spawn(move || -> Result<()> {
             let rt = tokio::runtime::Runtime::new()?;
             rt.block_on(run_node())?;
-            Ok::<(), AnyhowError>(())
+            Ok(())
         });
 
     match sn_node_thread {
@@ -101,7 +101,7 @@ async fn run_node() -> Result<()> {
             EnvFilter::from_default_env().add_directive(
                 module_log_filter
                     .parse()
-                    .map_err(|_| anyhow!("Could not parse module log filter"))?,
+                    .map_err(|_| eyre!("Could not parse module log filter"))?,
             )
         }
     };

--- a/src/bin/testnet.rs
+++ b/src/bin/testnet.rs
@@ -72,9 +72,9 @@ async fn main() -> Result<(), String> {
         args.push("--features");
         args.push("always-joinable");
     }
-    if cfg!(feature = "testing") {
+    if cfg!(feature = "test-utils") {
         args.push("--features");
-        args.push("testing");
+        args.push("test-utils");
     }
 
     println!("Building current sn_node");

--- a/src/client/client_api/blob_apis.rs
+++ b/src/client/client_api/blob_apis.rs
@@ -355,8 +355,8 @@ mod tests {
         test_utils::{create_test_client, run_w_backoff_delayed},
     };
     use crate::retry_err_loop;
-    use anyhow::{anyhow, bail, Result};
     use bincode::deserialize;
+    use eyre::{bail, eyre, Result};
     use futures::future::join_all;
     use self_encryption::{SelfEncryptionError, Storage};
     use tokio::time::{Duration, Instant};
@@ -547,7 +547,7 @@ mod tests {
             }
             Ok(())
         } else {
-            Err(anyhow!(
+            Err(eyre!(
                 "It didn't return DataMap::Chunks, instead: {:?}",
                 root_data_map
             ))

--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -155,7 +155,7 @@ async fn attempt_bootstrap(session: &mut Session, client_pk: PublicKey) -> Resul
 mod tests {
     use super::*;
     use crate::client::utils::test_utils::{create_test_client, create_test_client_with};
-    use anyhow::Result;
+    use eyre::Result;
     use std::{
         collections::HashSet,
         net::{IpAddr, Ipv4Addr, SocketAddr},

--- a/src/client/client_api/register_apis.rs
+++ b/src/client/client_api/register_apis.rs
@@ -235,7 +235,7 @@ mod tests {
         register::{Action, EntryHash, Permissions, PrivatePermissions, PublicPermissions, User},
         Error as DtError, PublicKey,
     };
-    use anyhow::{anyhow, bail, Result};
+    use eyre::{bail, eyre, Result};
     use std::{
         collections::{BTreeMap, BTreeSet},
         time::Instant,
@@ -389,7 +389,7 @@ mod tests {
                 assert_eq!(None, user_perms.is_allowed(Action::Write));
             }
             Permissions::Private(_) => {
-                return Err(anyhow!("Unexpectedly obtained incorrect user permissions",));
+                return Err(eyre!("Unexpectedly obtained incorrect user permissions",));
             }
         }
 
@@ -460,7 +460,7 @@ mod tests {
             .await
         {
             Err(_) => Ok(()),
-            Ok(_data) => Err(anyhow!(
+            Ok(_data) => Err(eyre!(
                 "Unexpectedly retrieved a register entry at index that's too high!",
             )),
         }
@@ -516,13 +516,11 @@ mod tests {
 
         match res {
             Err(Error::NoResponse) => Ok(()),
-            Err(err) => Err(anyhow!(
+            Err(err) => Err(eyre!(
                 "Unexpected error returned when deleting a nonexisting Private Register: {}",
                 err
             )),
-            Ok(_data) => Err(anyhow!(
-                "Unexpectedly retrieved a deleted Private Register!",
-            )),
+            Ok(_data) => Err(eyre!("Unexpectedly retrieved a deleted Private Register!",)),
         }
     }
 

--- a/src/client/config_handler.rs
+++ b/src/client/config_handler.rs
@@ -89,7 +89,7 @@ async fn read_config_file(filepath: &Path) -> Result<QuicP2pConfig, Error> {
 mod tests {
     use super::*;
     use crate::client::utils::test_utils::init_logger;
-    use anyhow::Result;
+    use eyre::Result;
     use rand::{distributions::Alphanumeric, thread_rng, Rng};
     use std::env::temp_dir;
     use std::fs::File;
@@ -116,7 +116,7 @@ mod tests {
         // convert to string for assert
         let mut str_path = path
             .to_str()
-            .ok_or(anyhow::anyhow!("No path for to_str".to_string()))?
+            .ok_or(eyre::eyre!("No path for to_str".to_string()))?
             .to_string();
         // normalise for mac
         if str_path.ends_with('/') {

--- a/src/client/utils/mod.rs
+++ b/src/client/utils/mod.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 /// Common utility functions for writing test cases.
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
 use rand::distributions::{Alphanumeric, Distribution, Standard};

--- a/src/client/utils/test_utils/mod.rs
+++ b/src/client/utils/test_utils/mod.rs
@@ -11,8 +11,8 @@ mod test_client;
 
 use crate::client::Error;
 use crate::types::Keypair;
-use anyhow::{anyhow, Context, Result as AnyhowResult};
 use dirs_next::home_dir;
+use eyre::{eyre, Context, Result};
 use std::path::Path;
 use std::{collections::HashSet, fs::File, io::BufReader, net::SocketAddr};
 #[cfg(test)]
@@ -76,8 +76,8 @@ pub fn gen_ed_keypair() -> Keypair {
 }
 
 /// Read local network bootstrapping/connection information
-pub fn read_network_conn_info() -> AnyhowResult<HashSet<SocketAddr>> {
-    let user_dir = home_dir().ok_or_else(|| anyhow!("Could not fetch home directory"))?;
+pub fn read_network_conn_info() -> Result<HashSet<SocketAddr>> {
+    let user_dir = home_dir().ok_or_else(|| eyre!("Could not fetch home directory"))?;
     let conn_info_path = user_dir.join(Path::new(GENESIS_CONN_INFO_FILEPATH));
 
     let file = File::open(&conn_info_path).with_context(|| {

--- a/src/client/utils/test_utils/test_client.rs
+++ b/src/client/utils/test_utils/test_client.rs
@@ -9,7 +9,7 @@
 use super::read_network_conn_info;
 use crate::client::{Client, Config};
 use crate::types::Keypair;
-use anyhow::Result;
+use eyre::Result;
 use std::{sync::Once, time::Duration};
 use tracing_subscriber::{fmt, EnvFilter};
 

--- a/src/messaging/data/mod.rs
+++ b/src/messaging/data/mod.rs
@@ -207,7 +207,7 @@ try_from!(Permissions, GetRegisterUserPermissions);
 mod tests {
     use super::*;
     use crate::types::{ChunkAddress, DataAddress, Keypair, PrivateChunk};
-    use anyhow::{anyhow, Result};
+    use eyre::{eyre, Result};
     use std::convert::{TryFrom, TryInto};
     use xor_name::XorName;
 
@@ -235,7 +235,7 @@ mod tests {
             assert!(format!("{:?}", errored_response).contains("GetRegister(Err(AccessDenied("));
             Ok(())
         } else {
-            Err(anyhow!("Could not generate public key"))
+            Err(eyre!("Could not generate public key"))
         }
     }
 
@@ -278,7 +278,7 @@ mod tests {
         use QueryResponse::*;
         let key = match gen_keys().first() {
             Some(key) => *key,
-            None => return Err(anyhow!("Could not generate public key")),
+            None => return Err(eyre!("Could not generate public key")),
         };
 
         let owner = PublicKey::Bls(bls::SecretKey::random().public_key());
@@ -289,7 +289,7 @@ mod tests {
             i_data,
             GetChunk(Ok(i_data.clone()))
                 .try_into()
-                .map_err(|_| anyhow!("Mismatched types".to_string()))?
+                .map_err(|_| eyre!("Mismatched types".to_string()))?
         );
         assert_eq!(
             Err(TryFromError::Response(e.clone())),

--- a/src/messaging/serialisation/wire_msg.rs
+++ b/src/messaging/serialisation/wire_msg.rs
@@ -255,8 +255,8 @@ mod tests {
         },
         types::{ChunkAddress, Keypair},
     };
-    use anyhow::Result;
     use bls::SecretKey;
+    use eyre::Result;
     use rand::rngs::OsRng;
     use xor_name::XorName;
 

--- a/src/node/state_db.rs
+++ b/src/node/state_db.rs
@@ -85,7 +85,7 @@ mod test {
     use super::{
         get_network_keypair, get_reward_pk, store_network_keypair, store_new_reward_keypair,
     };
-    use anyhow::{anyhow, Result};
+    use eyre::{eyre, Result};
     use rand::rngs::OsRng;
     use tempfile::{tempdir, TempDir};
 
@@ -120,12 +120,12 @@ mod test {
             assert_eq!(kp.public, keypair.public);
             Ok(())
         } else {
-            Err(anyhow!("Network keypair was not read from file"))
+            Err(eyre!("Network keypair was not read from file"))
         }
     }
 
     // creates a temp dir
     fn create_temp_root() -> Result<TempDir> {
-        tempdir().map_err(|e| anyhow!("Failed to create temp dir: {}", e))
+        tempdir().map_err(|e| eyre!("Failed to create temp dir: {}", e))
     }
 }

--- a/src/routing/core/bootstrap/join.rs
+++ b/src/routing/core/bootstrap/join.rs
@@ -434,8 +434,8 @@ mod tests {
         section::test_utils::*, section::NodeStateUtils, SectionAuthorityProviderUtils, ELDER_SIZE,
         MIN_ADULT_AGE, MIN_AGE,
     };
-    use anyhow::{anyhow, Error, Result};
     use assert_matches::assert_matches;
+    use eyre::{eyre, Error, Result};
     use futures::{
         future::{self, Either},
         pin_mut,
@@ -476,7 +476,7 @@ mod tests {
             let (wire_msg, recipients) = send_rx
                 .recv()
                 .await
-                .ok_or_else(|| anyhow!("JoinRequest was not received"))?;
+                .ok_or_else(|| eyre!("JoinRequest was not received"))?;
 
             let bootstrap_addrs: Vec<SocketAddr> =
                 recipients.iter().map(|(_name, addr)| *addr).collect();
@@ -501,7 +501,7 @@ mod tests {
             let (wire_msg, recipients) = send_rx
                 .recv()
                 .await
-                .ok_or_else(|| anyhow!("JoinRequest was not received"))?;
+                .ok_or_else(|| eyre!("JoinRequest was not received"))?;
             let (node_msg, dst_location) = assert_matches!(wire_msg.into_message(), Ok(MessageType::Node { msg, dst_location,.. }) =>
                 (msg, dst_location));
 
@@ -569,7 +569,7 @@ mod tests {
             let (wire_msg, recipients) = send_rx
                 .recv()
                 .await
-                .ok_or_else(|| anyhow!("JoinRequest was not received"))?;
+                .ok_or_else(|| eyre!("JoinRequest was not received"))?;
 
             assert_eq!(
                 recipients
@@ -603,7 +603,7 @@ mod tests {
             let (wire_msg, recipients) = send_rx
                 .recv()
                 .await
-                .ok_or_else(|| anyhow!("JoinRequest was not received"))?;
+                .ok_or_else(|| eyre!("JoinRequest was not received"))?;
 
             assert_eq!(
                 recipients
@@ -657,7 +657,7 @@ mod tests {
             let (wire_msg, _) = send_rx
                 .recv()
                 .await
-                .ok_or_else(|| anyhow!("JoinRequest was not received"))?;
+                .ok_or_else(|| eyre!("JoinRequest was not received"))?;
 
             assert_matches!(wire_msg.into_message(), Ok(MessageType::Node { msg, .. }) =>
                         assert_matches!(msg, NodeMsg::JoinRequest{..}));
@@ -693,7 +693,7 @@ mod tests {
             let (wire_msg, _) = send_rx
                 .recv()
                 .await
-                .ok_or_else(|| anyhow!("JoinRequest was not received"))?;
+                .ok_or_else(|| eyre!("JoinRequest was not received"))?;
 
             assert_matches!(wire_msg.into_message(), Ok(MessageType::Node { msg, .. }) =>
                             assert_matches!(msg, NodeMsg::JoinRequest{..}));
@@ -731,7 +731,7 @@ mod tests {
             let (wire_msg, _) = send_rx
                 .recv()
                 .await
-                .ok_or_else(|| anyhow!("JoinRequest was not received"))?;
+                .ok_or_else(|| eyre!("JoinRequest was not received"))?;
 
             assert_matches!(wire_msg.into_message(), Ok(MessageType::Node { msg, .. }) =>
                                 assert_matches!(msg, NodeMsg::JoinRequest{..}));
@@ -752,7 +752,7 @@ mod tests {
 
         if let Err(RoutingError::TryJoinLater) = join_result {
         } else {
-            return Err(anyhow!("Not getting an execpted network rejection."));
+            return Err(eyre!("Not getting an execpted network rejection."));
         }
 
         test_result
@@ -796,7 +796,7 @@ mod tests {
             let (wire_msg, _) = send_rx
                 .recv()
                 .await
-                .ok_or_else(|| anyhow!("NodeMsg was not received"))?;
+                .ok_or_else(|| eyre!("NodeMsg was not received"))?;
 
             let node_msg =
                 assert_matches!(wire_msg.into_message(), Ok(MessageType::Node{ msg, .. }) => msg);
@@ -826,7 +826,7 @@ mod tests {
             let (wire_msg, _) = send_rx
                 .recv()
                 .await
-                .ok_or_else(|| anyhow!("NodeMsg was not received"))?;
+                .ok_or_else(|| eyre!("NodeMsg was not received"))?;
 
             let node_msg =
                 assert_matches!(wire_msg.into_message(), Ok(MessageType::Node{ msg, .. }) => msg);

--- a/src/routing/core/comm.rs
+++ b/src/routing/core/comm.rs
@@ -301,8 +301,8 @@ mod tests {
     use super::*;
     use crate::messaging::{section_info::SectionInfoMsg, DstLocation, WireMsg};
     use crate::types::PublicKey;
-    use anyhow::Result;
     use assert_matches::assert_matches;
+    use eyre::Result;
     use futures::future;
     use qp2p::Config;
     use std::{net::Ipv4Addr, time::Duration};

--- a/src/routing/core/delivery_group.rs
+++ b/src/routing/core/delivery_group.rs
@@ -170,7 +170,7 @@ mod tests {
         },
         SectionAuthorityProviderUtils, MIN_ADULT_AGE,
     };
-    use anyhow::{Context, Result};
+    use eyre::{ContextCompat, Result};
     use rand::seq::IteratorRandom;
     use secured_linked_list::SecuredLinkedList;
     use xor_name::Prefix;

--- a/src/routing/core/msg_handling/anti_entropy.rs
+++ b/src/routing/core/msg_handling/anti_entropy.rs
@@ -150,8 +150,8 @@ mod tests {
         section::test_utils::{gen_addr, gen_section_authority_provider},
         XorName, ELDER_SIZE, MIN_ADULT_AGE,
     };
-    use anyhow::{anyhow, Context, Result};
     use assert_matches::assert_matches;
+    use eyre::{eyre, Context, Result};
     use secured_linked_list::SecuredLinkedList;
     use xor_name::Prefix;
 
@@ -220,7 +220,7 @@ mod tests {
             dst_section_pk,
         )?;
 
-        let wire_msg = msg_to_send.ok_or_else(|| anyhow!("expected an anti-entropy message"))?;
+        let wire_msg = msg_to_send.ok_or_else(|| eyre!("expected an anti-entropy message"))?;
         let msg_type = wire_msg
             .into_message()
             .context("failed to deserialised anti-entropy message")?;

--- a/src/routing/dkg/proposal.rs
+++ b/src/routing/dkg/proposal.rs
@@ -97,7 +97,7 @@ pub enum ProposalError {
 mod tests {
     use super::*;
     use crate::routing::{dkg, section};
-    use anyhow::Result;
+    use eyre::Result;
     use std::fmt::Debug;
     use xor_name::Prefix;
 

--- a/src/routing/dkg/session.rs
+++ b/src/routing/dkg/session.rs
@@ -368,8 +368,8 @@ mod tests {
         node::Node, section::section_authority_provider::ElderCandidatesUtils,
         section::test_utils::gen_addr, ELDER_SIZE, MIN_ADULT_AGE,
     };
-    use anyhow::{bail, Context, Result};
     use assert_matches::assert_matches;
+    use eyre::{bail, ContextCompat, Result};
     use proptest::prelude::*;
     use rand::{rngs::SmallRng, SeedableRng};
     use std::{collections::HashMap, iter};

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -45,7 +45,7 @@ pub use qp2p::{Config as TransportConfig, SendStream};
 
 pub use xor_name::{Prefix, XorName, XOR_NAME_LEN}; // TODO remove pub on API update
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "test-utils"))]
 pub use test_utils::*;
 
 // ############################################################################
@@ -80,7 +80,7 @@ pub(crate) const fn supermajority(group_size: usize) -> usize {
     1 + group_size * 2 / 3
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "test-utils"))]
 mod test_utils {
     use crate::dbs::UsedSpace;
     use rand::{distributions::Alphanumeric, thread_rng, Rng};

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -90,7 +90,7 @@ mod test_utils {
     const TEST_MAX_CAPACITY: u64 = 1024 * 1024;
 
     /// Create a register store for routing examples
-    pub fn create_test_used_space_and_root_storage() -> anyhow::Result<(UsedSpace, PathBuf)> {
+    pub fn create_test_used_space_and_root_storage() -> eyre::Result<(UsedSpace, PathBuf)> {
         let used_space = UsedSpace::new(TEST_MAX_CAPACITY);
         let random_filename: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
 

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -45,12 +45,8 @@ pub use qp2p::{Config as TransportConfig, SendStream};
 
 pub use xor_name::{Prefix, XorName, XOR_NAME_LEN}; // TODO remove pub on API update
 
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use std::env::temp_dir;
-
-use crate::dbs::UsedSpace;
-use anyhow::Result as AnyhowResult;
-use std::path::{Path, PathBuf};
+#[cfg(any(test, feature = "testing"))]
+pub use test_utils::*;
 
 // ############################################################################
 // Private
@@ -78,23 +74,31 @@ pub const RECOMMENDED_SECTION_SIZE: usize = 2 * ELDER_SIZE;
 /// Number of elders per section.
 pub const ELDER_SIZE: usize = 7;
 
-const TEST_MAX_CAPACITY: u64 = 1024 * 1024;
-
-/// Create a register store for routing examples
-pub fn create_test_used_space_and_root_storage() -> AnyhowResult<(UsedSpace, PathBuf)> {
-    let used_space = UsedSpace::new(TEST_MAX_CAPACITY);
-    let random_filename: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
-
-    let tmp = temp_dir();
-    let storage_dir = Path::new(&tmp).join(random_filename);
-
-    Ok((used_space, storage_dir))
-}
-
 /// SuperMajority of a given group (i.e. > 2/3)
 #[inline]
 pub(crate) const fn supermajority(group_size: usize) -> usize {
     1 + group_size * 2 / 3
+}
+
+#[cfg(any(test, feature = "testing"))]
+mod test_utils {
+    use crate::dbs::UsedSpace;
+    use rand::{distributions::Alphanumeric, thread_rng, Rng};
+    use std::env::temp_dir;
+    use std::path::{Path, PathBuf};
+
+    const TEST_MAX_CAPACITY: u64 = 1024 * 1024;
+
+    /// Create a register store for routing examples
+    pub fn create_test_used_space_and_root_storage() -> anyhow::Result<(UsedSpace, PathBuf)> {
+        let used_space = UsedSpace::new(TEST_MAX_CAPACITY);
+        let random_filename: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+
+        let tmp = temp_dir();
+        let storage_dir = Path::new(&tmp).join(random_filename);
+
+        Ok((used_space, storage_dir))
+    }
 }
 
 #[cfg(test)]

--- a/src/routing/network/mod.rs
+++ b/src/routing/network/mod.rs
@@ -275,7 +275,7 @@ impl NetworkUtils for Network {
 mod tests {
     use super::*;
     use crate::routing::{dkg, section};
-    use anyhow::{Context, Result};
+    use eyre::{Context, Result};
     use rand::Rng;
 
     #[test]

--- a/src/routing/relocation.rs
+++ b/src/routing/relocation.rs
@@ -250,8 +250,8 @@ mod tests {
         routing_api::tests::SecretKeySet, section::NodeStateUtils, SectionAuthorityProviderUtils,
         ELDER_SIZE, MIN_AGE,
     };
-    use anyhow::Result;
     use assert_matches::assert_matches;
+    use eyre::Result;
     use itertools::Itertools;
     use proptest::prelude::*;
     use rand::{rngs::SmallRng, Rng, SeedableRng};

--- a/src/routing/routing_api/tests/mod.rs
+++ b/src/routing/routing_api/tests/mod.rs
@@ -43,9 +43,9 @@ use crate::routing::{
     MIN_ADULT_AGE, MIN_AGE,
 };
 use crate::types::{Keypair, PublicKey};
-use anyhow::{anyhow, Context, Result};
 use assert_matches::assert_matches;
 use ed25519_dalek::Signer;
+use eyre::{eyre, Context, Result};
 use rand::rngs::OsRng;
 use rand::{distributions::Alphanumeric, Rng};
 use resource_proof::ResourceProof;
@@ -963,7 +963,7 @@ async fn handle_untrusted_message(source: UntrustedMessageSource) -> Result<()> 
     let sender = *section_auth
         .addresses()
         .get(0)
-        .ok_or_else(|| anyhow!("section_auth is empty"))?;
+        .ok_or_else(|| eyre!("section_auth is empty"))?;
 
     let section_signed_section_auth = section_signed(&sk0, section_auth.clone())?;
     let mut section = Section::new(pk0, chain, section_signed_section_auth)?;

--- a/src/types/register/mod.rs
+++ b/src/types/register/mod.rs
@@ -205,7 +205,7 @@ mod tests {
         },
         utils, Error, Keypair, Result,
     };
-    use anyhow::anyhow;
+    use eyre::eyre;
     use proptest::prelude::*;
     use rand::{rngs::OsRng, seq::SliceRandom, thread_rng};
     use std::{
@@ -320,7 +320,7 @@ mod tests {
     }
 
     #[test]
-    fn register_get_by_hash() -> anyhow::Result<()> {
+    fn register_get_by_hash() -> eyre::Result<()> {
         let (_, register) = &mut create_public_reg_replicas(1)[0];
 
         let entry1 = b"value0".to_vec();
@@ -357,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    fn register_query_public_policy() -> anyhow::Result<()> {
+    fn register_query_public_policy() -> eyre::Result<()> {
         let register_name = XorName::random();
         let register_tag = 43_666;
 
@@ -417,7 +417,7 @@ mod tests {
     }
 
     #[test]
-    fn register_query_private_policy() -> anyhow::Result<()> {
+    fn register_query_private_policy() -> eyre::Result<()> {
         let register_name = XorName::random();
         let register_tag = 43_666;
 
@@ -490,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    fn register_public_write_fails_when_no_perms_for_authority() -> anyhow::Result<()> {
+    fn register_public_write_fails_when_no_perms_for_authority() -> eyre::Result<()> {
         let register_name = XorName::random();
         let register_tag = 43_666;
 
@@ -542,7 +542,7 @@ mod tests {
     }
 
     #[test]
-    fn register_private_write_fails_when_no_perms_for_authority() -> anyhow::Result<()> {
+    fn register_private_write_fails_when_no_perms_for_authority() -> eyre::Result<()> {
         let register_name = XorName::random();
         let register_tag = 43_666;
         let authority_keypair1 = Keypair::new_ed25519(&mut OsRng);
@@ -711,14 +711,14 @@ mod tests {
     }
 
     // check it fails due to not having permissions
-    fn check_op_not_allowed_failure<T>(result: Result<T>) -> anyhow::Result<()> {
+    fn check_op_not_allowed_failure<T>(result: Result<T>) -> eyre::Result<()> {
         match result {
             Err(Error::AccessDenied(_)) => Ok(()),
-            Err(err) => Err(anyhow!(
+            Err(err) => Err(eyre!(
                 "Error returned was the unexpected one for a non-allowed op: {}",
                 err
             )),
-            Ok(_) => Err(anyhow!(
+            Ok(_) => Err(eyre!(
                 "Register operation succeded unexpectedly, an AccessDenied error was expected"
                     .to_string(),
             )),

--- a/src/url/mod.rs
+++ b/src/url/mod.rs
@@ -1241,13 +1241,13 @@ impl fmt::Display for NativeUrl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::{anyhow, bail, Result};
+    use eyre::{bail, eyre, Result};
 
     macro_rules! verify_expected_result {
             ($result:expr, $pattern:pat $(if $cond:expr)?) => {
                 match $result {
                     $pattern $(if $cond)? => Ok(()),
-                    other => Err(anyhow!("Expecting {}, got {:?}", stringify!($pattern), other)),
+                    other => Err(eyre!("Expecting {}, got {:?}", stringify!($pattern), other)),
                 }
             }
         }
@@ -1543,17 +1543,14 @@ mod tests {
             "safe://heyyynunctugo4ucp3a8radnctugo4ucp3a8radnctugo4ucp3a8radnctmfp5zq75zq75zq7";
 
         match NativeUrl::from_xorurl(xorurl) {
-            Ok(_) => Err(anyhow!(
+            Ok(_) => Err(eyre!(
                 "Unexpectedly parsed an invalid (too long) xorurl".to_string(),
             )),
             Err(Error::InvalidXorUrl(msg)) => {
                 assert!(msg.starts_with("Invalid XOR-URL, encoded string too long"));
                 Ok(())
             }
-            other => Err(anyhow!(
-                "Error returned is not the expected one: {:?}",
-                other
-            )),
+            other => Err(eyre!("Error returned is not the expected one: {:?}", other)),
         }
     }
 
@@ -1570,17 +1567,14 @@ mod tests {
         // TODO: we need to add checksum to be able to detect even 1 single char change
         let len = xorurl.len() - 2;
         match NativeUrl::from_xorurl(&xorurl[..len]) {
-            Ok(_) => Err(anyhow!(
+            Ok(_) => Err(eyre!(
                 "Unexpectedly parsed an invalid (too short) xorurl".to_string(),
             )),
             Err(Error::InvalidXorUrl(msg)) => {
                 assert!(msg.starts_with("Invalid XOR-URL, encoded string too short"));
                 Ok(())
             }
-            other => Err(anyhow!(
-                "Error returned is not the expected one: {:?}",
-                other
-            )),
+            other => Err(eyre!("Error returned is not the expected one: {:?}", other)),
         }
     }
 

--- a/src/url/url_parts.rs
+++ b/src/url/url_parts.rs
@@ -225,7 +225,7 @@ fn validate_url_chars(url: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::{anyhow, Result};
+    use eyre::{eyre, Result};
 
     #[test]
     fn test_native_url_validate_url_chars_with_whitespace() -> Result<()> {
@@ -262,16 +262,13 @@ mod tests {
         for url in urls {
             match NativeUrlParts::parse(url, false) {
                 Ok(_) => {
-                    return Err(anyhow!(
-                        "Unexpectedly validated url with whitespace {}",
-                        url
-                    ));
+                    return Err(eyre!("Unexpectedly validated url with whitespace {}", url));
                 }
                 Err(Error::InvalidInput(msg)) => {
                     assert_eq!(msg, "The URL cannot contain whitespace".to_string());
                 }
                 Err(err) => {
-                    return Err(anyhow!("Error returned is not the expected one: {}", err));
+                    return Err(eyre!("Error returned is not the expected one: {}", err));
                 }
             };
         }
@@ -351,7 +348,7 @@ mod tests {
         for url in urls {
             match NativeUrlParts::parse(url, false) {
                 Ok(_) => {
-                    return Err(anyhow!(
+                    return Err(eyre!(
                         "Unexpectedly validated url with control character {}",
                         url
                     ));
@@ -360,7 +357,7 @@ mod tests {
                     assert_eq!(msg, "The URL cannot contain control characters".to_string());
                 }
                 Err(err) => {
-                    return Err(anyhow!("Error returned is not the expected one: {}", err));
+                    return Err(eyre!("Error returned is not the expected one: {}", err));
                 }
             };
         }
@@ -406,7 +403,7 @@ mod tests {
         for url in urls {
             match NativeUrlParts::parse(url, false) {
                 Ok(_) => {
-                    return Err(anyhow!(
+                    return Err(eyre!(
                         "Unexpectedly validated url with invalid character {}",
                         url
                     ));
@@ -415,7 +412,7 @@ mod tests {
                     assert_eq!(msg, "The URL cannot contain invalid characters".to_string());
                 }
                 Err(err) => {
-                    return Err(anyhow!("Error returned is not the expected one: {}", err));
+                    return Err(eyre!("Error returned is not the expected one: {}", err));
                 }
             };
         }

--- a/src/url/version_hash.rs
+++ b/src/url/version_hash.rs
@@ -71,7 +71,7 @@ impl VersionHash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::{bail, Result};
+    use eyre::{bail, Result};
 
     #[test]
     fn test_version_hash_encode_decode() -> Result<()> {


### PR DESCRIPTION
- 50b031240 **fix: Restore `criterion` dependency**

  This was removed in 62998935f, but is required for benchmarks (currently
  only `benches/put.rs`).

- 7e6036264 **refactor: Put routing test utils behind `testing` feature**

  With the merge of crates, we can use the same feature used for `client`
  test utils for routing's ones as well.
  
  This also removes `anyhow` from the library API (it still can't be a dev
  dependency since the `sn_node` binary also depends on it).

- e94adee3c **refactor!: Rename `testing` feature to `test-utils`**

  This is a better name for the purpose (including test utility functions
  in the build).
  
  BREAKING CHANGE: The `testing` feature has been renamed to `test-utils`.

- 0ce05dde7 **refactor!: Switch from `anyhow` to `eyre`**

  This is *almost* the smallest change to get things compiling.
  Technically, `eyre` also re-exports its `eyre!` macro as `anyhow!`, but
  I deemed it confusing to leave that in.
  
  In future we might also want to move away from `Error` to `Report` and
  from `Context` to `WrapErr` to better align with `eyre`'s idioms.
  
  BREAKING CHANGE: Functions exposed with the `test-utils` feature enabled
  now return `eyre::Report` rather than `anyhow::Error`.

- 65726b7d5 **chore: Update `bls_dkg`**

  This fully removes `anyhow` from our dependencies 🎉

- d45f78903 **feat: Use `color-eyre` in `sn_node` for pretty errors**

  This doesn't actually do anything for now since `run_node` swallows all
  errors (apart from an error if the verbosity handling code is buggy,
  which it currently isn't...).

- 03d740492 **refactor(sn_node): Make `run_node` infallible**

  This is a better reflection of the *current* logic (though not what we
  want eventually). The only way `run_node` would return an error is if
  our verbosity handling was buggy, which is a good case for `expect`.
