### PR TITLE
ci: git push without using origin remote

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -32,5 +32,5 @@ jobs:
         run: ./resources/scripts/bump_version.sh
       - shell: bash
         run: |
-          git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" origin main
+          git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" HEAD:main
           git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" HEAD:main --tags

--- a/resources/scripts/bump_version.sh
+++ b/resources/scripts/bump_version.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 commit_message=""
 sn_version=""
 sn_api_version=""
@@ -65,6 +67,7 @@ function amend_version_bump_commit() {
     git reset --soft HEAD~1
     git add --all
     git commit -m "$commit_message"
+    git --no-pager log
 }
 
 function amend_tags() {


### PR DESCRIPTION
Also adds some debugging text to try and determine exactly where a failure is.
