### PR TITLE
Change default local address to `0.0.0.0`

### DIFF
--- a/src/client/config_handler.rs
+++ b/src/client/config_handler.rs
@@ -20,7 +20,7 @@ use tokio::{
 };
 use tracing::{debug, warn};
 
-const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::LOCALHOST, 0);
+const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 
 /// Defaul amount of time to wait for responses to queries before giving up and returning an error.
 pub const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(90);
@@ -162,7 +162,7 @@ mod tests {
         }
 
         let expected_config = Config {
-            local_addr: (Ipv4Addr::LOCALHOST, 0).into(),
+            local_addr: (Ipv4Addr::UNSPECIFIED, 0).into(),
             root_dir: root_dir.clone(),
             qp2p: QuicP2pConfig::default(),
             query_timeout: DEFAULT_QUERY_TIMEOUT,

--- a/src/node/network.rs
+++ b/src/node/network.rs
@@ -20,12 +20,7 @@ use crate::routing::{
 use crate::types::PublicKey;
 use bls::{PublicKey as BlsPublicKey, PublicKeySet};
 use secured_linked_list::SecuredLinkedList;
-use std::{
-    collections::BTreeSet,
-    net::{Ipv4Addr, SocketAddr},
-    path::Path,
-    sync::Arc,
-};
+use std::{collections::BTreeSet, net::SocketAddr, path::Path, sync::Arc};
 use xor_name::{Prefix, XorName};
 
 ///
@@ -41,15 +36,16 @@ impl Network {
         config: &NodeConfig,
         used_space: UsedSpace,
     ) -> Result<(Self, EventStream)> {
-        let routing_config = RoutingConfig {
+        let mut routing_config = RoutingConfig {
             first: config.is_first(),
-            local_addr: config
-                .local_addr
-                .unwrap_or_else(|| SocketAddr::from((Ipv4Addr::LOCALHOST, 0))),
             bootstrap_nodes: config.hard_coded_contacts.clone(),
             network_config: config.network_config().clone(),
-            keypair: None,
+            ..Default::default()
         };
+        if let Some(local_addr) = config.local_addr {
+            routing_config.local_addr = local_addr;
+        }
+
         let (routing, event_stream) =
             RoutingNode::new(routing_config, used_space, root_dir.to_path_buf()).await?;
 

--- a/src/routing/routing_api/config.rs
+++ b/src/routing/routing_api/config.rs
@@ -34,7 +34,7 @@ impl Default for Config {
         Self {
             first: false,
             keypair: None,
-            local_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            local_addr: SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
             bootstrap_nodes: BTreeSet::new(),
             network_config: NetworkConfig::default(),
         }


### PR DESCRIPTION
- 8ab3f9096 **refactor: Centralise default node local address**

  `routing::Config::default` is now the sole determiner of the default
  value for local address, rather than also applying a default in
  `node::Network::new`.

- d0f79b1df **fix: Change default local address to `0.0.0.0`**

  As part of the recent refactoring of qp2p, the default local address was
  changed to `127.0.0.1`, on the basis that it is more secure to require
  users to opt-in to public reachability.
  
  Sadly, this change was quite disruptive, and optimises the less common
  case. Whilst it may still be desireable to default to local-only, the
  specifics of how this is configured needs more thought.
