### PR TITLE
Fixes to DKG Anti-entropy

### DIFF
--- a/sn/src/routing/dkg/session.rs
+++ b/sn/src/routing/dkg/session.rs
@@ -24,7 +24,7 @@ use crate::routing::{
 use crate::types::PublicKey;
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::{
-    message::Message as DkgMessage, Error as DkgError, KeyGen, MessageAndTarget,
+    message::Message as DkgMessage, Error as DkgError, KeyGen, MessageAndTarget, Phase,
 };
 use itertools::Itertools;
 use std::{
@@ -50,9 +50,74 @@ pub(crate) struct Session {
     pub(crate) complete: bool,
 }
 
+fn is_dkg_behind(expected: Phase, actual: Phase) -> bool {
+    if let (Phase::Contribution, Phase::Initialization) = (expected, actual) {
+        true
+    } else {
+        trace!("Our DKG session is ahead. Skipping DkgAE");
+        false
+    }
+}
+
 impl Session {
     pub(crate) fn timer_token(&self) -> u64 {
         self.timer_token
+    }
+
+    fn send_dkg_not_ready(
+        &mut self,
+        node: &Node,
+        message: DkgMessage,
+        session_id: &DkgSessionId,
+        sender: XorName,
+        section_pk: BlsPublicKey,
+    ) -> Result<Vec<Command>> {
+        let mut commands = vec![];
+        // When the message in trouble is an Acknowledgement,
+        // we shall query the ack.proposer .
+        let target = match message {
+            DkgMessage::Acknowledgment { ref ack, .. } => {
+                if let Some(name) = self.key_gen.node_id_from_index(ack.0) {
+                    name
+                } else {
+                    warn!("Cannot get node_id for index {:?}", ack.0);
+                    return Ok(vec![]);
+                }
+            }
+            _ => sender,
+        };
+
+        if let Some(peer) = self.peers().get(&target) {
+            trace!(
+                "Targeting DkgNotReady to {:?} on unhandable message {:?}",
+                target,
+                message
+            );
+            let node_msg = SystemMsg::DkgNotReady {
+                session_id: *session_id,
+                message,
+            };
+            let wire_msg = WireMsg::single_src(
+                node,
+                DstLocation::Node {
+                    name: target,
+                    section_pk,
+                },
+                node_msg,
+                section_pk,
+            )?;
+
+            commands.push(Command::SendMessage {
+                recipients: vec![peer.clone()],
+                wire_msg,
+            });
+        } else {
+            warn!(
+                "Failed to fetch peer of {:?} among {:?}",
+                target, self.elder_candidates
+            );
+        }
+        Ok(commands)
     }
 
     pub(crate) fn process_message(
@@ -80,51 +145,17 @@ impl Session {
                 }
                 commands.extend(self.check(node, session_id, section_pk)?);
             }
-            Err(DkgError::UnexpectedPhase { .. }) | Err(DkgError::MissingPart) => {
-                // When the message in trouble is an Acknowledgement,
-                // we shall query the ack.proposer .
-                let target = match message {
-                    DkgMessage::Acknowledgment { ref ack, .. } => {
-                        if let Some(name) = self.key_gen.node_id_from_index(ack.0) {
-                            name
-                        } else {
-                            warn!("Cannot get node_id for index {:?}", ack.0);
-                            return Ok(vec![]);
-                        }
-                    }
-                    _ => sender,
-                };
-
-                if let Some(peer) = self.peers().get(&target) {
-                    trace!(
-                        "Targeting DkgNotReady to {:?} on unhandable message {:?}",
-                        target,
-                        message
-                    );
-                    let node_msg = SystemMsg::DkgNotReady {
-                        session_id: *session_id,
-                        message,
-                    };
-                    let wire_msg = WireMsg::single_src(
-                        node,
-                        DstLocation::Node {
-                            name: target,
-                            section_pk,
-                        },
-                        node_msg,
-                        section_pk,
-                    )?;
-
-                    commands.push(Command::SendMessage {
-                        recipients: vec![peer.clone()],
-                        wire_msg,
-                    });
-                } else {
-                    warn!(
-                        "Failed to fetch peer of {:?} among {:?}",
-                        target, self.elder_candidates
-                    );
-                }
+            Err(DkgError::UnexpectedPhase { expected, actual })
+                if is_dkg_behind(expected, actual) =>
+            {
+                commands.extend(
+                    self.send_dkg_not_ready(node, message, session_id, sender, section_pk)?,
+                );
+            }
+            Err(DkgError::MissingPart) => {
+                commands.extend(
+                    self.send_dkg_not_ready(node, message, session_id, sender, section_pk)?,
+                );
             }
             Err(error) => {
                 error!("Error processing DKG message: {:?}", error);


### PR DESCRIPTION
- discard DKG session info for older sessions
- skip DkgStart and DkgRetry messages for expired sessions