### PR TITLE
chore: remove use of `indicatif` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,17 +1748,6 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.14.0"
-source = "git+https://github.com/mibac138/indicatif?branch=mpb-tick#564c518e8ddea3f1468cd82e054d596fbf4b4e2a"
-dependencies = [
- "console 0.15.0",
- "lazy_static",
- "number_prefix",
- "regex",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
@@ -3185,7 +3174,7 @@ dependencies = [
  "either",
  "flate2",
  "hyper",
- "indicatif 0.15.0",
+ "indicatif",
  "log",
  "quick-xml",
  "regex",
@@ -3206,7 +3195,7 @@ dependencies = [
  "either",
  "flate2",
  "hyper",
- "indicatif 0.15.0",
+ "indicatif",
  "log",
  "quick-xml",
  "regex",
@@ -3466,7 +3455,6 @@ dependencies = [
  "ed25519-dalek",
  "hex 0.4.3",
  "human-panic",
- "indicatif 0.14.0",
  "isatty",
  "multibase 0.6.0",
  "num-traits",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -56,10 +56,6 @@ features = [ "serde" ]
 version = "1.0.1"
 features = [ "serde" ]
 
-[dependencies.indicatif]
-git = "https://github.com/mibac138/indicatif"
-branch = "mpb-tick"
-
 [dependencies.reqwest]
 version = "~0.11"
 default-features = false

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -122,7 +122,7 @@ pub enum FilesSubCommands {
         #[structopt(short = "e", long = "exists", possible_values = &["ask", "preserve", "overwrite"], default_value="ask")]
         exists: FileExistsAction,
         /// How to display progress.
-        #[structopt(short = "i", long = "progress", possible_values = &["bars", "text", "none"], default_value="bars")]
+        #[structopt(short = "i", long = "progress", possible_values = &["text", "none"], default_value="text")]
         progress: ProgressIndicator,
         /// Preserves modification times, access times, and modes from the original file
         #[structopt(short = "p", long = "preserve")]


### PR DESCRIPTION
This was another crate that was using a git reference. It provides progress bars and other
mechanisms for updating terminal user interfaces with progress on long running tasks. We were using
this crate to display some progress bars during the `files get` command.

Obviously, removing the crate means we no longer have the progress bars in the UI, but we already
had a text-based mechanism for displaying progress, so for the time being, we can fall back on this.
We can look at other progress bar crates or refactor `files get` to work in parallel.

The main crate used a design that made use of threads for handling the display and update of
multiple progress bars, but our code for `files get` is synchronous. The forked crate was used
because it had a mechanism for updating the display in a single-threaded manner.

Removing this crate now means we should be able to get `sn_cli` published, which I would argue is
currently of higher priority.
