### PR TITLE
Fix log filtering

### DIFF
--- a/src/bin/sn_node.rs
+++ b/src/bin/sn_node.rs
@@ -123,7 +123,7 @@ async fn run_node() -> Result<()> {
     } else {
         println!("Starting logging to stdout");
 
-        tracing_subscriber::fmt().init();
+        tracing_subscriber::fmt::init();
 
         None
     };

--- a/src/bin/testnet.rs
+++ b/src/bin/testnet.rs
@@ -59,6 +59,8 @@ struct Cmd {
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
+    tracing_subscriber::fmt::init();
+
     let path = std::path::Path::new("nodes");
     remove_dir_all(&path).await.unwrap_or(()); // Delete nodes directory if it exists;
     create_dir_all(&path)


### PR DESCRIPTION
- f5534255b **chore: Enable logging in `testnet`**

- d7940639e **chore: Fix log initialisation in `sn_node`**

  Contrary to the documentation, `tracing_subscriber::fmt().init()` is not
  equivalent to `tracing_subscriber::fmt::init()`, as the former does not
  apply env filtering whilst the latter does.
