### PR TITLE
fix: Setting Sub Names Ignores Url Labels

### DIFF
--- a/src/url/mod.rs
+++ b/src/url/mod.rs
@@ -637,7 +637,7 @@ impl Url {
     /// sets sub_names portion of URL
     pub fn set_sub_names(&mut self, sub_names: &str) -> Result<()> {
         let tmpurl = format!("{}{}.{}", URL_PROTOCOL, sub_names, self.top_name());
-        let parts = UrlParts::parse(&tmpurl, false)?;
+        let parts = UrlParts::parse(&tmpurl, true)?;
         self.sub_names = parts.sub_names;
         self.sub_names_vec = parts.sub_names_vec;
         self.public_name = parts.public_name;


### PR DESCRIPTION
New URLs for NrsMapContainer content were longer than 63 characters and were failing validation when the URL was being parsed while fetching NrsMapContainer content in `sn_api`.

The `set_sub_names` function is only being called in this single place in the API, so the impact of this change should be quite low. It doesn't break the unit test for the function.