### PR TITLE
fix: avoid network_knowledge lookup when sending DKGNotReady or DkgSessionUnknown

### DIFF
--- a/sn/src/routing/core/msg_handling/dkg.rs
+++ b/sn/src/routing/core/msg_handling/dkg.rs
@@ -77,7 +77,7 @@ impl Core {
         &self,
         session_id: DkgSessionId,
         message: DkgMessage,
-        sender: XorName,
+        sender: Peer,
     ) -> Result<Vec<Command>> {
         trace!(
             "{} {:?} from {}",
@@ -123,7 +123,7 @@ impl Core {
         session_id: DkgSessionId,
         message_history: Vec<DkgMessage>,
         message: DkgMessage,
-        sender: XorName,
+        sender: Peer,
     ) -> Result<Vec<Command>> {
         let section_key = self.network_knowledge().section_key().await;
         let mut commands = self
@@ -132,7 +132,7 @@ impl Core {
                 &self.node.read().await.clone(),
                 session_id,
                 message_history,
-                sender,
+                sender.name(),
                 section_key,
             )
             .await?;

--- a/sn/src/routing/core/msg_handling/mod.rs
+++ b/sn/src/routing/core/msg_handling/mod.rs
@@ -481,8 +481,7 @@ impl Core {
                     message,
                     sender
                 );
-                self.handle_dkg_message(session_id, message, sender.name())
-                    .await
+                self.handle_dkg_message(session_id, message, sender).await
             }
             SystemMsg::DkgFailureObservation {
                 session_id,
@@ -506,7 +505,7 @@ impl Core {
                 message,
                 session_id,
             } => {
-                self.handle_dkg_retry(session_id, message_history, message, sender.name())
+                self.handle_dkg_retry(session_id, message_history, message, sender)
                     .await
             }
             // The following type of messages are all handled by upper sn_node layer.
@@ -693,7 +692,7 @@ impl Core {
                 trace!("DkgSessionInfo handling {:?} - {:?}", session_id, elders);
                 commands.extend(self.handle_dkg_start(session_id, prefix, elders).await?);
                 commands.extend(
-                    self.handle_dkg_retry(session_id, message_cache, message, sender.name())
+                    self.handle_dkg_retry(session_id, message_cache, message, sender)
                         .await?,
                 );
                 Ok(commands)


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
