### PR TITLE
feat(priority): allow setting priority of a msg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,9 +1795,8 @@ dependencies = [
 
 [[package]]
 name = "qp2p"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26cbbfcf54607f4b3259fcd7e127e7bbf70dab72ee685deddde174d9a51bb022"
+version = "0.15.0"
+source = "git+https://github.com/oetyng/qp2p?branch=stream-priority#0ffe19cbe0fb0f4160269f1e1c0314f6c793f3d1"
 dependencies = [
  "backoff",
  "base64 0.12.3",
@@ -1807,6 +1806,7 @@ dependencies = [
  "futures",
  "igd",
  "quinn",
+ "quinn-proto",
  "rcgen",
  "rustls",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ itertools = "0.10.0"
 lazy_static = "1"
 lru = "0.6.5"
 multibase = "~0.8.0"
-qp2p = "~0.14.1"
+qp2p = { git = "https://github.com/oetyng/qp2p", branch = "stream-priority" }
 rand = "~0.7.3"
 rayon = "1.5.1"
 resource_proof = "0.8.0"

--- a/src/messaging/msg_kind.rs
+++ b/src/messaging/msg_kind.rs
@@ -46,3 +46,16 @@ pub enum MsgKind {
     // FIXME: find an example.
     SectionAuthMsg(SectionAuth),
 }
+
+impl MsgKind {
+    /// The priority of the message, when handled by lower level comms.
+    pub fn priority(&self) -> i32 {
+        match self {
+            Self::SectionAuthMsg(_) => 2,
+            Self::NodeBlsShareAuthMsg(_) => 1,
+            Self::NodeAuthMsg(_) => 0,
+            Self::SectionInfoMsg => -1,
+            Self::ServiceMsg(_) => -2,
+        }
+    }
+}


### PR DESCRIPTION
Lower levels will handle the msgs according to their priority.

A more granular approach can be used when MsgKind has a flatter structure.
