### PR TITLE
fix: make spot and its address public

### DIFF
--- a/src/client/client_api/blob_apis.rs
+++ b/src/client/client_api/blob_apis.rs
@@ -111,9 +111,10 @@ impl Client {
         encrypt_blob(blob.bytes(), owner.as_ref())
     }
 
-    /// Encrypts a small piece of t(d)ata (spot) and returns the resulting address and the chunk.
+    /// Packages a small piece of t(d)ata (spot) and returns the resulting address and the chunk.
+    /// The chunk content will be in plain text if it has public scope, or encrypted if it is instead private.
     /// Does not store anything to the network.
-    pub fn encrypt_spot(&self, spot: Spot, scope: Scope) -> Result<(SpotAddress, Chunk)> {
+    pub fn package_spot(&self, spot: Spot, scope: Scope) -> Result<(SpotAddress, Chunk)> {
         let encryption = encryption(scope, self.public_key());
         let chunk = to_chunk(spot.bytes(), encryption.as_ref())?;
         if chunk.value().len() >= self_encryption::MIN_ENCRYPTABLE_BYTES {
@@ -131,7 +132,7 @@ impl Client {
     /// Directly writes a [`Spot`] to the network in the
     /// form of a single chunk, without any batching.
     pub async fn write_spot_to_network(&self, spot: Spot, scope: Scope) -> Result<SpotAddress> {
-        let (address, chunk) = self.encrypt_spot(spot, scope)?;
+        let (address, chunk) = self.package_spot(spot, scope)?;
         self.send_cmd(DataCmd::StoreChunk(chunk)).await?;
         Ok(address)
     }

--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -12,7 +12,7 @@ mod data;
 mod queries;
 mod register_apis;
 
-pub use self::data::{Blob, BlobAddress, Spot};
+pub use self::data::{Blob, BlobAddress, Spot, SpotAddress};
 use crate::client::{connections::Session, errors::Error, Config};
 use crate::messaging::data::CmdError;
 use crate::types::{Keypair, PublicKey};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -32,7 +32,7 @@ mod errors;
 
 // Export public API.
 
-pub use client_api::Client;
+pub use client_api::{Blob, BlobAddress, Client, Spot, SpotAddress};
 pub use config_handler::{Config, DEFAULT_QUERY_TIMEOUT};
 pub use errors::ErrorMessage;
 pub use errors::{Error, Result};


### PR DESCRIPTION
Also changes the misleading name of `encrypt_spot`, to `package_spot`, since
when scope is public, there actually will not be any ecryption.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
