### PR TITLE
Reduce redundant space used by chunks

### DIFF
--- a/sn/src/dbs/kv_store/kv.rs
+++ b/sn/src/dbs/kv_store/kv.rs
@@ -11,6 +11,9 @@ use serde::{de::DeserializeOwned, Serialize};
 
 pub(crate) trait Key: ToDbKey + PartialEq + Eq + DeserializeOwned {}
 
+/// A value in a key-value store.
+///
+/// The KV-store is paramaterised by the value type, from which a key can be derived.
 pub(crate) trait Value: Serialize + DeserializeOwned {
     type Key: Key;
     fn key(&self) -> &Self::Key;

--- a/sn/src/dbs/kv_store/mod.rs
+++ b/sn/src/dbs/kv_store/mod.rs
@@ -174,6 +174,14 @@ impl<V: Value + Send + Sync> KvStore<V> {
             .collect();
         Ok(keys)
     }
+
+    // We should avoid manually flushing in real code, since it can take a lot of time - tuning
+    // `flush_every_ms` would be preferrable. This is useful in tests, however.
+    #[cfg(test)]
+    pub(crate) async fn flush(&self) -> Result<()> {
+        let _bytes_flushed = self.db.flush_async().await?;
+        Ok(())
+    }
 }
 
 pub(crate) fn convert<T: DeserializeOwned>(key: sled::IVec) -> Result<T> {

--- a/sn/src/dbs/kv_store/mod.rs
+++ b/sn/src/dbs/kv_store/mod.rs
@@ -33,15 +33,14 @@ const DB_DIR: &str = "db";
 /// `KvStore` is a store of keys and values into a Sled db, while maintaining a maximum disk
 /// usage to restrict storage.
 #[derive(Clone, Debug)]
-pub(crate) struct KvStore<K, V> {
+pub(crate) struct KvStore<V> {
     // tracks space used.
     used_space: UsedSpace,
     db: Db,
-    _k: PhantomData<K>,
     _v: PhantomData<V>,
 }
 
-impl<K: Key, V: Value> KvStore<K, V>
+impl<V: Value> KvStore<V>
 where
     Self: Subdir,
 {
@@ -65,13 +64,12 @@ where
         Ok(KvStore {
             used_space,
             db,
-            _k: PhantomData,
             _v: PhantomData,
         })
     }
 }
 
-impl<K: Key, V: Value + Send + Sync> KvStore<K, V> {
+impl<V: Value + Send + Sync> KvStore<V> {
     ///
     pub(crate) async fn total_used_space(&self) -> u64 {
         self.used_space.total().await

--- a/sn/src/dbs/kv_store/mod.rs
+++ b/sn/src/dbs/kv_store/mod.rs
@@ -163,7 +163,6 @@ impl<V: Value + Send + Sync> KvStore<V> {
     }
 
     /// Lists all keys of currently stored data.
-    #[cfg_attr(not(test), allow(unused))]
     pub(crate) fn keys(&self) -> Result<Vec<V::Key>> {
         let keys = self
             .db

--- a/sn/src/dbs/kv_store/tests.rs
+++ b/sn/src/dbs/kv_store/tests.rs
@@ -33,7 +33,7 @@ struct Id(u64);
 impl ToDbKey for Id {}
 impl Key for Id {}
 
-impl Subdir for KvStore<Id, TestData> {
+impl Subdir for KvStore<TestData> {
     fn subdir() -> &'static Path {
         Path::new("test")
     }
@@ -84,7 +84,7 @@ async fn used_space_increases() -> Result<()> {
 
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let db = KvStore::<Id, TestData>::new(root.path(), used_space)?;
+    let db = KvStore::<TestData>::new(root.path(), used_space)?;
 
     let used_space_before = db.total_used_space().await;
 
@@ -119,7 +119,7 @@ async fn used_space_decreases() -> Result<()> {
 
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let db = KvStore::<Id, TestData>::new(root.path(), used_space)?;
+    let db = KvStore::<TestData>::new(root.path(), used_space)?;
 
     for (index, (data, _size)) in chunks.data_and_sizes.iter().enumerate().rev() {
         let the_data = &TestData {
@@ -155,7 +155,7 @@ async fn successful_put() -> Result<()> {
 
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let db = KvStore::<Id, TestData>::new(root.path(), used_space)?;
+    let db = KvStore::<TestData>::new(root.path(), used_space)?;
 
     for (index, (data, _size)) in chunks.data_and_sizes.iter().enumerate().rev() {
         let the_data = &TestData {
@@ -301,7 +301,7 @@ async fn overwrite_value() -> Result<()> {
 async fn get_fails_when_key_does_not_exist() -> Result<()> {
     let root = temp_dir()?;
     let used_space = UsedSpace::new(u64::MAX);
-    let db: KvStore<Id, TestData> = KvStore::new(root.path(), used_space)?;
+    let db: KvStore<TestData> = KvStore::new(root.path(), used_space)?;
 
     let id = Id(new_rng().gen());
     match db.get(&id) {

--- a/sn/src/routing/core/chunk_store/mod.rs
+++ b/sn/src/routing/core/chunk_store/mod.rs
@@ -18,7 +18,7 @@ use std::{
 use tokio::sync::RwLock;
 use tracing::info;
 
-type Db = KvStore<ChunkAddress, Chunk>;
+type Db = KvStore<Chunk>;
 
 impl Subdir for Db {
     fn subdir() -> &'static Path {


### PR DESCRIPTION
- 41b7e53c6 **refactor(sn): remove redundant `K` type parameter from `KvStore`**

  The `Value` trait already included an associated type for the key type,
  and this can be referenced directly in signatures without the need for
  an additional generic type parameter.

- 75cca06aa **fix(sn): make `KvStore::store` perform atomic immutable writes**

  `KvStore` is the database abstraction we use to persist chunks. This is
  itself backed by `sled`. `sled` uses a log as one of the underlying
  storage primitives, which means that all inserts (even overwrites) will
  consume additional space (until the log is compacted, which may happen
  irregularly).
  
  However, chunks themselves are write-once which means that we would only
  ever need to write a value once. As such, we can use `compare_and_swap`
  to write the value only if it's not currently set. Since chunks are
  content-addressable, we furthermore don't need to do anything if the
  value did already exist and wasn't written, since there is only one
  possible value for a given key.

- e613e3cdc **chore(sn): remove unused `KvStore::store_batch`**

  Although this was commented to indicate it will be used again soon, it
  is trivial to recover code from git history, but it may be non-trivial
  to maintain or fix unused code. That's the case for trying to fix used
  space handling in `store_batch`, since `sled::Tree::apply_batch` cannot
  perform compare-and-swap operations. As such, the whole operation
  probably needs a rethink, and since it's not currently used we can defer
  that until it's needed.

- 2823174c5 **chore(sn): remove unnecessary `allow(unused)`**


- 0860efc0b **refactor(sn): add `KvStore::flush` to avoid waiting in tests**

  Some `KvStore` tests verify that used space adjusts appropriately when
  data is written (also when data is removed, but those tests are disabled
  since it's not predictable when sled will compact its log). We measure
  used space by measuring the size of the database files.
  
  sled flushes to disk asynchronously by default, and the tests were
  accounting for this by looping until the size changed. This could lead
  to hung tests in the case of bugs with used space calculation, which
  would be harder to debug than a concrete failure. As such, a test-only
  `flush` method has been added to `KvStore`, which is now used by the
  tests to force a flush to disk.
