### PR TITLE
refactor: Replace `SectionUtils` trail with an inherent impl

### DIFF
--- a/src/routing/core/api.rs
+++ b/src/routing/core/api.rs
@@ -21,9 +21,7 @@ use crate::routing::{
     error::Result,
     node::Node,
     routing_api::command::Command,
-    section::{
-        ElderCandidatesUtils, NodeStateUtils, SectionKeyShare, SectionKeysProvider, SectionUtils,
-    },
+    section::{ElderCandidatesUtils, NodeStateUtils, SectionKeyShare, SectionKeysProvider},
     Error, Event,
 };
 use resource_proof::ResourceProof;

--- a/src/routing/core/bootstrap/join.rs
+++ b/src/routing/core/bootstrap/join.rs
@@ -20,7 +20,6 @@ use crate::routing::{
     messages::{NodeMsgAuthorityUtils, WireMsgUtils},
     node::Node,
     peer::PeerUtils,
-    section::SectionUtils,
     SectionAuthorityProviderUtils, FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
 };
 use crate::types::PublicKey;

--- a/src/routing/core/bootstrap/relocate.rs
+++ b/src/routing/core/bootstrap/relocate.rs
@@ -22,7 +22,6 @@ use crate::routing::{
     peer::PeerUtils,
     relocation::RelocatePayloadUtils,
     routing_api::command::Command,
-    section::SectionUtils,
     SectionAuthorityProviderUtils,
 };
 use crate::types::PublicKey;

--- a/src/routing/core/chunk_records.rs
+++ b/src/routing/core/chunk_records.rs
@@ -12,7 +12,7 @@ use crate::messaging::{
     system::{NodeCmd, NodeQuery, SystemMsg},
     AuthorityProof, EndUser, MessageId, ServiceAuth,
 };
-use crate::routing::{error::convert_to_error_message, section::SectionUtils, Error};
+use crate::routing::{error::convert_to_error_message, Error};
 use crate::types::{Chunk, ChunkAddress, PublicKey};
 use std::collections::BTreeSet;
 use tracing::info;

--- a/src/routing/core/connectivity.rs
+++ b/src/routing/core/connectivity.rs
@@ -12,7 +12,7 @@ use crate::routing::{
     error::Result,
     peer::PeerUtils,
     routing_api::command::Command,
-    section::{NodeStateUtils, SectionPeersUtils, SectionUtils},
+    section::{NodeStateUtils, SectionPeersUtils},
     SectionAuthorityProviderUtils,
 };
 use std::{collections::BTreeSet, iter, net::SocketAddr};

--- a/src/routing/core/delivery_group.rs
+++ b/src/routing/core/delivery_group.rs
@@ -14,7 +14,7 @@ use crate::messaging::{
 use crate::routing::{
     error::{Error, Result},
     peer::PeerUtils,
-    section::{SectionPeersUtils, SectionUtils},
+    section::SectionPeersUtils,
     supermajority, SectionAuthorityProviderUtils, ELDER_SIZE,
 };
 use itertools::Itertools;

--- a/src/routing/core/messaging.rs
+++ b/src/routing/core/messaging.rs
@@ -21,7 +21,7 @@ use crate::routing::{
     peer::PeerUtils,
     relocation::RelocateState,
     routing_api::command::Command,
-    section::{SectionKeyShare, SectionUtils},
+    section::SectionKeyShare,
     SectionAuthorityProviderUtils,
 };
 use crate::types::PublicKey;

--- a/src/routing/core/mod.rs
+++ b/src/routing/core/mod.rs
@@ -40,7 +40,7 @@ use crate::routing::{
     node::Node,
     relocation::RelocateState,
     routing_api::command::Command,
-    section::{SectionKeyShare, SectionKeysProvider, SectionUtils},
+    section::{SectionKeyShare, SectionKeysProvider},
     Elders, Event, NodeElderChange, SectionAuthorityProviderUtils,
 };
 use capacity::Capacity;

--- a/src/routing/core/msg_handling/agreement.rs
+++ b/src/routing/core/msg_handling/agreement.rs
@@ -17,7 +17,7 @@ use crate::routing::{
     error::Result,
     peer::PeerUtils,
     routing_api::command::Command,
-    section::{ElderCandidatesUtils, SectionPeersUtils, SectionUtils},
+    section::{ElderCandidatesUtils, SectionPeersUtils},
     Event, SectionAuthorityProviderUtils, MIN_AGE,
 };
 

--- a/src/routing/core/msg_handling/anti_entropy.rs
+++ b/src/routing/core/msg_handling/anti_entropy.rs
@@ -16,7 +16,6 @@ use crate::routing::{
     error::{Error, Result},
     messages::WireMsgUtils,
     routing_api::command::Command,
-    section::SectionUtils,
     SectionAuthorityProviderUtils,
 };
 use crate::types::PublicKey;

--- a/src/routing/core/msg_handling/bad_msgs.rs
+++ b/src/routing/core/msg_handling/bad_msgs.rs
@@ -12,8 +12,7 @@ use crate::messaging::{
     NodeMsgAuthority,
 };
 use crate::routing::{
-    messages::NodeMsgAuthorityUtils, peer::PeerUtils, routing_api::command::Command,
-    section::SectionUtils, Result,
+    messages::NodeMsgAuthorityUtils, peer::PeerUtils, routing_api::command::Command, Result,
 };
 use bls::PublicKey as BlsPublicKey;
 use std::net::SocketAddr;

--- a/src/routing/core/msg_handling/dkg.rs
+++ b/src/routing/core/msg_handling/dkg.rs
@@ -15,7 +15,7 @@ use crate::routing::{
     dkg::DkgFailureSigSetUtils,
     error::{Error, Result},
     routing_api::command::Command,
-    section::{SectionKeyShare, SectionPeersUtils, SectionUtils},
+    section::{SectionKeyShare, SectionPeersUtils},
     SectionAuthorityProviderUtils,
 };
 use bls_dkg::key_gen::message::Message as DkgMessage;

--- a/src/routing/core/msg_handling/join.rs
+++ b/src/routing/core/msg_handling/join.rs
@@ -15,12 +15,9 @@ use crate::messaging::{
     WireMsg,
 };
 use crate::routing::{
-    error::Result,
-    peer::PeerUtils,
-    relocation::RelocatePayloadUtils,
-    routing_api::command::Command,
-    section::{SectionPeersUtils, SectionUtils},
-    FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
+    error::Result, peer::PeerUtils, relocation::RelocatePayloadUtils,
+    routing_api::command::Command, section::SectionPeersUtils, FIRST_SECTION_MAX_AGE,
+    FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
 };
 use bls::PublicKey as BlsPublicKey;
 

--- a/src/routing/core/msg_handling/mod.rs
+++ b/src/routing/core/msg_handling/mod.rs
@@ -29,7 +29,6 @@ use crate::routing::{
     messages::{NodeMsgAuthorityUtils, WireMsgUtils},
     relocation::RelocateState,
     routing_api::command::Command,
-    section::SectionUtils,
     Error, Event, MessageReceived, Result, SectionAuthorityProviderUtils,
 };
 use crate::types::{Chunk, Keypair, PublicKey};

--- a/src/routing/core/msg_handling/relocation.rs
+++ b/src/routing/core/msg_handling/relocation.rs
@@ -17,7 +17,7 @@ use crate::routing::{
     peer::PeerUtils,
     relocation::{self, RelocateAction, RelocateDetailsUtils, RelocateState},
     routing_api::command::Command,
-    section::{NodeStateUtils, SectionPeersUtils, SectionUtils},
+    section::{NodeStateUtils, SectionPeersUtils},
     Event, SectionAuthorityProviderUtils, ELDER_SIZE,
 };
 use xor_name::XorName;

--- a/src/routing/core/msg_handling/resource_proof.rs
+++ b/src/routing/core/msg_handling/resource_proof.rs
@@ -13,7 +13,6 @@ use crate::routing::{
     ed25519,
     peer::PeerUtils,
     routing_api::command::Command,
-    section::SectionUtils,
     Error, Result,
 };
 use ed25519_dalek::Verifier;

--- a/src/routing/core/msg_handling/service_msgs.rs
+++ b/src/routing/core/msg_handling/service_msgs.rs
@@ -14,8 +14,7 @@ use crate::messaging::{
     AuthorityProof, DstLocation, EndUser, MessageId, MsgKind, NodeAuth, ServiceAuth, WireMsg,
 };
 use crate::routing::{
-    core::capacity::CHUNK_COPY_COUNT, error::Result, peer::PeerUtils,
-    routing_api::command::Command, section::SectionUtils,
+    core::capacity::CHUNK_COPY_COUNT, error::Result, peer::PeerUtils, routing_api::command::Command,
 };
 use crate::types::{ChunkAddress, PublicKey};
 use itertools::Itertools;

--- a/src/routing/core/msg_handling/update_section.rs
+++ b/src/routing/core/msg_handling/update_section.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Core;
-use crate::routing::{error::Result, peer::PeerUtils, section::SectionUtils, Event};
+use crate::routing::{error::Result, peer::PeerUtils, Event};
 use std::collections::BTreeSet;
 
 impl Core {

--- a/src/routing/relocation.rs
+++ b/src/routing/relocation.rs
@@ -20,9 +20,7 @@ use crate::routing::{
     ed25519::{self, Keypair, Verifier},
     error::Error,
     peer::PeerUtils,
-    section::{
-        section_authority_provider::SectionAuthorityProviderUtils, SectionPeersUtils, SectionUtils,
-    },
+    section::{section_authority_provider::SectionAuthorityProviderUtils, SectionPeersUtils},
 };
 use xor_name::XorName;
 

--- a/src/routing/routing_api/dispatcher.rs
+++ b/src/routing/routing_api/dispatcher.rs
@@ -20,7 +20,6 @@ use crate::routing::{
     node::Node,
     peer::PeerUtils,
     section::SectionPeersUtils,
-    section::SectionUtils,
     Error, Prefix, XorName,
 };
 // use bls::PublicKey;

--- a/src/routing/routing_api/mod.rs
+++ b/src/routing/routing_api/mod.rs
@@ -35,7 +35,6 @@ use crate::routing::{
     messages::WireMsgUtils,
     node::Node,
     peer::PeerUtils,
-    section::SectionUtils,
     SectionAuthorityProviderUtils, MIN_ADULT_AGE,
 };
 use crate::{dbs::UsedSpace, messaging::data::ChunkDataExchange};

--- a/src/routing/routing_api/tests/mod.rs
+++ b/src/routing/routing_api/tests/mod.rs
@@ -33,7 +33,6 @@ use crate::routing::{
     relocation::{self, RelocatePayloadUtils},
     section::{
         test_utils::*, ElderCandidatesUtils, NodeStateUtils, SectionKeyShare, SectionPeersUtils,
-        SectionUtils,
     },
     supermajority, Error, Event, Result as RoutingResult, SectionAuthorityProviderUtils,
     ELDER_SIZE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE, MIN_AGE,


### PR DESCRIPTION
- b68f7d47c **refactor: Replace `SectionUtils` trail with an inherent impl**

  This is functionally equivalent for our current usage but lets us cut
  out a bunch of imports and duplicate signatures, and makes it easier to
  identify unused functions (like `extend_chain`).
  
  The methods are all `pub(super)`, which matches the visibility of the
  removed `SectionUtils` trait.
