### PR TITLE
fix(client): send ChunkWrite to 3 random Elders

### DIFF
--- a/src/node/event_mapping/node_msg.rs
+++ b/src/node/event_mapping/node_msg.rs
@@ -58,7 +58,7 @@ pub(super) fn map_node_msg(
                         correlation_id: msg_id,
                     }),
                     dst: src.to_dst(),
-                    aggregation: true,
+                    aggregation: false,
                 }),
                 ctx: Some(MsgContext::Node { msg, src }),
             }

--- a/src/node/metadata/chunk_records.rs
+++ b/src/node/metadata/chunk_records.rs
@@ -139,7 +139,7 @@ impl ChunkRecords {
                 origin,
             }),
             targets: target_holders,
-            aggregation: true,
+            aggregation: false,
         })
     }
 
@@ -260,7 +260,7 @@ impl ChunkRecords {
                 origin,
             }),
             targets,
-            aggregation: true,
+            aggregation: false,
         })
     }
 


### PR DESCRIPTION
... also removing aggregation of the ChunkWrites.
Previously we sent to 7 Elders, which lead to a major load on Adults.
3 out of 7 is the smallest number to have at least 1 correctly functioning Elder,
which will forward the msg.
We send to random Elders as to spread the load.
Aggregation of the ChunkWrites are removed both because it's not needed
as the msg has authority from the sender, and also because less than
supermajority of Elders will now be sending the cmds.
