### PR TITLE
feat: add spot entry to datatype enum

### DIFF
--- a/examples/client_blob.rs
+++ b/examples/client_blob.rs
@@ -37,12 +37,7 @@ async fn main() -> Result<()> {
     println!("Storing data.. ({} bytes)", blob.bytes().len());
 
     let address = client.write_blob_to_network(blob, Scope::Public).await?;
-    let xorurl = Url::encode_blob(
-        *address.name(),
-        Scope::Public,
-        ContentType::Raw,
-        DEFAULT_XORURL_BASE,
-    )?;
+    let xorurl = Url::encode_blob(address, ContentType::Raw, DEFAULT_XORURL_BASE)?;
     println!("Blob stored at xorurl: {}", xorurl);
 
     let delay = 5;

--- a/examples/network_split.rs
+++ b/examples/network_split.rs
@@ -237,12 +237,7 @@ async fn upload_data() -> Result<(BlobAddress, [u8; 32])> {
     println!("Storing data w/ hash {:?}", output);
 
     let address = client.write_blob_to_network(blob, Scope::Public).await?;
-    let xorurl = Url::encode_blob(
-        *address.name(),
-        address.scope(),
-        ContentType::Raw,
-        DEFAULT_XORURL_BASE,
-    )?;
+    let xorurl = Url::encode_blob(address, ContentType::Raw, DEFAULT_XORURL_BASE)?;
     println!("Blob stored at xorurl: {}", xorurl);
 
     let delay = 2;

--- a/src/client/client_api/register_apis.rs
+++ b/src/client/client_api/register_apis.rs
@@ -234,7 +234,7 @@ mod tests {
     use crate::{
         client::{
             utils::test_utils::{create_test_client, gen_ed_keypair, run_w_backoff_delayed},
-            Error,
+            BlobAddress, Error,
         },
         url::Url,
     };
@@ -606,8 +606,7 @@ mod tests {
         use crate::url::*;
         let xor_name = XorName::random();
         let url = match Url::encode_blob(
-            xor_name,
-            Scope::Public,
+            BlobAddress::Public(xor_name),
             ContentType::Raw,
             XorUrlBase::Base32z,
         ) {

--- a/src/types/register/mod.rs
+++ b/src/types/register/mod.rs
@@ -205,6 +205,7 @@ mod tests {
         },
         utils, Error, Keypair, Result,
     };
+    use crate::client::BlobAddress;
     use crate::url::Url;
     use eyre::eyre;
     use proptest::prelude::*;
@@ -1161,10 +1162,8 @@ mod tests {
 
     fn random_url() -> Result<Url> {
         use crate::url::*;
-        let xor_name = XorName::random();
         let url = Url::encode_blob(
-            xor_name,
-            Scope::Public,
+            BlobAddress::Public(XorName::random()),
             ContentType::Raw,
             XorUrlBase::Base32z,
         )


### PR DESCRIPTION
BREAKING CHANGE:
This is to facilitate the new way that files are stored on the network, which was updated to support changes in self encryption.

Self encryption doesn't allow encryption of files less than 3072 bytes in size, so a new type of data was created to support storage of smaller files. This data type is known as a 'spot'.

We need to distinguish between blobs and spots when retrieving files, and the solution is for the DataType on XorUrls to be marked as the Spot type when they are saved (which will be done in the API).

The `encode_blob` and `encode_spot` functions are both introduced for convenience. These accept a BlobAddress and a SpotAddress, respectively. Added a couple of extra tests for checking that `encode_spot` was setting fields correctly.