### PR TITLE
ci: exit successfully if no changes detected

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -23,8 +23,6 @@ jobs:
           toolchain: stable
           override: true
       - shell: bash
-        run: echo "GITHUB_ACTOR = $GITHUB_ACTOR"
-      - shell: bash
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"

--- a/resources/scripts/bump_version.sh
+++ b/resources/scripts/bump_version.sh
@@ -43,6 +43,12 @@ function determine_which_crates_have_changes() {
         echo "smart-release has determined sn_cli crate has changes"
         sn_cli_has_changes=true
     fi
+    if [[ $safe_network_has_changes == false ]] || \
+       [[ $sn_api_has_changes == false ]] || \
+       [[ $sn_cli_has_changes == false ]]; then
+        echo "smart-release detected no changes in any crates. Exiting."
+        exit 0
+    fi
 }
 
 function generate_version_bump_commit() {


### PR DESCRIPTION
If smart-release doesn't detect any changes, we want the version bumping workflow to just complete without any errors.
