### PR TITLE
WIP: fix: use split barrier updates directly for sibling section updates

### DIFF
--- a/sn/src/bin/testnet.rs
+++ b/sn/src/bin/testnet.rs
@@ -47,7 +47,7 @@ const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
 
 const BASE_TRACING_DIRECTIVES: &str = "testnet=info,sn_launch_tool=debug";
 const NODES_DIR: &str = "local-test-network";
-const DEFAULT_INTERVAL: &str = "10000";
+const DEFAULT_INTERVAL: &str = "1000";
 const DEFAULT_NODE_COUNT: u32 = 45;
 
 #[derive(Debug, StructOpt)]

--- a/sn/src/prefix_map/mod.rs
+++ b/sn/src/prefix_map/mod.rs
@@ -121,13 +121,6 @@ impl NetworkPrefixMap {
             .collect()
     }
 
-    /// Get `SectionAuthorityProvider` of a known section with the given prefix.
-    pub(crate) fn get(&self, prefix: &Prefix) -> Option<SectionAuthorityProvider> {
-        self.sections
-            .get(prefix)
-            .map(|entry| entry.value().value.clone())
-    }
-
     /// Get signed `SectionAuthorityProvider` of a known section with the given prefix.
     pub(crate) fn get_signed(
         &self,

--- a/sn/src/prefix_map/mod.rs
+++ b/sn/src/prefix_map/mod.rs
@@ -121,6 +121,14 @@ impl NetworkPrefixMap {
             .collect()
     }
 
+    #[allow(dead_code)]
+    /// Get `SectionAuthorityProvider` of a known section with the given prefix.
+    pub(crate) fn get(&self, prefix: &Prefix) -> Option<SectionAuthorityProvider> {
+        self.sections
+            .get(prefix)
+            .map(|entry| entry.value().value.clone())
+    }
+
     /// Get signed `SectionAuthorityProvider` of a known section with the given prefix.
     pub(crate) fn get_signed(
         &self,

--- a/sn/src/routing/network_knowledge/mod.rs
+++ b/sn/src/routing/network_knowledge/mod.rs
@@ -350,11 +350,6 @@ impl NetworkKnowledge {
     }
 
     // Get SectionAuthorityProvider of a known section with the given prefix.
-    pub(super) fn get_sap(&self, prefix: &Prefix) -> Option<SectionAuthorityProvider> {
-        self.prefix_map.get(prefix)
-    }
-
-    // Get SectionAuthorityProvider of a known section with the given prefix.
     pub(super) async fn get_closest_or_opposite_signed_sap(
         &self,
         name: &XorName,


### PR DESCRIPTION
Previously we relied on network knowledge updates, which isn't necessarily needed?

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
