### PR TITLE
feat(data): distinguish between spot and blob

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -192,12 +192,12 @@ jobs:
       # register api
       - name: Client reg tests against local network
         shell: bash
-        run: timeout 10m cargo test --release --features=always-joinable,test-utils -- client_api::reg && sleep 5
+        run: timeout 10m cargo test --release --features=always-joinable,test-utils -- client_api::reg --test-threads=1 && sleep 5
       
       # blob api
       - name: Client blob tests against local network
         shell: bash
-        run: timeout 10m cargo test --release --features=always-joinable,test-utils -- client_api::blob && sleep 5
+        run: timeout 10m cargo test --release --features=always-joinable,test-utils -- client_api::blob --test-threads=1 && sleep 5
       
       - name: Run example app for Blob API against local network
         shell: bash

--- a/examples/client_blob.rs
+++ b/examples/client_blob.rs
@@ -8,7 +8,7 @@
 
 use eyre::Result;
 use safe_network::{
-    client::{utils::test_utils::read_network_conn_info, Client, Config},
+    client::{client_api::Blob, utils::test_utils::read_network_conn_info, Client, Config},
     types::utils::random_bytes,
     url::{ContentType, Scope, Url, DEFAULT_XORURL_BASE},
 };
@@ -33,10 +33,10 @@ async fn main() -> Result<()> {
     let pk = client.public_key();
     println!("Client Public Key: {}", pk);
 
-    let random_bytes = random_bytes(self_encryption::MIN_ENCRYPTABLE_BYTES);
-    println!("Storing data.. ({} bytes)", random_bytes.len());
+    let blob = Blob::new(random_bytes(self_encryption::MIN_ENCRYPTABLE_BYTES))?;
+    println!("Storing data.. ({} bytes)", blob.bytes().len());
 
-    let address = client.write_to_network(random_bytes, Scope::Public).await?;
+    let address = client.write_blob_to_network(blob, Scope::Public).await?;
     let xorurl = Url::encode_blob(
         *address.name(),
         Scope::Public,

--- a/src/client/client_api/blob_apis.rs
+++ b/src/client/client_api/blob_apis.rs
@@ -117,7 +117,7 @@ impl Client {
         let encryption = encryption(scope, self.public_key());
         let chunk = to_chunk(spot.bytes(), encryption.as_ref())?;
         if chunk.value().len() >= self_encryption::MIN_ENCRYPTABLE_BYTES {
-            return Err(Error::Generic("You might need to pad the spot contents, as the encryption of it made it slightly too big".to_string()));
+            return Err(Error::Generic("You might need to pad the spot contents and then store it as a `Blob`, as the encryption has made it slightly too big".to_string()));
         }
         let name = *chunk.name();
         let address = if encryption.is_some() {

--- a/src/client/client_api/data/mod.rs
+++ b/src/client/client_api/data/mod.rs
@@ -8,4 +8,148 @@
 
 mod pac_man;
 
-pub(crate) use pac_man::{get_data_chunks, SecretKey};
+pub(crate) use pac_man::{encrypt_blob, to_chunk, SecretKey};
+
+use crate::{
+    client::{Error, Result},
+    url::Scope,
+};
+
+use bytes::Bytes;
+use self_encryption::MIN_ENCRYPTABLE_BYTES;
+use xor_name::XorName;
+
+/// Data of size more than 0 bytes less than [`MIN_ENCRYPTABLE_BYTES`] bytes.
+///
+/// A `Spot` cannot be self-encrypted, thus is encrypted using the client encryption keys instead.
+#[allow(missing_debug_implementations)]
+#[derive(Clone)]
+pub struct Spot {
+    bytes: Bytes,
+}
+
+/// Data of size larger than or equal to [`MIN_ENCRYPTABLE_BYTES`] bytes.
+///
+/// A `Blob` is spread across multiple chunks in the network.
+/// This is done using self-encryption, which produces at least 4 chunks (3 for the contents, 1 for the `BlobSecretKey`).
+#[allow(missing_debug_implementations)]
+#[derive(Clone)]
+pub struct Blob {
+    bytes: Bytes,
+}
+
+impl Spot {
+    /// Enforces size > 0 and size < [`MIN_ENCRYPTABLE_BYTES`] bytes.
+    pub fn new(bytes: Bytes) -> Result<Self> {
+        if bytes.len() >= MIN_ENCRYPTABLE_BYTES {
+            Err(Error::Generic(
+                "The provided bytes is too large to be a `Spot`".to_string(),
+            ))
+        } else if bytes.is_empty() {
+            Err(Error::Generic("Cannot store empty bytes.".to_string()))
+        } else {
+            Ok(Self { bytes })
+        }
+    }
+
+    /// Returns the bytes.
+    pub fn bytes(&self) -> Bytes {
+        self.bytes.clone()
+    }
+}
+
+impl Blob {
+    /// Enforces size >= [`MIN_ENCRYPTABLE_BYTES`] bytes.
+    pub fn new(bytes: Bytes) -> Result<Self> {
+        if MIN_ENCRYPTABLE_BYTES > bytes.len() {
+            Err(Error::Generic(
+                "The provided bytes is too small to be a `Blob`".to_string(),
+            ))
+        } else {
+            Ok(Self { bytes })
+        }
+    }
+
+    /// Returns the bytes.
+    pub fn bytes(&self) -> Bytes {
+        self.bytes.clone()
+    }
+}
+
+/// Address of a Blob.
+#[derive(
+    Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, serde::Serialize, serde::Deserialize, Debug,
+)]
+pub enum BlobAddress {
+    /// Private namespace.
+    Private(XorName),
+    /// Public namespace.
+    Public(XorName),
+}
+
+impl BlobAddress {
+    /// The xorname.
+    pub fn name(&self) -> &XorName {
+        match self {
+            Self::Public(name) | Self::Private(name) => name,
+        }
+    }
+
+    /// The namespace scope of the Blob
+    pub fn scope(&self) -> Scope {
+        if self.is_public() {
+            Scope::Public
+        } else {
+            Scope::Private
+        }
+    }
+
+    /// Returns true if public.
+    pub fn is_public(self) -> bool {
+        matches!(self, BlobAddress::Public(_))
+    }
+
+    /// Returns true if private.
+    pub fn is_private(self) -> bool {
+        !self.is_public()
+    }
+}
+
+/// Address of a Spot.
+#[derive(
+    Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, serde::Serialize, serde::Deserialize, Debug,
+)]
+pub enum SpotAddress {
+    /// Private namespace.
+    Private(XorName),
+    /// Public namespace.
+    Public(XorName),
+}
+
+impl SpotAddress {
+    /// The xorname.
+    pub fn name(&self) -> &XorName {
+        match self {
+            Self::Public(name) | Self::Private(name) => name,
+        }
+    }
+
+    /// The namespace scope of the Spot
+    pub fn scope(&self) -> Scope {
+        if self.is_public() {
+            Scope::Public
+        } else {
+            Scope::Private
+        }
+    }
+
+    /// Returns true if public.
+    pub fn is_public(self) -> bool {
+        matches!(self, SpotAddress::Public(_))
+    }
+
+    /// Returns true if private.
+    pub fn is_private(self) -> bool {
+        !self.is_public()
+    }
+}

--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -12,7 +12,7 @@ mod data;
 mod queries;
 mod register_apis;
 
-pub use self::blob_apis::BlobAddress;
+pub use self::data::{Blob, BlobAddress, Spot};
 use crate::client::{connections::Session, errors::Error, Config};
 use crate::messaging::data::CmdError;
 use crate::types::{Keypair, PublicKey};
@@ -175,8 +175,8 @@ mod tests {
     async fn long_lived_connection_survives() -> Result<()> {
         let client = create_test_client(None).await?;
         tokio::time::sleep(tokio::time::Duration::from_secs(40)).await;
-        let data = random_bytes(self_encryption::MIN_ENCRYPTABLE_BYTES);
-        let _ = client.write_to_network(data, Scope::Public).await?;
+        let spot = Spot::new(random_bytes(self_encryption::MIN_ENCRYPTABLE_BYTES / 2))?;
+        let _ = client.write_spot_to_network(spot, Scope::Public).await?;
         Ok(())
     }
 


### PR DESCRIPTION
A `Blob` is at least 3072 bytes, as that is min self encryptable bytes.
A `Spot` is smaller than that, and will be encrypted with the client
encryption keys.
Both of these are type safe in that the construction of them will
validate their size.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
