### PR TITLE
feat: accept empty url scheme

### DIFF
--- a/src/url/url_parts.rs
+++ b/src/url/url_parts.rs
@@ -94,7 +94,7 @@ impl UrlParts {
 
         // Validate the url scheme is 'safe' if it is not empty
         let scheme = parsing_url.scheme().to_string();
-        if scheme != "" && scheme != URL_SCHEME {
+        if !scheme.is_empty() && scheme != URL_SCHEME {
             let msg = format!("invalid scheme: '{}'. expected: '{}'", scheme, URL_SCHEME);
             return Err(Error::InvalidXorUrl(msg));
         }

--- a/src/url/url_parts.rs
+++ b/src/url/url_parts.rs
@@ -92,9 +92,9 @@ impl UrlParts {
             Error::InvalidXorUrl(msg)
         })?;
 
-        // Validate the url scheme is 'safe'
+        // Validate the url scheme is 'safe' if it is not empty
         let scheme = parsing_url.scheme().to_string();
-        if scheme != URL_SCHEME {
+        if scheme != "" && scheme != URL_SCHEME {
             let msg = format!("invalid scheme: '{}'. expected: '{}'", scheme, URL_SCHEME);
             return Err(Error::InvalidXorUrl(msg));
         }


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
- accept empty url scheme in the SAFE Url parser
- free `cli` and `api` from the `"safe://"` prepending shenanigans