### PR TITLE
fix(client): use the original payload destination when resending message

### DIFF
--- a/src/client/connections/listeners.rs
+++ b/src/client/connections/listeners.rs
@@ -16,11 +16,11 @@ use crate::client::connections::messaging::{rebuild_message_for_ae_resend, send_
 use crate::client::Error;
 use crate::messaging::data::Error as DataError;
 use crate::messaging::data::ServiceError;
+use crate::messaging::ServiceAuth;
 use crate::messaging::{
     data::{CmdError, ServiceMsg},
     MessageId, MessageType, WireMsg,
 };
-use crate::messaging::{DstLocation, ServiceAuth};
 
 impl Session {
     // Listen for incoming messages on a connection
@@ -58,12 +58,9 @@ impl Session {
             trace!("Incoming message from {:?}", &src);
             match message_type {
                 MessageType::Service {
-                    msg_id,
-                    msg,
-                    auth,
-                    dst_location,
+                    msg_id, msg, auth, ..
                 } => {
-                    self.handle_client_msg(msg_id, msg, src, auth.into_inner(), dst_location)
+                    self.handle_client_msg(msg_id, msg, src, auth.into_inner())
                         .await
                 }
                 msg_type => {
@@ -83,7 +80,6 @@ impl Session {
         msg: ServiceMsg,
         src: SocketAddr,
         auth: ServiceAuth,
-        dst_location: DstLocation,
     ) {
         debug!("ServiceMsg with id {:?} received from {:?}", msg_id, src);
         let queries = self.pending_queries.clone();

--- a/src/client/connections/listeners.rs
+++ b/src/client/connections/listeners.rs
@@ -152,9 +152,9 @@ impl Session {
 
                     if let Some((wire_msg, elders)) = rebuild_message_for_ae_resend(
                         msg_id,
-                        message,
+                        message.payload,
                         auth,
-                        dst_location.name(),
+                        message.dst_location.name(),
                         network,
                     )
                     .await

--- a/src/messaging/data/mod.rs
+++ b/src/messaging/data/mod.rs
@@ -37,9 +37,20 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, convert::TryFrom};
 use xor_name::XorName;
 
+use super::DstLocation;
+
 /// Derivable Id of an operation. Query/Response should return the same id for simple tracking purposes.
 /// TODO: make uniquer per requester for some operations
 pub type OperationId = String;
+
+/// A message payload along with the destination it was meant for
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct SourceMessage {
+    /// Source message payload
+    pub payload: Bytes,
+    /// The destination it was meant for
+    pub dst_location: DstLocation,
+}
 
 /// A message indicating that an error occurred as a node was handling a client's message.
 #[allow(clippy::large_enum_variant)]
@@ -55,7 +66,7 @@ pub struct ServiceError {
     /// Message that triggered this error.
     ///
     /// This could be used to retry the message if the error could be handled.
-    pub source_message: Option<Bytes>,
+    pub source_message: Option<SourceMessage>,
 }
 
 /// Network service messages that clients or nodes send in order to use the services,

--- a/src/messaging/serialisation/wire_msg.rs
+++ b/src/messaging/serialisation/wire_msg.rs
@@ -8,7 +8,7 @@
 
 use super::wire_msg_header::WireMsgHeader;
 use crate::messaging::{
-    data::{ServiceError, ServiceMsg},
+    data::{ServiceError, ServiceMsg, SourceMessage},
     node::NodeMsg,
     AuthorityProof, DstLocation, Error, MessageId, MessageType, MsgKind, NodeMsgAuthority, Result,
     ServiceAuth,
@@ -106,11 +106,11 @@ impl WireMsg {
                 })?;
 
                 let auth = if let ServiceMsg::ServiceError(ServiceError {
-                    source_message: Some(data),
+                    source_message: Some(SourceMessage { payload, .. }),
                     ..
                 }) = &msg
                 {
-                    AuthorityProof::verify(auth, data)?
+                    AuthorityProof::verify(auth, payload)?
                 } else {
                     AuthorityProof(auth)
                 };

--- a/src/routing/core/msg_handling/service_msgs.rs
+++ b/src/routing/core/msg_handling/service_msgs.rs
@@ -8,7 +8,7 @@
 
 use super::Core;
 use crate::dbs::convert_to_error_message as convert_db_error_to_error_message;
-use crate::messaging::data::{ServiceError, ServiceMsg};
+use crate::messaging::data::{ServiceError, ServiceMsg, SourceMessage};
 use crate::messaging::{
     data::{ChunkRead, CmdError, DataCmd, DataQuery, QueryResponse, RegisterRead, RegisterWrite},
     node::{NodeMsg, NodeQueryResponse},
@@ -353,7 +353,10 @@ impl Core {
             let service_msg = ServiceMsg::ServiceError(ServiceError {
                 reason: Some(crate::messaging::data::Error::WrongDestination),
                 sap: Some(return_sap),
-                source_message: Some(payload),
+                source_message: Some(SourceMessage {
+                    payload,
+                    dst_location,
+                }),
             });
 
             let payload = match WireMsg::serialize_msg_payload(&service_msg) {

--- a/src/routing/error.rs
+++ b/src/routing/error.rs
@@ -121,7 +121,7 @@ pub enum Error {
     ServiceMsg(#[from] crate::messaging::data::Error),
     /// Network service error.
     #[error("Service error:: {0:?}")]
-    ServiceError(crate::messaging::data::ServiceError),
+    ServiceError(Box<crate::messaging::data::ServiceError>),
     /// Network data error.
     #[error("Network data error:: {0}")]
     NetworkData(#[from] crate::types::Error),


### PR DESCRIPTION
with updated dest section key
