### PR TITLE
feat(bytes): encapsulate storage mechanism

### DIFF
--- a/examples/client_blob.rs
+++ b/examples/client_blob.rs
@@ -8,7 +8,7 @@
 
 use eyre::Result;
 use safe_network::{
-    client::{client_api::Blob, utils::test_utils::read_network_conn_info, Client, Config},
+    client::{utils::test_utils::read_network_conn_info, Client, Config},
     types::utils::random_bytes,
     url::{ContentType, Scope, Url, DEFAULT_XORURL_BASE},
 };
@@ -33,20 +33,20 @@ async fn main() -> Result<()> {
     let pk = client.public_key();
     println!("Client Public Key: {}", pk);
 
-    let blob = Blob::new(random_bytes(self_encryption::MIN_ENCRYPTABLE_BYTES))?;
-    println!("Storing data.. ({} bytes)", blob.bytes().len());
+    let bytes = random_bytes(self_encryption::MIN_ENCRYPTABLE_BYTES);
+    println!("Storing {} bytes..", bytes.len());
 
-    let address = client.write_blob_to_network(blob, Scope::Public).await?;
-    let xorurl = Url::encode_blob(address, ContentType::Raw, DEFAULT_XORURL_BASE)?;
-    println!("Blob stored at xorurl: {}", xorurl);
+    let address = client.upload(bytes, Scope::Public).await?;
+    let xorurl = Url::encode_bytes(address, ContentType::Raw, DEFAULT_XORURL_BASE)?;
+    println!("Bytes stored at xorurl: {}", xorurl);
 
     let delay = 5;
-    println!("Fetching Blob from the network in {} secs...", delay);
+    println!("Reading bytes from the network in {} secs...", delay);
     sleep(Duration::from_secs(delay)).await;
 
-    println!("...fetching Blob from the network now...");
-    let _ = client.read_blob(address).await?;
-    println!("Blob read from {:?}", address);
+    println!("...reading bytes from the network now...");
+    let _ = client.read_bytes(address).await?;
+    println!("Bytes read from {:?}", address);
 
     println!();
 

--- a/examples/network_split.rs
+++ b/examples/network_split.rs
@@ -24,11 +24,7 @@ use tiny_keccak::{Hasher, Sha3};
 
 use eyre::{eyre, Context, Result};
 use safe_network::{
-    client::{
-        client_api::{Blob, BlobAddress},
-        utils::test_utils::read_network_conn_info,
-        Client, Config,
-    },
+    client::{utils::test_utils::read_network_conn_info, BytesAddress, Client, Config},
     types::utils::random_bytes,
     url::{ContentType, Scope, Url, DEFAULT_XORURL_BASE},
 };
@@ -190,23 +186,23 @@ pub async fn run_split() -> Result<()> {
     let client = Client::new(config, bootstrap_nodes, None).await?;
 
     for (address, hash) in all_data_put {
-        println!("...fetching Blob at address {:?} ...", address);
-        let mut data = client.read_blob(address).await;
+        println!("...reading bytes at address {:?} ...", address);
+        let mut bytes = client.read_bytes(address).await;
 
         let mut attempts = 0;
-        while data.is_err() && attempts < 10 {
+        while bytes.is_err() && attempts < 10 {
             attempts += 1;
             // do some retries to ensure we're not just timing out by chance
             sleep(Duration::from_secs(1)).await;
-            data = client.read_blob(address).await;
+            bytes = client.read_bytes(address).await;
         }
 
-        let data = data?;
-        println!("Blob read from {:?}:", address);
+        let bytes = bytes?;
+        println!("Bytes read from {:?}:", address);
 
         let mut hasher = Sha3::v256();
         let mut output = [0; 32];
-        hasher.update(&data);
+        hasher.update(&bytes);
         hasher.finalize(&mut output);
 
         assert_eq!(output, hash);
@@ -217,7 +213,7 @@ pub async fn run_split() -> Result<()> {
     Ok(())
 }
 
-async fn upload_data() -> Result<(BlobAddress, [u8; 32])> {
+async fn upload_data() -> Result<(BytesAddress, [u8; 32])> {
     // Now we upload the data.
     println!("Reading network bootstrap information...");
     let (genesis_key, bootstrap_nodes) =
@@ -227,37 +223,37 @@ async fn upload_data() -> Result<(BlobAddress, [u8; 32])> {
     let config = Config::new(None, None, genesis_key, None, Some(QUERY_TIMEOUT)).await;
     let client = Client::new(config, bootstrap_nodes, None).await?;
 
-    let blob = Blob::new(random_bytes(1024 * 1024))?;
+    let bytes = random_bytes(1024 * 1024);
 
     let mut hasher = Sha3::v256();
     let mut output = [0; 32];
-    hasher.update(&blob.bytes());
+    hasher.update(&bytes);
     hasher.finalize(&mut output);
 
-    println!("Storing data w/ hash {:?}", output);
+    println!("Storing bytes w/ hash {:?}", output);
 
-    let address = client.write_blob_to_network(blob, Scope::Public).await?;
-    let xorurl = Url::encode_blob(address, ContentType::Raw, DEFAULT_XORURL_BASE)?;
-    println!("Blob stored at xorurl: {}", xorurl);
+    let address = client.upload(bytes, Scope::Public).await?;
+    let xorurl = Url::encode_bytes(address, ContentType::Raw, DEFAULT_XORURL_BASE)?;
+    println!("Bytes stored at xorurl: {}", xorurl);
 
     let delay = 2;
-    println!("Fetching Blob from the network in {} secs...", delay);
+    println!("Reading bytes from the network in {} secs...", delay);
     sleep(Duration::from_secs(delay)).await;
 
-    println!("...fetching Blob from the network now...");
-    let mut data = client.read_blob(address).await;
+    println!("...reading bytes from the network now...");
+    let mut bytes = client.read_bytes(address).await;
 
     let mut attempts = 0;
-    while data.is_err() && attempts < 10 {
+    while bytes.is_err() && attempts < 10 {
         attempts += 1;
         // do some retries to ensure we're not just timing out by chance
         sleep(Duration::from_secs(1)).await;
-        data = client.read_blob(address).await;
+        bytes = client.read_bytes(address).await;
     }
 
-    let _data = data?;
+    let _bytes = bytes?;
 
-    println!("Blob successfully read from {:?}:", address);
+    println!("Bytes successfully read from {:?}:", address);
 
     Ok((address, output))
 }

--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -12,7 +12,7 @@ mod data;
 mod queries;
 mod register_apis;
 
-pub use self::data::{Blob, BlobAddress, Spot, SpotAddress};
+pub use self::data::{BlobAddress, BytesAddress, SpotAddress};
 use crate::client::{connections::Session, errors::Error, Config};
 use crate::messaging::data::{CmdError, DataQuery, ServiceMsg};
 use crate::types::{ChunkAddress, Keypair, PublicKey};
@@ -199,8 +199,8 @@ mod tests {
     async fn long_lived_connection_survives() -> Result<()> {
         let client = create_test_client().await?;
         tokio::time::sleep(tokio::time::Duration::from_secs(40)).await;
-        let spot = Spot::new(random_bytes(self_encryption::MIN_ENCRYPTABLE_BYTES / 2))?;
-        let _ = client.write_spot_to_network(spot, Scope::Public).await?;
+        let bytes = random_bytes(self_encryption::MIN_ENCRYPTABLE_BYTES / 2);
+        let _ = client.upload(bytes, Scope::Public).await?;
         Ok(())
     }
 

--- a/src/client/client_api/register_apis.rs
+++ b/src/client/client_api/register_apis.rs
@@ -225,6 +225,7 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
+    use crate::client::BytesAddress;
     use crate::messaging::data::Error as ErrorMessage;
     use crate::retry_loop_for_pattern;
     use crate::types::{
@@ -605,8 +606,8 @@ mod tests {
     fn random_url() -> Result<Url> {
         use crate::url::*;
         let xor_name = XorName::random();
-        let url = match Url::encode_blob(
-            BlobAddress::Public(xor_name),
+        let url = match Url::encode_bytes(
+            BytesAddress::Blob(BlobAddress::Public(xor_name)),
             ContentType::Raw,
             XorUrlBase::Base32z,
         ) {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -32,7 +32,7 @@ mod errors;
 
 // Export public API.
 
-pub use client_api::{Blob, BlobAddress, Client, Spot, SpotAddress};
+pub use client_api::{BlobAddress, BytesAddress, Client, SpotAddress};
 pub use config_handler::{Config, DEFAULT_QUERY_TIMEOUT};
 pub use errors::ErrorMessage;
 pub use errors::{Error, Result};

--- a/src/types/register/mod.rs
+++ b/src/types/register/mod.rs
@@ -205,7 +205,7 @@ mod tests {
         },
         utils, Error, Keypair, Result,
     };
-    use crate::client::BlobAddress;
+    use crate::client::{BlobAddress, BytesAddress};
     use crate::url::Url;
     use eyre::eyre;
     use proptest::prelude::*;
@@ -1162,8 +1162,8 @@ mod tests {
 
     fn random_url() -> Result<Url> {
         use crate::url::*;
-        let url = Url::encode_blob(
-            BlobAddress::Public(XorName::random()),
+        let url = Url::encode_bytes(
+            BytesAddress::Blob(BlobAddress::Public(XorName::random())),
             ContentType::Raw,
             XorUrlBase::Base32z,
         )


### PR DESCRIPTION
`DataType` enum is simplified to `SafeKey` | `Bytes` | `Register`
`Spot` and `Blob` are - instead of data types - storage mechanisms of `Bytes`.

***

`Bytes` is a simpler, more accurate and direct description
of the "data type", while `Data` is vague and ambiguous
(seems to be what all members of `DataType` are), and
`Spot` and `Blob` are the two size dependent (due to optimisations) 
storage mechanisms for `Bytes`, simply meaning
- `As one chunk, optionally using encryption key`, or
- `As 4+ chunks, using self encryption`.

Fn `read_bytes` (taking `BytesAddress` enum) solves
which underlying storage mechanism is to be used, 
as `BytesAddress` is either `Spot(SpotAddress)` or `Blob(BlobAddress)`

`upload_bytes` uses `bytes.len()` to choose underlying storage
mechanism, and returns `BytesAddress`.

***

BREAKING CHANGE: Public enum `DataType` is modified, and APIs for
`Blob` and `Spot` are replaced with  corresponding for `Bytes`.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
