### PR TITLE
Fix PrefixMap deadlock

### DIFF
--- a/src/prefix_map/mod.rs
+++ b/src/prefix_map/mod.rs
@@ -284,13 +284,14 @@ impl NetworkPrefixMap {
     fn prune(&self, mut prefix: Prefix) {
         // TODO: can this be optimized?
         loop {
-            {
+            let is_covered = {
                 let descendants: Vec<_> = self.descendants(&prefix).collect();
                 let descendant_prefixes: Vec<&Prefix> =
                     descendants.iter().map(|item| item.key()).collect();
-                if prefix.is_covered_by(descendant_prefixes) {
-                    let _ = self.sections.remove(&prefix);
-                }
+                prefix.is_covered_by(descendant_prefixes)
+            };
+            if is_covered {
+                let _ = self.sections.remove(&prefix);
             }
 
             if prefix.is_empty() {


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
`let descendants: Vec<_> = self.descendants(&prefix).collect();` was holding a read reference to the DashMap while we wrote to it using `let _ = self.sections.remove(&prefix);` sometimes resulting in a deadlock! 
