### PR TITLE
fix(routing): don't bail out when handling ElderAgreement if prefix-map is not updated

### DIFF
--- a/sn/src/messaging/system/join.rs
+++ b/sn/src/messaging/system/join.rs
@@ -58,9 +58,8 @@ pub enum JoinResponse {
     Retry {
         /// The SectionAuthorityProvider of the section.
         section_auth: SectionAuthorityProvider,
-        /// The number of active members of the section.
-        /// For the usage of stepped-fixed-age during genesis sectin only.
-        section_members: u8,
+        /// The age of the node as expected by the section.
+        expected_age: u8,
     },
     /// Response redirecting a joining peer to join a different section,
     /// containing addresses of nodes that are closer (than the recipient) to the

--- a/sn/src/prefix_map/mod.rs
+++ b/sn/src/prefix_map/mod.rs
@@ -221,8 +221,9 @@ impl NetworkPrefixMap {
         // Check the SAP's key is the last key of the proof chain
         if proof_chain.last_key() != &signed_section_auth.value.public_key_set.public_key() {
             return Err(Error::UntrustedSectionAuthProvider(format!(
-                "section key ({:?}) doesn't match proof chain last key ({:?})",
+                "section key ({:?}, {:?}) doesn't match proof chain last key ({:?})",
                 signed_section_auth.value.public_key_set.public_key(),
+                signed_section_auth.value.prefix,
                 proof_chain.last_key()
             )));
         }

--- a/sn/src/routing/core/msg_handling/agreement.rs
+++ b/sn/src/routing/core/msg_handling/agreement.rs
@@ -259,44 +259,31 @@ impl Core {
 
         let snapshot = self.state_snapshot().await;
         let old_chain = self.section.chain().await;
+        let node_name = self.node.read().await.name();
 
         for (section_auth, key_sig) in updates {
-            info!("Updating elders to: {:?}", &section_auth);
-            if section_auth
-                .value
-                .prefix
-                .matches(&self.node.read().await.name())
-            {
+            let prefix = section_auth.value.prefix;
+            info!("New SAP agreed for {:?}: {:?}", prefix, section_auth);
+
+            // Let's update our own Section info if the new SAP's prefix
+            // matches my name, i.e. it's my section's new SAP
+            if prefix.matches(&node_name) {
+                info!("Updating my section's SAP to: {:?}", &section_auth);
                 let _updated = self
                     .section
                     .update_elders(section_auth.clone(), key_sig)
                     .await;
+            }
 
-                if self
-                    .network
-                    .update(section_auth, &self.section_chain().await)?
-                {
-                    info!("Updated our section's state in network's NetworkPrefixMap");
-                    self.write_prefix_map().await;
+            // Let's update our network knowledge with new SAP even if it's of our own section
+            // FIXME: we are not passing the correct proof chain to update the NetworkPrefixMap
+            match self.network.update(section_auth, &old_chain) {
+                Err(e) => error!("Error updating our NetworkPrefixMap: {:?}", e),
+                Ok(true) => {
+                    info!("Updated our NetworkPrefixMap for {:?}", prefix);
+                    self.write_prefix_map().await
                 }
-            } else {
-                // Update the old chain to become the neighbour's chain.
-                // FIXME: we shouldn't be updating our section info since it
-                // doesn't match our prefix???
-                if let Err(e) = self.section.chain.write().await.insert(
-                    &key_sig.public_key,
-                    section_auth.value.section_key(),
-                    key_sig.signature,
-                ) {
-                    error!("Error generating neighbouring section's proof_chain for knowledge update on split: {:?}", e);
-                }
-
-                info!("Updating neighbouring section's SAP");
-                if let Err(e) = self.network.update(section_auth, &old_chain) {
-                    error!("Error updating neighbouring section's details on our NetworkPrefixMap: {:?}", e);
-                } else {
-                    self.write_prefix_map().await;
-                }
+                _ => {}
             }
         }
 

--- a/sn/src/routing/core/msg_handling/agreement.rs
+++ b/sn/src/routing/core/msg_handling/agreement.rs
@@ -273,6 +273,16 @@ impl Core {
                     .section
                     .update_elders(section_auth.clone(), key_sig)
                     .await;
+            } else {
+                // FIXME: we shouldn't be updating our section info since it
+                // doesn't match our prefix???
+                if let Err(err) = self.section.chain.write().await.insert(
+                    &key_sig.public_key,
+                    section_auth.value.section_key(),
+                    key_sig.signature,
+                ) {
+                    error!("Error generating neighbouring section's proof_chain for knowledge update on split: {:?}", err);
+                }
             }
 
             // Let's update our network knowledge with new SAP even if it's of our own section

--- a/sn/src/routing/routing_api/tests/mod.rs
+++ b/sn/src/routing/routing_api/tests/mod.rs
@@ -30,7 +30,7 @@ use crate::routing::{
     relocation::{self, RelocatePayloadUtils},
     section::{test_utils::*, ElderCandidatesUtils, NodeStateUtils, Section, SectionKeyShare},
     supermajority, Error, Event, Result as RoutingResult, SectionAuthorityProviderUtils,
-    ELDER_SIZE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE, MIN_AGE,
+    ELDER_SIZE, FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE, MIN_AGE,
 };
 use crate::types::{Keypair, PublicKey};
 use assert_matches::assert_matches;
@@ -83,7 +83,10 @@ async fn receive_join_request_without_resource_proof_response() -> Result<()> {
 
     let new_node_comm = create_comm().await?;
     let new_node = Node::new(
-        ed25519::gen_keypair(&Prefix::default().range_inclusive(), FIRST_SECTION_MIN_AGE),
+        ed25519::gen_keypair(
+            &Prefix::default().range_inclusive(),
+            FIRST_SECTION_MAX_AGE - ELDER_SIZE as u8 * 2,
+        ),
         new_node_comm.our_connection_info(),
     );
 
@@ -161,7 +164,10 @@ async fn receive_join_request_with_resource_proof_response() -> Result<()> {
     let dispatcher = Dispatcher::new(core);
 
     let new_node = Node::new(
-        ed25519::gen_keypair(&Prefix::default().range_inclusive(), FIRST_SECTION_MIN_AGE),
+        ed25519::gen_keypair(
+            &Prefix::default().range_inclusive(),
+            FIRST_SECTION_MAX_AGE - ELDER_SIZE as u8 * 2,
+        ),
         gen_addr(),
     );
 
@@ -212,7 +218,7 @@ async fn receive_join_request_with_resource_proof_response() -> Result<()> {
         {
             assert_eq!(*peer.name(), new_node.name());
             assert_eq!(*peer.addr(), new_node.addr);
-            assert_eq!(peer.age(), FIRST_SECTION_MIN_AGE);
+            assert_eq!(peer.age(), FIRST_SECTION_MAX_AGE - ELDER_SIZE as u8 * 2);
             assert_eq!(previous_name, None);
             assert_eq!(dst_key, None);
 

--- a/sn/src/routing/routing_api/tests/mod.rs
+++ b/sn/src/routing/routing_api/tests/mod.rs
@@ -487,9 +487,9 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
         Prefix::default(),
         sk_set.public_keys(),
     );
-    let section_signed_section_auth = section_signed(sk_set.secret_key(), section_auth.clone())?;
+    let section_signed_sap = section_signed(sk_set.secret_key(), section_auth.clone())?;
 
-    let section = Section::new(*chain.root_key(), chain, section_signed_section_auth)?;
+    let section = Section::new(*chain.root_key(), chain, section_signed_sap)?;
     let mut expected_new_elders = BTreeSet::new();
 
     for peer in section_auth.peers() {
@@ -620,11 +620,11 @@ async fn handle_online_command(
                 ..
             }) => {
                 if let JoinResponse::Approval {
-                    section_auth: section_signed_section_auth,
+                    section_auth: section_signed_sap,
                     ..
                 } = *response
                 {
-                    assert_eq!(section_signed_section_auth.value, *section_auth);
+                    assert_eq!(section_signed_sap.value, *section_auth);
                     assert_eq!(recipients, [(*peer.name(), *peer.addr())]);
                     status.node_approval_sent = true;
                 }
@@ -1483,13 +1483,12 @@ async fn handle_demote_during_split() -> Result<()> {
     let sk_set_v1_p1 = SecretKeySet::random();
 
     // Create agreement on `OurElder` for both sub-sections
-    let create_our_elders_command = |sk, section_auth| -> Result<_> {
-        let section_signed_section_auth = section_signed(sk, section_auth)?;
-        let proposal = Proposal::OurElders(section_signed_section_auth);
+    let create_our_elders_command = |section_signed_sap| -> Result<_> {
+        let proposal = Proposal::OurElders(section_signed_sap);
         let signature = sk_set_v0.secret_key().sign(&proposal.as_signable_bytes()?);
         let sig = KeyedSig {
             signature,
-            public_key: sk_set_v0.secret_key().public_key(),
+            public_key: sk_set_v0.public_keys().public_key(),
         };
 
         Ok(Command::HandleElderAgreement { proposal, sig })
@@ -1501,18 +1500,21 @@ async fn handle_demote_during_split() -> Result<()> {
         prefix0,
         sk_set_v1_p0.public_keys(),
     );
-    let command = create_our_elders_command(sk_set_v1_p0.secret_key(), section_auth)?;
-    let commands = dispatcher.handle_command(command, "cmd-id").await?;
+
+    let section_signed_sap = section_signed(sk_set_v1_p0.secret_key(), section_auth)?;
+    let command = create_our_elders_command(section_signed_sap)?;
+    let commands = dispatcher.handle_command(command, "cmd-id-1").await?;
     assert_matches!(&commands[..], &[]);
 
     // Handle agreement on `OurElders` for prefix-1.
     let section_auth =
         SectionAuthorityProvider::new(peers_b.iter().copied(), prefix1, sk_set_v1_p1.public_keys());
-    let command = create_our_elders_command(sk_set_v1_p1.secret_key(), section_auth)?;
-    let commands = dispatcher.handle_command(command, "cmd-id").await?;
+
+    let section_signed_sap = section_signed(sk_set_v1_p1.secret_key(), section_auth)?;
+    let command = create_our_elders_command(section_signed_sap)?;
+    let commands = dispatcher.handle_command(command, "cmd-id-2").await?;
 
     let mut update_recipients = HashSet::new();
-
     for command in commands {
         let (recipients, wire_msg) = match command {
             Command::SendMessage {
@@ -1597,14 +1599,10 @@ async fn create_section(
     sk_set: &SecretKeySet,
     section_auth: &SectionAuthorityProvider,
 ) -> Result<(Section, SectionKeyShare)> {
-    let section_chain = SecuredLinkedList::new(sk_set.secret_key().public_key());
-    let section_signed_section_auth = section_signed(sk_set.secret_key(), section_auth.clone())?;
+    let section_chain = SecuredLinkedList::new(sk_set.public_keys().public_key());
+    let section_signed_sap = section_signed(sk_set.secret_key(), section_auth.clone())?;
 
-    let section = Section::new(
-        *section_chain.root_key(),
-        section_chain,
-        section_signed_section_auth,
-    )?;
+    let section = Section::new(*section_chain.root_key(), section_chain, section_signed_sap)?;
 
     for peer in section_auth.peers() {
         let mut peer = peer;

--- a/sn/src/routing/section/mod.rs
+++ b/sn/src/routing/section/mod.rs
@@ -87,7 +87,7 @@ impl Section {
         // Check if SAP's section key matches SAP signature's key
         if section_auth.sig.public_key != section_auth.value.public_key_set.public_key() {
             return Err(Error::UntrustedSectionAuthProvider(format!(
-                "section key doesn't match signature'ssss key: {:?}",
+                "section key doesn't match signature's key: {:?}",
                 section_auth.value
             )));
         }


### PR DESCRIPTION
This PR also changes the `JoinResponse::Retry` message to return the expected age for the joining node.