### PR TITLE
Trivial miscellania

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -320,7 +320,7 @@ jobs:
 
       - name: Print Network Log Stats
         shell: bash
-        run: cargo run --bin log_cmds_inspector --release --features=always-joinable,test-utils $HOME/.safe/node/local-test-network
+        run: cd sn && cargo run --bin log_cmds_inspector --release --features=always-joinable,test-utils $HOME/.safe/node/local-test-network
         if: failure()
 
       - name: Upload Node Logs

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -27,17 +27,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dorny/paths-filter@v2
-        id: messaging_changes
+        id: changes
         with:
           filters: |
-            src:
+            messaging:
               - 'sn/src/messaging/**'
               - 'sn/src/types/**'
-      - uses: dorny/paths-filter@v2
-        id: node_changes
-        with:
-          filters: |
-            src:
+            node:
               - 'sn/src/node/**'
               - 'sn/src/routing/**'
               - 'sn/src/messaging/**'
@@ -45,49 +41,23 @@ jobs:
               - 'sn/src/dbs/**'
               - 'sn/src/prefix_map/**'
               - 'sn/src/url/**'
-      - uses: dorny/paths-filter@v2
-        id: client_changes
-        with:
-          filters: |
-            src:
+            client:
               - 'sn/src/client/**'
               - 'sn/src/messaging/**'
               - 'sn/src/types/**'
               - 'sn/src/dbs/**'
               - 'sn/src/prefix_map/**'
               - 'sn/src/url/**'
-      - uses: dorny/paths-filter@v2
-        id: routing_changes
-        with:
-          filters: |
-            src:
+            routing:
               - 'sn/src/routing/**'
               - 'sn/src/messaging/**'
               - 'sn/src/types/**'
               - 'sn/src/prefix_map/**'
-      - uses: dorny/paths-filter@v2
-        id: url_changes
-        with:
-          filters: |
-            src:
-              - 'sn/src/url/**'
-      - uses: dorny/paths-filter@v2
-        id: data_types_changes
-        with:
-          filters: |
-            src:
+            types:
               - 'sn/src/types/**'
-      - uses: dorny/paths-filter@v2
-        id: dbs_changes
-        with:
-          filters: |
-            src:
+            dbs:
               - 'sn/src/dbs/**'
-      - uses: dorny/paths-filter@v2
-        id: prefix_map_changes
-        with:
-          filters: |
-            src:
+            prefix_map:
               - 'sn/src/prefix_map/**'
 
       - name: Mac install ripgrep
@@ -128,43 +98,33 @@ jobs:
         run: cd sn && cargo build --all-targets --release --features=always-joinable,test-utils
 
       - name: Run Data Types tests
-        if: steps.data_types_changes.outputs.src == 'true'
+        if: steps.changes.outputs.types == 'true'
         run: cd sn && cargo test --release --features=always-joinable,test-utils -- types
         timeout-minutes: 10
 
       - name: Run DBs tests
-        if: steps.dbs_changes.outputs.src == 'true'
+        if: steps.changes.outputs.dbs == 'true'
         run: cd sn && cargo test --release --features=always-joinable,test-utils -- dbs
         timeout-minutes: 5
 
       - name: Run PrefixMap tests
-        if: steps.prefix_map_changes.outputs.src == 'true'
+        if: steps.changes.outputs.prefix_map == 'true'
         run: cd sn && cargo test --release --features=always-joinable,test-utils -- prefix_map
         timeout-minutes: 5
 
-      - name: Run URL tests
-        if: steps.url_changes.outputs.src == 'true'
-        run: cd sn && cargo test --release --features=always-joinable,test-utils -- url
-        timeout-minutes: 5
-
       - name: Run Messaging tests
-        if: steps.messaging_changes.outputs.src == 'true'
+        if: steps.changes.outputs.messaging == 'true'
         run: cd sn && cargo test --release --features=always-joinable,test-utils -- messaging
         timeout-minutes: 5
 
       - name: Run Node tests
-        if: steps.node_changes.outputs.src == 'true'
+        if: steps.changes.outputs.node == 'true'
         run: cd sn && cargo test --release --features=always-joinable,test-utils -- node
         timeout-minutes: 5
 
       - name: Run Routing tests
-        if: steps.routing_changes.outputs.src == 'true'
+        if: steps.changes.outputs.routing == 'true'
         run: cd sn && cargo test --release --features=always-joinable,test-utils -- routing
-        timeout-minutes: 5
-
-      - name: Run Doc tests
-        if: steps.node_changes.outputs.src == 'true'
-        run: cd sn && cargo test --release --features=always-joinable,test-utils client --doc
         timeout-minutes: 5
 
       - run: ./target/release/testnet

--- a/sn/src/messaging/authority.rs
+++ b/sn/src/messaging/authority.rs
@@ -130,11 +130,12 @@ impl SectionAuth {
 /// Verified authority.
 ///
 /// Values of this type constitute a proof that the signature is valid for a particular payload.
-/// This is made possible by performing verification in all possible constructors of the type.
+/// This is made possible by keeping the field private, and performing verification in all possible
+/// constructors of the type.
 ///
 /// Validation is defined by the [`VerifyAuthority`] impl for `T`.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct AuthorityProof<T>(pub(crate) T);
+pub struct AuthorityProof<T>(T);
 
 impl<T: VerifyAuthority> AuthorityProof<T> {
     /// Verify the authority of `inner`.

--- a/sn/src/messaging/serialisation/wire_msg.rs
+++ b/sn/src/messaging/serialisation/wire_msg.rs
@@ -131,7 +131,7 @@ impl WireMsg {
                 {
                     AuthorityProof::verify(auth, payload)?
                 } else {
-                    AuthorityProof(auth)
+                    AuthorityProof::verify(auth, &self.payload)?
                 };
 
                 Ok(MessageType::Service {


### PR DESCRIPTION
- 3a5622fdf **fix(sn): restore `ServiceMsg` authority check**

  The `AuthorityProof` struct is designed to be a proof of valid
  authority, by ensuring all possible constructors either generate or
  validate a signature. This can only be guaranteed if the field remains
  module-private. At some point it seems the field was made `pub(crate)`,
  which meant we were missing an authority check for some `ServiceMsg`s,

- 97c540e68 **ci(sn): merge paths filter steps**

  The `dorny/paths-filter@v2` action can be configured with multiple named
  filters, which is a bit more concise and should be more efficient than
  running multiple steps.
  
  In the process, some redundant entries have been removed:
  
  - `url` is no longer present in `sn` (removed in 3fe9d7a66).
  - doctests have been removed, as we no longer have any (and the
    condition seemed mismatched for this – we would run it on `node`
    changes, but specify `client` as the test filter 🤷).

- 950ffe87c **ci(sn): change directory when printing network log stats**

  This should let us reuse the compiled artifacts.
