### PR TITLE
Ci longer delay before query

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -192,12 +192,12 @@ jobs:
       # register api
       - name: Client reg tests against local network
         shell: bash
-        run: timeout 5m cargo test --release --features=always-joinable,test-utils -- client_api::reg && sleep 5
+        run: timeout 10m cargo test --release --features=always-joinable,test-utils -- client_api::reg && sleep 5
       
       # blob api
       - name: Client blob tests against local network
         shell: bash
-        run: timeout 5m cargo test --release --features=always-joinable,test-utils -- client_api::blob && sleep 5
+        run: timeout 10m cargo test --release --features=always-joinable,test-utils -- client_api::blob && sleep 5
       
       - name: Run example app for Blob API against local network
         shell: bash

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Initial client tests...
         shell: bash
         # always joinable not actually needed here, but should speed up compilation as we've just built with it
-        run: timeout 5m cargo test --release --features=always-joinable,test-utils -- client_api --skip client_api::reg --skip client_api::blob --test-threads=1 && sleep 5
+        run: timeout 5m cargo test --release --features=always-joinable,test-utils -- client_api --skip client_api::reg --skip client_api::blob && sleep 5
 
       # register api
       - name: Client reg tests against local network
@@ -197,7 +197,7 @@ jobs:
       # blob api
       - name: Client blob tests against local network
         shell: bash
-        run: timeout 5m cargo test --release --features=always-joinable,test-utils -- client_api::blob --test-threads=1 && sleep 5
+        run: timeout 5m cargo test --release --features=always-joinable,test-utils -- client_api::blob && sleep 5
       
       - name: Run example app for Blob API against local network
         shell: bash

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -158,7 +158,7 @@ jobs:
 
       - run: ./target/release/testnet
         env:
-          NODE_COUNT: 15 # TODO: change it back to 43 (this should be a split section)
+          NODE_COUNT: 45 # TODO: change it back to 43 (this should be a split section)
 
       # a catchall to ensure any new client api tests are run (ideally any major new section should have its own test run)
       - name: Initial client tests...
@@ -199,12 +199,12 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: rm -rf ~/.safe/node
 
-      # - name: Run example of split and chunk check
-      #   shell: bash
-      #   run: timeout 10m cargo run --release  --features=always-joinable,test-utils --example network_split
+      - name: Run example of split and chunk check
+        shell: bash
+        run: timeout 10m cargo run --release  --features=always-joinable,test-utils --example network_split
 
-      # - name: Was there a section split?
-      #   run: ./scripts/has_split.sh
+      - name: Was there a section split?
+        run: ./scripts/has_split.sh
 
       - name: Are nodes still running...?
         if: failure() && matrix.os != 'windows-latest'

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -158,7 +158,30 @@ jobs:
 
       - run: ./target/release/testnet
         env:
-          NODE_COUNT: 45 # TODO: change it back to 43 (this should be a split section)
+          NODE_COUNT: 43
+
+      - name: Was there a section split?
+        run: ./scripts/has_split.sh
+        id: split-check-1
+
+      - name: Kill Section if no split (unix)
+        if: matrix.os != 'windows-latest' && steps.split-check-1.outcome == 'failure' 
+        run: killall sn_node
+      
+      - name: Kill section if no split (win)
+        if: matrix.os == 'windows-latest' && steps.split-check-1.outcome == 'failure'
+        shell: cmd 
+        run: taskkill /IM sn_node.exe /F
+
+      - name: Restart Section if no split
+        if: steps.split-check-1.outcome == 'failure' 
+        run: ./target/release/testnet
+        env:
+          NODE_COUNT: 43
+
+      - name: Was there a section split?
+        run: ./scripts/has_split.sh
+        id: split-check-2
 
       # a catchall to ensure any new client api tests are run (ideally any major new section should have its own test run)
       - name: Initial client tests...
@@ -182,29 +205,33 @@ jobs:
 
       - name: Kill the current network (not needed for next test)
         if: matrix.os != 'windows-latest'
-        run: killall sn_node
+        run: |
+          killall sn_node
+          rm -rf ~/.safe/node
         shell: bash
 
       - name: Kill the current network (not needed for next test)
         if: matrix.os == 'windows-latest'
-        run: taskkill /IM sn_node.exe /F
+        run: |
+          taskkill /IM sn_node.exe /F
+          rd /s /q %USERPROFILE%\.safe\node
         shell: cmd
 
-      - name: Remove node dir and logs for next test
-        if: matrix.os == 'windows-latest'
-        run: rd /s /q %USERPROFILE%\.safe\node
-        shell: cmd
+      # - name: Remove node dir and logs for next test
+      #   if: matrix.os == 'windows-latest'
+      #   run: rd /s /q %USERPROFILE%\.safe\node
+      #   shell: cmd
 
-      - name: Remove node dir and logs for next test
-        if: matrix.os != 'windows-latest'
-        run: rm -rf ~/.safe/node
+      # - name: Remove node dir and logs for next test
+      #   if: matrix.os != 'windows-latest'
+      #   run: rm -rf ~/.safe/node
 
-      - name: Run example of split and chunk check
-        shell: bash
-        run: timeout 10m cargo run --release  --features=always-joinable,test-utils --example network_split
+      # - name: Run example of split and chunk check
+      #   shell: bash
+      #   run: timeout 10m cargo run --release  --features=always-joinable,test-utils --example network_split
 
-      - name: Was there a section split?
-        run: ./scripts/has_split.sh
+      # - name: Was there a section split?
+      #   run: ./scripts/has_split.sh
 
       - name: Are nodes still running...?
         if: failure() && matrix.os != 'windows-latest'

--- a/src/client/client_api/blob_apis.rs
+++ b/src/client/client_api/blob_apis.rs
@@ -271,6 +271,7 @@ mod tests {
 
     const BLOB_TEST_QUERY_TIMEOUT: u64 = 60;
     const MIN_BLOB_SIZE: usize = self_encryption::MIN_ENCRYPTABLE_BYTES;
+    const DELAY_DIVIDER: usize = 500_000;
 
     #[test]
     fn deterministic_chunking() -> Result<()> {
@@ -308,7 +309,7 @@ mod tests {
             .await?;
 
         // the larger the file, the longer we have to wait before we start querying
-        let delay = usize::max(1, blob.len() / 2_000_000);
+        let delay = usize::max(1, blob.len() / DELAY_DIVIDER);
 
         // Assert that the blob is stored.
         let read_data =
@@ -447,7 +448,7 @@ mod tests {
         let address = client.write_to_network(blob.clone(), scope).await?;
 
         // the larger the file, the longer we have to wait before we start querying
-        let delay = usize::max(1, size / 2_000_000);
+        let delay = usize::max(1, size / DELAY_DIVIDER);
 
         // now that it was written to the network we should be able to retrieve it
         let read_data = run_w_backoff_delayed(|| client.read_blob(address), 10, delay).await?;
@@ -462,7 +463,7 @@ mod tests {
         let address = client.write_to_network(data.clone(), Scope::Public).await?;
 
         // the larger the file, the longer we have to wait before we start querying
-        let delay = usize::max(1, len / 2_000_000);
+        let delay = usize::max(1, len / DELAY_DIVIDER);
 
         let read_data =
             run_w_backoff_delayed(|| client.read_blob_from(address, pos, len), 10, delay).await?;

--- a/src/client/utils/test_utils/mod.rs
+++ b/src/client/utils/test_utils/mod.rs
@@ -63,7 +63,7 @@ where
 }
 
 fn get_backoff_policy(retries: u8) -> Backoff {
-    let min = Duration::from_secs(2);
+    let min = Duration::from_millis(500);
     let max = Duration::from_secs(30);
     Backoff::new(retries as u32, min, max)
 }

--- a/src/client/utils/test_utils/mod.rs
+++ b/src/client/utils/test_utils/mod.rs
@@ -52,7 +52,10 @@ where
     for duration in &backoff {
         match f().await {
             Ok(val) => return Ok(val),
-            Err(_) => tokio::time::sleep(duration).await,
+            Err(_) => {
+                tokio::time::sleep(duration).await;
+                debug!("**** retrying *** ");
+            }
         }
     }
 


### PR DESCRIPTION
Prior our delay would mean we started querying well before chunks were actually put.

W/ some 20mb testing this seems more reasonable, and initial query doesnt fire until all cmds are complete