### PR TITLE
chore: update sn_api reference style

### DIFF
--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -32,6 +32,7 @@ pretty-hex = "~0.2"
 prettytable-rs = "~0.8"
 rand = "~0.7"
 relative-path = "1.3.2"
+sn_api = { path = "../sn_api", version = "0.38.0", default-features=false, features = ["app", "authd_client"] }
 sn_launch_tool = "~0.7.0"
 serde = "1.0.123"
 serde_json = "1.0.62"
@@ -43,50 +44,44 @@ tracing-subscriber = "~0.2.15"
 url = "2.2.2"
 xor_name = "3.0.0"
 
-  [dependencies.bls]
-  package = "blsttc"
-  version = "2.0.1"
+[dependencies.bls]
+package = "blsttc"
+version = "2.0.1"
 
-  [dependencies.bytes]
-  version = "1.0.1"
-  features = [ "serde" ]
+[dependencies.bytes]
+version = "1.0.1"
+features = [ "serde" ]
 
-  [dependencies.ed25519-dalek]
-  version = "1.0.1"
-  features = [ "serde" ]
+[dependencies.ed25519-dalek]
+version = "1.0.1"
+features = [ "serde" ]
 
-  [dependencies.indicatif]
-  git = "https://github.com/mibac138/indicatif"
-  branch = "mpb-tick"
+[dependencies.indicatif]
+git = "https://github.com/mibac138/indicatif"
+branch = "mpb-tick"
 
-  [dependencies.reqwest]
-  version = "~0.11"
-  default-features = false
-  features = [ "rustls-tls" ]
-  optional = true
+[dependencies.reqwest]
+version = "~0.11"
+default-features = false
+features = [ "rustls-tls" ]
+optional = true
 
-  [dependencies.sn_api]
-  path = "../sn_api"
-  version = "~0.38"
-  default-features = false
-  features = [ "app", "authd_client", "testing" ]
+[dependencies.tokio]
+version = "1.6.0"
+features = [ "macros" ]
 
-  [dependencies.tokio]
-  version = "1.6.0"
-  features = [ "macros" ]
-
-  [dependencies.self_update]
-  git = "https://github.com/jacderida/self_update.git"
-  branch = "github_download_json_parsing"
-  default-features = false
-  features = [
-  "rustls",
-  "archive-tar",
-  "archive-zip",
-  "compression-flate2",
-  "compression-zip-deflate"
+[dependencies.self_update]
+git = "https://github.com/jacderida/self_update.git"
+branch = "github_download_json_parsing"
+default-features = false
+features = [
+    "rustls",
+    "archive-tar",
+    "archive-zip",
+    "compression-flate2",
+    "compression-zip-deflate"
 ]
-  optional = true
+optional = true
 
 [features]
 default = [ "testing", "self-update" ]


### PR DESCRIPTION
This way of referencing seems to be required for `smart-release`.

Also took the opportunity to fix the indentation on the other references, as there appeared to be no reason for them to be indented.