### PR TITLE
chore: update cli install script for single repo

### DIFF
--- a/resources/scripts/install.sh
+++ b/resources/scripts/install.sh
@@ -14,22 +14,29 @@ sn_cli_install_dir() {
   fi
 }
 
-sn_cli_latest_version() {
-  curl -s "https://api.github.com/repos/maidsafe/sn_cli/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/'
+get_download_url() {
+  local platform="$1"
+  local download_url=$(curl -s "https://api.github.com/repos/maidsafe/safe_network/releases/latest" \
+    | grep "sn_cli.*-$platform.tar.gz" \
+    | grep "browser_download_url" \
+    | awk -F ':' '{ print $3 }' \
+    | sed 's/"//')
+  echo "https:$download_url"
 }
 
 sn_cli_download() {
   if cmd_has "curl"; then
-    curl --compressed -q "$@"
+    echo "in here"
+    curl -L --compressed -q "$@"
   elif cmd_has "wget"; then
     # Emulate curl with wget
     ARGS=$(echo "$*" | command sed -e 's/--progress-bar /--progress=bar /' \
-                            -e 's/-L //' \
-                            -e 's/--compressed //' \
-                            -e 's/-I /--server-response /' \
-                            -e 's/-s /-q /' \
-                            -e 's/-o /-O /' \
-                            -e 's/-C - /-c /')
+      -e 's/-L //' \
+      -e 's/--compressed //' \
+      -e 's/-I /--server-response /' \
+      -e 's/-s /-q /' \
+      -e 's/-o /-O /' \
+      -e 's/-C - /-c /')
     # shellcheck disable=SC2086
     eval wget $ARGS
   fi
@@ -90,10 +97,10 @@ sn_cli_profile_is_bash_or_zsh() {
   case "${test_profile-}" in
     *"/.bashrc" | *"/.bash_profile" | *"/.zshrc")
       return
-    ;;
+      ;;
     *)
       return 1
-    ;;
+      ;;
   esac
 }
 
@@ -103,73 +110,77 @@ sn_cli_install() {
   sn_cli_exec="safe"
   uname_output=$(uname -a)
   case $uname_output in
-      *aarch64*)
-          arch="aarch64"
-          ;;
-      Linux*)
-          ;;
-      Darwin*)
-          platform="apple-darwin"
-          ;;
-      MSYS_NT* | MINGW*)
-          platform="pc-windows-msvc"
-          sn_cli_exec="safe.exe"
-          ;;
-      *)
-          echo "Platform not supported by the Safe CLI installation script."
-          exit 1
+    *aarch64*)
+      arch="aarch64"
+      ;;
+    Linux*)
+      ;;
+    Darwin*)
+      platform="apple-darwin"
+      ;;
+    MSYS_NT* | MINGW*)
+      platform="pc-windows-msvc"
+      sn_cli_exec="safe.exe"
+      ;;
+    *)
+      echo "Platform not supported by the Safe CLI installation script."
+      exit 1
   esac
 
-  if [ -z "$safe_version" ]; then safe_version=$(sn_cli_latest_version); fi
-  cli_package="sn_cli-$safe_version-$arch-$platform.tar.gz"
-  cli_package_url="https://sn-api.s3.eu-west-2.amazonaws.com/$cli_package"
+  cli_package_url=$(get_download_url "$arch-$platform")
+  archive_file_name=$(awk -F '/' '{ print $9 }' <<< $cli_package_url)
   tmp_dir=$(mktemp -d)
-  tmp_dir_package=$tmp_dir/$cli_package
+  tmp_archive_path=$tmp_dir/$archive_file_name
 
   echo "=> Downloading Safe CLI package from '$cli_package_url'..."
-  sn_cli_download "$cli_package_url" -o "$tmp_dir_package"
+  echo "=> Saving to '$tmp_archive_path'..."
+  sn_cli_download "$cli_package_url" -o "$tmp_archive_path"
 
   install_dir="$(sn_cli_install_dir)"
   echo "=> Unpacking Safe CLI to '$install_dir'..."
   mkdir -p "$install_dir"
-  tar -xzf $tmp_dir_package -C $install_dir
+  tar -xzf $tmp_archive_path -C $install_dir
 
   case $uname_output in
-      Linux* | Darwin*)
-          sn_cli_profile="$(sn_cli_detect_profile)"
-          sn_cli_in_path_str="\\nexport PATH=\$PATH:$install_dir"
+    Linux* | Darwin*)
+      sn_cli_profile="$(sn_cli_detect_profile)"
+      sn_cli_in_path_str="\\nexport PATH=\$PATH:$install_dir"
 
-          if [ -z "${sn_cli_profile-}" ] ; then
-            local tried_profile
-            if [ -n "${PROFILE}" ]; then
-              tried_profile="${sn_cli_profile} (as defined in \$PROFILE), "
-            fi
-            echo "=> Shell profile not found. Tried ${tried_profile-}~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile"
-            echo "=> Create one of them and run this script again"
-            echo "   OR"
-            echo "=> Append the following lines to the correct file yourself:"
-            command printf "${sn_cli_in_path_str}"
-            echo
-          else
-            echo "=> Adding statement to '$sn_cli_profile' profile to have Safe CLI binary path in the \$PATH"
-            if ! command grep -qc "$install_dir" "$sn_cli_profile"; then
-              command printf "${sn_cli_in_path_str}" >> "$sn_cli_profile"
-              echo "=> Statement appended to '$sn_cli_profile' profile"
-              echo "=> Close and reopen your terminal to start using Safe CLI"
-            else
-              echo "=> Profile '${sn_cli_profile}' already contains a statement to set Safe CLI in the \$PATH"
-            fi
-          fi
-          ;;
-      MSYS_NT* | MINGW*)
-          if ! command grep -qc "$install_dir" <<< $PATH; then
-            echo "=> Adding Safe CLI binary path to the PATH in the system for all users"
-            setx PATH "$PATH:$install_dir" -m
-            echo "=> Close and reopen your terminal to start using Safe CLI"
-          else
-            echo "=> Safe CLI binary path was already set in the PATH"
-          fi
-          ;;
+      # Set this *just incase* the release process has been modified and the binary in the archive
+      # hasn't been set to executable (though ideally it should be and that bug should be fixed).
+      chmod +x "$install_dir/safe"
+
+      if [ -z "${sn_cli_profile-}" ] ; then
+        local tried_profile
+        if [ -n "${PROFILE}" ]; then
+          tried_profile="${sn_cli_profile} (as defined in \$PROFILE), "
+        fi
+        echo "=> Shell profile not found. Tried ${tried_profile-}~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile"
+        echo "=> Create one of them and run this script again"
+        echo "   OR"
+        echo "=> Append the following lines to the correct file yourself:"
+        command printf "${sn_cli_in_path_str}"
+        echo
+      else
+        echo "=> Adding statement to '$sn_cli_profile' profile to have Safe CLI binary path in the \$PATH"
+        if ! command grep -qc "$install_dir" "$sn_cli_profile"; then
+          command printf "${sn_cli_in_path_str}" >> "$sn_cli_profile"
+          echo "=> Statement appended to '$sn_cli_profile' profile"
+          echo "=> Close and reopen your terminal to start using Safe CLI"
+        else
+          echo "=> Profile '${sn_cli_profile}' already contains a statement to set Safe CLI in the \$PATH"
+        fi
+      fi
+      ;;
+    MSYS_NT* | MINGW*)
+      if ! command grep -qc "$install_dir" <<< $PATH; then
+        echo "=> Adding Safe CLI binary path to the PATH in the system for all users"
+        setx PATH "$PATH:$install_dir" -m
+        echo "=> Close and reopen your terminal to start using Safe CLI"
+      else
+        echo "=> Safe CLI binary path was already set in the PATH"
+      fi
+      ;;
   esac
 
   sn_cli_reset
@@ -186,36 +197,6 @@ sn_cli_reset() {
     sn_cli_profile_is_bash_or_zsh sn_cli_install
 }
 
-usage() {
-    printf "Usage: $0 [-v=<version> or --version=<version>]\n\n"
-    printf "To install a specific version of safe, you can optionally supply a version number.\n"
-    printf "You should supply it without the 'v' prefix.\n\n"
-    printf "Example: ./install.sh --version=0.33.0\n\n"
-    printf "If no version number is supplied, the latest version will be installed.\n"
-    exit 1
-}
-
-# It would have been nice to wrap the argument parsing in a little function, but
-# unfortunately it seems to be the case that you can't consume "$@" inside a
-# function.
-
-# The reason for doing this manually and not using getopts or getopt, is because
-# macOS doesn't have a getopts install and the version of getopt it has by
-# default is not the GNU one, so the behaviour will be different on macOS and
-# Linux. For that reason, we just parse them 'manually'.
-safe_version=""
-for arg in "$@"; do
-    case $arg in
-        -v=*|--version=*)
-            safe_version="${arg#*=}"
-            shift
-            ;;
-        *)
-            printf "The %s argument is not supported\n\n" "$arg"
-            usage
-            ;;
-    esac
-done
 sn_cli_install
 
 } # this ensures the entire script is downloaded #


### PR DESCRIPTION
Modify the install process so that it downloads the CLI directly from the Github release rather than
an S3 bucket, which doesn't get updated any more.

Unfortunately, we lose some functionality here, namely, the ability to install a specific version of
the CLI. The reason for this is because of the way the release process is currently setup to assign
the tag name to the Github Release. Since we now have 3 crates in the same repo, the tag name that
we're currently assigning is just the version of the `safe_network` crate. So we can't query for a
specific version of the CLI. We can perhaps change the release process so that the tag name is
assigned the version number of each component, and then we'd be able to go for a specific CLI
version.