### PR TITLE
More peers less problems

### DIFF
--- a/sn/src/routing/core/api.rs
+++ b/sn/src/routing/core/api.rs
@@ -190,10 +190,7 @@ impl Core {
         wire_msg.set_dst_section_pk(dst_pk);
 
         let command = Command::SendMessageDeliveryGroup {
-            recipients: targets
-                .into_iter()
-                .map(|peer| (peer.name(), peer.addr()))
-                .collect(),
+            recipients: targets.into_iter().collect(),
             delivery_group_size: dg_size,
             wire_msg,
         };

--- a/sn/src/routing/core/bootstrap/join.rs
+++ b/sn/src/routing/core/bootstrap/join.rs
@@ -178,11 +178,7 @@ impl<'a> Join<'a> {
                     section_auth,
                     expected_age,
                 } => {
-                    let new_recipients: Vec<_> = section_auth
-                        .elders
-                        .iter()
-                        .map(|(name, addr)| Peer::new(*name, *addr))
-                        .collect();
+                    let new_recipients = section_auth.peers();
 
                     let prefix = section_auth.prefix;
 
@@ -245,10 +241,9 @@ impl<'a> Join<'a> {
 
                     // Ignore already used recipients
                     let new_recipients: Vec<_> = section_auth
-                        .elders
-                        .iter()
-                        .filter(|(_, addr)| !used_recipient.contains(addr))
-                        .map(|(name, addr)| Peer::new(*name, *addr))
+                        .peers()
+                        .into_iter()
+                        .filter(|peer| !used_recipient.contains(&peer.addr()))
                         .collect();
 
                     if new_recipients.is_empty() {

--- a/sn/src/routing/core/bootstrap/join.rs
+++ b/sn/src/routing/core/bootstrap/join.rs
@@ -572,14 +572,7 @@ mod tests {
                 (msg, dst_location));
 
             assert_eq!(dst_location.section_pk(), Some(pk));
-            itertools::assert_equal(
-                recipients,
-                section_auth
-                    .elders()
-                    .iter()
-                    .map(|(name, addr)| Peer::new(*name, *addr))
-                    .collect::<Vec<_>>(),
-            );
+            itertools::assert_equal(recipients, section_auth.peers());
             assert_matches!(node_msg, SystemMsg::JoinRequest(request) => {
                 assert_eq!(request.section_key, pk);
             });

--- a/sn/src/routing/core/bootstrap/relocate.rs
+++ b/sn/src/routing/core/bootstrap/relocate.rs
@@ -143,11 +143,7 @@ impl JoiningAsRelocated {
                     return Ok(None);
                 }
 
-                let new_recipients: Vec<_> = section_auth
-                    .elders
-                    .iter()
-                    .map(|(name, addr)| Peer::new(*name, *addr))
-                    .collect();
+                let new_recipients = section_auth.peers();
 
                 // if we are relocating, and we didn't generate
                 // the relocation payload yet, we do it now
@@ -178,10 +174,9 @@ impl JoiningAsRelocated {
 
                 // Ignore already used recipients
                 let new_recipients: Vec<_> = section_auth
-                    .elders
-                    .iter()
-                    .filter(|(_, addr)| !self.used_recipients.contains(addr))
-                    .map(|(name, addr)| Peer::new(*name, *addr))
+                    .peers()
+                    .into_iter()
+                    .filter(|elder| !self.used_recipients.contains(&elder.addr()))
                     .collect();
 
                 if new_recipients.is_empty() {

--- a/sn/src/routing/core/comm.rs
+++ b/sn/src/routing/core/comm.rs
@@ -11,6 +11,7 @@ use crate::messaging::{system::LoadReport, WireMsg};
 use crate::routing::{
     error::{Error, Result},
     log_markers::LogMarker,
+    Peer,
 };
 use bytes::Bytes;
 use futures::{
@@ -136,19 +137,22 @@ impl Comm {
     /// Sends a message on an existing connection. If no such connection exists, returns an error.
     pub(crate) async fn send_on_existing_connection(
         &self,
-        recipients: &[(XorName, SocketAddr)],
+        recipients: &[Peer],
         mut wire_msg: WireMsg,
     ) -> Result<(), Error> {
         trace!("Sending msg on existing connection to {:?}", recipients);
-        for (name, addr) in recipients {
-            wire_msg.set_dst_xorname(*name);
+        for recipient in recipients {
+            let name = recipient.name();
+            let addr = recipient.addr();
+
+            wire_msg.set_dst_xorname(name);
 
             let bytes = wire_msg.serialize()?;
             let priority = wire_msg.msg_kind().priority();
-            let retries = self.back_pressure.get(addr).await; // TODO: more laid back retries with lower priority, more aggressive with higher
+            let retries = self.back_pressure.get(&addr).await; // TODO: more laid back retries with lower priority, more aggressive with higher
 
             self.connected_peers
-                .get_by_address(addr)
+                .get_by_address(&addr)
                 .map(|res| res.ok_or(None))
                 .and_then(|client| async move {
                     client
@@ -166,11 +170,11 @@ impl Comm {
                         name,
                         err
                     );
-                    Error::FailedSend(*addr, *name)
+                    Error::FailedSend(addr, name)
                 })?;
 
             // count outgoing msgs..
-            self.msg_count.increase_outgoing(*addr);
+            self.msg_count.increase_outgoing(addr);
         }
 
         Ok(())
@@ -209,9 +213,12 @@ impl Comm {
     /// `SendStatus::MinDeliveryGroupSizeReached` or `SendStatus::MinDeliveryGroupSizeFailed` depending
     /// on if the minimum delivery group size is met or not. The failed recipients are sent along
     /// with the status. It returns a `SendStatus::AllRecipients` if message is sent to all the recipients.
-    pub(crate) async fn send(
+    #[allow(clippy::needless_lifetimes)] // this is firing a false positive here
+                                         // we need an explicit lifetime for the compiler to see
+                                         // that `recipient` lives long enough in the closure
+    pub(crate) async fn send<'r>(
         &self,
-        recipients: &[(XorName, SocketAddr)],
+        recipients: &'r [Peer],
         delivery_group_size: usize,
         wire_msg: WireMsg,
     ) -> Result<SendStatus> {
@@ -243,35 +250,36 @@ impl Comm {
         // Run all the sends concurrently (using `FuturesUnordered`). If any of them fails, pick
         // the next recipient and try to send to them. Proceed until the needed number of sends
         // succeeds or if there are no more recipients to pick.
-        let send = |recipient: (XorName, SocketAddr), msg_bytes: Bytes| async move {
+        let send = |recipient: &'r Peer, msg_bytes: Bytes| async move {
             trace!(
                 "Sending message ({} bytes, msg_id: {:?}) to {} of delivery group size {}",
                 msg_bytes.len(),
                 msg_id,
-                recipient.1,
+                recipient,
                 delivery_group_size,
             );
 
-            let retries = self.back_pressure.get(&recipient.1).await; // TODO: more laid back retries with lower priority, more aggressive with higher
+            let retries = self.back_pressure.get(&recipient.addr()).await; // TODO: more laid back retries with lower priority, more aggressive with higher
 
-            let connection =
-                if let Some(connection) = self.connected_peers.get_by_address(&recipient.1).await {
-                    Ok(connection.connection().clone())
-                } else {
-                    self.endpoint.connect_to(&recipient.1).await.map(
-                        |(connection, connection_incoming)| {
-                            let _ = task::spawn(handle_incoming_messages(
-                                connection.id(),
-                                connection.remote_address(),
-                                connection_incoming,
-                                self.event_tx.clone(),
-                                self.msg_count.clone(),
-                                self.connected_peers.clone(),
-                            ));
-                            connection
-                        },
-                    )
-                };
+            let connection = if let Some(connection) =
+                self.connected_peers.get_by_address(&recipient.addr()).await
+            {
+                Ok(connection.connection().clone())
+            } else {
+                self.endpoint.connect_to(&recipient.addr()).await.map(
+                    |(connection, connection_incoming)| {
+                        let _ = task::spawn(handle_incoming_messages(
+                            connection.id(),
+                            connection.remote_address(),
+                            connection_incoming,
+                            self.event_tx.clone(),
+                            self.msg_count.clone(),
+                            self.connected_peers.clone(),
+                        ));
+                        connection
+                    },
+                )
+            };
 
             let result = future::ready(connection)
                 .err_into()
@@ -291,12 +299,12 @@ impl Comm {
                     }
                 });
 
-            (result, recipient.1)
+            (result, recipient.addr())
         };
 
         let mut tasks: FuturesUnordered<_> = recipients[0..delivery_group_size]
             .iter()
-            .map(|(name, recipient)| send((*name, *recipient), msg_bytes.clone()))
+            .map(|recipient| send(recipient, msg_bytes.clone()))
             .collect();
 
         let mut next = delivery_group_size;
@@ -319,7 +327,7 @@ impl Comm {
                     failed_recipients.push(addr);
 
                     if next < recipients.len() {
-                        tasks.push(send(recipients[next], msg_bytes.clone()));
+                        tasks.push(send(&recipients[next], msg_bytes.clone()));
                         next += 1;
                     }
                 }
@@ -444,6 +452,7 @@ mod tests {
     use super::*;
     use crate::messaging::data::{DataQuery, ServiceMsg};
     use crate::messaging::{DstLocation, MessageId, MsgKind, ServiceAuth};
+    use crate::routing::Peer;
     use crate::types::{ChunkAddress, Keypair};
     use assert_matches::assert_matches;
     use eyre::Result;
@@ -460,26 +469,22 @@ mod tests {
         let (tx, _rx) = mpsc::channel(1);
         let comm = Comm::new(local_addr(), Config::default(), tx).await?;
 
-        let mut peer0 = Peer::new().await?;
-        let mut peer1 = Peer::new().await?;
+        let (peer0, mut rx0) = new_peer().await?;
+        let (peer1, mut rx1) = new_peer().await?;
 
         let original_message = new_test_message()?;
 
         let status = comm
-            .send(
-                &[(peer0.name, peer0.addr), (peer1.name, peer1.addr)],
-                2,
-                original_message.clone(),
-            )
+            .send(&[peer0, peer1], 2, original_message.clone())
             .await?;
 
         assert_matches!(status, SendStatus::AllRecipients);
 
-        if let Some(bytes) = peer0.rx.recv().await {
+        if let Some(bytes) = rx0.recv().await {
             assert_eq!(WireMsg::from(bytes)?, original_message.clone());
         }
 
-        if let Some(bytes) = peer1.rx.recv().await {
+        if let Some(bytes) = rx1.recv().await {
             assert_eq!(WireMsg::from(bytes)?, original_message);
         }
 
@@ -491,25 +496,21 @@ mod tests {
         let (tx, _rx) = mpsc::channel(1);
         let comm = Comm::new(local_addr(), Config::default(), tx).await?;
 
-        let mut peer0 = Peer::new().await?;
-        let mut peer1 = Peer::new().await?;
+        let (peer0, mut rx0) = new_peer().await?;
+        let (peer1, mut rx1) = new_peer().await?;
 
         let original_message = new_test_message()?;
         let status = comm
-            .send(
-                &[(peer0.name, peer0.addr), (peer1.name, peer1.addr)],
-                1,
-                original_message.clone(),
-            )
+            .send(&[peer0, peer1], 1, original_message.clone())
             .await?;
 
         assert_matches!(status, SendStatus::AllRecipients);
 
-        if let Some(bytes) = peer0.rx.recv().await {
+        if let Some(bytes) = rx0.recv().await {
             assert_eq!(WireMsg::from(bytes)?, original_message);
         }
 
-        assert!(time::timeout(TIMEOUT, peer1.rx.recv())
+        assert!(time::timeout(TIMEOUT, rx1.recv())
             .await
             .unwrap_or_default()
             .is_none());
@@ -530,15 +531,13 @@ mod tests {
             tx,
         )
         .await?;
-        let invalid_addr = get_invalid_addr().await?;
+        let invalid_peer = get_invalid_peer().await?;
 
-        let status = comm
-            .send(&[(XorName::random(), invalid_addr)], 1, new_test_message()?)
-            .await?;
+        let status = comm.send(&[invalid_peer], 1, new_test_message()?).await?;
 
         assert_matches!(
             &status,
-            &SendStatus::MinDeliveryGroupSizeFailed(_) => vec![invalid_addr]
+            &SendStatus::MinDeliveryGroupSizeFailed(_) => vec![invalid_peer.addr()]
         );
 
         Ok(())
@@ -556,23 +555,16 @@ mod tests {
             tx,
         )
         .await?;
-        let mut peer = Peer::new().await?;
-        let invalid_addr = get_invalid_addr().await?;
-        let name = XorName::random();
+        let (peer, mut rx) = new_peer().await?;
+        let invalid_peer = get_invalid_peer().await?;
 
         let message = new_test_message()?;
-        let status = comm
-            .send(
-                &[(name, invalid_addr), (peer.name, peer.addr)],
-                1,
-                message.clone(),
-            )
-            .await?;
+        let status = comm.send(&[invalid_peer, peer], 1, message.clone()).await?;
         assert_matches!(status, SendStatus::MinDeliveryGroupSizeReached(failed_recipients) => {
-            assert_eq!(&failed_recipients, &[invalid_addr])
+            assert_eq!(&failed_recipients, &[invalid_peer.addr()])
         });
 
-        if let Some(bytes) = peer.rx.recv().await {
+        if let Some(bytes) = rx.recv().await {
             assert_eq!(WireMsg::from(bytes)?, message);
         }
         Ok(())
@@ -590,25 +582,18 @@ mod tests {
             tx,
         )
         .await?;
-        let mut peer = Peer::new().await?;
-        let invalid_addr = get_invalid_addr().await?;
-        let name = XorName::random();
+        let (peer, mut rx) = new_peer().await?;
+        let invalid_peer = get_invalid_peer().await?;
 
         let message = new_test_message()?;
-        let status = comm
-            .send(
-                &[(name, invalid_addr), (peer.name, peer.addr)],
-                2,
-                message.clone(),
-            )
-            .await?;
+        let status = comm.send(&[invalid_peer, peer], 2, message.clone()).await?;
 
         assert_matches!(
             status,
-            SendStatus::MinDeliveryGroupSizeFailed(_) => vec![invalid_addr]
+            SendStatus::MinDeliveryGroupSizeFailed(_) => vec![invalid_peer]
         );
 
-        if let Some(bytes) = peer.rx.recv().await {
+        if let Some(bytes) = rx.recv().await {
             assert_eq!(WireMsg::from(bytes)?, message);
         }
         Ok(())
@@ -626,7 +611,7 @@ mod tests {
 
         let msg0 = new_test_message()?;
         let status = send_comm
-            .send(&[(name, recv_addr)], 1, msg0.clone())
+            .send(&[Peer::new(name, recv_addr)], 1, msg0.clone())
             .await?;
         assert_matches!(status, SendStatus::AllRecipients);
 
@@ -647,7 +632,7 @@ mod tests {
 
         let msg1 = new_test_message()?;
         let status = send_comm
-            .send(&[(name, recv_addr)], 1, msg1.clone())
+            .send(&[Peer::new(name, recv_addr)], 1, msg1.clone())
             .await?;
         assert_matches!(status, SendStatus::AllRecipients);
 
@@ -676,7 +661,11 @@ mod tests {
 
         // Send a message to establish the connection
         let status = comm1
-            .send(&[(XorName::random(), addr0)], 1, new_test_message()?)
+            .send(
+                &[Peer::new(XorName::random(), addr0)],
+                1,
+                new_test_message()?,
+            )
             .await?;
         assert_matches!(status, SendStatus::AllRecipients);
 
@@ -701,7 +690,11 @@ mod tests {
 
         // Establish a connection by sending a message
         let status = client_comm
-            .send(&[(XorName::random(), node_addr)], 1, new_test_message()?)
+            .send(
+                &[Peer::new(XorName::random(), node_addr)],
+                1,
+                new_test_message()?,
+            )
             .await?;
         assert_matches!(status, SendStatus::AllRecipients);
 
@@ -717,7 +710,10 @@ mod tests {
 
         // We can reply to the client over the existing connection
         node_comm
-            .send_on_existing_connection(&[(XorName::random(), client_addr)], new_test_message()?)
+            .send_on_existing_connection(
+                &[Peer::new(XorName::random(), client_addr)],
+                new_test_message()?,
+            )
             .await?;
 
         assert_matches!(client_rx.recv().await, Some(ConnectionEvent::Received(_)));
@@ -752,37 +748,25 @@ mod tests {
         Ok(wire_msg)
     }
 
-    struct Peer {
-        addr: SocketAddr,
-        name: XorName,
-        rx: mpsc::Receiver<Bytes>,
-    }
+    async fn new_peer() -> Result<(Peer, mpsc::Receiver<Bytes>)> {
+        let (endpoint, mut incoming_connections, _) =
+            Endpoint::new(local_addr(), &[], Config::default()).await?;
+        let addr = endpoint.public_addr();
 
-    impl Peer {
-        async fn new() -> Result<Self> {
-            let (endpoint, mut incoming_connections, _) =
-                Endpoint::new(local_addr(), &[], Config::default()).await?;
-            let addr = endpoint.public_addr();
+        let (tx, rx) = mpsc::channel(1);
 
-            let (tx, rx) = mpsc::channel(1);
-
-            let _handle = tokio::spawn(async move {
-                while let Some((_, mut incoming_messages)) = incoming_connections.next().await {
-                    while let Ok(Some(msg)) = incoming_messages.next().await {
-                        let _ = tx.send(msg).await;
-                    }
+        let _handle = tokio::spawn(async move {
+            while let Some((_, mut incoming_messages)) = incoming_connections.next().await {
+                while let Ok(Some(msg)) = incoming_messages.next().await {
+                    let _ = tx.send(msg).await;
                 }
-            });
+            }
+        });
 
-            Ok(Self {
-                addr,
-                rx,
-                name: XorName::random(),
-            })
-        }
+        Ok((Peer::new(XorName::random(), addr), rx))
     }
 
-    async fn get_invalid_addr() -> Result<SocketAddr> {
+    async fn get_invalid_peer() -> Result<Peer> {
         let socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await?;
         let addr = socket.local_addr()?;
 
@@ -793,7 +777,7 @@ mod tests {
             let _ = socket;
         });
 
-        Ok(addr)
+        Ok(Peer::new(XorName::random(), addr))
     }
 
     fn local_addr() -> SocketAddr {

--- a/sn/src/routing/core/delivery_group.rs
+++ b/sn/src/routing/core/delivery_group.rs
@@ -632,10 +632,9 @@ mod tests {
 
     fn choose_elder_name(section_auth: &SectionAuthorityProvider) -> Result<XorName> {
         section_auth
-            .elders()
-            .keys()
+            .names()
+            .into_iter()
             .choose(&mut rand::thread_rng())
-            .copied()
             .context("no elders")
     }
 }

--- a/sn/src/routing/core/messaging.rs
+++ b/sn/src/routing/core/messaging.rs
@@ -504,14 +504,7 @@ impl Core {
     // TODO: consider changing this so it sends only to a subset of the elders
     // (say 1/3 of the ones closest to our name or so)
     pub(crate) async fn send_message_to_our_elders(&self, node_msg: SystemMsg) -> Result<Command> {
-        let targets: Vec<_> = self
-            .network_knowledge
-            .authority_provider()
-            .await
-            .elders()
-            .iter()
-            .map(|(name, address)| Peer::new(*name, *address))
-            .collect();
+        let targets: Vec<_> = self.network_knowledge.authority_provider().await.peers();
 
         let dst_section_pk = self.network_knowledge().section_key().await;
         let cmd = self

--- a/sn/src/routing/core/messaging.rs
+++ b/sn/src/routing/core/messaging.rs
@@ -437,7 +437,7 @@ impl Core {
             wire_msg.set_dst_xorname(self.node.read().await.name());
 
             commands.push(Command::HandleMessage {
-                sender: self.node.read().await.addr,
+                sender_addr: self.node.read().await.addr,
                 wire_msg,
                 original_bytes: None,
             });

--- a/sn/src/routing/core/mod.rs
+++ b/sn/src/routing/core/mod.rs
@@ -44,7 +44,7 @@ use crate::routing::{
     node::Node,
     relocation::RelocateState,
     routing_api::command::Command,
-    Elders, Event, NodeElderChange, SectionAuthorityProviderUtils,
+    Elders, Event, NodeElderChange, Peer, SectionAuthorityProviderUtils,
 };
 use crate::types::utils::write_data_to_disk;
 use backoff::ExponentialBackoff;
@@ -172,7 +172,11 @@ impl Core {
         let message = SystemMsg::AntiEntropyProbe(dst);
         let section_key = matching_section.section_key();
         let dst_name = matching_section.prefix().name();
-        let recipients = matching_section.elders.into_iter().collect::<Vec<_>>();
+        let recipients: Vec<_> = matching_section
+            .elders
+            .into_iter()
+            .map(|(name, addr)| Peer::new(name, addr))
+            .collect();
 
         info!(
             "ProbeMessage target {:?} w/key {:?}",

--- a/sn/src/routing/core/mod.rs
+++ b/sn/src/routing/core/mod.rs
@@ -54,7 +54,6 @@ use liveness_tracking::Liveness;
 use resource_proof::ResourceProof;
 use std::{
     collections::{BTreeMap, BTreeSet},
-    net::SocketAddr,
     path::PathBuf,
     sync::Arc,
 };
@@ -70,7 +69,7 @@ pub(crate) const CONCURRENT_JOINS: usize = 5;
 
 // store up to 100 in use backoffs
 pub(crate) type AeBackoffCache =
-    Arc<RwLock<LRUCache<(XorName, SocketAddr, ExponentialBackoff), BACKOFF_CACHE_LIMIT>>>;
+    Arc<RwLock<LRUCache<(Peer, ExponentialBackoff), BACKOFF_CACHE_LIMIT>>>;
 
 // State + logic of a routing node.
 pub(crate) struct Core {

--- a/sn/src/routing/core/mod.rs
+++ b/sn/src/routing/core/mod.rs
@@ -172,11 +172,7 @@ impl Core {
         let message = SystemMsg::AntiEntropyProbe(dst);
         let section_key = matching_section.section_key();
         let dst_name = matching_section.prefix().name();
-        let recipients: Vec<_> = matching_section
-            .elders
-            .into_iter()
-            .map(|(name, addr)| Peer::new(name, addr))
-            .collect();
+        let recipients = matching_section.peers();
 
         info!(
             "ProbeMessage target {:?} w/key {:?}",

--- a/sn/src/routing/core/msg_handling/agreement.rs
+++ b/sn/src/routing/core/msg_handling/agreement.rs
@@ -205,7 +205,7 @@ impl Core {
 
             for peer in peers {
                 if !self.network_knowledge.is_elder(&peer.name()).await {
-                    ae_update_recipients.push((peer.name(), peer.addr()));
+                    ae_update_recipients.push(peer);
                 }
             }
 

--- a/sn/src/routing/core/msg_handling/anti_entropy.rs
+++ b/sn/src/routing/core/msg_handling/anti_entropy.rs
@@ -17,6 +17,7 @@ use crate::routing::{
     log_markers::LogMarker,
     messages::WireMsgUtils,
     routing_api::command::Command,
+    Peer,
 };
 use crate::types::PublicKey;
 use backoff::{backoff::Backoff, ExponentialBackoff};
@@ -133,7 +134,7 @@ impl Core {
             self.create_or_wait_for_backoff(&src_name, &sender).await;
 
             let cmd = self
-                .send_direct_message((src_name, sender), bounced_msg, dst_section_pk)
+                .send_direct_message(Peer::new(src_name, sender), bounced_msg, dst_section_pk)
                 .await?;
 
             return Ok(vec![cmd]);
@@ -215,7 +216,7 @@ impl Core {
                 self.create_or_wait_for_backoff(name, addr).await;
 
                 let cmd = self
-                    .send_direct_message((*name, *addr), bounced_msg, dst_section_pk)
+                    .send_direct_message(Peer::new(*name, *addr), bounced_msg, dst_section_pk)
                     .await?;
                 Ok(vec![cmd])
             }
@@ -232,7 +233,7 @@ impl Core {
 
                 let cmd = self
                     .send_direct_message(
-                        (*name, *addr),
+                        Peer::new(*name, *addr),
                         bounced_msg,
                         *self.network_knowledge.genesis_key(),
                     )
@@ -313,7 +314,7 @@ impl Core {
                     trace!("{}", LogMarker::AeSendRedirect);
 
                     return Ok(Some(Command::SendMessage {
-                        recipients: vec![(src_location.name(), sender)],
+                        recipients: vec![Peer::new(src_location.name(), sender)],
                         wire_msg,
                     }));
                 }
@@ -421,7 +422,7 @@ impl Core {
         )?;
 
         Ok(Some(Command::SendMessage {
-            recipients: vec![(src_location.name(), sender)],
+            recipients: vec![Peer::new(src_location.name(), sender)],
             wire_msg,
         }))
     }
@@ -457,7 +458,7 @@ impl Core {
         trace!("{} in ae_redirect", LogMarker::AeSendRedirect);
 
         Ok(Command::SendMessage {
-            recipients: vec![(src_location.name(), sender)],
+            recipients: vec![Peer::new(src_location.name(), sender)],
             wire_msg,
         })
     }

--- a/sn/src/routing/core/msg_handling/dkg.rs
+++ b/sn/src/routing/core/msg_handling/dkg.rs
@@ -17,11 +17,11 @@ use crate::routing::{
     log_markers::LogMarker,
     network_knowledge::SectionKeyShare,
     routing_api::command::Command,
-    SectionAuthorityProviderUtils,
+    Peer, SectionAuthorityProviderUtils,
 };
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::message::Message as DkgMessage;
-use std::{collections::BTreeSet, net::SocketAddr};
+use std::collections::BTreeSet;
 use xor_name::XorName;
 
 impl Core {
@@ -164,7 +164,7 @@ impl Core {
 
     pub(crate) async fn check_lagging(
         &self,
-        peer: (XorName, SocketAddr),
+        peer: Peer,
         public_key: &BlsPublicKey,
     ) -> Result<Option<Command>> {
         if self.network_knowledge.has_chain_key(public_key).await

--- a/sn/src/routing/core/msg_handling/join.rs
+++ b/sn/src/routing/core/msg_handling/join.rs
@@ -84,7 +84,7 @@ impl Core {
             trace!("Sending {:?} to {}", node_msg, peer);
             return Ok(vec![
                 self.send_direct_message(
-                    (peer.name(), peer.addr()),
+                    peer,
                     node_msg,
                     self.network_knowledge.section_key().await,
                 )
@@ -133,7 +133,7 @@ impl Core {
             trace!("{}", LogMarker::SendJoinRetryNotCorrectKey);
             return Ok(vec![
                 self.send_direct_message(
-                    (peer.name(), peer.addr()),
+                    peer,
                     node_msg,
                     self.network_knowledge.section_key().await,
                 )
@@ -156,7 +156,7 @@ impl Core {
 
             return Ok(vec![
                 self.send_direct_message(
-                    (peer.name(), peer.addr()),
+                    peer,
                     node_msg,
                     self.network_knowledge.section_key().await,
                 )
@@ -186,12 +186,8 @@ impl Core {
                 trace!("{}", LogMarker::SendJoinRejected);
 
                 trace!("Sending {:?} to {}", node_msg, peer);
-                self.send_direct_message(
-                    (peer.name(), peer.addr()),
-                    node_msg,
-                    self.network_knowledge.section_key().await,
-                )
-                .await?
+                self.send_direct_message(peer, node_msg, self.network_knowledge.section_key().await)
+                    .await?
             } else {
                 // It's reachable, let's then send the proof challenge
                 self.send_resource_proof_challenge(&peer).await?
@@ -232,7 +228,7 @@ impl Core {
             trace!("Sending {:?} to {}", node_msg, peer);
             return Ok(vec![
                 self.send_direct_message(
-                    (peer.name(), peer.addr()),
+                    peer,
                     node_msg,
                     self.network_knowledge.section_key().await,
                 )
@@ -258,7 +254,7 @@ impl Core {
             trace!("Sending {:?} to {}", node_msg, peer);
             return Ok(vec![
                 self.send_direct_message(
-                    (peer.name(), peer.addr()),
+                    peer,
                     node_msg,
                     self.network_knowledge.section_key().await,
                 )

--- a/sn/src/routing/core/msg_handling/proposals.rs
+++ b/sn/src/routing/core/msg_handling/proposals.rs
@@ -12,7 +12,7 @@ use crate::messaging::{
     signature_aggregator::Error as AggregatorError, system::Proposal, MessageId,
 };
 use crate::routing::{
-    core::ProposalUtils, dkg::SigShare, routing_api::command::Command, Result,
+    core::ProposalUtils, dkg::SigShare, routing_api::command::Command, Peer, Result,
     SectionAuthorityProviderUtils,
 };
 use std::net::SocketAddr;
@@ -75,7 +75,10 @@ impl Core {
         }
 
         let mut commands = vec![];
-        commands.extend(self.check_lagging((src_name, sender), sig_share_pk).await?);
+        commands.extend(
+            self.check_lagging(Peer::new(src_name, sender), sig_share_pk)
+                .await?,
+        );
 
         match proposal.as_signable_bytes() {
             Err(error) => error!(

--- a/sn/src/routing/core/msg_handling/proposals.rs
+++ b/sn/src/routing/core/msg_handling/proposals.rs
@@ -15,8 +15,6 @@ use crate::routing::{
     core::ProposalUtils, dkg::SigShare, routing_api::command::Command, Peer, Result,
     SectionAuthorityProviderUtils,
 };
-use std::net::SocketAddr;
-use xor_name::XorName;
 
 // Decisions
 impl Core {
@@ -26,8 +24,7 @@ impl Core {
         msg_id: MessageId,
         proposal: Proposal,
         sig_share: SigShare,
-        src_name: XorName,
-        sender: SocketAddr,
+        sender: Peer,
     ) -> Result<Vec<Command>> {
         let sig_share_pk = &sig_share.public_key_set.public_key();
 
@@ -42,7 +39,7 @@ impl Core {
                 // it's signed by the new key created by the DKG so we don't
                 // know it yet. We only require the src_name of the
                 // proposal to be one of the DKG participants.
-                if !section_auth.contains_elder(&src_name) {
+                if !section_auth.contains_elder(&sender.name()) {
                     trace!(
                         "Ignoring proposal from src not being a DKG participant: {:?}",
                         proposal
@@ -53,11 +50,16 @@ impl Core {
         } else {
             // Proposal from other section shall be ignored.
             // TODO: check this is for our prefix , or a child prefix, otherwise just drop it
-            if !self.network_knowledge.prefix().await.matches(&src_name) {
+            if !self
+                .network_knowledge
+                .prefix()
+                .await
+                .matches(&sender.name())
+            {
                 trace!(
-                    "Ignore proposal {:?} from other section, src_name {:?}: {:?}",
+                    "Ignore proposal {:?} from other section, src {}: {:?}",
                     proposal,
-                    src_name,
+                    sender,
                     msg_id
                 );
                 return Ok(vec![]);
@@ -75,10 +77,7 @@ impl Core {
         }
 
         let mut commands = vec![];
-        commands.extend(
-            self.check_lagging(Peer::new(src_name, sender), sig_share_pk)
-                .await?,
-        );
+        commands.extend(self.check_lagging(sender, sig_share_pk).await?);
 
         match proposal.as_signable_bytes() {
             Err(error) => error!(

--- a/sn/src/routing/core/msg_handling/resource_proof.rs
+++ b/sn/src/routing/core/msg_handling/resource_proof.rs
@@ -59,11 +59,7 @@ impl Core {
         }));
 
         trace!("{}", LogMarker::SendResourceProofChallenge);
-        self.send_direct_message(
-            (peer.name(), peer.addr()),
-            response,
-            self.network_knowledge.section_key().await,
-        )
-        .await
+        self.send_direct_message(*peer, response, self.network_knowledge.section_key().await)
+            .await
     }
 }

--- a/sn/src/routing/dkg/session.rs
+++ b/sn/src/routing/dkg/session.rs
@@ -19,7 +19,7 @@ use crate::routing::{
     network_knowledge::SectionKeyShare,
     node::Node,
     routing_api::command::{next_timer_token, Command},
-    SectionAuthorityProviderUtils,
+    Peer, SectionAuthorityProviderUtils,
 };
 use crate::types::PublicKey;
 use bls::PublicKey as BlsPublicKey;
@@ -28,7 +28,6 @@ use itertools::Itertools;
 use std::{
     collections::{BTreeSet, VecDeque},
     iter, mem,
-    net::SocketAddr,
     time::Duration,
 };
 use xor_name::XorName;
@@ -83,13 +82,13 @@ impl Session {
         Ok(commands)
     }
 
-    fn recipients(&self) -> Vec<(XorName, SocketAddr)> {
+    fn recipients(&self) -> Vec<Peer> {
         self.elder_candidates
             .elders
             .iter()
             .enumerate()
             .filter(|(index, _)| *index != self.participant_index)
-            .map(|(_, (name, addr))| (*name, *addr))
+            .map(|(_, (name, addr))| Peer::new(*name, *addr))
             .collect()
     }
 
@@ -392,7 +391,7 @@ mod tests {
     use eyre::{bail, ContextCompat, Result};
     use proptest::prelude::*;
     use rand::{rngs::SmallRng, SeedableRng};
-    use std::{collections::HashMap, iter};
+    use std::{collections::HashMap, iter, net::SocketAddr};
     use xor_name::Prefix;
 
     #[tokio::test]
@@ -523,7 +522,7 @@ mod tests {
                         assert_eq!(session_id, *expected_dkg_key);
                         Ok(recipients
                             .into_iter()
-                            .map(|addr| (addr.1, message.clone()))
+                            .map(|peer| (peer.addr(), message.clone()))
                             .collect())
                     }
                     other_message => bail!("Unexpected message: {:?}", other_message),

--- a/sn/src/routing/dkg/session.rs
+++ b/sn/src/routing/dkg/session.rs
@@ -16,7 +16,7 @@ use crate::routing::{
     error::Result,
     log_markers::LogMarker,
     messages::WireMsgUtils,
-    network_knowledge::SectionKeyShare,
+    network_knowledge::{ElderCandidatesUtils, SectionKeyShare},
     node::Node,
     routing_api::command::{next_timer_token, Command},
     Peer, SectionAuthorityProviderUtils,
@@ -84,11 +84,9 @@ impl Session {
 
     fn recipients(&self) -> Vec<Peer> {
         self.elder_candidates
-            .elders
-            .iter()
+            .peers()
             .enumerate()
-            .filter(|(index, _)| *index != self.participant_index)
-            .map(|(_, (name, addr))| Peer::new(*name, *addr))
+            .filter_map(|(index, peer)| (index != self.participant_index).then(|| peer))
             .collect()
     }
 

--- a/sn/src/routing/messages/msg_authority.rs
+++ b/sn/src/routing/messages/msg_authority.rs
@@ -7,22 +7,14 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{NodeMsgAuthority, SrcLocation};
-use crate::routing::{
-    ed25519::{self},
-    error::{Error, Result},
-    Peer,
-};
+use crate::routing::ed25519::{self};
 use bls::PublicKey as BlsPublicKey;
-use std::net::SocketAddr;
 use xor_name::XorName;
 
 pub(crate) trait NodeMsgAuthorityUtils {
     fn src_location(&self) -> SrcLocation;
 
     fn name(&self) -> XorName;
-
-    // If this location is `Node`, returns the corresponding `Peer` with `addr`. Otherwise error.
-    fn peer(&self, addr: SocketAddr) -> Result<Peer>;
 
     // Verify if the section key of the NodeMsgAuthority can be trusted
     // based on a set of known keys.
@@ -52,18 +44,6 @@ impl NodeMsgAuthorityUtils for NodeMsgAuthority {
             NodeMsgAuthority::Node(node_auth) => ed25519::name(&node_auth.public_key),
             NodeMsgAuthority::BlsShare(bls_share_auth) => bls_share_auth.src_name,
             NodeMsgAuthority::Section(section_auth) => section_auth.src_name,
-        }
-    }
-
-    // If this location is `Node`, returns the corresponding `Peer` with `addr`. Otherwise error.
-    fn peer(&self, addr: SocketAddr) -> Result<Peer> {
-        match self {
-            NodeMsgAuthority::Node(node_auth) => {
-                Ok(Peer::new(ed25519::name(&node_auth.public_key), addr))
-            }
-            NodeMsgAuthority::Section(_) | NodeMsgAuthority::BlsShare(_) => {
-                Err(Error::InvalidSrcLocation)
-            }
         }
     }
 

--- a/sn/src/routing/network_knowledge/mod.rs
+++ b/sn/src/routing/network_knowledge/mod.rs
@@ -538,7 +538,7 @@ impl NetworkKnowledge {
         excluded_names: &BTreeSet<XorName>,
     ) -> Option<(ElderCandidates, ElderCandidates)> {
         trace!("{}", LogMarker::SplitAttempt);
-        if self.authority_provider().await.elders().len() < ELDER_SIZE {
+        if self.authority_provider().await.elders.len() < ELDER_SIZE {
             trace!("No attempt to split as our section does not have enough elders.");
             return None;
         }

--- a/sn/src/routing/network_knowledge/section_authority_provider.rs
+++ b/sn/src/routing/network_knowledge/section_authority_provider.rs
@@ -9,10 +9,7 @@
 use crate::messaging::{system::ElderCandidates, SectionAuthorityProvider};
 use crate::routing::{Peer, Prefix, XorName};
 use bls::{PublicKey, PublicKeySet};
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    net::SocketAddr,
-};
+use std::{collections::BTreeSet, net::SocketAddr};
 
 /// The information about elder candidates in a DKG round.
 pub(crate) trait ElderCandidatesUtils {
@@ -88,9 +85,6 @@ pub trait SectionAuthorityProviderUtils {
     /// Returns the set of elder names.
     fn names(&self) -> BTreeSet<XorName>;
 
-    /// Returns a map of name to socket_addr.
-    fn elders(&self) -> BTreeMap<XorName, SocketAddr>;
-
     /// Returns the list of socket addresses.
     fn addresses(&self) -> Vec<SocketAddr>;
 
@@ -139,7 +133,7 @@ impl SectionAuthorityProviderUtils for SectionAuthorityProvider {
     /// Returns `ElderCandidates`, which doesn't have key related infos.
     fn elder_candidates(&self) -> ElderCandidates {
         ElderCandidates {
-            elders: self.elders(),
+            elders: self.elders.clone(),
             prefix: self.prefix,
         }
     }
@@ -169,14 +163,6 @@ impl SectionAuthorityProviderUtils for SectionAuthorityProvider {
     /// Returns the set of elder names.
     fn names(&self) -> BTreeSet<XorName> {
         self.elders.keys().copied().collect()
-    }
-
-    /// Returns a map of name to socket_addr.
-    fn elders(&self) -> BTreeMap<XorName, SocketAddr> {
-        self.elders
-            .iter()
-            .map(|(name, addr)| (*name, *addr))
-            .collect()
     }
 
     fn addresses(&self) -> Vec<SocketAddr> {

--- a/sn/src/routing/network_knowledge/section_authority_provider.rs
+++ b/sn/src/routing/network_knowledge/section_authority_provider.rs
@@ -118,15 +118,10 @@ impl SectionAuthorityProviderUtils for SectionAuthorityProvider {
         elder_candidates: ElderCandidates,
         pk_set: PublicKeySet,
     ) -> SectionAuthorityProvider {
-        let elders = elder_candidates
-            .elders
-            .iter()
-            .map(|(name, addr)| (*name, *addr))
-            .collect();
         SectionAuthorityProvider {
             prefix: elder_candidates.prefix,
             public_key_set: pk_set,
-            elders,
+            elders: elder_candidates.elders,
         }
     }
 
@@ -226,11 +221,7 @@ pub(crate) mod test_utils {
         count: usize,
     ) -> (SectionAuthorityProvider, Vec<Node>, SecretKeySet) {
         let nodes = gen_sorted_nodes(&prefix, count, false);
-        let elders = nodes
-            .iter()
-            .map(Node::peer)
-            .map(|peer| (peer.name(), peer.addr()))
-            .collect();
+        let elders = nodes.iter().map(|node| (node.name(), node.addr)).collect();
 
         let secret_key_set = SecretKeySet::random();
         let section_auth = SectionAuthorityProvider::from_elder_candidates(

--- a/sn/src/routing/routing_api/command.rs
+++ b/sn/src/routing/routing_api/command.rs
@@ -86,7 +86,7 @@ pub(crate) enum Command {
     HandleDkgFailure(DkgFailureSigSet),
     /// Send a message to the given `recipients`.
     SendMessage {
-        recipients: Vec<(XorName, SocketAddr)>,
+        recipients: Vec<Peer>,
         wire_msg: WireMsg,
     },
     /// Parses WireMsg to send to the correct location
@@ -95,7 +95,7 @@ pub(crate) enum Command {
     PrepareNodeMsgToSend { msg: SystemMsg, dst: DstLocation },
     /// Send a message to `delivery_group_size` peers out of the given `recipients`.
     SendMessageDeliveryGroup {
-        recipients: Vec<(XorName, SocketAddr)>,
+        recipients: Vec<Peer>,
         delivery_group_size: usize,
         wire_msg: WireMsg,
     },

--- a/sn/src/routing/routing_api/command.rs
+++ b/sn/src/routing/routing_api/command.rs
@@ -32,7 +32,9 @@ pub(crate) enum Command {
     /// Handle `message` from `sender`.
     /// Holding the WireMsg that has been received from the network,
     HandleMessage {
-        sender: SocketAddr,
+        // This is the only command that uses `SocketAddr` instead of `Peer`, because we haven't
+        // deserialized/verified the src at this stage.
+        sender_addr: SocketAddr,
         wire_msg: WireMsg,
         #[debug(skip)]
         // original bytes to avoid reserializing for entropy checks
@@ -41,7 +43,7 @@ pub(crate) enum Command {
     // TODO: rename this as/when this is all node for clarity
     /// Handle Node, either directly or notify via event listener
     HandleSystemMessage {
-        sender: SocketAddr,
+        sender: Peer,
         msg_id: MessageId,
         msg: SystemMsg,
         msg_authority: NodeMsgAuthority,
@@ -53,7 +55,7 @@ pub(crate) enum Command {
     },
     /// Handle verified node message after aggregation either directly or notify via event listener
     HandleBlockingMessage {
-        sender: SocketAddr,
+        sender: Peer,
         msg_id: MessageId,
         msg: SystemMsg,
         msg_authority: NodeMsgAuthority,
@@ -64,14 +66,14 @@ pub(crate) enum Command {
         msg: SystemMsg,
         msg_authority: NodeMsgAuthority,
         dst_location: DstLocation,
-        sender: SocketAddr,
+        sender: Peer,
         #[debug(skip)]
         known_keys: Vec<BlsPublicKey>,
     },
     /// Handle a timeout previously scheduled with `ScheduleTimeout`.
     HandleTimeout(u64),
     /// Handle peer that's been detected as lost.
-    HandlePeerLost(SocketAddr),
+    HandlePeerLost(Peer),
     /// Handle agreement on a proposal.
     HandleAgreement { proposal: Proposal, sig: KeyedSig },
     /// Handle agree on elders. This blocks node message processing until complete.

--- a/sn/src/routing/routing_api/dispatcher.rs
+++ b/sn/src/routing/routing_api/dispatcher.rs
@@ -261,12 +261,12 @@ impl Dispatcher {
                 self.core.prepare_node_msg(msg, dst).await
             }
             Command::HandleMessage {
-                sender,
+                sender_addr,
                 wire_msg,
                 original_bytes,
             } => {
                 self.core
-                    .handle_message(sender, wire_msg, original_bytes)
+                    .handle_message(sender_addr, wire_msg, original_bytes)
                     .await
             }
             Command::HandleTimeout(token) => self.core.handle_timeout(token).await,
@@ -284,7 +284,7 @@ impl Dispatcher {
                     Ok(vec![])
                 }
             },
-            Command::HandlePeerLost(addr) => self.core.handle_peer_lost(&addr).await,
+            Command::HandlePeerLost(peer) => self.core.handle_peer_lost(&peer.addr()).await,
             Command::HandleDkgOutcome {
                 section_auth,
                 outcome,

--- a/sn/src/routing/routing_api/dispatcher.rs
+++ b/sn/src/routing/routing_api/dispatcher.rs
@@ -20,12 +20,12 @@ use crate::routing::{
     messages::WireMsgUtils,
     network_knowledge::NetworkKnowledge,
     node::Node,
-    Error, Prefix, XorName,
+    Error, Peer, Prefix, XorName,
 };
 use crate::types::PublicKey;
 use itertools::Itertools;
 use std::collections::BTreeSet;
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 use tokio::time::MissedTickBehavior;
 use tokio::{sync::watch, time};
 use tracing::Instrument;
@@ -379,7 +379,7 @@ impl Dispatcher {
 
     async fn send_message(
         &self,
-        recipients: &[(XorName, SocketAddr)],
+        recipients: &[Peer],
         delivery_group_size: usize,
         wire_msg: WireMsg,
     ) -> Result<Vec<Command>> {
@@ -404,7 +404,7 @@ impl Dispatcher {
 
     async fn deliver_messages(
         &self,
-        recipients: &[(XorName, SocketAddr)],
+        recipients: &[Peer],
         delivery_group_size: usize,
         wire_msg: WireMsg,
     ) -> Result<Vec<Command>> {
@@ -436,7 +436,7 @@ impl Dispatcher {
                 // or validated as part of the routing library.
                 debug!("Sending client msg to {:?}: {:?}", socket_addr, wire_msg);
 
-                let recipients = vec![(*name, socket_addr)];
+                let recipients = vec![Peer::new(*name, socket_addr)];
                 wire_msg.set_dst_section_pk(self.core.network_knowledge().section_key().await);
 
                 let command = Command::SendMessage {

--- a/sn/src/routing/routing_api/mod.rs
+++ b/sn/src/routing/routing_api/mod.rs
@@ -449,11 +449,11 @@ async fn handle_connection_events(
 ) {
     while let Some(event) = incoming_conns.recv().await {
         match event {
-            ConnectionEvent::Received((sender, bytes)) => {
+            ConnectionEvent::Received((sender_addr, bytes)) => {
                 trace!(
                     "New message ({} bytes) received from: {}",
                     bytes.len(),
-                    sender
+                    sender_addr
                 );
 
                 // bytes.clone is cheap
@@ -467,19 +467,19 @@ async fn handle_connection_events(
 
                 let span = {
                     let core = &dispatcher.core;
-                    trace_span!("handle_message", name = %core.node.read().await.name(), %sender, msg_id = ?wire_msg.msg_id())
+                    trace_span!("handle_message", name = %core.node.read().await.name(), %sender_addr, msg_id = ?wire_msg.msg_id())
                 };
                 let _span_guard = span.enter();
                 let len = bytes.len();
                 let command = Command::HandleMessage {
-                    sender,
+                    sender_addr,
                     wire_msg,
                     original_bytes: Some(bytes),
                 };
                 trace!(
                     "{:?} from {} length {}",
                     LogMarker::DispatchHandleMsgCmd,
-                    sender,
+                    sender_addr,
                     len,
                 );
 

--- a/sn/src/routing/routing_api/tests/mod.rs
+++ b/sn/src/routing/routing_api/tests/mod.rs
@@ -567,7 +567,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
         let expected_dkg_start_recipients: Vec<_> = expected_new_elders
             .iter()
             .filter(|peer| peer.name() != node_name)
-            .map(|peer| (peer.name(), peer.addr()))
+            .copied()
             .collect();
         assert_eq!(recipients, expected_dkg_start_recipients);
 
@@ -623,7 +623,7 @@ async fn handle_online_command(
                 } = *response
                 {
                     assert_eq!(section_signed_sap.value, *section_auth);
-                    assert_eq!(recipients, [(peer.name(), peer.addr())]);
+                    assert_eq!(recipients, [*peer]);
                     status.node_approval_sent = true;
                 }
             }
@@ -635,7 +635,7 @@ async fn handle_online_command(
                     continue;
                 }
 
-                assert_eq!(recipients, [(peer.name(), peer.addr())]);
+                assert_eq!(recipients, [*peer]);
 
                 status.relocate_details = Some(details.clone());
             }
@@ -859,9 +859,8 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
         itertools::assert_equal(actual_elder_candidates.peers(), expected_new_elders.clone());
 
         let expected_dkg_start_recipients: Vec<_> = expected_new_elders
-            .iter()
+            .into_iter()
             .filter(|peer| peer.name() != node_name)
-            .map(|peer| (peer.name(), peer.addr()))
             .collect();
 
         assert_eq!(recipients, expected_dkg_start_recipients);
@@ -1162,7 +1161,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
 
         if recipients
             .into_iter()
-            .map(|recp| recp.1)
+            .map(|recp| recp.addr())
             .collect::<Vec<_>>()
             != [relocated_peer.addr()]
         {
@@ -1258,7 +1257,7 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
     let commands = dispatcher
         .handle_command(
             Command::SendMessage {
-                recipients: vec![(node.name(), node.addr)],
+                recipients: vec![node.peer()],
                 wire_msg,
             },
             "cmd-id",
@@ -1399,10 +1398,9 @@ async fn handle_elders_update() -> Result<()> {
 
     let update_expected_recipients: HashSet<_> = other_elder_peers
         .into_iter()
-        .map(|peer| (peer.name(), peer.addr()))
-        .chain(iter::once((promoted_peer.name(), promoted_peer.addr())))
-        .chain(iter::once((demoted_peer.name(), demoted_peer.addr())))
-        .chain(iter::once((adult_peer.name(), adult_peer.addr())))
+        .chain(iter::once(promoted_peer))
+        .chain(iter::once(demoted_peer))
+        .chain(iter::once(adult_peer))
         .collect();
 
     assert_eq!(update_actual_recipients, update_expected_recipients);
@@ -1529,8 +1527,8 @@ async fn handle_demote_during_split() -> Result<()> {
                 ..
             })
         ) {
-            for (name, socket) in recipients {
-                let _old = update_recipients.insert(name, socket);
+            for recipient in recipients {
+                let _old = update_recipients.insert(recipient.name(), recipient.addr());
             }
         }
     }

--- a/sn/src/routing/routing_api/tests/mod.rs
+++ b/sn/src/routing/routing_api/tests/mod.rs
@@ -104,7 +104,7 @@ async fn receive_join_request_without_resource_proof_response() -> Result<()> {
 
     let mut commands = get_internal_commands(
         Command::HandleMessage {
-            sender: new_node.addr,
+            sender_addr: new_node.addr,
             wire_msg,
             original_bytes: None,
         },
@@ -198,7 +198,7 @@ async fn receive_join_request_with_resource_proof_response() -> Result<()> {
 
     let commands = get_internal_commands(
         Command::HandleMessage {
-            sender: new_node.addr,
+            sender_addr: new_node.addr,
             wire_msg,
             original_bytes: None,
         },
@@ -304,7 +304,7 @@ async fn receive_join_request_from_relocated_node() -> Result<()> {
 
     let inner_commands = get_internal_commands(
         Command::HandleMessage {
-            sender: relocated_node.addr,
+            sender_addr: relocated_node.addr,
             wire_msg,
             original_bytes: None,
         },
@@ -378,7 +378,7 @@ async fn aggregate_proposals() -> Result<()> {
 
         let commands = get_internal_commands(
             Command::HandleMessage {
-                sender: node.addr,
+                sender_addr: node.addr,
                 wire_msg,
                 original_bytes: None,
             },
@@ -414,7 +414,7 @@ async fn aggregate_proposals() -> Result<()> {
 
     let mut commands = get_internal_commands(
         Command::HandleMessage {
-            sender: nodes[THRESHOLD].addr,
+            sender_addr: nodes[THRESHOLD].addr,
             wire_msg,
             original_bytes: None,
         },
@@ -974,7 +974,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
 
     let _commands = get_internal_commands(
         Command::HandleMessage {
-            sender: old_node.addr,
+            sender_addr: old_node.addr,
             wire_msg,
             original_bytes: None,
         },
@@ -1054,7 +1054,7 @@ async fn untrusted_ae_message_msg_errors() -> Result<()> {
 
     let _commands = get_internal_commands(
         Command::HandleMessage {
-            sender: sender.addr,
+            sender_addr: sender.addr,
             wire_msg,
             original_bytes: None,
         },


### PR DESCRIPTION
- 6959cbf7f **refactor(sn): replace `(XorName, SocketAddr)` with `Peer`**

  In many places, we pass around `Peer`s which were then converted to
  `(XorName, SocketAddr)`. Most of the time this ends up at the
  `Comm::send*` methods. These methods have been updated to take `Peer`,
  and this change has been propagated to anything else that was storing or
  passing `(XorName, SocketAddr)`. Overall this is a nice simplification,
  and removes more conversions than it introduces.

- e92677fee **refactor(sn)!: remove `SectionAuthorityProviderUtils::elders`**

  Since the `elders` field of `SectionAuthorityProvider` is public, this
  method is essentially equivalent to `sap.elders.clone()`. Furthermore,
  it was barely used (5 call sites).
  
  BREAKING CHANGE: The `SectionAuthorityProviderUtils` trait's `elders`
  method has been removed.

- 9f39635e1 **refactor(sn): use `peers()` instead of `Peer::new` when available**

  This was only useful in a couple of places, but it makes sense to use
  the `peers` method when it exists.

- 3597f7df8 **refactor(sn): simplify some iterator chains**


- 971dffa38 **refactor(sn): thread a `Peer` through more places**

  Rather than using separate `XorName` and `SocketAddr` arguments/fields,
  we can use `Peer`. This doesn't buy us much currently, but in future we
  could store an open `Connection` to the peer inside the struct, letting
  us reuse connections to reply to incoming messages etc.
