### PR TITLE
fix(client): read_from client API was incorrectly using provided length value as an end index

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -10,7 +10,7 @@ env:
   RUST_LOG: "safe_network=trace"
   SAFE_AUTH_PASSPHRASE: "x"
   SAFE_AUTH_PASSWORD: "y"
-  SN_QUERY_TIMEOUT: 240 # 4 mins
+  SN_QUERY_TIMEOUT: 20 # 20 secs
   SN_AE_WAIT: 1 # 1 sec
   SN_ELDER_COUNT: 5
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/sn/src/client/config_handler.rs
+++ b/sn/src/client/config_handler.rs
@@ -219,6 +219,22 @@ mod tests {
             let _some_last_char = str_path.pop();
         }
 
+        let expected_query_timeout = std::env::var(SN_QUERY_TIMEOUT)
+            .map(|v| {
+                v.parse()
+                    .map(Duration::from_secs)
+                    .unwrap_or(DEFAULT_QUERY_TIMEOUT)
+            })
+            .unwrap_or(DEFAULT_QUERY_TIMEOUT);
+
+        let expected_standard_wait = std::env::var(SN_AE_WAIT)
+            .map(|v| {
+                v.parse()
+                    .map(Duration::from_secs)
+                    .unwrap_or(DEFAULT_AE_WAIT)
+            })
+            .unwrap_or(DEFAULT_AE_WAIT);
+
         let expected_config = ClientConfig {
             local_addr: (Ipv4Addr::UNSPECIFIED, 0).into(),
             root_dir: root_dir.clone(),
@@ -228,8 +244,8 @@ mod tests {
                 keep_alive_interval: Some(Duration::from_secs(30)),
                 ..Default::default()
             },
-            query_timeout: DEFAULT_QUERY_TIMEOUT,
-            standard_wait: DEFAULT_AE_WAIT,
+            query_timeout: expected_query_timeout,
+            standard_wait: expected_standard_wait,
         };
         assert_eq!(format!("{:?}", config), format!("{:?}", expected_config));
         assert_eq!(serialize(&config)?, serialize(&expected_config)?);

--- a/sn/src/client/errors.rs
+++ b/sn/src/client/errors.rs
@@ -172,9 +172,6 @@ pub enum Error {
     /// Could not chunk all the data required to encrypt the data. (Expected, Actual)
     #[error("Not all data was chunked! Required {}, but we have {}.)", _0, _1)]
     NotAllDataWasChunked(usize, usize),
-    /// InvalidPositionOrLength
-    #[error("Invalid position or length: {0}")]
-    InvalidPositionOrLength(String),
 }
 
 impl From<(CmdError, OperationId)> for Error {

--- a/sn_api/src/app/resolver/safe_data.rs
+++ b/sn_api/src/app/resolver/safe_data.rs
@@ -1,0 +1,137 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+pub use super::{ContentType, DataType, Url, VersionHash, XorUrlBase};
+use crate::app::{
+    files::{FileInfo, FilesMap},
+    multimap::MultimapKeyValues,
+    nrs::NrsMap,
+    register::{Entry, EntryHash},
+    XorName,
+};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// SafeData contains the data types fetchable using the Safe Network resolver
+#[allow(clippy::large_enum_variant)]
+// FilesContainer is significantly larger than the other variants
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub enum SafeData {
+    SafeKey {
+        xorurl: String,
+        xorname: XorName,
+        resolved_from: String,
+    },
+    FilesContainer {
+        xorurl: String,
+        xorname: XorName,
+        type_tag: u64,
+        version: VersionHash,
+        files_map: FilesMap,
+        data_type: DataType,
+        metadata: Option<FileInfo>,
+        resolves_into: Option<Url>,
+        resolved_from: String,
+    },
+    PublicBlob {
+        xorurl: String,
+        xorname: XorName,
+        data: Bytes,
+        media_type: Option<String>,
+        metadata: Option<FileInfo>,
+        resolved_from: String,
+    },
+    NrsMapContainer {
+        public_name: Option<String>,
+        xorurl: String,
+        xorname: XorName,
+        type_tag: u64,
+        version: VersionHash,
+        nrs_map: NrsMap,
+        data_type: DataType,
+        resolves_into: Option<Url>,
+        resolved_from: String,
+    },
+    Multimap {
+        xorurl: String,
+        xorname: XorName,
+        type_tag: u64,
+        data: MultimapKeyValues,
+        resolved_from: String,
+    },
+    PublicRegister {
+        xorurl: String,
+        xorname: XorName,
+        type_tag: u64,
+        data: BTreeSet<(EntryHash, Entry)>,
+        resolved_from: String,
+    },
+    PrivateRegister {
+        xorurl: String,
+        xorname: XorName,
+        type_tag: u64,
+        data: BTreeSet<(EntryHash, Entry)>,
+        resolved_from: String,
+    },
+}
+
+impl SafeData {
+    pub fn xorurl(&self) -> String {
+        use SafeData::*;
+        match self {
+            SafeKey { xorurl, .. }
+            | FilesContainer { xorurl, .. }
+            | PublicBlob { xorurl, .. }
+            | NrsMapContainer { xorurl, .. }
+            | Multimap { xorurl, .. }
+            | PublicRegister { xorurl, .. }
+            | PrivateRegister { xorurl, .. } => xorurl.clone(),
+        }
+    }
+
+    pub fn resolved_from(&self) -> String {
+        use SafeData::*;
+        match self {
+            SafeKey { resolved_from, .. }
+            | FilesContainer { resolved_from, .. }
+            | PublicBlob { resolved_from, .. }
+            | NrsMapContainer { resolved_from, .. }
+            | Multimap { resolved_from, .. }
+            | PublicRegister { resolved_from, .. }
+            | PrivateRegister { resolved_from, .. } => resolved_from.clone(),
+        }
+    }
+
+    pub fn resolves_into(&self) -> Option<Url> {
+        use SafeData::*;
+        match self {
+            SafeKey { .. }
+            | PublicBlob { .. }
+            | Multimap { .. }
+            | PublicRegister { .. }
+            | PrivateRegister { .. } => None,
+            FilesContainer { resolves_into, .. } | NrsMapContainer { resolves_into, .. } => {
+                resolves_into.clone()
+            }
+        }
+    }
+
+    pub fn metadata(&self) -> Option<FileInfo> {
+        use SafeData::*;
+        match self {
+            SafeKey { .. }
+            | Multimap { .. }
+            | PublicRegister { .. }
+            | PrivateRegister { .. }
+            | NrsMapContainer { .. } => None,
+            FilesContainer { metadata, .. } | PublicBlob { metadata, .. } => metadata.clone(),
+        }
+    }
+}

--- a/sn_api/src/app/safe_client.rs
+++ b/sn_api/src/app/safe_client.rs
@@ -118,25 +118,23 @@ impl SafeAppClient {
         debug!("Attempting to fetch data from {:?}", address.name());
         let client = self.get_safe_client()?;
         let data = if let Some((start, end)) = range {
+            let start = start.map(|start_index| start_index as usize).unwrap_or(0);
             let len = end
-                .map(|end_index| end_index - start.unwrap_or(0))
-                .unwrap_or(0);
-            client
-                .read_from(
-                    address,
-                    start.map(|val| val as usize).unwrap_or(0),
-                    len as usize,
-                )
-                .await
+                .map(|end_index| end_index as usize - start)
+                .unwrap_or(usize::MAX);
+
+            client.read_from(address, start, len).await
         } else {
             client.read_bytes(address).await
         }
         .map_err(|e| Error::NetDataError(format!("Failed to GET Blob: {:?}", e)))?;
+
         debug!(
             "{} bytes of data successfully retrieved from: {:?}",
             data.len(),
             address.name()
         );
+
         Ok(data)
     }
 


### PR DESCRIPTION
This also has a minor refactoring in sn_api moving the `SafeData` struct into its own file.