### PR TITLE
ci: include sn_cli in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,10 @@ jobs:
           path: artifacts/prod/aarch64-unknown-linux-musl/release
 
       - shell: bash
-        run: make safe_network-package-version-artifacts-for-release
+        run: |
+          make clean-deploy
+          make safe_network-package-version-artifacts-for-release
+          make sn_cli-package-version-artifacts-for-release
 
       - shell: bash
         id: versioning
@@ -94,7 +97,9 @@ jobs:
       - name: generate release description first pass
         shell: bash
         run: |
-          ./resources/scripts/get_release_description.sh "${{ steps.versioning.outputs.sn_version }}" > release_description.md
+          ./resources/scripts/get_release_description.sh \
+            "${{ steps.versioning.outputs.sn_version }}" \
+            "${{ steps.versioning.outputs.sn_cli_version }}" > release_description.md
 
       # The second pass uses Python to extract the changelog entries for this version.
       # Python can easily do a string replace and avoid all the pain with newlines you get in Bash.
@@ -134,6 +139,9 @@ jobs:
           prerelease: false
           body_path: release_description.md
 
+      #
+      # sn_node assets
+      #
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -216,6 +224,93 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-aarch64-unknown-linux-musl.tar.gz
           asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-aarch64-unknown-linux-musl.tar.gz
+          asset_content_type: application/zip
+
+      #
+      # safe assets
+      #
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-unknown-linux-musl.zip
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-unknown-linux-musl.zip
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-pc-windows-msvc.zip
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-pc-windows-msvc.zip
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-apple-darwin.zip
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-apple-darwin.zip
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-arm-unknown-linux-musleabi.zip
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-arm-unknown-linux-musleabi.zip
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-armv7-unknown-linux-musleabihf.zip
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-armv7-unknown-linux-musleabihf.zip
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-aarch64-unknown-linux-musl.zip
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-aarch64-unknown-linux-musl.zip
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-unknown-linux-musl.tar.gz
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-unknown-linux-musl.tar.gz
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-pc-windows-msvc.tar.gz
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-pc-windows-msvc.tar.gz
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-apple-darwin.tar.gz
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-apple-darwin.tar.gz
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-arm-unknown-linux-musleabi.tar.gz
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-arm-unknown-linux-musleabi.tar.gz
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-armv7-unknown-linux-musleabihf.tar.gz
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-armv7-unknown-linux-musleabihf.tar.gz
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-aarch64-unknown-linux-musl.tar.gz
+          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-aarch64-unknown-linux-musl.tar.gz
           asset_content_type: application/zip
 
   # At first glance, it seems like it would be possible to check the commit message in the `if` condition

--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,13 @@ safe_network-build-artifacts-for-deploy:
 		rm safe_network-$$arch.zip; \
 	done
 
-.ONESHELL:
-safe_network-package-version-artifacts-for-release:
+clean-deploy:
 	rm -f *.zip *.tar.gz
 	rm -rf ${DEPLOY_PATH}
 	mkdir -p ${DEPLOY_PROD_PATH}
 
+.ONESHELL:
+safe_network-package-version-artifacts-for-release:
 	declare -a architectures=( \
 		"x86_64-unknown-linux-musl" \
 		"x86_64-pc-windows-msvc" \
@@ -96,11 +97,7 @@ safe_network-package-version-artifacts-for-release:
 	mv *.zip ${DEPLOY_PROD_PATH}
 
 .ONESHELL:
-sn_cli-package-version-artifacts-for-deploy:
-	rm -f *.zip *.tar.gz
-	rm -rf ${DEPLOY_PATH}
-	mkdir -p ${DEPLOY_PROD_PATH}
-
+sn_cli-package-version-artifacts-for-release:
 	declare -a architectures=( \
 		"x86_64-unknown-linux-musl" \
 		"x86_64-pc-windows-msvc" \

--- a/resources/scripts/get_release_description.sh
+++ b/resources/scripts/get_release_description.sh
@@ -6,6 +6,12 @@ if [[ -z "$sn_version" ]]; then
     exit 1
 fi
 
+sn_cli_version=$2
+if [[ -z "$sn_cli_version" ]]; then
+    echo "You must supply a version number for sn_cli"
+    exit 1
+fi
+
 # The single quotes around EOF is to stop attempted variable and backtick expansion.
 read -r -d '' release_description << 'EOF'
 Command line interface for the Safe Network. Refer to [Safe CLI User Guide](https://github.com/maidsafe/sn_cli/blob/master/README.md) for detailed instructions.
@@ -17,6 +23,10 @@ __SN_CHANGELOG_TEXT__
 ## Safe API Changelog
 
 __SN_API_CHANGELOG_TEXT__
+
+## Safe CLI Changelog
+
+__SN_CLI_CHANGELOG_TEXT__
 
 ## SHA-256 checksums for sn_node binaries:
 ```
@@ -43,6 +53,33 @@ tar.gz: SN_TAR_ARMv7_CHECKSUM
 Aarch64
 zip: SN_ZIP_AARCH64_CHECKSUM
 tar.gz: SN_TAR_AARCH64_CHECKSUM
+```
+
+## SHA-256 checksums for safe binaries:
+```
+Linux
+zip: SN_CLI_ZIP_LINUX_CHECKSUM
+tar.gz: SN_CLI_TAR_LINUX_CHECKSUM
+
+macOS
+zip: SN_CLI_ZIP_MACOS_CHECKSUM
+tar.gz: SN_CLI_TAR_MACOS_CHECKSUM
+
+Windows
+zip: SN_CLI_ZIP_WIN_CHECKSUM
+tar.gz: SN_CLI_TAR_WIN_CHECKSUM
+
+ARM
+zip: SN_CLI_ZIP_ARM_CHECKSUM
+tar.gz: SN_CLI_TAR_ARM_CHECKSUM
+
+ARMv7
+zip: SN_CLI_ZIP_ARMv7_CHECKSUM
+tar.gz: SN_CLI_TAR_ARMv7_CHECKSUM
+
+Aarch64
+zip: SN_CLI_ZIP_AARCH64_CHECKSUM
+tar.gz: SN_CLI_TAR_AARCH64_CHECKSUM
 ```
 EOF
 
@@ -83,6 +120,43 @@ sn_tar_aarch64_checksum=$(sha256sum \
     "./deploy/prod/sn_node-$sn_version-aarch64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 
+sn_cli_zip_linux_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-unknown-linux-musl.zip" | \
+    awk '{ print $1 }')
+sn_cli_zip_macos_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-apple-darwin.zip" | \
+    awk '{ print $1 }')
+sn_cli_zip_win_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-pc-windows-msvc.zip" | \
+    awk '{ print $1 }')
+sn_cli_zip_arm_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-arm-unknown-linux-musleabi.zip" | \
+    awk '{ print $1 }')
+sn_cli_zip_armv7_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-armv7-unknown-linux-musleabihf.zip" | \
+    awk '{ print $1 }')
+sn_cli_zip_aarch64_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-aarch64-unknown-linux-musl.zip" | \
+    awk '{ print $1 }')
+sn_cli_tar_linux_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-unknown-linux-musl.tar.gz" | \
+    awk '{ print $1 }')
+sn_cli_tar_macos_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-apple-darwin.tar.gz" | \
+    awk '{ print $1 }')
+sn_cli_tar_win_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-pc-windows-msvc.tar.gz" | \
+    awk '{ print $1 }')
+sn_cli_tar_arm_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-arm-unknown-linux-musleabi.tar.gz" | \
+    awk '{ print $1 }')
+sn_cli_tar_armv7_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-armv7-unknown-linux-musleabihf.tar.gz" | \
+    awk '{ print $1 }')
+sn_cli_tar_aarch64_checksum=$(sha256sum \
+    "./deploy/prod/sn_cli-$sn_cli_version-aarch64-unknown-linux-musl.tar.gz" | \
+    awk '{ print $1 }')
+
 release_description=$(sed "s/SN_ZIP_LINUX_CHECKSUM/$sn_zip_linux_checksum/g" <<< "$release_description")
 release_description=$(sed "s/SN_ZIP_MACOS_CHECKSUM/$sn_zip_macos_checksum/g" <<< "$release_description")
 release_description=$(sed "s/SN_ZIP_WIN_CHECKSUM/$sn_zip_win_checksum/g" <<< "$release_description")
@@ -94,6 +168,19 @@ release_description=$(sed "s/SN_TAR_MACOS_CHECKSUM/$sn_tar_macos_checksum/g" <<<
 release_description=$(sed "s/SN_TAR_WIN_CHECKSUM/$sn_tar_win_checksum/g" <<< "$release_description")
 release_description=$(sed "s=SN_TAR_ARM_CHECKSUM=$sn_tar_arm_checksum=g" <<< "$release_description")
 release_description=$(sed "s=SN_TAR_ARMv7_CHECKSUM=$sn_tar_armv7_checksum=g" <<< "$release_description")
-release_description=$(sed "s=SN_TAR_AARCH64_CHECKSUM=$sn_tar_aarch64_checksum=g" <<< "$release_description")
+
+release_description=$(sed "s/SN_CLI_ZIP_LINUX_CHECKSUM/$sn_cli_zip_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/SN_CLI_ZIP_MACOS_CHECKSUM/$sn_cli_zip_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/SN_CLI_ZIP_WIN_CHECKSUM/$sn_cli_zip_win_checksum/g" <<< "$release_description")
+release_description=$(sed "s=SN_CLI_ZIP_ARM_CHECKSUM=$sn_cli_zip_arm_checksum=g" <<< "$release_description")
+release_description=$(sed "s=SN_CLI_ZIP_ARMv7_CHECKSUM=$sn_cli_zip_armv7_checksum=g" <<< "$release_description")
+release_description=$(sed "s=SN_CLI_ZIP_AARCH64_CHECKSUM=$sn_cli_zip_aarch64_checksum=g" <<< "$release_description")
+release_description=$(sed "s/SN_CLI_TAR_LINUX_CHECKSUM/$sn_cli_tar_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/SN_CLI_TAR_MACOS_CHECKSUM/$sn_cli_tar_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/SN_CLI_TAR_WIN_CHECKSUM/$sn_cli_tar_win_checksum/g" <<< "$release_description")
+release_description=$(sed "s=SN_CLI_TAR_ARM_CHECKSUM=$sn_cli_tar_arm_checksum=g" <<< "$release_description")
+release_description=$(sed "s=SN_CLI_TAR_ARMv7_CHECKSUM=$sn_cli_tar_armv7_checksum=g" <<< "$release_description")
+release_description=$(sed "s=SN_CLI_TAR_AARCH64_CHECKSUM=$sn_cli_tar_aarch64_checksum=g" <<< "$release_description")
+release_description=$(sed "s=SN_CLI_TAR_AARCH64_CHECKSUM=$sn_cli_tar_aarch64_checksum=g" <<< "$release_description")
 
 echo "$release_description"


### PR DESCRIPTION
A lot of work had already been done for this previously, so this commit is just filling in the missing gaps:

* Include the CLI in the release description
* Package the CLI artifacts for deploy
* Upload the artifacts to the GH release

For now I'm avoiding extending publishing for `sn_cli` because we don't have any crates up yet, and we can't get one up until we resolve the issue with the `self_update` reference. We need to get this done because `smart-release` won't work properly until a crate is published.

I've tested this with a dummy release on my fork:
https://github.com/jacderida/safe_network/releases/tag/safe_network-v0.48.0