### PR TITLE
fix(sn_api): set `formatting` feature for `time` dependency

### DIFF
--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1.0.62"
 sha3 = "~0.9"
 safe_network = { path = "../sn", version = "0.36.3" }
 thiserror = "1.0.23"
-time = "0.3.4"
+time = { version = "0.3.4", features = ["formatting"] }
 uhttp_uri = "~0.5"
 url = "2.2.0"
 urlencoding = "1.1.1"


### PR DESCRIPTION
- b05f7b64c **fix(sn_api): set `formatting` feature for `time` dependency**

  We use time formatting, so this feature should be necessary for the
  crate to compile. Weirdly, compilation only fails when publishing, not
  when checking or building. It's assumed this has something to do with
  feature resolution in workspaces 🤷
