### PR TITLE
Upgrade `wagoid/commitlint-github-action`

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,10 +4,8 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@f114310111fdbd07e99f47f9ca13d62b3ec98372
+      - uses: wagoid/commitlint-github-action@59203cb6ee1ce85035e6fe7b3aa878cf80653739


### PR DESCRIPTION
- 755aa9579 **ci: upgrade `wagoid/commitlint-github-action`**

  The new version has tighter defaults, which should prevent us from
  committing dodgy commit types like `wip`. The `GITHUB_TOKEN` has also
  been removed, since the repository is public and the action is read
  only.
