### PR TITLE
chore: avoid serialise and use original bytes where possible

### DIFF
--- a/src/routing/core/messaging.rs
+++ b/src/routing/core/messaging.rs
@@ -313,6 +313,7 @@ impl Core {
             commands.push(Command::HandleMessage {
                 sender: self.node.addr,
                 wire_msg,
+                original_bytes: None,
             });
         }
 

--- a/src/routing/core/msg_handling/anti_entropy.rs
+++ b/src/routing/core/msg_handling/anti_entropy.rs
@@ -235,7 +235,7 @@ impl Core {
     // bring the sender's knowledge about us up to date.
     pub(crate) async fn check_for_entropy(
         &self,
-        original_wire_msg: &WireMsg,
+        original_bytes: Bytes,
         src_location: &SrcLocation,
         dst_section_pk: &BlsPublicKey,
         dst_name: Option<XorName>,
@@ -248,7 +248,7 @@ impl Core {
             return Ok(None);
         }
 
-        let bounced_msg = original_wire_msg.serialize()?;
+        let bounced_msg = original_bytes;
 
         let ae_msg = match self
             .section
@@ -423,7 +423,13 @@ mod tests {
 
         let command = env
             .core
-            .check_for_entropy(&msg, &src_location, &dst_section_pk, None, sender)
+            .check_for_entropy(
+                msg.serialize()?,
+                &src_location,
+                &dst_section_pk,
+                None,
+                sender,
+            )
             .await?;
 
         assert!(command.is_none());
@@ -446,7 +452,13 @@ mod tests {
         let dst_name = Some(env.other_sap.value.prefix.name());
         match env
             .core
-            .check_for_entropy(&msg, &src_location, &dst_section_pk, dst_name, sender)
+            .check_for_entropy(
+                msg.serialize()?,
+                &src_location,
+                &dst_section_pk,
+                dst_name,
+                sender,
+            )
             .await
         {
             Err(Error::NoMatchingSection) => {}
@@ -463,7 +475,13 @@ mod tests {
         // with the SAP we inserted for other prefix
         let command = env
             .core
-            .check_for_entropy(&msg, &src_location, &dst_section_pk, dst_name, sender)
+            .check_for_entropy(
+                msg.serialize()?,
+                &src_location,
+                &dst_section_pk,
+                dst_name,
+                sender,
+            )
             .await?;
 
         let msg_type = assert_matches!(command, Some(Command::SendMessage { wire_msg, .. }) => {
@@ -494,7 +512,13 @@ mod tests {
 
         let command = env
             .core
-            .check_for_entropy(&msg, &src_location, &dst_section_pk, None, sender)
+            .check_for_entropy(
+                msg.serialize()?,
+                &src_location,
+                &dst_section_pk,
+                None,
+                sender,
+            )
             .await?;
 
         let msg_type = assert_matches!(command, Some(Command::SendMessage { wire_msg, .. }) => {

--- a/src/routing/core/msg_handling/mod.rs
+++ b/src/routing/core/msg_handling/mod.rs
@@ -45,6 +45,7 @@ impl Core {
         &self,
         sender: SocketAddr,
         wire_msg: WireMsg,
+        original_bytes: Option<Bytes>,
     ) -> Result<Vec<Command>> {
         // Deserialize the payload of the incoming message
         let payload = wire_msg.payload.clone();
@@ -113,9 +114,12 @@ impl Core {
                         _ => match dst_location.section_pk() {
                             None => {}
                             Some(dst_section_pk) => {
+                                let msg_bytes = original_bytes.unwrap_or(wire_msg.serialize()?);
+
                                 if let Some(ae_command) = self
                                     .check_for_entropy(
-                                        &wire_msg,
+                                        // a cheap clone w/ Bytes
+                                        msg_bytes,
                                         &msg_authority.src_location(),
                                         &dst_section_pk,
                                         dst_location.name(),
@@ -175,9 +179,11 @@ impl Core {
                     }
                 };
 
+                let msg_bytes = original_bytes.unwrap_or(wire_msg.serialize()?);
                 if let Some(command) = self
                     .check_for_entropy(
-                        &wire_msg,
+                        // a cheap clone w/ Bytes
+                        msg_bytes,
                         &src_location,
                         &received_section_pk,
                         msg.dst_address(),

--- a/src/routing/routing_api/command.rs
+++ b/src/routing/routing_api/command.rs
@@ -29,6 +29,8 @@ pub(crate) enum Command {
     HandleMessage {
         sender: SocketAddr,
         wire_msg: WireMsg,
+        // original bytes to avoid reserializing for entropy checks
+        original_bytes: Option<Bytes>,
     },
     // TODO: rename this as/when this is all node for clarity
     /// Handle Node, either directly or notify via event listener

--- a/src/routing/routing_api/dispatcher.rs
+++ b/src/routing/routing_api/dispatcher.rs
@@ -196,11 +196,15 @@ impl Dispatcher {
             Command::PrepareNodeMsgToSend { msg, dst } => {
                 self.core.read().await.prepare_node_msg(msg, dst)
             }
-            Command::HandleMessage { sender, wire_msg } => {
+            Command::HandleMessage {
+                sender,
+                wire_msg,
+                original_bytes,
+            } => {
                 self.core
                     .read()
                     .await
-                    .handle_message(sender, wire_msg)
+                    .handle_message(sender, wire_msg, original_bytes)
                     .await
             }
             Command::HandleTimeout(token) => self.core.write().await.handle_timeout(token),

--- a/src/routing/routing_api/mod.rs
+++ b/src/routing/routing_api/mod.rs
@@ -435,7 +435,9 @@ async fn handle_connection_events(
                     bytes.len(),
                     sender
                 );
-                let wire_msg = match WireMsg::from(bytes) {
+
+                // bytes.clone is cheap
+                let wire_msg = match WireMsg::from(bytes.clone()) {
                     Ok(wire_msg) => wire_msg,
                     Err(error) => {
                         error!("Failed to deserialize message header: {}", error);
@@ -449,7 +451,11 @@ async fn handle_connection_events(
                 };
                 let _span_guard = span.enter();
 
-                let command = Command::HandleMessage { sender, wire_msg };
+                let command = Command::HandleMessage {
+                    sender,
+                    wire_msg,
+                    original_bytes: Some(bytes),
+                };
                 let _ = task::spawn(dispatcher.clone().handle_commands(command));
             }
         }

--- a/src/routing/routing_api/tests/mod.rs
+++ b/src/routing/routing_api/tests/mod.rs
@@ -100,6 +100,7 @@ async fn receive_join_request_without_resource_proof_response() -> Result<()> {
         Command::HandleMessage {
             sender: new_node.addr,
             wire_msg,
+            original_bytes: None,
         },
         &dispatcher,
     )
@@ -175,6 +176,7 @@ async fn receive_join_request_with_resource_proof_response() -> Result<()> {
         Command::HandleMessage {
             sender: new_node.addr,
             wire_msg,
+            original_bytes: None,
         },
         &dispatcher,
     )
@@ -280,6 +282,7 @@ async fn receive_join_request_from_relocated_node() -> Result<()> {
         Command::HandleMessage {
             sender: relocated_node.addr,
             wire_msg,
+            original_bytes: None,
         },
         &dispatcher,
     )
@@ -352,6 +355,7 @@ async fn aggregate_proposals() -> Result<()> {
             Command::HandleMessage {
                 sender: node.addr,
                 wire_msg,
+                original_bytes: None,
             },
             &dispatcher,
         )
@@ -383,6 +387,7 @@ async fn aggregate_proposals() -> Result<()> {
         Command::HandleMessage {
             sender: nodes[THRESHOLD].addr,
             wire_msg,
+            original_bytes: None,
         },
         &dispatcher,
     )
@@ -903,7 +908,11 @@ async fn handle_untrusted_accumulated_message() -> Result<()> {
     let wire_msg = WireMsg::new_msg(MessageId::new(), payload, msg_kind, dst_location)?;
 
     let commands = dispatcher
-        .handle_command(Command::HandleMessage { sender, wire_msg })
+        .handle_command(Command::HandleMessage {
+            sender,
+            wire_msg,
+            original_bytes: None,
+        })
         .await?;
 
     let mut bounce_sent = false;
@@ -1016,6 +1025,7 @@ async fn check_we_send_ae_update_when_msg_bounced_as_untrusted() -> Result<()> {
         Command::HandleMessage {
             sender: other_node.addr,
             wire_msg: bounced_wire_msg,
+            original_bytes: None,
         },
         &dispatcher,
     )
@@ -1137,6 +1147,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
         Command::HandleMessage {
             sender: old_node.addr,
             wire_msg,
+            original_bytes: None,
         },
         &dispatcher,
     )
@@ -1218,6 +1229,7 @@ async fn untrusted_ae_message_msg_errors() -> Result<()> {
         Command::HandleMessage {
             sender: sender.addr,
             wire_msg,
+            original_bytes: None,
         },
         &dispatcher,
     )


### PR DESCRIPTION
Every time we run `check_for_entropy` we're _reserializing_ the `WireMsg`. 

Now we are not