### PR TITLE
Fix qp2p config updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,8 +1738,6 @@ dependencies = [
 [[package]]
 name = "qp2p"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124962f4b566a6be0d37840116fd07bd8b8ce78fdb623e51ec48382716194162"
 dependencies = [
  "backoff",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,8 +1738,7 @@ dependencies = [
 [[package]]
 name = "qp2p"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124962f4b566a6be0d37840116fd07bd8b8ce78fdb623e51ec48382716194162"
+source = "git+https://github.com/joshuef/qp2p?branch=Feat-NoRetryConns#62d9301a21bd65d04aeec3048113f75c705345af"
 dependencies = [
  "backoff",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,8 @@ dependencies = [
 [[package]]
 name = "qp2p"
 version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "124962f4b566a6be0d37840116fd07bd8b8ce78fdb623e51ec48382716194162"
 dependencies = [
  "backoff",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,8 @@ hex_fmt = "~0.3.0"
 itertools = "0.10.0"
 lazy_static = "1"
 multibase = "~0.8.0"
-qp2p = {path="../qp2p"}
+qp2p = "0.19.0"
+# qp2p = {path="../qp2p"}
 # qp2p = {git="https://github.com/joshuef/qp2p", branch="Fix-DefaultsAndRemoveConnRetry"}
 
 rand = "~0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,9 @@ hex_fmt = "~0.3.0"
 itertools = "0.10.0"
 lazy_static = "1"
 multibase = "~0.8.0"
-qp2p = "0.19.0"
+# qp2p = "0.19.0"
 # qp2p = {path="../qp2p"}
-# qp2p = {git="https://github.com/joshuef/qp2p", branch="Fix-DefaultsAndRemoveConnRetry"}
+qp2p = {git="https://github.com/joshuef/qp2p", branch="Feat-NoRetryConns"}
 
 rand = "~0.7.3"
 rayon = "1.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,9 @@ hex_fmt = "~0.3.0"
 itertools = "0.10.0"
 lazy_static = "1"
 multibase = "~0.8.0"
-qp2p = "~0.19.0"
+qp2p = {path="../qp2p"}
+# qp2p = {git="https://github.com/joshuef/qp2p", branch="Fix-DefaultsAndRemoveConnRetry"}
+
 rand = "~0.7.3"
 rayon = "1.5.1"
 resource_proof = "0.8.0"

--- a/src/client/client_api/blob_apis.rs
+++ b/src/client/client_api/blob_apis.rs
@@ -347,13 +347,13 @@ mod tests {
                 // Read first part
                 let read_data_1 = {
                     let pos = 0;
-                    seek(data.clone(), pos, len).await?
+                    seek_for_test(data.clone(), pos, len).await?
                 };
 
                 // Read second part
                 let read_data_2 = {
                     let pos = len;
-                    seek(data.clone(), pos, len).await?
+                    seek_for_test(data.clone(), pos, len).await?
                 };
 
                 // Join parts
@@ -457,7 +457,7 @@ mod tests {
         Ok(())
     }
 
-    async fn seek(data: Bytes, pos: usize, len: usize) -> Result<Bytes> {
+    async fn seek_for_test(data: Bytes, pos: usize, len: usize) -> Result<Bytes> {
         let client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
         let address = client.write_to_network(data.clone(), Scope::Public).await?;
 

--- a/src/client/client_api/blob_apis.rs
+++ b/src/client/client_api/blob_apis.rs
@@ -450,7 +450,7 @@ mod tests {
         let delay = usize::max(1, size / 2_000_000);
 
         // now that it was written to the network we should be able to retrieve it
-        let read_data = run_w_backoff_delayed(|| client.read_blob(address), 1, delay).await?;
+        let read_data = run_w_backoff_delayed(|| client.read_blob(address), 10, delay).await?;
         // then the content should be what we stored
         compare(blob, read_data)?;
 

--- a/src/client/config_handler.rs
+++ b/src/client/config_handler.rs
@@ -65,10 +65,13 @@ impl Config {
             .unwrap_or_else(default_dir);
         // If a config file path was provided we try to read it,
         // otherwise we use default qp2p config.
-        let qp2p = match &config_file_path {
+        let mut qp2p = match &config_file_path {
             None => QuicP2pConfig::default(),
             Some(path) => read_config_file(path).await.unwrap_or_default(),
         };
+
+        qp2p.idle_timeout = Some(Duration::from_secs(5));
+        qp2p.keep_alive_interval = Some(Duration::from_secs(1));
 
         Self {
             local_addr: local_addr.unwrap_or_else(|| SocketAddr::from(DEFAULT_LOCAL_ADDR)),

--- a/src/client/utils/test_utils/mod.rs
+++ b/src/client/utils/test_utils/mod.rs
@@ -60,8 +60,8 @@ where
 }
 
 fn get_backoff_policy(retries: u8) -> Backoff {
-    let min = Duration::from_millis(100);
-    let max = Duration::from_secs(10);
+    let min = Duration::from_secs(1);
+    let max = Duration::from_secs(30);
     Backoff::new(retries as u32, min, max)
 }
 
@@ -109,7 +109,7 @@ macro_rules! retry_loop {
         loop {
             match $async_func.await {
                 Ok(val) => break val,
-                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(200)).await,
+                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(1000)).await,
             }
         }
     };
@@ -122,7 +122,7 @@ macro_rules! retry_err_loop {
     ($async_func:expr) => {
         loop {
             match $async_func.await {
-                Ok(_) => tokio::time::sleep(std::time::Duration::from_millis(200)).await,
+                Ok(_) => tokio::time::sleep(std::time::Duration::from_millis(1000)).await,
                 Err(err) => break err,
             }
         }
@@ -138,7 +138,7 @@ macro_rules! retry_loop_for_pattern {
             let result = $async_func.await;
             match &result {
                 $pattern $(if $cond)? => break result,
-                Ok(_) | Err(_) => tokio::time::sleep(std::time::Duration::from_millis(200)).await,
+                Ok(_) | Err(_) => tokio::time::sleep(std::time::Duration::from_millis(1000)).await,
             }
         }
     };

--- a/src/client/utils/test_utils/mod.rs
+++ b/src/client/utils/test_utils/mod.rs
@@ -60,8 +60,8 @@ where
 }
 
 fn get_backoff_policy(retries: u8) -> Backoff {
-    let min = Duration::from_secs(1);
-    let max = Duration::from_secs(30);
+    let min = Duration::from_secs(10);
+    let max = Duration::from_secs(60);
     Backoff::new(retries as u32, min, max)
 }
 
@@ -109,7 +109,7 @@ macro_rules! retry_loop {
         loop {
             match $async_func.await {
                 Ok(val) => break val,
-                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(1000)).await,
+                Err(_) => tokio::time::sleep(std::time::Duration::from_secs(10)).await,
             }
         }
     };
@@ -122,7 +122,7 @@ macro_rules! retry_err_loop {
     ($async_func:expr) => {
         loop {
             match $async_func.await {
-                Ok(_) => tokio::time::sleep(std::time::Duration::from_millis(1000)).await,
+                Ok(_) => tokio::time::sleep(std::time::Duration::from_secs(10)).await,
                 Err(err) => break err,
             }
         }
@@ -138,7 +138,7 @@ macro_rules! retry_loop_for_pattern {
             let result = $async_func.await;
             match &result {
                 $pattern $(if $cond)? => break result,
-                Ok(_) | Err(_) => tokio::time::sleep(std::time::Duration::from_millis(1000)).await,
+                Ok(_) | Err(_) => tokio::time::sleep(std::time::Duration::from_secs(10)).await,
             }
         }
     };


### PR DESCRIPTION
- uses qp2p which doesnt retry new conns, seems to help w/ mem
- lowers all test retry sleeps as we have qp2p retry now
- adds lower client conn idle times