### PR TITLE
fix(sn): fix test for `GetChunk` 'data not found' failures

### DIFF
--- a/sn/src/messaging/data/mod.rs
+++ b/sn/src/messaging/data/mod.rs
@@ -164,7 +164,7 @@ impl QueryResponse {
         match self {
             GetChunk(result) => match result {
                 Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMessage::DataNotFound(_)),
+                Err(error) => matches!(*error, ErrorMessage::ChunkNotFound(_)),
             },
             GetRegister((result, _op_id)) => match result {
                 Ok(_) => false,


### PR DESCRIPTION
- fcf8f2444 **fix(sn): fix test for `GetChunk` 'data not found' failures**

  `QueryResponse::failed_with_data_not_found` is used to prevent sending
  'data not found' errors to clients. Clients, in turn, do not retry
  errors, only timeouts.
  
  Recently (c0b1770154) the error type returned when a chunk is not found
  was changed from `NoSuchData` to `ChunkNotFound`, but the check in
  `failed_with_data_not_found` was not updated. This could lead to
  spurious client errors when they attempt to read data before it is
  available (which would otherwise be covered by the retry on timeout,
  since nodes would not forward the data-not-found response).
