### PR TITLE
refactor(url): simplify data type, impl scope

### DIFF
--- a/examples/client_blob.rs
+++ b/examples/client_blob.rs
@@ -9,7 +9,7 @@
 use anyhow::{Context, Result};
 use safe_network::{
     client::{utils::test_utils::read_network_conn_info, Client, Config},
-    url::{ContentType, NativeUrl, DEFAULT_XORURL_BASE},
+    url::{ContentType, NativeUrl, Scope, DEFAULT_XORURL_BASE},
 };
 use std::{
     io::{stdout, Write},
@@ -36,7 +36,12 @@ async fn main() -> Result<()> {
     println!("Storing data on Blob: {}", raw_data);
 
     let address = client.store_public_blob(raw_data.as_bytes()).await?;
-    let xorurl = NativeUrl::encode_blob(*address.name(), ContentType::Raw, DEFAULT_XORURL_BASE)?;
+    let xorurl = NativeUrl::encode_blob(
+        *address.name(),
+        Scope::Public,
+        ContentType::Raw,
+        DEFAULT_XORURL_BASE,
+    )?;
     println!("Blob stored at xorurl: {}", xorurl);
 
     let delay = 10;

--- a/examples/network_split.rs
+++ b/examples/network_split.rs
@@ -27,7 +27,7 @@ use safe_network::{
         utils::generate_random_vector, utils::test_utils::read_network_conn_info, Client, Config,
     },
     types::ChunkAddress,
-    url::{ContentType, NativeUrl, DEFAULT_XORURL_BASE},
+    url::{ContentType, NativeUrl, Scope, DEFAULT_XORURL_BASE},
 };
 
 #[cfg(not(target_os = "windows"))]
@@ -227,7 +227,12 @@ async fn put_data() -> Result<(ChunkAddress, [u8; 32])> {
     println!("Storing data w/ hash {:?}", output);
 
     let address = client.store_public_blob(&raw_data).await?;
-    let xorurl = NativeUrl::encode_blob(*address.name(), ContentType::Raw, DEFAULT_XORURL_BASE)?;
+    let xorurl = NativeUrl::encode_blob(
+        *address.name(),
+        Scope::Public,
+        ContentType::Raw,
+        DEFAULT_XORURL_BASE,
+    )?;
     println!("Blob stored at xorurl: {}", xorurl);
 
     let delay = 2;


### PR DESCRIPTION
Before, data types were duplicate, as there was one for private, and one
for public.
Now we split out the scope into it's own enum. This makes the structure
more sane.
BREAKING CHANGE: This changes the structure of the NativeUrl.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
