### PR TITLE
ci: update use of smart-release for new version

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -27,7 +27,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
       - shell: bash
-        run: cargo install cargo-smart-release --version 0.5.6
+        run: cargo install cargo-smart-release
       - shell: bash
         run: ./resources/scripts/bump_version.sh
       - shell: bash

--- a/resources/scripts/bump_version.sh
+++ b/resources/scripts/bump_version.sh
@@ -19,7 +19,6 @@ function determine_which_crates_have_changes() {
         --no-changelog-preview \
         --allow-fully-generated-changelogs \
         --no-changelog-github-release \
-        --no-isolate-dependencies-from-breaking-changes \
         safe_network sn_api 2>&1)
     if [[ $output == *"WOULD auto-bump dependent package 'safe_network'"* ]]; then
         echo "smart-release identified changes in safe_network"
@@ -43,7 +42,6 @@ function generate_version_bump_commit() {
         --no-changelog-preview \
         --allow-fully-generated-changelogs \
         --no-changelog-github-release \
-        --no-isolate-dependencies-from-breaking-changes \
         --execute \
         safe_network sn_api
 }


### PR DESCRIPTION
Removes the use of the `--no-isolate-dependencies-from-breaking-changes` argument, which then performs 'safety bumps' for crates that are dependent on other crates which have had breaking changes, even if that crate has no changes itself. The tool seems better designed to work this way.
