### PR TITLE
Connection management part 6

### DIFF
--- a/sn/src/routing/network_knowledge/mod.rs
+++ b/sn/src/routing/network_knowledge/mod.rs
@@ -29,7 +29,6 @@ use crate::routing::{
 };
 use bls::PublicKey as BlsPublicKey;
 pub(crate) use elder_candidates::ElderCandidates;
-use futures::{stream, StreamExt};
 pub(crate) use node_state::NodeState;
 use peer::Peer;
 pub(crate) use section_authority_provider::SectionAuthorityProvider;
@@ -563,24 +562,20 @@ impl NetworkKnowledge {
     ///
     /// Peers are held in `signed_sap` and `section_peers`, and we match relevant peers with both.
     pub(super) async fn merge_connections(&self, sources: impl IntoIterator<Item = &Peer>) {
-        let connections: BTreeMap<_, _> = stream::iter(sources)
-            .filter_map(|peer| async move {
-                peer.connection()
-                    .await
-                    .map(|connection| (peer.addr(), connection))
-            })
-            .collect()
-            .await;
+        let sources: BTreeMap<_, _> = sources
+            .into_iter()
+            .map(|peer| (peer.addr(), peer))
+            .collect();
 
         for elder in self.signed_sap.read().await.elders() {
-            if let Some(connection) = connections.get(&elder.addr()) {
-                elder.set_connection(connection.clone()).await;
+            if let Some(source) = sources.get(&elder.addr()) {
+                elder.merge_connection(source).await;
             }
         }
 
         for node in self.section_peers.iter() {
-            if let Some(connection) = connections.get(&node.addr()) {
-                node.peer().set_connection(connection.clone()).await;
+            if let Some(source) = sources.get(&node.addr()) {
+                node.peer().merge_connection(source).await;
             }
         }
     }


### PR DESCRIPTION
- 11a328ae0 **refactor(sn): replace `Comm::send` closure with normal `fn`**

  The closure was rather massive. Separating out makes it easier to see
  what's going on.

- 334f5d353 **refactor(sn): simplify `Comm::send` error handling**

  There's now a dedicated error type for `Comm::send_to_one` that better
  represents the possible states. In particular, a connection error could
  never be from a reused connection, and we avoid having to wrap errors as
  much.

- 62908feef **refactor(sn): only recreate failed connections in `Comm::send`**

  `Peer`s may hold connections that have been lost due to timeouts etc. As
  such, we want to handle connection loss when sending by trying again and
  forcing a reconnection. We would previously do this by passing a
  `force_reconnection` flag, however in the event of concurrent sends this
  might lead to more connections being opened than necessary.
  
  The new approach tests the existing connection to see if it's the same
  one that previously failed, and will only reconnect if so.
  
  This does not fully protect from 'stampedes' of new connections, since
  the same issue exists when the `Peer` has no connection (e.g. many
  concurrent sends for the same peer may lead to many connections being
  made), but this will be followed up separately.

- bbb92bf3c **refactor(sn): prevent concurrent sends from opening many connections**

  This is an optimisation in favour of reducing the number of connections
  we open, at the cost of reduced parallelism when sending multiple
  messages to the same unconnected `Peer` (which is fairly common when
  performing DKG rounds with new peers, e.g.).
  
  The implementation is based on giving `Peer` the responsibility of
  creating new connections if necessary, meaning it can take the write
  lock and see if any competing attempt already set a new connection - and
  if so, avoid creating another one. A 'fast path' is included that will
  return immediately if there's an existing valid connection.

- cc6ffc467 **refactor(sn): prefer existing connection when merging `Peer`s**

  This is a probably-premature optimisation to minimise when we take write
  locks on `Peer::connection`. Previously when merging connections we
  would prioritise the source connection (e.g. we would overwrite an
  existing connection in the target). In particular, this would cause
  write-locking even if it was the same connection, which could lead to
  needless contention when trying to read connections.
  
  This commit changes to instead retain the existing connection if we have
  one, and does so in a way that minimises the likelihood that we need to
  take a write lock at all.
