### PR TITLE
test: Install `color-eyre` for all tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2292,7 @@ dependencies = [
  "color-eyre",
  "crdts",
  "criterion",
+ "ctor",
  "custom_debug",
  "dashmap",
  "dirs-next 2.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 [dev-dependencies]
 assert_matches = "1.3"
 criterion = { version = "0.3", features = ["async_tokio"] }
+ctor = "0.1.20"
 proptest = "0.10.1"
 rand = { version = "0.7.3", features = ["small_rng"] }
 rand_xorshift = "~0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,3 +51,12 @@ pub mod node;
 pub mod routing;
 pub mod types;
 pub mod url;
+
+#[cfg(test)]
+#[ctor::ctor]
+fn test_setup() {
+    // If you look down the call stack for `color_eyre::install`, the only error can come from
+    // `OnceCell::set` if it's called twice. We could ignore the error, but it would be better to
+    // ensure we only call it once.
+    color_eyre::install().expect("color_eyre::install can only be called once");
+}


### PR DESCRIPTION
- d88a79c76 **test: Install `color-eyre` for all tests**

  This uses [`ctor`] to run a constructor function at the crate root when
  compiled for the `test` target. The constructor function simply calls
  `color_eyre::install`.
  
  [`ctor`]: https://docs.rs/ctor
