### PR TITLE
fix(chunks): do not double-encrypt in packing step

### DIFF
--- a/src/client/client_api/data/pac_man.rs
+++ b/src/client/client_api/data/pac_man.rs
@@ -93,7 +93,7 @@ pub(crate) fn pack(
                 .collect();
             if expected_total > chunks.len() {
                 // as we flatten above, we need to check outcome here
-                return Err(Error::Generic("Not all data was chunked!".to_string()));
+                return Err(Error::NotAllDataWasChunked(expected_total, chunks.len()));
             }
             chunk_content = pack_data_map(DataMapLevel::Additional(data_map))?;
         }
@@ -109,7 +109,10 @@ pub(crate) fn pack(
 
     if expected_total > all_chunks.len() {
         // as we flatten above, we need to check outcome here
-        return Err(Error::Generic("Not all data was chunked!".to_string()));
+        return Err(Error::NotAllDataWasChunked(
+            expected_total,
+            all_chunks.len(),
+        ));
     }
 
     Ok((address, all_chunks))

--- a/src/client/errors.rs
+++ b/src/client/errors.rs
@@ -145,6 +145,9 @@ pub enum Error {
     /// Could not retrieve all chunks required to decrypt the data. (Expected, Actual)
     #[error("Not enough chunks! Required {}, but we have {}.)", _0, _1)]
     NotEnoughChunks(usize, usize),
+    /// Could not chunk all the data required to encrypt the data. (Expected, Actual)
+    #[error("Not all data was chunked! Required {}, but we have {}.)", _0, _1)]
+    NotAllDataWasChunked(usize, usize),
 }
 
 impl From<(CmdError, OperationId)> for Error {


### PR DESCRIPTION
Encryption is an option which was passed in when wrapping
bytes in `Chunk`, also when the bytes were self encrypted..
So, since no need to encrypt what is self-encrypted, we pass in
`None` for those cases
Also now propagates any error when packing data map.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
