### PR TITLE
Join flow connection management

### DIFF
--- a/resources/jq-filters/connection-tracing.jq
+++ b/resources/jq-filters/connection-tracing.jq
@@ -6,6 +6,13 @@ reduce inputs as $item ([]; . + [$item])
     event: .fields.message,
     conn_id: .fields.connection_id,
     src_addr: .fields.src,
-    trace: .spans | map("\(.name)\(if .command then " (\(.command))" else "" end)\(if .recipients then " (\(.recipients))" else "" end)") | join(" -> ")
+    trace: .spans | map(
+        . as $span
+        | {}
+        | if $span.command then . + {command: $span.command} else . end
+        | if $span.recipients then . + {recipients: $span.recipients} else . end
+        | if $span.wire_msg then . + {wire_msg: $span.wire_msg} else . end
+        | if length > 0 then {"\($span.name)": .} else $span.name end
+    )
   })
 | sort_by(.timestamp)

--- a/sn/Cargo.toml
+++ b/sn/Cargo.toml
@@ -39,6 +39,7 @@ default = []
 always-joinable = []
 chaos = []
 unstable-no-connection-pooling = []
+unstable-wiremsg-debuginfo = []
 test-utils = []
 
 [dependencies]

--- a/sn/src/bin/testnet.rs
+++ b/sn/src/bin/testnet.rs
@@ -105,6 +105,10 @@ async fn main() -> Result<()> {
             args.push("--features");
             args.push("unstable-no-connection-pooling");
         }
+        if cfg!(feature = "unstable-wiremsg-debuginfo") {
+            args.push("--features");
+            args.push("unstable-wiremsg-debuginfo");
+        }
 
         info!("Building current sn_node");
         debug!("Building current sn_node with args: {:?}", args);

--- a/sn/src/routing/core/bootstrap/join.rs
+++ b/sn/src/routing/core/bootstrap/join.rs
@@ -24,13 +24,12 @@ use crate::routing::{
     messages::{NodeMsgAuthorityUtils, WireMsgUtils},
     network_knowledge::NetworkKnowledge,
     node::Node,
-    Peer, MIN_ADULT_AGE,
+    Peer, UnnamedPeer, MIN_ADULT_AGE,
 };
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use bls::PublicKey as BlsPublicKey;
 use futures::future;
 use resource_proof::ResourceProof;
-use std::net::SocketAddr;
 use tokio::{sync::mpsc, time::Duration};
 use tracing::Instrument;
 use xor_name::Prefix;
@@ -44,7 +43,7 @@ pub(crate) async fn join_network(
     node: Node,
     comm: &Comm,
     incoming_conns: &mut mpsc::Receiver<ConnectionEvent>,
-    bootstrap_addr: SocketAddr,
+    bootstrap_peer: UnnamedPeer,
     genesis_key: BlsPublicKey,
 ) -> Result<(Node, NetworkKnowledge)> {
     let (send_tx, send_rx) = mpsc::channel(1);
@@ -56,7 +55,7 @@ pub(crate) async fn join_network(
 
     let state = Join::new(node, send_tx, incoming_conns, prefix_map);
 
-    future::join(state.run(bootstrap_addr), send_messages(send_rx, comm))
+    future::join(state.run(bootstrap_peer), send_messages(send_rx, comm))
         .instrument(span)
         .await
         .0
@@ -101,15 +100,17 @@ impl<'a> Join<'a> {
     // - `ResourceChallenge`: carry out resource proof calculation.
     // - `Approval`: returns the initial `Section` value to use by this node,
     //    completing the bootstrap.
-    async fn run(self, bootstrap_addr: SocketAddr) -> Result<(Node, NetworkKnowledge)> {
+    async fn run(self, bootstrap_peer: UnnamedPeer) -> Result<(Node, NetworkKnowledge)> {
         // Use our XorName as we do not know their name or section key yet.
-        let dst_xorname = self.node.name();
+        let bootstrap_peer = bootstrap_peer.named(self.node.name());
         let genesis_key = self.prefix_map.genesis_key();
+
         let (target_section_key, recipients) =
-            if let Ok(sap) = self.prefix_map.section_by_name(&dst_xorname) {
+            if let Ok(sap) = self.prefix_map.section_by_name(&bootstrap_peer.name()) {
+                sap.merge_connections([&bootstrap_peer]).await;
                 (sap.section_key(), sap.elders_vec())
             } else {
-                (genesis_key, vec![Peer::new(dst_xorname, bootstrap_addr)])
+                (genesis_key, vec![bootstrap_peer])
             };
 
         self.join(genesis_key, target_section_key, recipients).await
@@ -274,6 +275,9 @@ impl<'a> Join<'a> {
                         resource_proof_response: None,
                     };
 
+                    section_auth
+                        .merge_connections(recipients.iter().chain([&sender]))
+                        .await;
                     let new_recipients = section_auth.elders_vec();
                     self.send_join_requests(join_request, &new_recipients, section_key, true)
                         .await?;
@@ -329,6 +333,9 @@ impl<'a> Join<'a> {
                         resource_proof_response: None,
                     };
 
+                    section_auth
+                        .merge_connections(recipients.iter().chain([&sender]))
+                        .await;
                     self.send_join_requests(join_request, &new_recipients, section_key, true)
                         .await?;
                 }
@@ -424,10 +431,7 @@ impl<'a> Join<'a> {
                                 msg: SystemMsg::JoinResponse(resp),
                                 msg_authority,
                                 ..
-                            }) => (
-                                *resp,
-                                Peer::new(msg_authority.src_location().name(), sender.addr()),
-                            ),
+                            }) => (*resp, sender.named(msg_authority.src_location().name())),
                             Ok(
                                 MessageType::Service { msg_id, .. }
                                 | MessageType::System { msg_id, .. },
@@ -504,7 +508,7 @@ mod tests {
         pin_mut,
     };
     use secured_linked_list::SecuredLinkedList;
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, net::SocketAddr};
     use tokio::task;
     use xor_name::XorName;
 
@@ -536,7 +540,12 @@ mod tests {
         );
 
         // Create the bootstrap task, but don't run it yet.
-        let bootstrap = async move { state.run(bootstrap_addr).await.map_err(Error::from) };
+        let bootstrap = async move {
+            state
+                .run(UnnamedPeer::addressed(bootstrap_addr))
+                .await
+                .map_err(Error::from)
+        };
 
         // Create the task that executes the body of the test, but don't run it either.
         let others = async {
@@ -639,7 +648,7 @@ mod tests {
             NetworkPrefixMap::new(genesis_key),
         );
 
-        let bootstrap_task = state.run(bootstrap_node.addr);
+        let bootstrap_task = state.run(UnnamedPeer::addressed(bootstrap_node.addr));
         let test_task = async move {
             // Receive JoinRequest
             let (wire_msg, recipients) = send_rx
@@ -742,7 +751,7 @@ mod tests {
             NetworkPrefixMap::new(section_key),
         );
 
-        let bootstrap_task = state.run(bootstrap_node.addr);
+        let bootstrap_task = state.run(UnnamedPeer::addressed(bootstrap_node.addr));
         let test_task = async {
             let (wire_msg, _) = send_rx
                 .recv()
@@ -830,7 +839,7 @@ mod tests {
             NetworkPrefixMap::new(section_key),
         );
 
-        let bootstrap_task = state.run(bootstrap_node.addr);
+        let bootstrap_task = state.run(UnnamedPeer::addressed(bootstrap_node.addr));
         let test_task = async {
             let (wire_msg, _) = send_rx
                 .recv()

--- a/sn/src/routing/core/comm.rs
+++ b/sn/src/routing/core/comm.rs
@@ -310,13 +310,16 @@ impl Comm {
                             .and_then(|(connection, connection_incoming)| async move {
                                 recipient.set_connection(connection.clone()).await;
                                 self.connected_peers.insert(connection.clone()).await;
-                                let _ = task::spawn(handle_incoming_messages(
-                                    connection.clone(),
-                                    connection_incoming,
-                                    self.event_tx.clone(),
-                                    self.msg_count.clone(),
-                                    self.connected_peers.clone(),
-                                ));
+                                let _ = task::spawn(
+                                    handle_incoming_messages(
+                                        connection.clone(),
+                                        connection_incoming,
+                                        self.event_tx.clone(),
+                                        self.msg_count.clone(),
+                                        self.connected_peers.clone(),
+                                    )
+                                    .in_current_span(),
+                                );
                                 Ok(connection)
                             })
                             .await,

--- a/sn/src/routing/core/comm.rs
+++ b/sn/src/routing/core/comm.rs
@@ -86,7 +86,7 @@ impl Comm {
         bootstrap_nodes: &[SocketAddr],
         config: qp2p::Config,
         event_tx: mpsc::Sender<ConnectionEvent>,
-    ) -> Result<(Self, SocketAddr)> {
+    ) -> Result<(Self, UnnamedPeer)> {
         // Bootstrap to the network returning the connection to a node.
         // We can use the returned channels to listen for incoming messages and disconnection events
         let (endpoint, incoming_connections, bootstrap_peer) =
@@ -125,7 +125,7 @@ impl Comm {
                 back_pressure: BackPressure::new(),
                 connected_peers,
             },
-            bootstrap_peer.remote_address(),
+            UnnamedPeer::connected(bootstrap_peer),
         ))
     }
 

--- a/sn/src/routing/core/comm.rs
+++ b/sn/src/routing/core/comm.rs
@@ -11,7 +11,7 @@ use crate::messaging::{system::LoadReport, WireMsg};
 use crate::routing::{
     error::{Error, Result},
     log_markers::LogMarker,
-    Peer, Sender,
+    Peer, UnnamedPeer,
 };
 use bytes::Bytes;
 use futures::{
@@ -428,7 +428,7 @@ impl Comm {
 
 #[derive(Debug)]
 pub(crate) enum ConnectionEvent {
-    Received((Sender, Bytes)),
+    Received((UnnamedPeer, Bytes)),
 }
 
 #[tracing::instrument(skip_all)]
@@ -471,7 +471,7 @@ async fn handle_incoming_messages(
             Ok(msg) => {
                 let _send_res = event_tx
                     .send(ConnectionEvent::Received((
-                        Sender::Connected(connection.clone()),
+                        UnnamedPeer::connected(connection.clone()),
                         msg,
                     )))
                     .await;

--- a/sn/src/routing/core/messaging.rs
+++ b/sn/src/routing/core/messaging.rs
@@ -25,7 +25,7 @@ use crate::routing::{
     network_knowledge::{ElderCandidates, NodeState, SectionKeyShare},
     relocation::RelocateState,
     routing_api::command::Command,
-    Peer, Sender,
+    Peer, UnnamedPeer,
 };
 use crate::types::PublicKey;
 use bls::PublicKey as BlsPublicKey;
@@ -538,7 +538,7 @@ impl Core {
             wire_msg.set_dst_xorname(self.node.read().await.name());
 
             commands.push(Command::HandleMessage {
-                sender: Sender::Ourself,
+                sender: UnnamedPeer::addressed(self.our_connection_info()),
                 wire_msg,
                 original_bytes: None,
             });

--- a/sn/src/routing/messages/mod.rs
+++ b/sn/src/routing/messages/mod.rs
@@ -58,6 +58,9 @@ impl WireMsgUtils for WireMsg {
 
         let wire_msg = WireMsg::new_msg(MessageId::new(), msg_payload, msg_kind, dst)?;
 
+        #[cfg(feature = "unstable-wiremsg-debuginfo")]
+        let wire_msg = wire_msg.set_payload_debug(node_msg);
+
         Ok(wire_msg)
     }
 
@@ -76,6 +79,9 @@ impl WireMsgUtils for WireMsg {
         );
 
         let wire_msg = WireMsg::new_msg(MessageId::new(), msg_payload, msg_kind, dst)?;
+
+        #[cfg(feature = "unstable-wiremsg-debuginfo")]
+        let wire_msg = wire_msg.set_payload_debug(node_msg);
 
         Ok(wire_msg)
     }

--- a/sn/src/routing/mod.rs
+++ b/sn/src/routing/mod.rs
@@ -25,7 +25,9 @@
 // ############################################################################
 pub(crate) use self::{
     core::MIN_LEVEL_WHEN_FULL,
-    network_knowledge::{peer::Sender, section_keys::SectionKeyShare, SectionAuthorityProvider},
+    network_knowledge::{
+        peer::UnnamedPeer, section_keys::SectionKeyShare, SectionAuthorityProvider,
+    },
 };
 pub use self::{
     dkg::SectionAuthUtils,

--- a/sn/src/routing/network_knowledge/peer.rs
+++ b/sn/src/routing/network_knowledge/peer.rs
@@ -57,7 +57,19 @@ impl fmt::Debug for Peer {
 
 impl Display for Peer {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{} at {}", self.name, self.addr)
+        write!(
+            f,
+            "{} at {} ({})",
+            self.name,
+            self.addr,
+            match self.connection.try_read() {
+                Ok(guard) => guard
+                    .as_ref()
+                    .map(|_| "connected")
+                    .unwrap_or("not connected"),
+                Err(_) => "<locked>",
+            }
+        )
     }
 }
 

--- a/sn/src/routing/network_knowledge/peer.rs
+++ b/sn/src/routing/network_knowledge/peer.rs
@@ -106,15 +106,6 @@ impl Peer {
         }
     }
 
-    /// Creates a new `Peer` given a `name` and a `connection` to the peer.
-    pub(crate) fn connected(name: XorName, connection: qp2p::Connection) -> Self {
-        Self {
-            name,
-            addr: connection.remote_address(),
-            connection: Arc::new(RwLock::new(Some(connection))),
-        }
-    }
-
     /// Returns the `XorName` of the peer.
     pub fn name(&self) -> XorName {
         self.name
@@ -145,22 +136,49 @@ impl Peer {
     }
 }
 
-/// A peer who sent us a message.
+/// A peer whose name we don't yet know.
 ///
-/// When we receive a message, we don't know the identity of the sender, so we cannot represent them
-/// as a [`Peer`]. Contrary to `Peer`, we must have a physical connection to the peer, in order to
-/// have received the message.
+/// An `UnnamedPeer` represents a connected peer when we don't yet know the peer's name. For
+/// example, when we receive a message we don't know the identity of the sender.
+///
+/// One rough edge to this is that `UnnamedPeer` is also used to represent messages from "ourself".
+/// in this case there is no physical connection, and we technically would know our own identity.
+/// It's possible that we're self-sending at the wrong level of the API (e.g. we currently serialise
+/// and self-deliver a `WireMsg`, when we could instead directly generate the appropriate
+/// `Command`). One benefit of this is it also works with tests, where we also often don't have an
+/// actual connection.
 #[derive(Clone, Debug)]
-pub(crate) enum Sender {
-    /// The message was sent from ourself.
-    Ourself,
+pub(crate) struct UnnamedPeer {
+    addr: SocketAddr,
+    connection: Option<qp2p::Connection>,
+}
 
-    /// The message was sent from a connected peer.
-    Connected(qp2p::Connection),
+impl UnnamedPeer {
+    pub(crate) fn addressed(addr: SocketAddr) -> Self {
+        Self {
+            addr,
+            connection: None,
+        }
+    }
 
-    /// The message was sent from a test.
-    #[cfg(test)]
-    Test(SocketAddr),
+    pub(crate) fn connected(connection: qp2p::Connection) -> Self {
+        Self {
+            addr: connection.remote_address(),
+            connection: Some(connection),
+        }
+    }
+
+    pub(crate) fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub(crate) fn named(self, name: XorName) -> Peer {
+        Peer {
+            name,
+            addr: self.addr,
+            connection: Arc::new(RwLock::new(self.connection)),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/sn/src/routing/routing_api/command.rs
+++ b/sn/src/routing/routing_api/command.rs
@@ -126,8 +126,18 @@ impl fmt::Display for Command {
             Command::HandleElderAgreement { .. } => write!(f, "HandleElderAgreement"),
             Command::HandleDkgOutcome { .. } => write!(f, "HandleDkgOutcome"),
             Command::HandleDkgFailure(_) => write!(f, "HandleDkgFailure"),
+            #[cfg(not(feature = "unstable-wiremsg-debuginfo"))]
             Command::SendMessage { wire_msg, .. } => {
                 write!(f, "SendMessage {:?}", wire_msg.msg_id())
+            }
+            #[cfg(feature = "unstable-wiremsg-debuginfo")]
+            Command::SendMessage { wire_msg, .. } => {
+                write!(
+                    f,
+                    "SendMessage {:?} {:?}",
+                    wire_msg.msg_id(),
+                    wire_msg.payload_debug
+                )
             }
             Command::ParseAndSendWireMsg(wire_msg) => {
                 write!(f, "ParseAndSendWireMsg {:?}", wire_msg.msg_id())

--- a/sn/src/routing/routing_api/command.rs
+++ b/sn/src/routing/routing_api/command.rs
@@ -13,7 +13,7 @@ use crate::messaging::{
 use crate::routing::{
     network_knowledge::{NetworkKnowledge, SectionAuthorityProvider, SectionKeyShare},
     node::Node,
-    Peer, Sender, XorName,
+    Peer, UnnamedPeer, XorName,
 };
 use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;
@@ -31,7 +31,7 @@ pub(crate) enum Command {
     /// Handle `message` from `sender`.
     /// Holding the WireMsg that has been received from the network,
     HandleMessage {
-        sender: Sender,
+        sender: UnnamedPeer,
         wire_msg: WireMsg,
         #[debug(skip)]
         // original bytes to avoid reserializing for entropy checks

--- a/sn/src/routing/routing_api/mod.rs
+++ b/sn/src/routing/routing_api/mod.rs
@@ -151,7 +151,7 @@ impl Routing {
             let node_name = ed25519::name(&keypair.public);
             info!("{} Bootstrapping a new node.", node_name);
 
-            let (comm, bootstrap_addr) = Comm::bootstrap(
+            let (comm, bootstrap_peer) = Comm::bootstrap(
                 config.local_addr,
                 config
                     .bootstrap_nodes
@@ -168,7 +168,7 @@ impl Routing {
                 node_name,
                 std::process::id(),
                 comm.our_connection_info(),
-                bootstrap_addr,
+                bootstrap_peer.addr(),
                 genesis_key
             );
 
@@ -177,7 +177,7 @@ impl Routing {
                 joining_node,
                 &comm,
                 &mut connection_event_rx,
-                bootstrap_addr,
+                bootstrap_peer,
                 genesis_key,
             )
             .await?;

--- a/sn/src/routing/routing_api/tests/mod.rs
+++ b/sn/src/routing/routing_api/tests/mod.rs
@@ -29,7 +29,7 @@ use crate::routing::{
     },
     node::Node,
     relocation::{self, RelocatePayloadUtils},
-    supermajority, Error, Event, Peer, Result as RoutingResult, Sender, FIRST_SECTION_MAX_AGE,
+    supermajority, Error, Event, Peer, Result as RoutingResult, UnnamedPeer, FIRST_SECTION_MAX_AGE,
     FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE, MIN_AGE,
 };
 use crate::{elder_count, init_test_logger};
@@ -104,7 +104,7 @@ async fn receive_join_request_without_resource_proof_response() -> Result<()> {
 
     let mut commands = get_internal_commands(
         Command::HandleMessage {
-            sender: Sender::Ourself,
+            sender: UnnamedPeer::addressed(new_node.addr),
             wire_msg,
             original_bytes: None,
         },
@@ -197,7 +197,7 @@ async fn receive_join_request_with_resource_proof_response() -> Result<()> {
 
     let commands = get_internal_commands(
         Command::HandleMessage {
-            sender: Sender::Test(new_node.addr),
+            sender: UnnamedPeer::addressed(new_node.addr),
             wire_msg,
             original_bytes: None,
         },
@@ -306,7 +306,7 @@ async fn receive_join_request_from_relocated_node() -> Result<()> {
 
     let inner_commands = get_internal_commands(
         Command::HandleMessage {
-            sender: Sender::Test(relocated_node.addr),
+            sender: UnnamedPeer::addressed(relocated_node.addr),
             wire_msg,
             original_bytes: None,
         },
@@ -380,7 +380,7 @@ async fn aggregate_proposals() -> Result<()> {
 
         let commands = get_internal_commands(
             Command::HandleMessage {
-                sender: Sender::Ourself,
+                sender: UnnamedPeer::addressed(node.addr),
                 wire_msg,
                 original_bytes: None,
             },
@@ -416,7 +416,7 @@ async fn aggregate_proposals() -> Result<()> {
 
     let mut commands = get_internal_commands(
         Command::HandleMessage {
-            sender: Sender::Ourself,
+            sender: UnnamedPeer::addressed(nodes[threshold()].addr),
             wire_msg,
             original_bytes: None,
         },
@@ -973,7 +973,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
 
     let _commands = get_internal_commands(
         Command::HandleMessage {
-            sender: Sender::Ourself,
+            sender: UnnamedPeer::addressed(old_node.addr),
             wire_msg,
             original_bytes: None,
         },
@@ -1053,7 +1053,7 @@ async fn untrusted_ae_message_msg_errors() -> Result<()> {
 
     let _commands = get_internal_commands(
         Command::HandleMessage {
-            sender: Sender::Ourself,
+            sender: UnnamedPeer::addressed(sender.addr),
             wire_msg,
             original_bytes: None,
         },
@@ -1267,10 +1267,7 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
     assert!(commands.is_empty());
 
     let msg_type = assert_matches!(comm_rx.recv().await, Some(ConnectionEvent::Received((sender, bytes))) => {
-        assert_matches!(
-            sender,
-            Sender::Connected(connection) => assert_eq!(connection.remote_address(), node.addr)
-        );
+        assert_eq!(sender.addr(), node.addr);
         assert_matches!(WireMsg::deserialize(bytes), Ok(msg_type) => msg_type)
     });
 


### PR DESCRIPTION
- 3693f8eb6 **refactor(sn): replace `Sender` with `UnknownPeer`**

  The `UnknownPeer` struct is more general, and will make it easier to
  propagate connections into more places (e.g. this already propagates
  connections into `HandleSystemMsg`). It's also generally easier to use
  than `Sender`, and doesn't need any special casing for test-only
  purposes.
  
  The downside is that we lose the 'sending to ourself' representation.
  This wasn't being used so far though, so it's only a hypothetical. The
  comment on `UnknownPeer` attempts to document that 'rough edge' (since
  we would otherwise expect to only know peers either through
  advertisement, where the name would be known, or through direct
  connection, where the connection would be present).

- 92a077572 **chore(sn): add a feature for increased `WireMsg` debug info**

  When we serialize to a `WireMsg`, we lose visibility of the exact
  contents of the message. Serialization is necessary in order to obtain a
  signature for the message, so we can't simply hold the message
  unserialised until send time (at least, not without passing around a
  keypair, which we don't want to do).
  
  As a hacky alternative, an `unstable-wiremsg-debuginfo` feature has been
  added. When enabled, this adds a `payload_debug` field to `WireMsg`
  which can be set to contain a debug representation of the message
  contents. Since `WireMsg` is constructed with `Bytes`, its necessary for
  callers to set this themselves.

- dbb452216 **chore(sn): inherit span on `Comm::send` incoming message listener**

  Since we spawn a detached future, we need to explicitly inherit the
  span.

- fbe96c7e2 **chore(sn): add 'connectedness' to `Peer`'s `Display`**


- 5ba7a5743 **chore(sn): improve `connection-tracing` jq filter output**

  The new format splits the `trace` out into an array and adds `wire_msg`
  to the details, if present.

- f36a5facc **refactor(sn): reuse connections during join flow**

  This only saves a few connections, but it proves out the machinery for
  carrying them around. Once additional mechanism was added,
  `SectionAuthorityProvider::merge_connections`, which takes an iterator
  of peers and sets any relevant connection handles in the SAP's elders.
