### PR TITLE
Feat log analysis tool v2

### DIFF
--- a/src/client/connections/messaging.rs
+++ b/src/client/connections/messaging.rs
@@ -537,7 +537,8 @@ pub(crate) async fn send_message(
 
     if failures > 0 {
         error!(
-            "Sending the message to {}/{} of the elders failed",
+            "Sending the message ({:?}) to {}/{} of the elders failed",
+            msg_id,
             failures,
             elders.len()
         );

--- a/src/client/connections/messaging.rs
+++ b/src/client/connections/messaging.rs
@@ -537,10 +537,12 @@ pub(crate) async fn send_message(
 
     if failures > 0 {
         error!(
-            "Sending the message ({:?}) to {}/{} of the elders failed",
+            "Sending the message ({:?}) from {} to {}/{} of the elders failed: {:?}",
             msg_id,
+            endpoint.public_addr(),
             failures,
-            elders.len()
+            elders.len(),
+            elders,
         );
     }
 


### PR DESCRIPTION
Adding some subcommands to the logs inspector tool to be able to generate reports based on a provided msg id or command id. The following three sub-commands are supported with this PR:
- `completed-cmds`: which is the previously existing check on commands spawned/succeeded/failed
- `commands <cmd-id>`: show a report of all commands and sub-commands correlated to the provided id
- `messages <msg-id>`: show a report of all commands/sub-commands correlated to the provided msg id, i.e. commands that were executed as part of handling the message which matches the provided msg id.

```
$ cargo run --release --bin log_cmds_inspector -- ~/.safe/node/local-test-network/ messages 7193..2595
Inspecting testnet logs folder: ~/.safe/node/local-test-network/

...

*** REPORT: The following commands were found for msg id 7193..2595 ***
==> Log entries for sub-command 1826186887:
/home/bochaco/.safe/node/local-test-network/sn-node-16/sn_node.log.2021-10-18-13: Oct 18 10:22:47.691 TRACE tokio-runtime-worker handle_message: safe_network::routing::routing_api:DispatchHandleMsgCmd from 127.0.0.1:48180 length 1065 name=37d105.. sender=127.0.0.1:48180 msg_id=MessageId(7193..2595)
/home/bochaco/.safe/node/local-test-network/sn-node-16/sn_node.log.2021-10-18-13: Oct 18 10:22:47.691 TRACE tokio-runtime-worker handle_message: safe_network::routing::routing_api::dispatcher:CommandHandleSpawned HandleMessage MessageId(7193..2595) cmd_id=1826186887 name=37d105.. sender=127.0.0.1:48180 msg_id=MessageId(7193..2595)
/home/bochaco/.safe/node/local-test-network/sn-node-16/sn_node.log.2021-10-18-13: Oct 18 10:22:47.691 TRACE tokio-runtime-worker handle_command: safe_network::routing::routing_api::dispatcher:CommandHandleStart HandleMessage MessageId(7193..2595) name=37d105.. prefix=() age=85 elder=true cmd_id=1826186887
/home/bochaco/.safe/node/local-test-network/sn-node-16/sn_node.log.2021-10-18-13: Oct 18 10:22:47.706 TRACE tokio-runtime-worker handle_command: safe_network::routing::routing_api::dispatcher:CommandHandleEnd HandleMessage MessageId(7193..2595) name=37d105.. prefix=() age=85 elder=true cmd_id=1826186887

==> Log entries for sub-command 1826186887.0:
/home/bochaco/.safe/node/local-test-network/sn-node-16/sn_node.log.2021-10-18-13: Oct 18 10:22:47.706 TRACE tokio-runtime-worker safe_network::routing::routing_api::dispatcher:CommandHandleSpawned HandleSystemMessage MessageId(7193..2595) cmd_id=1826186887.0
/home/bochaco/.safe/node/local-test-network/sn-node-16/sn_node.log.2021-10-18-13: Oct 18 10:22:47.706 TRACE tokio-runtime-worker handle_command: safe_network::routing::routing_api::dispatcher:CommandHandleStart HandleSystemMessage MessageId(7193..2595) name=37d105.. prefix=() age=85 elder=true cmd_id=1826186887.0
/home/bochaco/.safe/node/local-test-network/sn-node-16/sn_node.log.2021-10-18-13: Oct 18 10:22:47.706 TRACE tokio-runtime-worker handle_command: safe_network::routing::routing_api::dispatcher:CommandHandleEnd HandleSystemMessage MessageId(7193..2595) name=37d105.. prefix=() age=85 elder=true cmd_id=1826186887.0

...

```