### PR TITLE
ci: use specific version of smart-release

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -27,7 +27,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
       - shell: bash
-        run: cargo install cargo-smart-release
+        run: cargo install cargo-smart-release --version 0.5.6
       - shell: bash
         run: ./resources/scripts/bump_version.sh
       - shell: bash


### PR DESCRIPTION
As of today, there's been a newly published version of `smart-release`, 0.6.0, which is newer than
the version I had installed on my development machine. This was the one being installed on the build
agent. Sadly, the behaviour of the 2 are different, and this was what was causing a problem in the
process.

It now looks like they expect you to run the tool by knowing in advance which crates have changes,
which doesn't work for our automated process. After playing around with it for about 20/30 minutes,
I couldn't quite get what it was expecting me to do. This could well be wrong though. It needs
further investigation.

For now, I'm just going to stick with the same version I was running locally.
