### PR TITLE
fix: remove unnecessary option return value

### DIFF
--- a/src/messaging/location.rs
+++ b/src/messaging/location.rs
@@ -115,12 +115,12 @@ impl DstLocation {
         }
     }
 
-    /// Returns the name of this location, or `None` if it is `Direct`.
-    pub fn name(&self) -> Option<XorName> {
+    /// Returns the name of this location
+    pub fn name(&self) -> XorName {
         match self {
-            Self::EndUser(user) => Some(user.0),
-            Self::Node { name, .. } => Some(*name),
-            Self::Section { name, .. } => Some(*name),
+            Self::EndUser(user) => user.0,
+            Self::Node { name, .. } => *name,
+            Self::Section { name, .. } => *name,
         }
     }
 

--- a/src/routing/core/api.rs
+++ b/src/routing/core/api.rs
@@ -22,7 +22,7 @@ use crate::routing::{
     node::Node,
     routing_api::command::Command,
     section::{ElderCandidatesUtils, NodeStateUtils, SectionKeyShare, SectionKeysProvider},
-    Error, Event,
+    Event,
 };
 use resource_proof::ResourceProof;
 use secured_linked_list::SecuredLinkedList;
@@ -191,7 +191,7 @@ impl Core {
             wire_msg.src_section_pk(),
         );
 
-        let target_name = dst_location.name().ok_or(Error::CannotRoute)?;
+        let target_name = dst_location.name();
 
         // To avoid loop: if destination is to Node, targets are multiple, self is an elder,
         //     self section prefix matches the destination name, then don't carry out a relay.

--- a/src/routing/core/msg_handling/anti_entropy.rs
+++ b/src/routing/core/msg_handling/anti_entropy.rs
@@ -237,50 +237,48 @@ impl Core {
         original_bytes: Bytes,
         src_location: &SrcLocation,
         dst_section_pk: &BlsPublicKey,
-        dst_name: Option<XorName>,
+        dst_name: XorName,
         sender: SocketAddr,
     ) -> Result<Option<Command>> {
         // Check if the message has reached the correct section,
         // if not, we'll need to respond with AE
 
         // Let's try to find a section closer to the destination, if it's not for us.
-        if let Some(name) = dst_name {
-            if !self.section.prefix().matches(&name) {
-                match self.network.closest_or_opposite(&name) {
-                    Some(section_auth) => {
-                        let bounced_msg = original_bytes;
-                        // Redirect to the closest section
-                        let ae_msg = SystemMsg::AntiEntropyRedirect {
-                            section_auth: section_auth.value.clone(),
-                            section_signed: section_auth.sig,
-                            bounced_msg,
-                        };
-                        let wire_msg = WireMsg::single_src(
-                            &self.node,
-                            src_location.to_dst(),
-                            ae_msg,
-                            self.section.authority_provider().section_key(),
-                        )?;
-                        return Ok(Some(Command::SendMessage {
-                            recipients: vec![(src_location.name(), sender)],
-                            wire_msg,
-                        }));
-                    }
-                    None => {
-                        // TODO: do we want to reroute some data messages to another seciton here using check_for_better_section_sap_for_data ?
-                        // if not we can remove that function.
+        if !self.section.prefix().matches(&dst_name) {
+            match self.network.closest_or_opposite(&dst_name) {
+                Some(section_auth) => {
+                    let bounced_msg = original_bytes;
+                    // Redirect to the closest section
+                    let ae_msg = SystemMsg::AntiEntropyRedirect {
+                        section_auth: section_auth.value.clone(),
+                        section_signed: section_auth.sig,
+                        bounced_msg,
+                    };
+                    let wire_msg = WireMsg::single_src(
+                        &self.node,
+                        src_location.to_dst(),
+                        ae_msg,
+                        self.section.authority_provider().section_key(),
+                    )?;
+                    return Ok(Some(Command::SendMessage {
+                        recipients: vec![(src_location.name(), sender)],
+                        wire_msg,
+                    }));
+                }
+                None => {
+                    // TODO: do we want to reroute some data messages to another seciton here using check_for_better_section_sap_for_data ?
+                    // if not we can remove that function.
 
-                        // TODO: instead of just dropping the message, don't we actually need
-                        // to get up to date info from other Elders in our section as it may be
-                        // a section key we are not aware of yet?
-                        // ...and once we acquired new key/s we attempt AE check again?
-                        error!(
-                                "Anti-Entropy: cannot reply with redirect msg for dst_name {:?} and key {:?} to a closest section. Resending our SAP",
-                                name, dst_section_pk
-                            );
+                    // TODO: instead of just dropping the message, don't we actually need
+                    // to get up to date info from other Elders in our section as it may be
+                    // a section key we are not aware of yet?
+                    // ...and once we acquired new key/s we attempt AE check again?
+                    error!(
+                            "Anti-Entropy: cannot reply with redirect msg for dst_name {:?} and key {:?} to a closest section. Resending our SAP",
+                            dst_name, dst_section_pk
+                        );
 
-                        return Err(Error::NoMatchingSection);
-                    }
+                    return Err(Error::NoMatchingSection);
                 }
             }
         }
@@ -435,7 +433,7 @@ mod tests {
                 msg.serialize()?,
                 &src_location,
                 &dst_section_pk,
-                None,
+                XorName::random(),
                 sender,
             )
             .await?;
@@ -457,7 +455,7 @@ mod tests {
 
         // since it's not aware of the other prefix, it shall fail with NoMatchingSection
         let dst_section_pk = other_pk;
-        let dst_name = Some(env.other_sap.value.prefix.name());
+        let dst_name = env.other_sap.value.prefix.name();
         match env
             .core
             .check_for_entropy(
@@ -524,7 +522,7 @@ mod tests {
                 msg.serialize()?,
                 &src_location,
                 &dst_section_pk,
-                None,
+                XorName::random(),
                 sender,
             )
             .await?;

--- a/src/routing/core/msg_handling/mod.rs
+++ b/src/routing/core/msg_handling/mod.rs
@@ -152,6 +152,16 @@ impl Core {
                 msg,
                 dst_location,
             } => {
+                let dst_name = match msg.dst_address() {
+                    Some(name) => name,
+                    None => {
+                        error!(
+                            "Service msg has been dropped since {:?} is not a valid msg to send from a client {}.",
+                            msg, sender
+                        );
+                        return Ok(vec![]);
+                    }
+                };
                 let user = match self.comm.get_connection_id(&sender).await {
                     Some(name) => EndUser(name),
                     None => {
@@ -162,6 +172,7 @@ impl Core {
                         return Ok(vec![]);
                     }
                 };
+
                 let src_location = SrcLocation::EndUser(user);
 
                 if self.is_not_elder() {
@@ -185,7 +196,7 @@ impl Core {
                         msg_bytes,
                         &src_location,
                         &received_section_pk,
-                        msg.dst_address(),
+                        dst_name,
                         sender,
                     )
                     .await?


### PR DESCRIPTION
DstLocation name returned an option even though there was no None case in
the method body.
Additional cleanup made as a result of this.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
