### PR TITLE
fix: adult choice per chunk and handling db errors

### DIFF
--- a/sn/src/dbs/mod.rs
+++ b/sn/src/dbs/mod.rs
@@ -12,8 +12,7 @@ mod event_store;
 mod kv_store;
 
 pub(crate) use encoding::{deserialise, serialise};
-pub(crate) use errors::Result;
-pub(crate) use errors::{convert_to_error_message, Error};
+pub(crate) use errors::{convert_to_error_message, Error, Result};
 pub(crate) use event_store::EventStore;
 pub use kv_store::used_space::UsedSpace;
 pub(crate) use kv_store::{to_db_key::ToDbKey, KvStore};

--- a/sn/src/routing/core/chunk_records.rs
+++ b/sn/src/routing/core/chunk_records.rs
@@ -89,7 +89,7 @@ impl Core {
             origin: EndUser(origin.name()),
         });
 
-        let targets = self.get_chunk_holder_adults(&target).await;
+        let targets = self.get_adults_who_should_store_chunk(&target).await;
 
         let aggregation = false;
 
@@ -130,7 +130,7 @@ impl Core {
             operation_id
         );
 
-        let targets = self.get_chunk_holder_adults(address.name()).await;
+        let targets = self.get_adults_holding_chunk(address.name()).await;
 
         if targets.is_empty() {
             return self


### PR DESCRIPTION
We a) ensure we choose only adults with space for chunks
and b) when we do hit a DbError for any chunk put, we republish that chunk via elders

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
