### PR TITLE
fix: use cached prefixmap during joins

### DIFF
--- a/sn/src/routing/core/bootstrap/join.rs
+++ b/sn/src/routing/core/bootstrap/join.rs
@@ -105,9 +105,14 @@ impl<'a> Join<'a> {
         // Use our XorName as we do not know their name or section key yet.
         let dst_xorname = self.node.name();
         let recipients = vec![Peer::new(dst_xorname, bootstrap_addr)];
-        let genesis_key = self.prefix_map.genesis_key();
+        let target_key = if let Some(sap) = self.prefix_map.closest_or_opposite(&dst_xorname, None)
+        {
+            sap.section_key()
+        } else {
+            self.prefix_map.genesis_key()
+        };
 
-        self.join(genesis_key, recipients).await
+        self.join(target_key, recipients).await
     }
 
     #[tracing::instrument(skip(self))]


### PR DESCRIPTION
Previously we always defaults to genesis key on join. But we can use a
cached prefixmap when available, this avoids a Retry always and then a later check where we want
an updated key (which we dont get as actually we may already have it in
the prefix map... so there was no change)

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
