### PR TITLE
ci: release workflow for sn_api crate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,13 +85,12 @@ jobs:
       - shell: bash
         id: versioning
         run: |
-          version=$(grep "^version" < sn/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
-          echo "::set-output name=version::$version"
+          ./resources/scripts/output_versioning_info.sh
 
       - name: generate release description first pass
         shell: bash
         run: |
-          ./resources/scripts/get_release_description.sh "${{ steps.versioning.outputs.version }}" > release_description.md
+          ./resources/scripts/get_release_description.sh "${{ steps.versioning.outputs.sn_version }}" > release_description.md
 
       # The second pass uses Python to extract the changelog entries for this version.
       # Python can easily do a string replace and avoid all the pain with newlines you get in Bash.
@@ -99,7 +98,25 @@ jobs:
       - name: generate release description second pass
         shell: bash
         run: |
-          ./resources/scripts/insert_changelog_entry.py "${{ steps.versioning.outputs.version }}"
+          commit_message="${{ github.event.head_commit.message }}"
+          if [[ $commit_message == *"safe_network"* ]]; then
+            ./resources/scripts/insert_changelog_entry.py \
+              --sn-version "${{ steps.versioning.outputs.sn_version }}"
+          else
+            sed "s/__SN_CHANGELOG_TEXT__/No changes for this release/g" -i release_description.md
+          fi
+          if [[ $commit_message == *"sn_api"* ]]; then
+            ./resources/scripts/insert_changelog_entry.py \
+              --sn-api-version "${{ steps.versioning.outputs.sn_api_version }}"
+          else
+            sed "s/__SN_API_CHANGELOG_TEXT__/No changes for this release/g" -i release_description.md
+          fi
+          if [[ $commit_message == *"sn_cli"* ]]; then
+            ./resources/scripts/insert_changelog_entry.py \
+              --sn-cli-version "${{ steps.versioning.outputs.sn_cli_version }}"
+          else
+            sed "s/__SN_CLI_CHANGELOG_TEXT__/No changes for this release/g" -i release_description.md
+          fi
 
       - name: create github release
         id: create_release
@@ -107,8 +124,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ steps.versioning.outputs.version }}
-          release_name: Safe Network v${{ steps.versioning.outputs.version }}
+          tag_name: ${{ steps.versioning.outputs.gh_release_tag_name }}
+          release_name: ${{ steps.versioning.outputs.gh_release_name }}
           draft: false
           prerelease: false
           body_path: release_description.md
@@ -116,89 +133,94 @@ jobs:
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.zip
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-unknown-linux-musl.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-unknown-linux-musl.zip
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.zip
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-pc-windows-msvc.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-pc-windows-msvc.zip
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.zip
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-apple-darwin.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-apple-darwin.zip
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-arm-unknown-linux-musleabi.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-arm-unknown-linux-musleabi.zip
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-arm-unknown-linux-musleabi.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-arm-unknown-linux-musleabi.zip
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-armv7-unknown-linux-musleabihf.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-armv7-unknown-linux-musleabihf.zip
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-armv7-unknown-linux-musleabihf.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-armv7-unknown-linux-musleabihf.zip
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-aarch64-unknown-linux-musl.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-aarch64-unknown-linux-musl.zip
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-aarch64-unknown-linux-musl.zip
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-aarch64-unknown-linux-musl.zip
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-unknown-linux-musl.tar.gz
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-unknown-linux-musl.tar.gz
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-pc-windows-msvc.tar.gz
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-pc-windows-msvc.tar.gz
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-pc-windows-msvc.tar.gz
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.tar.gz
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-apple-darwin.tar.gz
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-apple-darwin.tar.gz
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-arm-unknown-linux-musleabi.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-arm-unknown-linux-musleabi.tar.gz
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-arm-unknown-linux-musleabi.tar.gz
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-arm-unknown-linux-musleabi.tar.gz
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-armv7-unknown-linux-musleabihf.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-armv7-unknown-linux-musleabihf.tar.gz
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-armv7-unknown-linux-musleabihf.tar.gz
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-armv7-unknown-linux-musleabihf.tar.gz
           asset_content_type: application/zip
 
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.version }}-aarch64-unknown-linux-musl.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.version }}-aarch64-unknown-linux-musl.tar.gz
+          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-aarch64-unknown-linux-musl.tar.gz
+          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-aarch64-unknown-linux-musl.tar.gz
           asset_content_type: application/zip
 
-  publish:
-    name: publish
+  # At first glance, it seems like it would be possible to check the commit message in the `if` condition
+  # for the presence of the crate name, by using `contains`. However, this doesn't work, so the commit
+  # message needs to be checked at the point of publishing. The reason is because of the dependencies
+  # between the publishing jobs. If one of the jobs doesn't run because its `if` condition was evaluated
+  # to false, the next job won't run, regardless of whether its `if` condition would evaluate to true.
+  publish_sn:
+    name: publish safe network
     runs-on: ubuntu-latest
     needs: [gh_release]
     if: |
@@ -216,4 +238,41 @@ jobs:
       - name: cargo login
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
       - name: cargo publish
-        run: cd sn && cargo publish --allow-dirty
+        run: |
+          commit_message="${{ github.event.head_commit.message }}"
+          if [[ $commit_message == *"safe_network"* ]]; then
+            # The safe_network crate doesn't have any dependencies so we can go ahead and publish
+            cd sn && cargo publish --allow-dirty
+          fi
+
+  publish_sn_api:
+    name: publish sn_api
+    runs-on: ubuntu-latest
+    needs: [publish_sn]
+    if: |
+      github.repository_owner == 'maidsafe' &&
+      startsWith(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - shell: bash
+        id: versioning
+        run: |
+          ./resources/scripts/output_versioning_info.sh
+      - name: cargo login
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+      - name: cargo publish
+        run: |
+          commit_message="${{ github.event.head_commit.message }}"
+          if [[ $commit_message == *"sn_api"* ]]; then
+            # The sn_api crate is dependent on safe_network and sometimes the new version doesn't
+            # become available on crates.io immediately, so this script will use a retry loop.
+            ./resources/scripts/publish_crate.sh \
+              "sn_api" "${{ steps.versioning.outputs.sn_version }}" "safe_network"
+          fi

--- a/resources/scripts/get_release_description.sh
+++ b/resources/scripts/get_release_description.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-version=$1
-if [[ -z "$version" ]]; then
-    echo "You must supply a version number for sn_cli."
+sn_version=$1
+if [[ -z "$sn_version" ]]; then
+    echo "You must supply a version number for safe_network"
     exit 1
 fi
 
@@ -13,6 +13,10 @@ Command line interface for the Safe Network. Refer to [Safe CLI User Guide](http
 ## Safe Network Changelog
 
 __SN_CHANGELOG_TEXT__
+
+## Safe API Changelog
+
+__SN_API_CHANGELOG_TEXT__
 
 ## SHA-256 checksums for sn_node binaries:
 ```
@@ -43,40 +47,40 @@ tar.gz: SN_TAR_AARCH64_CHECKSUM
 EOF
 
 sn_zip_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-x86_64-unknown-linux-musl.zip" | \
+    "./deploy/prod/sn_node-$sn_version-x86_64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 sn_zip_macos_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-x86_64-apple-darwin.zip" | \
+    "./deploy/prod/sn_node-$sn_version-x86_64-apple-darwin.zip" | \
     awk '{ print $1 }')
 sn_zip_win_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-x86_64-pc-windows-msvc.zip" | \
+    "./deploy/prod/sn_node-$sn_version-x86_64-pc-windows-msvc.zip" | \
     awk '{ print $1 }')
 sn_zip_arm_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-arm-unknown-linux-musleabi.zip" | \
+    "./deploy/prod/sn_node-$sn_version-arm-unknown-linux-musleabi.zip" | \
     awk '{ print $1 }')
 sn_zip_armv7_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-armv7-unknown-linux-musleabihf.zip" | \
+    "./deploy/prod/sn_node-$sn_version-armv7-unknown-linux-musleabihf.zip" | \
     awk '{ print $1 }')
 sn_zip_aarch64_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-aarch64-unknown-linux-musl.zip" | \
+    "./deploy/prod/sn_node-$sn_version-aarch64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 sn_tar_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-x86_64-unknown-linux-musl.tar.gz" | \
+    "./deploy/prod/sn_node-$sn_version-x86_64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_macos_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-x86_64-apple-darwin.tar.gz" | \
+    "./deploy/prod/sn_node-$sn_version-x86_64-apple-darwin.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_win_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-x86_64-pc-windows-msvc.tar.gz" | \
+    "./deploy/prod/sn_node-$sn_version-x86_64-pc-windows-msvc.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_arm_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-arm-unknown-linux-musleabi.tar.gz" | \
+    "./deploy/prod/sn_node-$sn_version-arm-unknown-linux-musleabi.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_armv7_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-armv7-unknown-linux-musleabihf.tar.gz" | \
+    "./deploy/prod/sn_node-$sn_version-armv7-unknown-linux-musleabihf.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_aarch64_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$version-aarch64-unknown-linux-musl.tar.gz" | \
+    "./deploy/prod/sn_node-$sn_version-aarch64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 
 release_description=$(sed "s/SN_ZIP_LINUX_CHECKSUM/$sn_zip_linux_checksum/g" <<< "$release_description")

--- a/resources/scripts/insert_changelog_entry.py
+++ b/resources/scripts/insert_changelog_entry.py
@@ -4,28 +4,50 @@
 # put that into the release description. This gets very painful in Bash because the entry
 # contains newline characters.
 
+import getopt
 import sys
 
-def get_changelog_entry(version):
+def get_changelog_entry(changelog_path, version):
     sn_changelog_content = ""
-    with open("sn/CHANGELOG.md", "r") as sn_changelog_file:
+    with open(changelog_path, "r") as sn_changelog_file:
         sn_changelog_content = sn_changelog_file.read()
     start = sn_changelog_content.find("## v{version}".format(version=version))
     end = sn_changelog_content.find("## v", start + 10)
     return sn_changelog_content[start:end].strip()
 
-def insert_changelog_entry(entry):
+def insert_changelog_entry(entry, pattern):
     release_description = ""
     with open("release_description.md", "r") as file:
         release_description = file.read()
-        release_description = release_description.replace("__SN_CHANGELOG_TEXT__", entry)
+        release_description = release_description.replace(pattern, entry)
     with open("release_description.md", "w") as file:
         file.write(release_description)
 
-def main(version):
-    sn_changelog_entry = get_changelog_entry(version)
-    insert_changelog_entry(sn_changelog_entry)
+def main(sn_version, sn_api_version, sn_cli_version):
+    if sn_version:
+        sn_changelog_entry = get_changelog_entry("sn/CHANGELOG.md", sn_version)
+        insert_changelog_entry(sn_changelog_entry, "__SN_CHANGELOG_TEXT__")
+    if sn_api_version:
+        sn_api_changelog_entry = get_changelog_entry("sn_api/CHANGELOG.md", sn_api_version)
+        insert_changelog_entry(sn_api_changelog_entry, "__SN_API_CHANGELOG_TEXT__")
+    if sn_cli_version:
+        sn_cli_changelog_entry = get_changelog_entry("sn_cli/CHANGELOG.md", sn_cli_version)
+        insert_changelog_entry(sn_cli_changelog_entry, "__SN_CLI_CHANGELOG_TEXT__")
 
 if __name__ == "__main__":
-    version = sys.argv[1]
-    main(version)
+    sn_version = ""
+    sn_api_version = ""
+    sn_cli_version = ""
+    opts, args = getopt.getopt(
+        sys.argv[1:],
+        "",
+        ["sn-version=", "sn-api-version=", "sn-cli-version="]
+    )
+    for opt, arg in opts:
+        if opt in "--sn-version":
+            sn_version = arg
+        elif opt in "--sn-api-version":
+            sn_api_version = arg
+        elif opt in "--sn-cli-version":
+            sn_cli_version = arg
+    main(sn_version, sn_api_version, sn_cli_version)

--- a/resources/scripts/output_versioning_info.sh
+++ b/resources/scripts/output_versioning_info.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+gh_release_name=""
+gh_release_tag_name=""
+commit_message=$(git log --oneline --pretty=format:%s | head -n 1)
+sn_version=$(grep "^version" < sn/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+sn_api_version=$(grep "^version" < sn_api/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+sn_cli_version=$(grep "^version" < sn_cli/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+
+if [[ $commit_message == *"safe_network"* ]]; then
+    gh_release_name="Safe Network v$sn_version/"
+    gh_release_tag_name="safe_network-v$sn_version/"
+fi
+if [[ $commit_message == *"sn_api"* ]]; then
+    gh_release_name="Safe API v$sn_api_version/"
+    gh_release_tag_name="safe_api-v$sn_api_version/"
+fi
+if [[ $commit_message == *"sn_cli"* ]]; then
+    gh_release_name="Safe CLI v$sn_cli_version/"
+    gh_release_tag_name="safe_cli-v$sn_cli_version/"
+fi
+
+# strip off any trailing '/' 
+gh_release_name=${gh_release_name::-1}
+gh_release_tag_name=${gh_release_tag_name::-1}
+
+echo "::set-output name=sn_version::$sn_version"
+echo "::set-output name=sn_api_version::$sn_api_version"
+echo "::set-output name=sn_cli_version::$sn_cli_version"
+echo "::set-output name=gh_release_name::$gh_release_name"
+echo "::set-output name=gh_release_tag_name::$gh_release_tag_name"

--- a/resources/scripts/publish_crate.sh
+++ b/resources/scripts/publish_crate.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# This script uses a retry loop to wait on dependent crates becoming available at the correct version.
+
+crate_name=$1
+dependent_crate_version=$2
+dependent_crate_name=$3
+
+if [[ -z "$crate_name" ]]; then
+    echo "You must supply the name of the crate to publish"
+    exit 1
+fi
+
+if [[ -z "$dependent_crate_version" ]]; then
+    echo "You must supply the version of the dependent crate"
+    exit 1
+fi
+
+if [[ -z "$dependent_crate_name" ]]; then
+    echo "You must supply the name of the dependent crate"
+    exit 1
+fi
+
+count=1
+max_retries=15
+current_version=$(cargo search $dependent_crate_name | head -n 1 | awk '{print $3}' | sed 's/\"//g')
+while [[ $current_version != $dependent_crate_version && $count -le $max_retries ]]
+do
+    echo "Version of $dependent_crate_name reported by crates.io is $current_version"
+    echo "Waiting for $dependent_crate_name crate to reach $dependent_crate_version"
+    echo "Attempted $count of $max_retries times. Will query again in 5 seconds..."
+    sleep 5
+    ((count++))
+    current_version=$(cargo search $dependent_crate_name | head -n 1 | awk '{print $3}' | sed 's/\"//g')
+done
+
+if [[ $count -gt $max_retries ]]; then
+    echo "Max retry attempts exceeded. Exiting with failure."
+    exit 1
+fi
+
+cd $crate_name
+cargo publish --allow-dirty


### PR DESCRIPTION
The release workflow has been extended to include the sn_api crate.

When there's a release, it's possible that any one, or many crates could have new releases, and the conditions used on jobs have been updated to take this into account. There's been additional scripting added for the changelogs and the release and tag names to be used, that also take this into account.

Tested on my fork:
https://github.com/jacderida/safe_network/actions/runs/1457492565
https://github.com/jacderida/safe_network/releases/tag/safe_api-v0.39.0