### PR TITLE
ci: prevent release workflow from running

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   build:
-    if: github.repository_owner == 'maidsafe'
+    if: |
+      github.repository_owner == 'maidsafe' &&
+      startsWith(github.event.head_commit.message, 'chore(release):')
     name: build
     runs-on: ${{ matrix.os }}
     strategy:

--- a/resources/scripts/bump_version.sh
+++ b/resources/scripts/bump_version.sh
@@ -22,12 +22,15 @@ function determine_which_crates_have_changes() {
         --no-isolate-dependencies-from-breaking-changes \
         safe_network sn_api 2>&1)
     if [[ $output == *"WOULD auto-bump dependent package 'safe_network'"* ]]; then
+        echo "smart-release identified changes in safe_network"
         safe_network_has_changes=true
     fi
     if [[ $output == *"WOULD auto-bump dependent package 'sn_api'"* ]]; then
+        echo "smart-release identified changes in sn_api"
         sn_api_has_changes=true
     fi
     if [[ $output == *"WOULD auto-bump dependent package 'sn_cli'"* ]]; then
+        echo "smart-release identified changes in sn_cli"
         sn_cli_has_changes=true
     fi
 }
@@ -61,13 +64,13 @@ function generate_new_commit_message() {
         commit_message="${commit_message}sn_cli-${sn_cli_version}/"
     fi
     commit_message=${commit_message::-1} # strip off any trailing '/'
+    echo "generated commit message -- $commit_message"
 }
 
 function amend_version_bump_commit() {
     git reset --soft HEAD~1
     git add --all
     git commit -m "$commit_message"
-    git --no-pager log
 }
 
 function amend_tags() {
@@ -76,6 +79,7 @@ function amend_tags() {
     if [[ $sn_cli_has_changes == true ]]; then git tag "sn_cli-v${sn_cli_version}" -f; fi
 }
 
+git --no-pager tag
 determine_which_crates_have_changes
 generate_version_bump_commit
 generate_new_commit_message


### PR DESCRIPTION
The release workflow now requires the release commit before it will run. This is to prevent the
build stage from running on any push to main, which will include a PR merge that doesn't have a
release commit.

Also added some debugging text for the version bump workflow, which is still failing on the GHA
build agent.
