### PR TITLE
ci: release workflow for safe_network crate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,217 +1,107 @@
-# main workflow
-#
-# Runs when a PR has been merged to the main branch.
-#
-# 1. Generates a release build.
-# 2. If the last commit is a chore(release), publish.
-
-name: Main
+name: 'workspace: release'
 
 on:
   push:
     branches:
       - main
 
-env:
-  RUST_BACKTRACE: 1
-
 jobs:
-
-  build_win_mac:
+  build:
     if: github.repository_owner == 'maidsafe'
-    name: Build Windows & macOS
+    name: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
         include:
           - os: windows-latest
-            build-script: make build
             target: x86_64-pc-windows-msvc
-          - os: macOS-latest
-            build-script: make build
+          - os: macos-latest
             target: x86_64-apple-darwin
-    steps:
-      - uses: actions/checkout@v2
-
-      # Install Rust
-      - uses: actions-rs/toolchain@v1
-        id: toolchain
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      # Cache.
-      - name: Cargo cache registry, index and build
-        uses: actions/cache@v2.1.4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}-${{ github.job }}
-
-      # Run build.
-      - shell: bash
-        run: ${{ matrix.build-script }}
-
-      # Upload artifacts.
-      - uses: actions/upload-artifact@master
-        with:
-          name: sn_node-${{ matrix.target }}-prod
-          path: artifacts
-
-  build_linux:
-    if: github.repository_owner == 'maidsafe'
-    name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        include:
           - os: ubuntu-latest
-            build-script: make musl
             target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: arm-unknown-linux-musleabi
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v2
-
-      # Install Rust
       - uses: actions-rs/toolchain@v1
         id: toolchain
         with:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Cache.
-      - name: Cargo cache registry, index and build
-        uses: actions/cache@v2.1.4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}-${{ github.job }}
-
-      # Run build.
       - shell: bash
-        run: ${{ matrix.build-script }}
-
-      # Upload artifacts.
+        run: make gha-build-${{ matrix.target }}
       - uses: actions/upload-artifact@master
         with:
-          name: sn_node-${{ matrix.target }}-prod
+          name: safe_network-${{ matrix.target }}
           path: artifacts
 
-  build_arm:
-    if: github.repository_owner == 'maidsafe'
-    name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        target: [arm-unknown-linux-musleabi, armv7-unknown-linux-musleabihf, aarch64-unknown-linux-musl]
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        id: toolchain
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Cargo cache registry, index and build
-        uses: actions/cache@v2.1.4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.target }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}-${{ github.job }}
-
-      - shell: bash
-        run: make ${{ matrix.target }}
-
-      - uses: actions/upload-artifact@master
-        with:
-          name: sn_node-${{ matrix.target }}-prod
-          path: artifacts
-
-  # Deploy to GH Release and S3 if we're on a `chore(release):` commit
-  deploy:
+  gh_release:
     if: |
       github.repository_owner == 'maidsafe' &&
       startsWith(github.event.head_commit.message, 'chore(release):')
-    name: Deploy
+    name: create github release
     runs-on: ubuntu-latest
-    needs: [build_win_mac, build_linux, build_arm]
+    needs: [build]
     env:
       AWS_ACCESS_KEY_ID: AKIAVVODCRMSJ5MV63VB
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: eu-west-2
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      # Checkout and get all the artifacts built in the previous jobs.
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@master
         with:
-          name: sn_node-x86_64-pc-windows-msvc-prod
+          name: safe_network-x86_64-pc-windows-msvc
           path: artifacts/prod/x86_64-pc-windows-msvc/release
       - uses: actions/download-artifact@master
         with:
-          name: sn_node-x86_64-unknown-linux-musl-prod
+          name: safe_network-x86_64-unknown-linux-musl
           path: artifacts/prod/x86_64-unknown-linux-musl/release
       - uses: actions/download-artifact@master
         with:
-          name: sn_node-x86_64-apple-darwin-prod
+          name: safe_network-x86_64-apple-darwin
           path: artifacts/prod/x86_64-apple-darwin/release
       - uses: actions/download-artifact@master
         with:
-          name: sn_node-arm-unknown-linux-musleabi-prod
+          name: safe_network-arm-unknown-linux-musleabi
           path: artifacts/prod/arm-unknown-linux-musleabi/release
       - uses: actions/download-artifact@master
         with:
-          name: sn_node-armv7-unknown-linux-musleabihf-prod
+          name: safe_network-armv7-unknown-linux-musleabihf
           path: artifacts/prod/armv7-unknown-linux-musleabihf/release
       - uses: actions/download-artifact@master
         with:
-          name: sn_node-aarch64-unknown-linux-musl-prod
+          name: safe_network-aarch64-unknown-linux-musl
           path: artifacts/prod/aarch64-unknown-linux-musl/release
 
-      # Get information for the release.
       - shell: bash
-        id: commit_message
-        run: |
-          commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
-          echo "::set-output name=commit_message::$commit_message"
+        run: make safe_network-package-version-artifacts-for-release
+
       - shell: bash
         id: versioning
         run: |
-          version=$(grep "^version" < Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+          version=$(grep "^version" < sn/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
           echo "::set-output name=version::$version"
 
-      # Create `deploy` directory and put the artifacts into tar/zip archives for deployment with the release.
-      - name: chmod
+      - name: generate release description first pass
         shell: bash
-        run: chmod -R +x artifacts/prod
-      - shell: bash
-        run: make package-version-artifacts-for-deploy
-
-      # Get release description (requires generated archives)
-      - name: Generate Release Description
-        shell: bash
-        id: release_description
         run: |
-          ./scripts/get_release_description.sh ${{ steps.versioning.outputs.version }} > RELEASE_DESCRIPTION.txt
+          ./resources/scripts/get_release_description.sh "${{ steps.versioning.outputs.version }}" > release_description.md
 
-      # Upload all the release archives to S3
-      - name: Upload archives to S3
-        run: aws s3 sync deploy/prod s3://sn-node --acl public-read
+      # The second pass uses Python to extract the changelog entries for this version.
+      # Python can easily do a string replace and avoid all the pain with newlines you get in Bash.
+      # The script operates on the release_description.md that was generated in the previous step.
+      - name: generate release description second pass
+        shell: bash
+        run: |
+          ./resources/scripts/insert_changelog_entry.py "${{ steps.versioning.outputs.version }}"
 
-      # Create the release and attach the generated description
-      - name: Create GitHub Release
+      - name: create github release
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -221,9 +111,8 @@ jobs:
           release_name: Safe Network v${{ steps.versioning.outputs.version }}
           draft: false
           prerelease: false
-          body_path: RELEASE_DESCRIPTION.txt
+          body_path: release_description.md
 
-      # Upload zip files
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -266,7 +155,6 @@ jobs:
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-aarch64-unknown-linux-musl.zip
           asset_content_type: application/zip
 
-      # Upload tar files
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -309,30 +197,23 @@ jobs:
           asset_name: sn_node-${{ steps.versioning.outputs.version }}-aarch64-unknown-linux-musl.tar.gz
           asset_content_type: application/zip
 
-  # Publish if we're on a `chore(release):` commit
   publish:
-    name: Publish
+    name: publish
     runs-on: ubuntu-latest
-    needs: [deploy]
+    needs: [gh_release]
     if: |
       github.repository_owner == 'maidsafe' &&
       startsWith(github.event.head_commit.message, 'chore(release):')
     steps:
       - uses: actions/checkout@v2
-      # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
         with:
           fetch-depth: '0'
-
-      # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Publish to crates.io.
-      - name: Cargo Login
+      - name: cargo login
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-
-      - name: Cargo Publish
-        run: cargo publish --allow-dirty
+      - name: cargo publish
+        run: cd sn && cargo publish --allow-dirty

--- a/resources/scripts/get_release_description.sh
+++ b/resources/scripts/get_release_description.sh
@@ -10,87 +10,86 @@ fi
 read -r -d '' release_description << 'EOF'
 Command line interface for the Safe Network. Refer to [Safe CLI User Guide](https://github.com/maidsafe/sn_cli/blob/master/README.md) for detailed instructions.
 
-## SHA-256 checksums for CLI binaries:
+## Safe Network Changelog
+
+__SN_CHANGELOG_TEXT__
+
+## SHA-256 checksums for sn_node binaries:
 ```
 Linux
-zip: ZIP_LINUX_CHECKSUM
-tar.gz: TAR_LINUX_CHECKSUM
+zip: SN_ZIP_LINUX_CHECKSUM
+tar.gz: SN_TAR_LINUX_CHECKSUM
 
 macOS
-zip: ZIP_MACOS_CHECKSUM
-tar.gz: TAR_MACOS_CHECKSUM
+zip: SN_ZIP_MACOS_CHECKSUM
+tar.gz: SN_TAR_MACOS_CHECKSUM
 
 Windows
-zip: ZIP_WIN_CHECKSUM
-tar.gz: TAR_WIN_CHECKSUM
+zip: SN_ZIP_WIN_CHECKSUM
+tar.gz: SN_TAR_WIN_CHECKSUM
 
 ARM
-zip: ZIP_ARM_CHECKSUM
-tar.gz: TAR_ARM_CHECKSUM
+zip: SN_ZIP_ARM_CHECKSUM
+tar.gz: SN_TAR_ARM_CHECKSUM
 
 ARMv7
-zip: ZIP_ARMv7_CHECKSUM
-tar.gz: TAR_ARMv7_CHECKSUM
+zip: SN_ZIP_ARMv7_CHECKSUM
+tar.gz: SN_TAR_ARMv7_CHECKSUM
 
 Aarch64
-zip: ZIP_AARCH64_CHECKSUM
-tar.gz: TAR_AARCH64_CHECKSUM
+zip: SN_ZIP_AARCH64_CHECKSUM
+tar.gz: SN_TAR_AARCH64_CHECKSUM
 ```
-
-## Related Links
-* [Safe CLI User Guide](https://github.com/maidsafe/sn_cli/blob/master/README.md)
-* [Safe Network Browser](https://github.com/maidsafe/sn_browser/releases/)
-* [Safe Network Node](https://github.com/maidsafe/sn_node/releases/latest/)
 EOF
 
-zip_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-x86_64-unknown-linux-musl.zip" | \
+sn_zip_linux_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-x86_64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
-zip_macos_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-x86_64-apple-darwin.zip" | \
+sn_zip_macos_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-x86_64-apple-darwin.zip" | \
     awk '{ print $1 }')
-zip_win_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-x86_64-pc-windows-msvc.zip" | \
+sn_zip_win_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-x86_64-pc-windows-msvc.zip" | \
     awk '{ print $1 }')
-zip_arm_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-arm-unknown-linux-musleabi.zip" | \
+sn_zip_arm_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-arm-unknown-linux-musleabi.zip" | \
     awk '{ print $1 }')
-zip_armv7_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-armv7-unknown-linux-musleabihf.zip" | \
+sn_zip_armv7_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-armv7-unknown-linux-musleabihf.zip" | \
     awk '{ print $1 }')
-zip_aarch64_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-aarch64-unknown-linux-musl.zip" | \
+sn_zip_aarch64_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-aarch64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
-tar_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-x86_64-unknown-linux-musl.tar.gz" | \
+sn_tar_linux_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-x86_64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
-tar_macos_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-x86_64-apple-darwin.tar.gz" | \
+sn_tar_macos_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-x86_64-apple-darwin.tar.gz" | \
     awk '{ print $1 }')
-tar_win_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-x86_64-pc-windows-msvc.tar.gz" | \
+sn_tar_win_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-x86_64-pc-windows-msvc.tar.gz" | \
     awk '{ print $1 }')
-tar_arm_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-arm-unknown-linux-musleabi.tar.gz" | \
+sn_tar_arm_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-arm-unknown-linux-musleabi.tar.gz" | \
     awk '{ print $1 }')
-tar_armv7_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-armv7-unknown-linux-musleabihf.tar.gz" | \
+sn_tar_armv7_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-armv7-unknown-linux-musleabihf.tar.gz" | \
     awk '{ print $1 }')
-tar_aarch64_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$version-aarch64-unknown-linux-musl.tar.gz" | \
+sn_tar_aarch64_checksum=$(sha256sum \
+    "./deploy/prod/sn_node-$version-aarch64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 
-release_description=$(sed "s/ZIP_LINUX_CHECKSUM/$zip_linux_checksum/g" <<< "$release_description")
-release_description=$(sed "s/ZIP_MACOS_CHECKSUM/$zip_macos_checksum/g" <<< "$release_description")
-release_description=$(sed "s/ZIP_WIN_CHECKSUM/$zip_win_checksum/g" <<< "$release_description")
-release_description=$(sed "s=ZIP_ARM_CHECKSUM=$zip_arm_checksum=g" <<< "$release_description")
-release_description=$(sed "s=ZIP_ARMv7_CHECKSUM=$zip_armv7_checksum=g" <<< "$release_description")
-release_description=$(sed "s=ZIP_AARCH64_CHECKSUM=$zip_aarch64_checksum=g" <<< "$release_description")
-release_description=$(sed "s/TAR_LINUX_CHECKSUM/$tar_linux_checksum/g" <<< "$release_description")
-release_description=$(sed "s/TAR_MACOS_CHECKSUM/$tar_macos_checksum/g" <<< "$release_description")
-release_description=$(sed "s/TAR_WIN_CHECKSUM/$tar_win_checksum/g" <<< "$release_description")
-release_description=$(sed "s=TAR_ARM_CHECKSUM=$tar_arm_checksum=g" <<< "$release_description")
-release_description=$(sed "s=TAR_ARMv7_CHECKSUM=$tar_armv7_checksum=g" <<< "$release_description")
-release_description=$(sed "s=TAR_AARCH64_CHECKSUM=$tar_aarch64_checksum=g" <<< "$release_description")
+release_description=$(sed "s/SN_ZIP_LINUX_CHECKSUM/$sn_zip_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/SN_ZIP_MACOS_CHECKSUM/$sn_zip_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/SN_ZIP_WIN_CHECKSUM/$sn_zip_win_checksum/g" <<< "$release_description")
+release_description=$(sed "s=SN_ZIP_ARM_CHECKSUM=$sn_zip_arm_checksum=g" <<< "$release_description")
+release_description=$(sed "s=SN_ZIP_ARMv7_CHECKSUM=$sn_zip_armv7_checksum=g" <<< "$release_description")
+release_description=$(sed "s=SN_ZIP_AARCH64_CHECKSUM=$sn_zip_aarch64_checksum=g" <<< "$release_description")
+release_description=$(sed "s/SN_TAR_LINUX_CHECKSUM/$sn_tar_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/SN_TAR_MACOS_CHECKSUM/$sn_tar_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/SN_TAR_WIN_CHECKSUM/$sn_tar_win_checksum/g" <<< "$release_description")
+release_description=$(sed "s=SN_TAR_ARM_CHECKSUM=$sn_tar_arm_checksum=g" <<< "$release_description")
+release_description=$(sed "s=SN_TAR_ARMv7_CHECKSUM=$sn_tar_armv7_checksum=g" <<< "$release_description")
+release_description=$(sed "s=SN_TAR_AARCH64_CHECKSUM=$sn_tar_aarch64_checksum=g" <<< "$release_description")
 
 echo "$release_description"

--- a/resources/scripts/insert_changelog_entry.py
+++ b/resources/scripts/insert_changelog_entry.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# The changelog file contains the changes for every version that's been released.
+# For a release, we want to extract the changelog entry for a particular version and
+# put that into the release description. This gets very painful in Bash because the entry
+# contains newline characters.
+
+import sys
+
+def get_changelog_entry(version):
+    sn_changelog_content = ""
+    with open("sn/CHANGELOG.md", "r") as sn_changelog_file:
+        sn_changelog_content = sn_changelog_file.read()
+    start = sn_changelog_content.find("## v{version}".format(version=version))
+    end = sn_changelog_content.find("## v", start + 10)
+    return sn_changelog_content[start:end].strip()
+
+def insert_changelog_entry(entry):
+    release_description = ""
+    with open("release_description.md", "r") as file:
+        release_description = file.read()
+        release_description = release_description.replace("__SN_CHANGELOG_TEXT__", entry)
+    with open("release_description.md", "w") as file:
+        file.write(release_description)
+
+def main(version):
+    sn_changelog_entry = get_changelog_entry(version)
+    insert_changelog_entry(sn_changelog_entry)
+
+if __name__ == "__main__":
+    version = sys.argv[1]
+    main(version)


### PR DESCRIPTION
The release process is largely the same, but with the introduction of the workspace I've just taken the opportunity to tidy up the workflow a little bit.

To make it a bit more descriptive, the workflow was renamed to 'release' rather than 'main'.

This workflow will be extended to include the changelogs and assets for `sn_api` and `sn_cli`.

I've tested it on my fork:
https://github.com/jacderida/safe_network/releases/tag/v0.38.0