### PR TITLE
fix(sn): fix `Eq` for `SectionPeers`

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -304,7 +304,7 @@ jobs:
 
       - name: Run sn_api tests
         run: ./resources/scripts/api_tests.sh
-        timeout-minutes: 5
+        timeout-minutes: 15
 
       - name: Are nodes still running...?
         if: failure() && matrix.os != 'windows-latest'

--- a/sn/src/messaging/system/section/mod.rs
+++ b/sn/src/messaging/system/section/mod.rs
@@ -31,7 +31,7 @@ pub struct SectionPeers {
 impl Eq for SectionPeers {}
 
 impl PartialEq for SectionPeers {
-    fn eq(&self, _other: &Self) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         // TODO: there must be a better way of doing this...
         let mut us: BTreeMap<XorName, SectionAuth<NodeState>> = BTreeMap::default();
         let mut them: BTreeMap<XorName, SectionAuth<NodeState>> = BTreeMap::default();
@@ -41,7 +41,7 @@ impl PartialEq for SectionPeers {
             let _prev = us.insert(*key, value.clone());
         }
 
-        for refmulti in self.members.iter() {
+        for refmulti in other.members.iter() {
             let (key, value) = refmulti.pair();
             let _prev = them.insert(*key, value.clone());
         }


### PR DESCRIPTION
- 1fcbabb12 **fix(sn): fix `Eq` for `SectionPeers`**

  This would have always returned true, since it was comparing with
  itself...
