### PR TITLE
refactor(routing): use the prefix map updating outcome to decide if current SAP and chain shall be updated

### DIFF
--- a/sn/src/routing/core/mod.rs
+++ b/sn/src/routing/core/mod.rs
@@ -249,10 +249,7 @@ impl Core {
             }
 
             if new.is_elder || old.is_elder {
-                commands.extend(
-                    self.send_ae_update_to_our_section(&self.network_knowledge)
-                        .await?,
-                );
+                commands.extend(self.send_ae_update_to_our_section().await);
             }
 
             let current: BTreeSet<_> = self.network_knowledge.authority_provider().await.names();
@@ -304,8 +301,8 @@ impl Core {
 
             let event = if let Some(sibling_elders) = sibling_elders {
                 info!("{}: {:?}", LogMarker::SplitSuccess, new.prefix);
-                // In case of split, send AEUpdate to sibling new elder nodes.
-                commands.extend(self.send_ae_update_to_sibling_section(&old).await?);
+                // In case of split, send AE-Update to sibling new elder nodes.
+                commands.extend(self.send_ae_update_to_sibling_section(&old).await);
 
                 Event::SectionSplit {
                     elders,

--- a/sn/src/routing/routing_api/mod.rs
+++ b/sn/src/routing/routing_api/mod.rs
@@ -172,6 +172,7 @@ impl Routing {
                 bootstrap_addr,
                 genesis_key
             );
+
             let joining_node = Node::new(keypair, comm.our_connection_info());
             let (node, network_knowledge) = join_network(
                 joining_node,

--- a/sn/src/routing/routing_api/tests/mod.rs
+++ b/sn/src/routing/routing_api/tests/mod.rs
@@ -898,7 +898,6 @@ enum UntrustedMessageSource {
 
 #[tokio::test(flavor = "multi_thread")]
 // Checking when we get AE info that is ahead of us we should handle it.
-#[ignore = "FIXME: once we have a DAG to manage all sections chains, this test can be re-enabled"]
 async fn ae_msg_from_the_future_is_handled() -> Result<()> {
     // Create first `Section` with a chain of length 2
     let sk0 = bls::SecretKey::random();
@@ -1287,7 +1286,6 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "FIXME: once we have a DAG to manage all sections chains, this test can be re-enabled"]
 async fn handle_elders_update() -> Result<()> {
     crate::init_test_logger();
     let _span = tracing::info_span!("handle_elders_update").entered();


### PR DESCRIPTION
This also prevents routing from bailing out fro a command processing when some msgs cannot be sent out, errors are logged but the rest of the process for a commands continues to completion.