### PR TITLE
chore: add tracing to client messages

### DIFF
--- a/src/client/client_api/mod.rs
+++ b/src/client/client_api/mod.rs
@@ -51,6 +51,7 @@ impl Client {
     ///
     /// TODO: update once data types are crdt compliant
     ///
+    #[instrument(skip_all, level = "debug")]
     pub async fn new(
         config: Config,
         bootstrap_nodes: BTreeSet<SocketAddr>,

--- a/src/client/utils/test_utils/test_client.rs
+++ b/src/client/utils/test_utils/test_client.rs
@@ -37,15 +37,18 @@ where
         let target = event.metadata().file().expect("will never be `None`");
         write!(
             writer,
-            "{} [{}:L{}]: ",
+            "{} [{}:L{}]:\n\t",
             level,
             target,
             event.metadata().line().expect("will never be `None`")
         )?;
 
+        let mut indentation = 0;
         // Write spans and fields of each span
         ctx.visit_spans(|span| {
-            write!(writer, "{}", span.name())?;
+            let indentation_string = "\t".repeat(indentation);
+            writeln!(writer, "{}{}", indentation_string, span.name())?;
+            indentation += 1;
 
             let ext = span.extensions();
 
@@ -59,9 +62,10 @@ where
                 .expect("will never be `None`");
 
             if !fields.is_empty() {
-                write!(writer, "{{{}}}", fields)?;
+                writeln!(writer, "{{{}}}", fields)?;
             }
-            write!(writer, ": ")?;
+
+            write!(writer, "{}", indentation_string.repeat(2))?;
 
             Ok(())
         })?;


### PR DESCRIPTION
adds some client test formatting to aid readability

example for one log line: 

```
DEBUG [src/client/connections/messaging.rs:L373]:
	get_register_entry
	get_register
	     send_query
	          Response obtained for query w/id MessageId(d764..c77d): Some(GetRegister((Ok(Register { authority: Ed25519(PublicKey(311c..d910)), crdt: RegisterCrdt { address: Public { name: 88d289(10001000).., tag: 10 }, data: MerkleReg { roots: {}, dag: {}, orphans: {} } }, policy: Public(PublicPolicy { owner: Ed25519(PublicKey(311c..d910)), permissions: {Key(Ed25519(PublicKey(311c..d910))): PublicPermissions { write: Some(true) }} }) }), "Get-\"hyeyyyyyyyyyybng1tf93a76au7eg3nhuxbtn35o1w4o4fz89c5h9rz7r9dr4farbbeyyyyyyyyyyy\"")))

```

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
