### PR TITLE
fix: add error message type for ChunkNotFound.

### DIFF
--- a/src/dbs/errors.rs
+++ b/src/dbs/errors.rs
@@ -97,6 +97,7 @@ pub(crate) fn convert_to_error_message(error: Error) -> ErrorMessage {
         Error::NotEnoughSpace => ErrorMessage::FailedToWriteFile,
         Error::DataIdNotFound(address) => ErrorMessage::DataNotFound(address),
         Error::NoSuchData(address) => ErrorMessage::DataNotFound(address),
+        Error::ChunkNotFound(xorname) => ErrorMessage::ChunkNotFound(xorname),
         Error::TempDirCreationFailed(_) => ErrorMessage::FailedToWriteFile,
         Error::DataExists => ErrorMessage::DataExists,
         Error::NetworkData(error) => convert_dt_error_to_error_message(error),

--- a/src/messaging/data/errors.rs
+++ b/src/messaging/data/errors.rs
@@ -11,7 +11,7 @@ use crate::types::PublicKey;
 use serde::{Deserialize, Serialize};
 use std::result;
 use thiserror::Error;
-use xor_name::Prefix;
+use xor_name::{Prefix, XorName};
 
 /// A specialised `Result` type.
 pub type Result<T, E = Error> = result::Result<T, E>;
@@ -24,6 +24,9 @@ pub enum Error {
     /// Access denied for supplied PublicKey
     #[error("Access denied for PublicKey: {0}")]
     AccessDenied(PublicKey),
+    /// Requested data not found
+    #[error("Requested chunk not found: {0:?}")]
+    ChunkNotFound(XorName),
     /// Requested data not found
     #[error("Requested data not found: {0:?}")]
     DataNotFound(DataAddress),


### PR DESCRIPTION
Should sort opId errors

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
