### PR TITLE
chore: avoid rebuild on windows for testnet

### DIFF
--- a/sn/src/bin/testnet.rs
+++ b/sn/src/bin/testnet.rs
@@ -30,11 +30,9 @@
 use dirs_next::home_dir;
 use eyre::{eyre, Result, WrapErr as _};
 use sn_launch_tool::Launch;
-use std::{
-    io,
-    path::PathBuf,
-    process::{Command, Stdio},
-};
+#[cfg(not(target_os = "windows"))]
+use std::process::{Command, Stdio};
+use std::{io, path::PathBuf};
 use structopt::StructOpt;
 use tokio::fs::{create_dir_all, remove_dir_all};
 use tokio::time::{sleep, Duration};
@@ -77,33 +75,41 @@ async fn main() -> Result<()> {
         .await
         .wrap_err("Cannot create nodes directory")?;
 
-    let mut args = vec!["build", "--release"];
+    // TODO:: Remove this conditional compilation once the issue on Windows
+    // got resoved within the new version of Rust.
+    #[cfg(not(target_os = "windows"))]
+    // For Windows guys, rember to use
+    // `cargo build --release --features=always-joinable,test-utils --bins`
+    // before executing the testnet.exe.
+    {
+        let mut args = vec!["build", "--release"];
 
-    // Keep features consistent to avoid recompiling when possible
-    if cfg!(feature = "always-joinable") {
-        args.push("--features");
-        args.push("always-joinable");
+        // Keep features consistent to avoid recompiling when possible
+        if cfg!(feature = "always-joinable") {
+            args.push("--features");
+            args.push("always-joinable");
+        }
+        if cfg!(feature = "test-utils") {
+            args.push("--features");
+            args.push("test-utils");
+        }
+
+        info!("Building current sn_node");
+        debug!("Building current sn_node with args: {:?}", args);
+        Command::new("cargo")
+            .args(args.clone())
+            .current_dir("sn")
+            // .env("RUST_LOG", "debug")
+            // .env("RUST_BACKTRACE", "1")
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .output()
+            .map_err(Into::into)
+            .and_then(|result| result.status.success().then(|| ()).ok_or_else(|| eyre!("Command exited with error")))
+            .wrap_err_with(|| format!("Failed to run build command with args: {:?}", args))?;
+
+        info!("sn_node built successfully");
     }
-    if cfg!(feature = "test-utils") {
-        args.push("--features");
-        args.push("test-utils");
-    }
-
-    info!("Building current sn_node");
-    debug!("Building current sn_node with args: {:?}", args);
-    Command::new("cargo")
-        .args(args.clone())
-        .current_dir("sn")
-        // .env("RUST_LOG", "debug")
-        // .env("RUST_BACKTRACE", "1")
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .output()
-        .map_err(Into::into)
-        .and_then(|result| result.status.success().then(|| ()).ok_or_else(|| eyre!("Command exited with error")))
-        .wrap_err_with(|| format!("Failed to run build command with args: {:?}", args))?;
-
-    info!("sn_node built successfully");
 
     run_network().await?;
 


### PR DESCRIPTION
Windows OS has an issue of re-building as unable to remove testnet.exe.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
