### PR TITLE
refactor: Remove unnecessary `RwLock` from `MsgCount` state

### DIFF
--- a/src/routing/core/comm.rs
+++ b/src/routing/core/comm.rs
@@ -137,7 +137,7 @@ impl Comm {
                 })?;
 
             // count outgoing msgs..
-            self.msg_count.increase_outgoing(*addr).await;
+            self.msg_count.increase_outgoing(*addr);
         }
 
         Ok(())
@@ -250,7 +250,7 @@ impl Comm {
                 Ok(()) => {
                     successes += 1;
                     // count outgoing msgs..
-                    self.msg_count.increase_outgoing(addr).await;
+                    self.msg_count.increase_outgoing(addr);
                 }
                 Err(Error::ConnectionClosed) => {
                     // The connection was closed by us which means
@@ -287,9 +287,9 @@ impl Comm {
         }
     }
 
-    pub(crate) async fn print_stats(&self) {
-        let incoming = self.msg_count.incoming().await;
-        let outgoing = self.msg_count.outgoing().await;
+    pub(crate) fn print_stats(&self) {
+        let incoming = self.msg_count.incoming();
+        let outgoing = self.msg_count.outgoing();
         info!("*** Incoming msgs: {:?} ***", incoming);
         info!("*** Outgoing msgs: {:?} ***", outgoing);
     }
@@ -320,7 +320,7 @@ async fn handle_incoming_messages(
     while let Some((src, msg)) = incoming_msgs.next().await {
         let _ = event_tx.send(ConnectionEvent::Received((src, msg))).await;
         // count incoming msgs..
-        msg_count.increase_incoming(src).await;
+        msg_count.increase_incoming(src);
     }
 }
 

--- a/src/routing/core/mod.rs
+++ b/src/routing/core/mod.rs
@@ -178,7 +178,7 @@ impl Core {
                     )))?);
                 }
 
-                self.print_network_stats().await;
+                self.print_network_stats();
             }
 
             if new.is_elder || old.is_elder {
@@ -268,11 +268,11 @@ impl Core {
         }
     }
 
-    pub(crate) async fn print_network_stats(&self) {
+    pub(crate) fn print_network_stats(&self) {
         self.network
             .network_stats(self.section.authority_provider())
             .print();
-        self.comm.print_stats().await;
+        self.comm.print_stats();
     }
 }
 

--- a/src/routing/core/msg_handling/agreement.rs
+++ b/src/routing/core/msg_handling/agreement.rs
@@ -113,7 +113,7 @@ impl Core {
         commands.extend(result);
         commands.push(self.send_node_approval(new_info)?);
 
-        self.print_network_stats().await;
+        self.print_network_stats();
 
         Ok(commands)
     }


### PR DESCRIPTION
- b952ec281 **refactor: remove unnecessary `RwLock` from `MsgCount` state**

  `DashMap` itself can synchronise concurrent mutable access to its data,
  being based on an `RwLock` internally. As such, we do not need to lock
  the individual values and can just use a plain `usize`. This also
  removes the need for `async` in that type.
