### PR TITLE
fix: avoid looping NodeErrorMsg wrapping

### DIFF
--- a/src/routing/core/msg_handling/mod.rs
+++ b/src/routing/core/msg_handling/mod.rs
@@ -186,7 +186,7 @@ impl Core {
         sender: SocketAddr,
         msg_id: MessageId,
         msg_authority: NodeMsgAuthority,
-        dst_location: DstLocation,
+        _dst_location: DstLocation,
         node_msg: NodeMsg,
         known_keys: &[BlsPublicKey],
     ) -> Result<Vec<Command>> {
@@ -373,16 +373,13 @@ impl Core {
                 error,
                 correlation_id,
             } => {
-                self.send_event(Event::MessageReceived {
+                trace!(
+                    "From {:?}({:?}), received error {:?} correlated to {:?}",
+                    msg_authority.src_location(),
                     msg_id,
-                    src: msg_authority.src_location(),
-                    dst: dst_location,
-                    msg: Box::new(MessageReceived::NodeMsgError {
-                        error,
-                        correlation_id,
-                    }),
-                })
-                .await;
+                    error,
+                    correlation_id
+                );
                 Ok(vec![])
             }
             _ => {
@@ -504,6 +501,20 @@ impl Core {
                     sending_nodes_pk,
                 )
                 .await
+            }
+            NodeMsg::NodeMsgError {
+                error,
+                correlation_id,
+            } => {
+                trace!(
+                    "From {:?}({:?}), received error {:?} correlated to {:?}, targeting {:?}",
+                    msg_authority.src_location(),
+                    msg_id,
+                    error,
+                    correlation_id,
+                    dst_location
+                );
+                Ok(vec![])
             }
             _ => {
                 warn!(

--- a/src/routing/routing_api/event.rs
+++ b/src/routing/routing_api/event.rs
@@ -148,12 +148,4 @@ pub enum MessageReceived {
         /// ID of causing query.
         correlation_id: MessageId,
     },
-    /// The returned error, from any msg handling on recipient node.
-    NodeMsgError {
-        /// The error.
-        // TODO: return node::Error instead
-        error: crate::messaging::data::Error,
-        /// ID of causing cmd.
-        correlation_id: MessageId,
-    },
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
