### PR TITLE
Automated version bump (misnamed on purpose)

### DIFF
--- a/.github/workflows/digital_ocean_testnet.yml
+++ b/.github/workflows/digital_ocean_testnet.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   launch-testnet:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     environment: approved_action
     name: Launch Digital Ocean testnet
     runs-on: ubuntu-latest
@@ -35,7 +36,7 @@ jobs:
     name: Run Client tests
     runs-on: ubuntu-latest
     needs: [launch-testnet]
-    if: always()
+    if: always() && !startsWith(github.event.pull_request.title, 'Automated version bump')
     steps:
       - uses: actions/checkout@v2
         with:
@@ -94,7 +95,7 @@ jobs:
     name: Destroy Digital Ocean testnet
     runs-on: ubuntu-latest
     needs: [launch-testnet, run-client-tests]
-    if: always()
+    if: always() && !startsWith(github.event.pull_request.title, 'Automated version bump')
     steps:
       - name: Kill testnet
         uses: maidsafe/sn_testnet_action@master


### PR DESCRIPTION
The PR is misnamed on purpose so the checks are skipped to test out the changes.

EDIT: We can't actually test the condition for the testnet flow since it's triggered by `pull_request_target` and so it uses the workflow file in the default branch.

EDIT 2: See example run [here](https://github.com/lionel1704/safe_network/pull/15)