### PR TITLE
fix(sn): fix a compilation error introduced by merge

### DIFF
--- a/sn/src/routing/core/mod.rs
+++ b/sn/src/routing/core/mod.rs
@@ -396,8 +396,7 @@ impl Core {
             .network_knowledge
             .authority_provider()
             .await
-            .peers()
-            .len();
+            .elder_count();
         let prefix = self.network_knowledge.prefix().await;
         debug!("{:?}: {:?} Elders, {:?} Adults.", prefix, elders, adults);
     }


### PR DESCRIPTION
- 0b504a471 **fix(sn): fix a compilation error introduced by merge**

  PR #743 removed the `SectionAuthorityProvider::peers` method, but a new
  call-site was introduced in #740, which was merged first. Thus,
  compilation broken when `main` was merged into #743 and this wasn't
  noticed in CI.
