### PR TITLE
chore: add in distinct client errors for comms failure

### DIFF
--- a/sn/src/client/client_api/queries.rs
+++ b/sn/src/client/client_api/queries.rs
@@ -81,6 +81,8 @@ impl Client {
                     match res {
                         Ok(Ok(query_result)) => Ok(Ok(query_result)),
                         Ok(Err(error @ Error::InsufficientElderConnections { .. })) => {
+                            warn!("Insufficient elder connections during a query attempt");
+
                             Err(error).map_err(backoff::Error::Transient)
                         }
                         Ok(Err(other_error)) => Err(other_error).map_err(backoff::Error::Permanent),

--- a/sn/src/client/errors.rs
+++ b/sn/src/client/errors.rs
@@ -12,6 +12,7 @@ use crate::messaging::{
     Error as MessagingError,
 };
 use crate::types::Error as DtError;
+use bls::PublicKey;
 use std::io;
 use thiserror::Error;
 
@@ -41,11 +42,21 @@ pub enum Error {
     /// qp2p's IncomingMessages errores
     #[error("An error was returned from IncomingMessages on one of our connections")]
     IncomingMessages,
+    /// Could not send queries to sufficient elder to retrieve reliable responses.
+    #[error(
+        "Failed to send messages to sufficent elders. A supermajority of responses is unobtainable. {0} were connected to, {1} needed."
+    )]
+    FailedToSendSufficentQuery(usize, usize),
     /// Could not connect to sufficient elder to retrieve reliable responses.
     #[error(
         "Problem connecting to sufficient elders. A supermajority of responses is unobtainable. {0} were connected to, {1} needed."
     )]
     InsufficientElderConnections(usize, usize),
+    /// Did not know of sufficient elders in the desired section to get supermajority of repsonses.
+    #[error(
+        "Problem finding sufficient elders. A supermajority of responses is unobtainable. {0} were known in this section, {1} needed."
+    )]
+    InsufficientElderKnowledge(usize, usize, PublicKey),
     /// Cannot store empty bytes..
     #[error("Cannot store empty bytes.")]
     EmptyBytesProvided,


### PR DESCRIPTION
Some situations were mislabelled as InsuffcientElderConnection, implying failed connections, but it was actually a failure in our network knowledge.

This commit adds clarifying error types for this situation

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
