### PR TITLE
chore: use explicit version for sn_api

### DIFF
--- a/sn_cmd_test_utilities/Cargo.toml
+++ b/sn_cmd_test_utilities/Cargo.toml
@@ -15,7 +15,7 @@ ctor = "~0.1"
 rand = "~0.7.3"
 serde = "1.0.123"
 serde_json = "1.0.62"
-sn_api = { path = "../sn_api", version = "~0.38", default-features=false, features = ["app", "authd_client"] }
+sn_api = { path = "../sn_api", version = "0.38.0", default-features=false, features = ["app", "authd_client"] }
 walkdir = "2.3.1"
 multibase = "~0.6.0"
 


### PR DESCRIPTION
The `smart-release` tool doesn't support using the `~` method for crates within the workspace.
