### PR TITLE
Fix unused dependency check and remove unused dependencies

### DIFF
--- a/.github/workflows/all_prs.yml
+++ b/.github/workflows/all_prs.yml
@@ -55,7 +55,7 @@ jobs:
           override: true
 
       - name: Run cargo-udeps
-        uses: aig787/cargo-udeps-action@v1
+        uses: aig787/cargo-udeps-action@1cd634a329e14ccfbccfe7c96497d14dac24a743
         with:
           version: 'latest'
           args: '--all-targets'

--- a/.github/workflows/all_prs.yml
+++ b/.github/workflows/all_prs.yml
@@ -51,7 +51,7 @@ jobs:
       # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2021-07-05
           override: true
 
       - name: Run cargo-udeps

--- a/.github/workflows/all_prs.yml
+++ b/.github/workflows/all_prs.yml
@@ -58,7 +58,7 @@ jobs:
         uses: aig787/cargo-udeps-action@1cd634a329e14ccfbccfe7c96497d14dac24a743
         with:
           version: 'latest'
-          args: '--all-targets'
+          args: '--all-targets --features test-utils'
 
   cargo-deny:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,17 +100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "attohttpc"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,12 +1199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "if_chain"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
-
-[[package]]
 name = "igd"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,7 +2248,6 @@ version = "0.28.3"
 dependencies = [
  "assert_matches",
  "async-recursion",
- "async-trait",
  "base64 0.10.1",
  "bincode",
  "bls_dkg",
@@ -2285,7 +2267,6 @@ dependencies = [
  "futures",
  "hex",
  "hex_fmt",
- "if_chain",
  "itertools 0.10.1",
  "lazy_static",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ test-utils = []
 
 [dependencies]
 async-recursion = "0.3.2"
-async-trait = "0.1.42"
 base64 = "~0.10.1"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "2.0.1" }
@@ -61,7 +60,6 @@ futures = "~0.3.13"
 hex = "~0.3.2"
 hex_fmt = "~0.3.0"
 itertools = "0.10.0"
-if_chain = "1.0.1"
 lazy_static = "1"
 lru = "0.6.5"
 multibase = "~0.8.0"


### PR DESCRIPTION
- ba1845740 **ci: Pin specific SHA for `aig787/cargo-udeps-action`**

  We should pin by default to ensure CI remains stable. We may want to add
  security advisory checking for GitHub Actions in future, to prompt us to
  update.

- 4bb18e541 **ci: Use `test-utils` feature when running udeps**

  The `test-utils` feature is required for benchmarks and some examples,
  and their dependencies are not counted if the feature is not enabled.

- 0e0dcbffb **chore: Remove unused dependencies**


- c9631d047 **ci: Pin specific nightly for cargo udeps job**

  This is a slightly speculative fix based on
  https://github.community/t/189130 and
  https://github.com/rust-lang/cargo/pull/9695. Although it seems this may
  have been fixed/worked around in cargo, the latest version of
  `cargo-udeps` still depends on cargo 0.54.0 which could be affected.
