### PR TITLE
Register entries contain Vec<u8> instead of Url

### DIFF
--- a/sn/src/types/errors.rs
+++ b/sn/src/types/errors.rs
@@ -51,6 +51,9 @@ pub enum Error {
     /// Entry already exists. Contains the current entry Key.
     #[error("Entry already exists {0}")]
     EntryExists(u8),
+    /// Entry is too big to fit inside a register
+    #[error("Entry is too big to fit inside a register: {0}, max: {1}")]
+    EntryTooBig(usize, usize),
     /// Supplied actions are not valid
     #[error("Some entry actions are not valid")]
     InvalidEntryActions(BTreeMap<Vec<u8>, Error>),

--- a/sn/src/types/register/metadata.rs
+++ b/sn/src/types/register/metadata.rs
@@ -7,10 +7,6 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::url::Url;
-use crdts::merkle_reg::Sha3Hash;
-use tiny_keccak::{Hasher, Sha3};
-
 /// An action on Register data type.
 #[derive(Clone, Debug, Copy, Eq, PartialEq)]
 pub enum Action {
@@ -21,12 +17,4 @@ pub enum Action {
 }
 
 /// An entry in a Register.
-pub type Entry = Url;
-
-impl Eq for Entry {}
-
-impl Sha3Hash for Entry {
-    fn hash(&self, hasher: &mut Sha3) {
-        hasher.update(self.to_string().as_bytes());
-    }
-}
+pub type Entry = Vec<u8>;

--- a/sn/src/types/register/metadata.rs
+++ b/sn/src/types/register/metadata.rs
@@ -16,5 +16,5 @@ pub enum Action {
     Write,
 }
 
-/// An entry in a Register.
+/// An entry in a Register (note that the vec<u8> is size limited: MAX_REG_ENTRY_SIZE)
 pub type Entry = Vec<u8>;

--- a/sn/src/url/mod.rs
+++ b/sn/src/url/mod.rs
@@ -228,7 +228,7 @@ impl UrlType {
 ///   public_name()   --> hnyynyzhjjjatqkfkjux8maaojtj8r59aphcnue6a11qgecpcebidkywmybnc
 ///   top_name() --> hnyynyzhjjjatqkfkjux8maaojtj8r59aphcnue6a11qgecpcebidkywmybnc
 ///   sub_names()   --> None
-#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Url {
     encoding_version: u64,      // currently only v1 supported
     public_name: String,        // "a.b.name" in "a.b.name"

--- a/sn_api/src/app/resolver/handlers.rs
+++ b/sn_api/src/app/resolver/handlers.rs
@@ -117,10 +117,10 @@ impl Safe {
             DataType::Register => {
                 let data = if retrieve_data {
                     match input_url.content_version() {
-                        None => self.fetch_register_entries(&input_url).await?,
+                        None => self.register_fetch_entries(&input_url).await?,
                         Some(v) => vec![(
                             v.entry_hash(),
-                            self.fetch_register_entry(&input_url, v.entry_hash())
+                            self.register_fetch_entry(&input_url, v.entry_hash())
                                 .await?,
                         )]
                         .into_iter()

--- a/sn_api/src/app/safe_client.rs
+++ b/sn_api/src/app/safe_client.rs
@@ -139,7 +139,8 @@ impl SafeAppClient {
     }
 
     // === Register data operations ===
-    pub async fn store_register(
+    /// Low level method to create a register
+    pub async fn create_register(
         &self,
         name: Option<XorName>,
         tag: u64,
@@ -189,6 +190,7 @@ impl SafeAppClient {
         Ok(xorname)
     }
 
+    /// Low level method to read all register entries
     pub async fn read_register(
         &self,
         address: RegisterAddress,
@@ -209,6 +211,7 @@ impl SafeAppClient {
         })
     }
 
+    /// Low level method to read a register entry
     pub async fn get_register_entry(
         &self,
         address: RegisterAddress,
@@ -235,6 +238,7 @@ impl SafeAppClient {
         Ok(entry)
     }
 
+    /// Low level method to write to register
     pub async fn write_to_register(
         &self,
         address: RegisterAddress,

--- a/sn_api/src/errors.rs
+++ b/sn_api/src/errors.rs
@@ -74,6 +74,9 @@ pub enum Error {
     /// InvalidAmount
     #[error("InvalidAmount: {0}")]
     InvalidAmount(String),
+    /// InvalidUtf8Sequence
+    #[error("InvalidUtf8Sequence: {0}")]
+    InvalidUtf8Sequence(#[from] std::str::Utf8Error),
     /// InvalidXorUrl
     #[error("InvalidXorUrl: {0}")]
     InvalidXorUrl(String),


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

- adapted registers to hold `Vec<u8>` instead of `Url` in both `sn` and `sn_api`
- did some renaming in the `sn_api` register function names to clear up some confusion because of duplicate names
    - higher level register methods in the `register` module are now all prefixed with `register_*`
    - lower level register methods in `safe_client` are NOT prefixed with `register_*`
- register entries are size-limited (check is on reg write) at `MIN_ENCRYPTABLE_BYTES`