### PR TITLE
Add GHA workflow to build a node and run a testnet on Digital Ocean

### DIFF
--- a/.github/workflows/digital_ocean_testnet.yml
+++ b/.github/workflows/digital_ocean_testnet.yml
@@ -58,7 +58,7 @@ jobs:
         run: cargo build --release --target x86_64-unknown-linux-musl --features="always-joinable"
 
       - name: Launch testnet
-        uses: maidsafe/safe-testnet-action@master
+        uses: maidsafe/sn_testnet_action@master
         with:
           do-token: ${{ secrets.DO_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -131,7 +131,7 @@ jobs:
     if: always() && github.event.inputs.stop-network == 'y'
     steps:
       - name: Kill testnet
-        uses: maidsafe/safe-testnet-action@master
+        uses: maidsafe/sn_testnet_action@master
         with:
           do-token: ${{ secrets.DO_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/digital_ocean_testnet.yml
+++ b/.github/workflows/digital_ocean_testnet.yml
@@ -31,40 +31,41 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.inputs.start-network == 'y'
     steps:
-      - uses: actions/checkout@v2
+      # - uses: actions/checkout@v2
 
       # Install Rust and required components
-      - uses: actions-rs/toolchain@v1
-        id: toolchain
-        with:
-          target: x86_64-unknown-linux-musl
-          profile: minimal
-          toolchain: stable
-          override: true
+      # - uses: actions-rs/toolchain@v1
+      #   id: toolchain
+      #   with:
+      #     target: x86_64-unknown-linux-musl
+      #     profile: minimal
+      #     toolchain: stable
+      #     override: true
 
       # Cache.
-      - name: Cargo cache registry, index and build
-        uses: actions/cache@v2.1.4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      # - name: Cargo cache registry, index and build
+      #   uses: actions/cache@v2.1.4
+      #   with:
+      #     path: |
+      #       ~/.cargo/registry
+      #       ~/.cargo/git
+      #       target
+      #     key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install musl-tools
-        run: sudo apt update -y && sudo apt install -y musl-tools
-      - name: Build node
-        run: cargo build --release --target x86_64-unknown-linux-musl --features="always-joinable"
+      # - name: Install musl-tools
+      #   run: sudo apt update -y && sudo apt install -y musl-tools
+      # - name: Build node
+      #   run: cargo build --release --target x86_64-unknown-linux-musl --features="always-joinable"
 
       - name: Launch testnet
-        uses: maidsafe/sn_testnet_action@master
+        uses: lionel1704/sn_testnet_action@commit-sha
         with:
           do-token: ${{ secrets.DO_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ssh-secret-key: ${{ secrets.SSH_SECRET_KEY  }}
           node-path: $GITHUB_WORKSPACE/target/x86_64-unknown-linux-musl/release/sn_node
+          build-node: true
           node-count: ${{ github.event.inputs.node-count }}
   
   run-client-tests:
@@ -131,7 +132,7 @@ jobs:
     if: always() && github.event.inputs.stop-network == 'y'
     steps:
       - name: Kill testnet
-        uses: maidsafe/sn_testnet_action@master
+        uses: lionel1704/sn_testnet_action@commit-sha
         with:
           do-token: ${{ secrets.DO_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/digital_ocean_testnet.yml
+++ b/.github/workflows/digital_ocean_testnet.yml
@@ -1,0 +1,139 @@
+name: Deploy testnet on Digital Ocean
+
+on: 
+  workflow_dispatch:
+    inputs:
+      start-network:
+        description: 'Run the start network script? (y/n)'
+        required: false
+        default: 'n'
+      node-count:
+        description: 'Number of nodes to be deployed'
+        required: false
+        default: 50
+      run-client-tests:
+        description: 'Run client tests? (y/n)'
+        required: false
+        default: 'n'
+      stop-network:
+        description: 'Kill network after client tests? (y/n)'
+        required: false
+        default: 'n'
+
+env:
+  CARGO_INCREMENTAL: '0'
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  launch-testnet:
+    name: Launch Digital Ocean testnet
+    runs-on: ubuntu-latest
+    if: github.event.inputs.start-network == 'y'
+    steps:
+      - uses: actions/checkout@v2
+
+      # Install Rust and required components
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          target: x86_64-unknown-linux-musl
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install musl-tools
+        run: sudo apt update -y && sudo apt install -y musl-tools
+      - name: Build node
+        run: cargo build --release --target x86_64-unknown-linux-musl --features="always-joinable"
+
+      - name: Launch testnet
+        uses: maidsafe/safe-testnet-action@master
+        with:
+          do-token: ${{ secrets.DO_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ssh-secret-key: ${{ secrets.SSH_SECRET_KEY  }}
+          node-path: $GITHUB_WORKSPACE/target/x86_64-unknown-linux-musl/release/sn_node
+          node-count: ${{ github.event.inputs.node-count }}
+  
+  run-client-tests:
+    name: Run Client tests
+    runs-on: ubuntu-latest
+    needs: [launch-testnet]
+    if: always() && github.event.inputs.run-client-tests == 'y'
+    steps:
+      - uses: actions/checkout@v2
+
+
+      - name: Set TESTNET_ID env
+        shell: bash
+        run: echo "TESTNET_ID=gha-testnet-$(echo $GITHUB_SHA | cut -c 1-7)" >> $GITHUB_ENV
+
+      # Install Rust and required components
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Download network config
+        shell: bash
+        run: |
+          mkdir -p ~/.safe/node
+          wget https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-node_connection_info.config -O ~/.safe/node/node_connection_info.config
+
+      # a catchall to ensure any new client api tests are run (ideally any major new section should have its own test run)
+      - name: Initital client tests...
+        shell: bash
+        # always joinable not actually needed here, but should speed up compilation as we've just built with it
+        run: cargo test --release --features=always-joinable,test-utils -- client_api --skip client_api::reg --skip client_api::blob --skip client_api::transfer && sleep 5
+
+      # register api
+      - name: Client reg tests
+        shell: bash
+        run: cargo test --release --features=always-joinable,test-utils -- client_api::reg && sleep 5
+      
+      # blob api
+      - name: Client blob tests
+        shell: bash
+        run: cargo test --release --features=always-joinable,test-utils -- client_api::blob --test-threads=1 && sleep 5
+      
+      - name: Run example app for Blob API
+        shell: bash
+        run: cargo run --release  --features=always-joinable,test-utils --example client_blob
+
+  kill-testnet:
+    name: Destroy Digital Ocean testnet
+    runs-on: ubuntu-latest
+    needs: [launch-testnet, run-client-tests]
+    if: always() && github.event.inputs.stop-network == 'y'
+    steps:
+      - name: Kill testnet
+        uses: maidsafe/safe-testnet-action@master
+        with:
+          do-token: ${{ secrets.DO_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          action: 'destroy'

--- a/.github/workflows/digital_ocean_testnet.yml
+++ b/.github/workflows/digital_ocean_testnet.yml
@@ -19,6 +19,8 @@ on:
         description: 'Kill network after client tests? (y/n)'
         required: false
         default: 'n'
+  pull_request_review:
+    types: [submitted, edited]
 
 env:
   CARGO_INCREMENTAL: '0'
@@ -29,50 +31,23 @@ jobs:
   launch-testnet:
     name: Launch Digital Ocean testnet
     runs-on: ubuntu-latest
-    if: github.event.inputs.start-network == 'y'
+    if: github.event.inputs.start-network == 'y' || (github.event_name == 'pull_request_review' && github.event.review.body == 'launch-testnet')
     steps:
-      # - uses: actions/checkout@v2
-
-      # Install Rust and required components
-      # - uses: actions-rs/toolchain@v1
-      #   id: toolchain
-      #   with:
-      #     target: x86_64-unknown-linux-musl
-      #     profile: minimal
-      #     toolchain: stable
-      #     override: true
-
-      # Cache.
-      # - name: Cargo cache registry, index and build
-      #   uses: actions/cache@v2.1.4
-      #   with:
-      #     path: |
-      #       ~/.cargo/registry
-      #       ~/.cargo/git
-      #       target
-      #     key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
-
-      # - name: Install musl-tools
-      #   run: sudo apt update -y && sudo apt install -y musl-tools
-      # - name: Build node
-      #   run: cargo build --release --target x86_64-unknown-linux-musl --features="always-joinable"
-
       - name: Launch testnet
-        uses: lionel1704/sn_testnet_action@commit-sha
+        uses: maidsafe/sn_testnet_action@master
         with:
           do-token: ${{ secrets.DO_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ssh-secret-key: ${{ secrets.SSH_SECRET_KEY  }}
-          node-path: $GITHUB_WORKSPACE/target/x86_64-unknown-linux-musl/release/sn_node
           build-node: true
-          node-count: ${{ github.event.inputs.node-count }}
+          node-count: ${{ github.event.inputs.node-count || 50 }}
   
   run-client-tests:
     name: Run Client tests
     runs-on: ubuntu-latest
     needs: [launch-testnet]
-    if: always() && github.event.inputs.run-client-tests == 'y'
+    if: always() && (github.event.inputs.run-client-tests == 'y' || (github.event_name == 'pull_request_review' && github.event.review.body == 'launch-testnet'))
     steps:
       - uses: actions/checkout@v2
 
@@ -129,10 +104,10 @@ jobs:
     name: Destroy Digital Ocean testnet
     runs-on: ubuntu-latest
     needs: [launch-testnet, run-client-tests]
-    if: always() && github.event.inputs.stop-network == 'y'
+    if: always() && (github.event.inputs.stop-network == 'y' || (github.event_name == 'pull_request_review' && github.event.review.body == 'launch-testnet'))
     steps:
       - name: Kill testnet
-        uses: lionel1704/sn_testnet_action@commit-sha
+        uses: maidsafe/sn_testnet_action@master
         with:
           do-token: ${{ secrets.DO_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This can be triggered manually or by commenting `launch-testnet` as a PR review.