### PR TITLE
fix: raise SectionSplit event whenever prefix changed

### DIFF
--- a/sn/examples/routing_minimal.rs
+++ b/sn/examples/routing_minimal.rs
@@ -238,12 +238,11 @@ async fn handle_event(index: usize, node: &mut Routing, event: Event) -> bool {
         }
         Event::SectionSplit {
             elders,
-            sibling_elders,
             self_status_change,
         } => {
             info!(
-                "Node #{} section split - elders: {:?}, sibling elders: {:?}, node elder status change: {:?}",
-                index, elders, sibling_elders, self_status_change
+                "Node #{} section split - elders: {:?}, node elder status change: {:?}",
+                index, elders, self_status_change
             );
         }
         Event::EldersChanged {

--- a/sn/src/node/event_mapping/mod.rs
+++ b/sn/src/node/event_mapping/mod.rs
@@ -42,7 +42,6 @@ pub(super) async fn map_routing_event(event: RoutingEvent, network_api: &Network
         } => map_node_msg(msg_id, src, dst, *msg),
         RoutingEvent::SectionSplit {
             elders,
-            sibling_elders,
             self_status_change,
         } => {
             let newbie = match self_status_change {
@@ -61,8 +60,6 @@ pub(super) async fn map_routing_event(event: RoutingEvent, network_api: &Network
                     our_prefix: elders.prefix,
                     our_key: PublicKey::from(elders.key),
                     our_new_elders: elders.added,
-                    their_new_elders: sibling_elders.added,
-                    sibling_key: PublicKey::from(sibling_elders.key),
                     newbie,
                 },
                 ctx: None,

--- a/sn/src/node/node_api/handle.rs
+++ b/sn/src/node/node_api/handle.rs
@@ -105,8 +105,6 @@ impl Node {
                 our_key,
                 our_prefix,
                 our_new_elders,
-                their_new_elders,
-                sibling_key,
                 newbie,
             } => {
                 debug!(
@@ -114,10 +112,7 @@ impl Node {
                     our_prefix,
                     our_prefix.sibling(),
                 );
-                debug!(
-                    "@@@@@@ SPLIT: Our key: {:?}, neighbour: {:?}",
-                    our_key, sibling_key
-                );
+                debug!("@@@@@@ SPLIT: Our key: {:?}", our_key);
                 if newbie {
                     info!("Beginning split as Newbie");
                     self.begin_split_as_newbie(our_key).await?;
@@ -133,7 +128,6 @@ impl Node {
                                 &network,
                                 our_prefix,
                                 our_new_elders,
-                                their_new_elders,
                             )
                             .await?,
                         ))

--- a/sn/src/node/node_api/split.rs
+++ b/sn/src/node/node_api/split.rs
@@ -35,16 +35,16 @@ impl Node {
         network_api: &Network,
         our_prefix: Prefix,
         our_new_elders: BTreeSet<XorName>,
-        their_new_elders: BTreeSet<XorName>,
     ) -> Result<NodeDuties> {
-        let sibling_prefix = our_prefix.sibling();
         let mut ops = vec![];
 
         // replicate state to our new elders
         ops.push(push_state(elder, our_prefix, MessageId::new(), our_new_elders).await?);
 
         // replicate state to our neighbour's new elders
-        ops.push(push_state(elder, sibling_prefix, MessageId::new(), their_new_elders).await?);
+        // TODO: Confirming when sibling's SAP is available, does this need to be carried out.
+        // let sibling_prefix = our_prefix.sibling();
+        // ops.push(push_state(elder, sibling_prefix, MessageId::new(), their_new_elders).await?);
 
         let our_adults = network_api.our_adults().await;
         // drop metadata state

--- a/sn/src/node/node_ops.rs
+++ b/sn/src/node/node_ops.rs
@@ -60,10 +60,6 @@ pub enum NodeDuty {
         our_key: PublicKey,
         /// The new Elders of our section.
         our_new_elders: BTreeSet<XorName>,
-        /// The new Elders of our sibling section.
-        their_new_elders: BTreeSet<XorName>,
-        /// The PK of the sibling section, as this event is fired during a split.
-        sibling_key: PublicKey,
         /// oldie or newbie?
         newbie: bool,
     },

--- a/sn/src/prefix_map/mod.rs
+++ b/sn/src/prefix_map/mod.rs
@@ -122,6 +122,7 @@ impl NetworkPrefixMap {
     }
 
     /// Get `SectionAuthorityProvider` of a known section with the given prefix.
+    #[allow(unused)]
     pub(crate) fn get(&self, prefix: &Prefix) -> Option<SectionAuthorityProvider> {
         self.sections
             .get(prefix)

--- a/sn/src/routing/network_knowledge/mod.rs
+++ b/sn/src/routing/network_knowledge/mod.rs
@@ -350,6 +350,7 @@ impl NetworkKnowledge {
     }
 
     // Get SectionAuthorityProvider of a known section with the given prefix.
+    #[allow(unused)]
     pub(super) fn get_sap(&self, prefix: &Prefix) -> Option<SectionAuthorityProvider> {
         self.prefix_map.get(prefix)
     }

--- a/sn/src/routing/routing_api/event.rs
+++ b/sn/src/routing/routing_api/event.rs
@@ -84,8 +84,6 @@ pub enum Event {
     SectionSplit {
         /// The Elders of our section.
         elders: Elders,
-        /// The Elders of the sibling section.
-        sibling_elders: Elders,
         /// Promoted, demoted or no change?
         self_status_change: NodeElderChange,
     },


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
