### PR TITLE
fix: order of target length in ElderConn error corrected

### DIFF
--- a/sn/src/client/connections/messaging.rs
+++ b/sn/src/client/connections/messaging.rs
@@ -587,8 +587,8 @@ pub(super) async fn send_message(
     if failures > successful_sends {
         error!("More send errors than success on send_message");
         Err(Error::InsufficientElderConnections(
-            elders.len(),
             successful_sends,
+            elders.len(),
         ))
     } else {
         Ok(())


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
