### PR TITLE
Connection management

### DIFF
--- a/sn/Cargo.toml
+++ b/sn/Cargo.toml
@@ -38,6 +38,7 @@ required-features = ["test-utils"]
 default = []
 always-joinable = []
 chaos = []
+unstable-no-connection-pooling = []
 test-utils = []
 
 [dependencies]

--- a/sn/src/bin/testnet.rs
+++ b/sn/src/bin/testnet.rs
@@ -101,6 +101,10 @@ async fn main() -> Result<()> {
             args.push("--features");
             args.push("test-utils");
         }
+        if cfg!(feature = "unstable-no-connection-pooling") {
+            args.push("--features");
+            args.push("unstable-no-connection-pooling");
+        }
 
         info!("Building current sn_node");
         debug!("Building current sn_node with args: {:?}", args);

--- a/sn/src/routing/core/bootstrap/join.rs
+++ b/sn/src/routing/core/bootstrap/join.rs
@@ -424,7 +424,9 @@ impl<'a> Join<'a> {
                             }) => {
                                 let sender_addr = match sender {
                                     Sender::Ourself => self.node.addr,
-                                    Sender::Connected(addr) => addr,
+                                    Sender::Connected(connection) => connection.remote_address(),
+                                    #[cfg(test)]
+                                    Sender::Test(addr) => addr,
                                 };
                                 (
                                     *resp,

--- a/sn/src/routing/core/comm.rs
+++ b/sn/src/routing/core/comm.rs
@@ -11,7 +11,7 @@ use crate::messaging::{system::LoadReport, WireMsg};
 use crate::routing::{
     error::{Error, Result},
     log_markers::LogMarker,
-    Peer,
+    Peer, Sender,
 };
 use bytes::Bytes;
 use futures::{
@@ -432,7 +432,7 @@ impl Comm {
 
 #[derive(Debug)]
 pub(crate) enum ConnectionEvent {
-    Received((SocketAddr, Bytes)),
+    Received((Sender, Bytes)),
 }
 
 #[tracing::instrument(skip_all)]
@@ -475,7 +475,9 @@ async fn handle_incoming_messages(
     while let Some(result) = incoming_msgs.next().await.transpose() {
         match result {
             Ok(msg) => {
-                let _send_res = event_tx.send(ConnectionEvent::Received((src, msg))).await;
+                let _send_res = event_tx
+                    .send(ConnectionEvent::Received((Sender::Connected(src), msg)))
+                    .await;
                 // count incoming msgs..
                 msg_count.increase_incoming(src);
             }

--- a/sn/src/routing/core/comm.rs
+++ b/sn/src/routing/core/comm.rs
@@ -133,12 +133,6 @@ impl Comm {
         self.endpoint.public_addr()
     }
 
-    /// Get the connection ID (XorName) of an existing connection with the provided socket address
-    pub(crate) async fn get_peer_connection_id(&self, address: &SocketAddr) -> Option<XorName> {
-        let peer = self.connected_peers.get_by_address(address).await?;
-        Some(peer.id())
-    }
-
     /// Get the SocketAddr of a connection using the connection ID (XorName)
     pub(crate) async fn get_peer_address(&self, connection_id: &XorName) -> Option<SocketAddr> {
         let peer = self.connected_peers.get_by_id(connection_id).await?;
@@ -761,7 +755,7 @@ mod tests {
         assert_matches!(node_rx.recv().await, Some(ConnectionEvent::Received(_)));
         assert!(
             node_comm
-                .get_peer_connection_id(&client_addr)
+                .get_peer_address(&ConnectedPeers::address_to_id(&client_addr))
                 .await
                 .is_some(),
             "did not find expected connection"

--- a/sn/src/routing/core/comm.rs
+++ b/sn/src/routing/core/comm.rs
@@ -282,7 +282,14 @@ impl Comm {
                 let (connection, reused) = if let Some(connection) =
                     (!force_reconnection).then(|| existing_connection).flatten()
                 {
-                    (Ok(connection.connection().clone()), true)
+                    let connection = connection.connection();
+                    trace!(
+                        connection_id = connection.id(),
+                        src = %connection.remote_address(),
+                        "{}",
+                        LogMarker::ConnectionReused
+                    );
+                    (Ok(connection.clone()), true)
                 } else {
                     (
                         self.endpoint

--- a/sn/src/routing/core/connected_peers.rs
+++ b/sn/src/routing/core/connected_peers.rs
@@ -73,7 +73,7 @@ impl ConnectedPeers {
         let _existing = self.peers.write().await.remove(&id);
     }
 
-    fn address_to_id(address: &SocketAddr) -> XorName {
+    pub(crate) fn address_to_id(address: &SocketAddr) -> XorName {
         match address.ip() {
             IpAddr::V4(ip) => {
                 XorName::from_content_parts(&[&ip.octets(), &address.port().to_be_bytes()])
@@ -108,10 +108,6 @@ pub(super) struct ConnectedPeer {
 }
 
 impl ConnectedPeer {
-    pub(super) fn id(&self) -> XorName {
-        self.id
-    }
-
     pub(super) fn address(&self) -> SocketAddr {
         self.connection.remote_address()
     }

--- a/sn/src/routing/core/connected_peers.rs
+++ b/sn/src/routing/core/connected_peers.rs
@@ -1,9 +1,8 @@
-use std::{
-    collections::HashMap,
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-};
+use std::net::SocketAddr;
+#[cfg(not(feature = "unstable-no-connection-pooling"))]
+use std::{collections::HashMap, net::IpAddr, sync::Arc};
 
+#[cfg(not(feature = "unstable-no-connection-pooling"))]
 use tokio::sync::RwLock;
 use xor_name::XorName;
 
@@ -22,9 +21,11 @@ use xor_name::XorName;
 /// ID.
 #[derive(Clone, Default)]
 pub(super) struct ConnectedPeers {
+    #[cfg(not(feature = "unstable-no-connection-pooling"))]
     peers: Arc<RwLock<HashMap<XorName, qp2p::Connection>>>,
 }
 
+#[cfg(not(feature = "unstable-no-connection-pooling"))]
 impl ConnectedPeers {
     /// Get the connected peer with the given `id`.
     ///
@@ -82,6 +83,18 @@ impl ConnectedPeers {
             }
         }
     }
+}
+
+#[cfg(feature = "unstable-no-connection-pooling")]
+impl ConnectedPeers {
+    pub(super) async fn get_by_id(&self, _id: &XorName) -> Option<ConnectedPeer> {
+        None
+    }
+    pub(super) async fn get_by_address(&self, _address: &SocketAddr) -> Option<ConnectedPeer> {
+        None
+    }
+    pub(super) async fn insert(&self, _connection: qp2p::Connection) {}
+    pub(super) async fn remove_by_address(&self, _address: &SocketAddr) {}
 }
 
 /// A peer connected to a node, as stored by [`ConnectedPeers`].

--- a/sn/src/routing/core/messaging.rs
+++ b/sn/src/routing/core/messaging.rs
@@ -25,7 +25,7 @@ use crate::routing::{
     network_knowledge::{ElderCandidates, NodeState, SectionKeyShare},
     relocation::RelocateState,
     routing_api::command::Command,
-    Peer,
+    Peer, Sender,
 };
 use crate::types::PublicKey;
 use bls::PublicKey as BlsPublicKey;
@@ -499,7 +499,7 @@ impl Core {
             wire_msg.set_dst_xorname(self.node.read().await.name());
 
             commands.push(Command::HandleMessage {
-                sender_addr: self.node.read().await.addr,
+                sender: Sender::Ourself,
                 wire_msg,
                 original_bytes: None,
             });

--- a/sn/src/routing/core/msg_handling/mod.rs
+++ b/sn/src/routing/core/msg_handling/mod.rs
@@ -52,9 +52,11 @@ impl Core {
         trace!("handling msg");
 
         // TODO: consider whether we should propagate `Sender` instead
-        let sender_addr = match sender {
+        let sender_addr = match &sender {
             Sender::Ourself => self.node.read().await.addr,
-            Sender::Connected(addr) => addr,
+            Sender::Connected(connection) => connection.remote_address(),
+            #[cfg(test)]
+            Sender::Test(addr) => *addr,
         };
 
         // Apply backpressure if needed.

--- a/sn/src/routing/log_markers.rs
+++ b/sn/src/routing/log_markers.rs
@@ -79,4 +79,5 @@ pub enum LogMarker {
     // Connections
     ConnectionOpened,
     ConnectionClosed,
+    ConnectionReused,
 }

--- a/sn/src/routing/mod.rs
+++ b/sn/src/routing/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use self::{
     core::ChunkStore,
     core::RegisterStorage,
     core::{CHUNK_COPY_COUNT, MIN_LEVEL_WHEN_FULL},
-    network_knowledge::{section_keys::SectionKeyShare, SectionAuthorityProvider},
+    network_knowledge::{peer::Sender, section_keys::SectionKeyShare, SectionAuthorityProvider},
 };
 pub use self::{
     dkg::SectionAuthUtils,

--- a/sn/src/routing/network_knowledge/peer.rs
+++ b/sn/src/routing/network_knowledge/peer.rs
@@ -111,6 +111,20 @@ impl Peer {
     }
 }
 
+/// A peer who sent us a message.
+///
+/// When we receive a message, we don't know the identity of the sender, so we cannot represent them
+/// as a [`Peer`]. Contrary to `Peer`, we must have a physical connection to the peer, in order to
+/// have received the message.
+#[derive(Clone, Debug)]
+pub(crate) enum Sender {
+    /// The message was sent from ourself.
+    Ourself,
+
+    /// The message was sent from a connected peer.
+    Connected(SocketAddr),
+}
+
 #[cfg(test)]
 pub(crate) mod test_utils {
     use super::*;

--- a/sn/src/routing/network_knowledge/peer.rs
+++ b/sn/src/routing/network_knowledge/peer.rs
@@ -122,7 +122,11 @@ pub(crate) enum Sender {
     Ourself,
 
     /// The message was sent from a connected peer.
-    Connected(SocketAddr),
+    Connected(qp2p::Connection),
+
+    /// The message was sent from a test.
+    #[cfg(test)]
+    Test(SocketAddr),
 }
 
 #[cfg(test)]

--- a/sn/src/routing/routing_api/command.rs
+++ b/sn/src/routing/routing_api/command.rs
@@ -13,14 +13,13 @@ use crate::messaging::{
 use crate::routing::{
     network_knowledge::{NetworkKnowledge, SectionAuthorityProvider, SectionKeyShare},
     node::Node,
-    Peer, XorName,
+    Peer, Sender, XorName,
 };
 use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;
 use custom_debug::Debug;
 use std::{
     fmt,
-    net::SocketAddr,
     sync::atomic::{AtomicU64, Ordering},
     time::Duration,
 };
@@ -32,9 +31,7 @@ pub(crate) enum Command {
     /// Handle `message` from `sender`.
     /// Holding the WireMsg that has been received from the network,
     HandleMessage {
-        // This is the only command that uses `SocketAddr` instead of `Peer`, because we haven't
-        // deserialized/verified the src at this stage.
-        sender_addr: SocketAddr,
+        sender: Sender,
         wire_msg: WireMsg,
         #[debug(skip)]
         // original bytes to avoid reserializing for entropy checks

--- a/sn/src/routing/routing_api/dispatcher.rs
+++ b/sn/src/routing/routing_api/dispatcher.rs
@@ -226,12 +226,12 @@ impl Dispatcher {
                 self.core.prepare_node_msg(msg, dst).await
             }
             Command::HandleMessage {
-                sender_addr,
+                sender,
                 wire_msg,
                 original_bytes,
             } => {
                 self.core
-                    .handle_message(sender_addr, wire_msg, original_bytes)
+                    .handle_message(sender, wire_msg, original_bytes)
                     .await
             }
             Command::HandleTimeout(token) => self.core.handle_timeout(token).await,

--- a/sn/src/routing/routing_api/tests/mod.rs
+++ b/sn/src/routing/routing_api/tests/mod.rs
@@ -195,7 +195,7 @@ async fn receive_join_request_with_resource_proof_response() -> Result<()> {
 
     let commands = get_internal_commands(
         Command::HandleMessage {
-            sender: Sender::Connected(new_node.addr),
+            sender: Sender::Test(new_node.addr),
             wire_msg,
             original_bytes: None,
         },
@@ -304,7 +304,7 @@ async fn receive_join_request_from_relocated_node() -> Result<()> {
 
     let inner_commands = get_internal_commands(
         Command::HandleMessage {
-            sender: Sender::Connected(relocated_node.addr),
+            sender: Sender::Test(relocated_node.addr),
             wire_msg,
             original_bytes: None,
         },
@@ -1252,7 +1252,10 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
     assert!(commands.is_empty());
 
     let msg_type = assert_matches!(comm_rx.recv().await, Some(ConnectionEvent::Received((sender, bytes))) => {
-        assert_matches!(sender, Sender::Connected(addr) => assert_eq!(addr, node.addr));
+        assert_matches!(
+            sender,
+            Sender::Connected(connection) => assert_eq!(connection.remote_address(), node.addr)
+        );
         assert_matches!(WireMsg::deserialize(bytes), Ok(msg_type) => msg_type)
     });
 


### PR DESCRIPTION
- 64373af6f **refactor(sn): add a feature to disable connection pooling**

  The feature is named with `unstable-` to indicate that it may be removed
  at any time. This allows us to better test changes to connection
  management, since we know that all reuse must be coming from connection
  management rather than pooling.

- 99fc5e735 **refactor(sn): add a log marker for reusing a connection**

  This is mostly informational, but it gives a good indication that
  connection reuse is occurring, and how many new connection attempts have
  been saved.

- 817099893 **refactor(sn): add an `Option<qp2p::Connection>` to `Peer`**

  This allows the `Peer` struct to carry an existing connection to the
  peer, if one exists. Currently, the connection must be set on
  construction with `Peer::connected`. A reference to the connection can
  be retrieved with `Peer::connection`. When sending a message using
  `Comm::send` or `Comm::send_on_existing_connection`, we now check the
  `Peer` before `ConnectedPeers`.
  
  We never actually set `connection` currently, but there are several
  possible next steps that would all depend on `Peer` carrying a
  `connection`, so introducing it separately makes sense.

- a7a7a4a07 **refactor(sn): represent `HandleMessage::sender` as an enum**

  This is a precursor to having `HandleMessage::sender` contain the
  originating `Connection` for connected peers. Since we use
  `HandleMessage` also when 'sending' messages to ourselves, we have to
  deal with the possibility that there may not be a connection. We could
  simply use `Option` for this, however the dedicated enum makes it
  clearer exactly what situation is represented.
  
  To facilitate later plumbing, `ConnectionEvent` now also uses `Sender`
  to represent the message sender.
  
  It's possible that we should make more use of the knowledge that a
  message was sent to ourselves, e.g. to short-circuit AE checks. For now,
  we more-or-less immediately lookup our own address, and proceed as if
  the message was actually sent from there.

- 0b7dcd228 **refactor(sn): use `qp2p::Connection` for connected senders**

  This gets us closer to being able to reuse incoming connections, without
  `ConnectedPeers` (though there's no functional change yet).
  
  Sadly, a `cfg(test)` variant was necessary to satisfy routing tests,
  which don't make actual connections but do make assertions on the sender
  address.

- 0e4a8a918 **refactor(sn): correlate client connections without `ConnectedPeers`**

  This is a first pass at introducing a mechanism to correlate client
  connections without using the `ConnectedPeers` cache/pool. The approach
  is centred on passing along the connected `Peer` that originated the
  request, which in most cases is enough to get the response to reply
  directly to the same `Peer` instance.
  
  Chunk queries need an additional mechanism, since the elder cannot reply
  right away, and instead must forward the query to nodes, and can only
  reply to the client once the nodes have themselves replied. For this we
  introduce a `pending_chunk_queries` field to `routing::Core`. When a
  chunk query is received from a client, a random `XorName` is generated
  as a correlation ID, and the client `Peer` is stored in the
  `pending_chunk_queries` cache under that `XorName`. The `XorName` is
  then passed as the 'end user' for the message to nodes, who send it back
  in their reply, allowing the receiving elder to correlate the response
  with the origin client `Peer`, and forward the response to the client
  over the `Peer`'s connection.
  
  There are some minor behavioural changes with this approach:
  
  1. Unlike the connection pooling approach, the client's exact connection
     must remain valid (e.g. if they reconnect while waiting for a
     response, they will never receive it). There is no way around this
     without a general-purpose connection cache, since we do not know on
     connection whether a peer has ever sent a client request. Thankfully
     it's not a big deal, since client operations are always idempotent,
     so client logic can handle any connection interruption by sending the
     same request(s) over a new connection.
  
  2. The `pending_chunk_queries` cache uses duration-based expiration,
     currently hard-coded to 5 minutes. Previously there was no timeout
     for this operation, and it would just depend on the connection
     remaining open in the pool. Since we cannot easily detect connection
     closure in `routing::Core`, and 5 mins is longer than the default
     client query timeout, this seems reasonable for now.
