### PR TITLE
Stable udeps

### DIFF
--- a/.github/workflows/all_prs.yml
+++ b/.github/workflows/all_prs.yml
@@ -42,6 +42,25 @@ jobs:
       - shell: bash
         run: cargo clippy --all-targets
 
+  cargo-udeps:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
+    name: Unused dependency check
+    runs-on: ubuntu-latest
+    env:
+      CARGO_HTTP_MULTIPLEXING: 'false'
+      RUSTFLAGS: ''
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Run cargo-udeps
+        uses: aig787/cargo-udeps-action@1cd634a329e14ccfbccfe7c96497d14dac24a743
+        with:
+          version: 'latest'
+          args: '--all-targets --features test-utils'
+
   cargo-deny:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     runs-on: ubuntu-latest


### PR DESCRIPTION
- af3485b54 **ci: restore cargo-udeps in a more stable form**

  This reverts commit 0a7201e55b461c0a6a21798a5f517601dbe4bbf4.
  `CARGO_HTTP_MULTIPLEXING` has been disabled, which seems to have
  resolved our network woes, and `-D warnings` is removed from `RUSTFLAGS`
  for that job, since new nightlies may introduce additional lints that we
  wouldn't otherwise block (the nightly has been 'unpinned' from
  `2020-07-05` as well, since this turned out not to be the problem).
