### PR TITLE
ci: exclude .cargo-lock file from artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,9 @@ jobs:
       - uses: actions/upload-artifact@master
         with:
           name: safe_network-${{ matrix.target }}
-          path: artifacts
+          path: |
+            artifacts
+            !artifacts/.cargo-lock
 
   gh_release:
     if: |


### PR DESCRIPTION
Trying to delete this file didn't work, so going to attempt to exclude it from the list of files that are uploaded.
