### PR TITLE
fix: avoid use outdated keyshare status

### DIFF
--- a/sn/src/routing/network_knowledge/mod.rs
+++ b/sn/src/routing/network_knowledge/mod.rs
@@ -254,6 +254,37 @@ impl NetworkKnowledge {
         }
     }
 
+    pub(super) async fn switch_to_sap(
+        &self,
+        signed_sap: SectionAuth<SectionAuthorityProvider>,
+        our_name: &XorName,
+    ) -> Result<()> {
+        let provided_sap = signed_sap.value.clone();
+        // We try to update our SAP and own chain only if we were flagged to,
+        // otherwise this update could be due to an AE message and we still don't have
+        // the key share for the new SAP, making this node unable to sign section messages
+        // and possibly being kicked out of the group of Elders.
+        if provided_sap.prefix().matches(our_name) {
+            let our_prev_prefix = self.prefix().await;
+            *self.signed_sap.write().await = signed_sap.clone();
+            *self.chain.write().await = self
+                .all_sections_chains
+                .read()
+                .await
+                .get_proof_chain(&self.genesis_key, &provided_sap.section_key())?;
+
+            // Remove any peer which doesn't belong to our new section's prefix
+            self.section_peers.retain(&provided_sap.prefix());
+            info!(
+                "Updated our section's SAP ({:?} to {:?}) with new one: {:?}",
+                our_prev_prefix,
+                provided_sap.prefix(),
+                provided_sap
+            );
+        }
+        Ok(())
+    }
+
     /// Update our network knowledge if the provided SAP is valid and can be verified
     /// with the provided proof chain.
     /// If the 'update_sap' flag is set to 'true', the provided SAP and chain will be
@@ -263,8 +294,6 @@ impl NetworkKnowledge {
         signed_sap: SectionAuth<SectionAuthorityProvider>,
         proof_chain: &SecuredLinkedList,
         updated_members: Option<SectionPeers>,
-        our_name: &XorName,
-        update_sap: bool,
     ) -> Result<bool> {
         let mut there_was_an_update = false;
         let provided_sap = signed_sap.value.clone();
@@ -288,29 +317,6 @@ impl NetworkKnowledge {
                     .write()
                     .await
                     .join(proof_chain.clone())?;
-
-                // We try to update our SAP and own chain only if we were flagged to,
-                // otherwise this update could be due to an AE message and we still don't have
-                // the key share for the new SAP, making this node unable to sign section messages
-                // and possibly being kicked out of the group of Elders.
-                if update_sap && provided_sap.prefix().matches(our_name) {
-                    let our_prev_prefix = self.prefix().await;
-                    *self.signed_sap.write().await = signed_sap.clone();
-                    *self.chain.write().await = self
-                        .all_sections_chains
-                        .read()
-                        .await
-                        .get_proof_chain(&self.genesis_key, &provided_sap.section_key())?;
-
-                    // Remove any peer which doesn't belong to our new section's prefix
-                    self.section_peers.retain(&provided_sap.prefix());
-                    info!(
-                        "Updated our section's SAP ({:?} to {:?}) with new one: {:?}",
-                        our_prev_prefix,
-                        provided_sap.prefix(),
-                        provided_sap
-                    );
-                }
             }
             Ok(false) => {
                 debug!(
@@ -334,7 +340,6 @@ impl NetworkKnowledge {
                     self.prefix().await,
                     self.members()
                 );
-                there_was_an_update = true;
             }
         }
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
