### PR TITLE
refactor: Remove an unnecessary clone of `Section`

### DIFF
--- a/src/routing/core/messaging.rs
+++ b/src/routing/core/messaging.rs
@@ -133,10 +133,7 @@ impl Core {
         Ok(cmd)
     }
 
-    pub(crate) fn send_ae_update_to_our_section(
-        &mut self,
-        section: Section,
-    ) -> Result<Vec<Command>> {
+    pub(crate) fn send_ae_update_to_our_section(&self, section: &Section) -> Result<Vec<Command>> {
         let nodes: Vec<_> = section
             .active_members()
             .filter(|peer| peer.name() != &self.node.name())

--- a/src/routing/core/mod.rs
+++ b/src/routing/core/mod.rs
@@ -181,7 +181,7 @@ impl Core {
             }
 
             if new.is_elder || old.is_elder {
-                commands.extend(self.send_ae_update_to_our_section(self.section.clone())?);
+                commands.extend(self.send_ae_update_to_our_section(&self.section)?);
             }
 
             let current: BTreeSet<_> = self.section.authority_provider().names();

--- a/src/routing/core/msg_handling/anti_entropy.rs
+++ b/src/routing/core/msg_handling/anti_entropy.rs
@@ -55,17 +55,13 @@ impl Core {
                     );
                     self.section
                         .merge_chain(&signed_section_auth, proof_chain)?;
-                    self.section.merge_members(members)?;
                 } else {
                     debug!(
                         "Anti-Entropy: discarded SAP for {:?} since it's the same as the one in our records: {:?}",
                         section_auth.prefix, section_auth
                     );
-
-                    self.section.merge_members(members)?;
-
-                    // Ok(vec![])
                 }
+                self.section.merge_members(members)?;
             }
             Err(err) => {
                 warn!(

--- a/src/routing/core/msg_handling/update_section.rs
+++ b/src/routing/core/msg_handling/update_section.rs
@@ -7,15 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Core;
-use crate::messaging::{
-    system::{SectionAuth, SectionPeers},
-    SectionAuthorityProvider,
-};
-use crate::routing::{
-    core::StateSnapshot, error::Result, peer::PeerUtils, routing_api::command::Command,
-    section::SectionUtils, Event,
-};
-use secured_linked_list::SecuredLinkedList;
+use crate::routing::{error::Result, peer::PeerUtils, section::SectionUtils, Event};
 use std::collections::BTreeSet;
 
 impl Core {


### PR DESCRIPTION
- aedbd7176 **chore: Make `clippy` happy again**

  These CI checks aren't required atm, so some lint got through.

- b789006fe **refactor: Remove an unnecessary clone of `Section`**

  This was being cloned to satisfy the borrow checker, however
  `Core::send_ae_update_to_our_section` does not need either `&mut self`
  or an owned `Section`, so fixing both of those means we no longer need
  the clone.
