### PR TITLE
Release Process and Specific Version Updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,25 +107,12 @@ jobs:
       - name: generate release description second pass
         shell: bash
         run: |
-          commit_message="${{ github.event.head_commit.message }}"
-          if [[ $commit_message == *"safe_network"* ]]; then
-            ./resources/scripts/insert_changelog_entry.py \
-              --sn-version "${{ steps.versioning.outputs.sn_version }}"
-          else
-            sed "s/__SN_CHANGELOG_TEXT__/No changes for this release/g" -i release_description.md
-          fi
-          if [[ $commit_message == *"sn_api"* ]]; then
-            ./resources/scripts/insert_changelog_entry.py \
-              --sn-api-version "${{ steps.versioning.outputs.sn_api_version }}"
-          else
-            sed "s/__SN_API_CHANGELOG_TEXT__/No changes for this release/g" -i release_description.md
-          fi
-          if [[ $commit_message == *"sn_cli"* ]]; then
-            ./resources/scripts/insert_changelog_entry.py \
-              --sn-cli-version "${{ steps.versioning.outputs.sn_cli_version }}"
-          else
-            sed "s/__SN_CLI_CHANGELOG_TEXT__/No changes for this release/g" -i release_description.md
-          fi
+          ./resources/scripts/insert_changelog_entry.py \
+            --sn-version "${{ steps.versioning.outputs.sn_version }}"
+          ./resources/scripts/insert_changelog_entry.py \
+            --sn-api-version "${{ steps.versioning.outputs.sn_api_version }}"
+          ./resources/scripts/insert_changelog_entry.py \
+            --sn-cli-version "${{ steps.versioning.outputs.sn_cli_version }}"
 
       - name: create github release
         id: create_release
@@ -374,4 +361,36 @@ jobs:
             # become available on crates.io immediately, so this script will use a retry loop.
             ./resources/scripts/publish_crate.sh \
               "sn_api" "${{ steps.versioning.outputs.sn_version }}" "safe_network"
+          fi
+
+  publish_sn_cli:
+    name: publish sn_cli
+    runs-on: ubuntu-latest
+    needs: [publish_sn_api]
+    if: |
+      github.repository_owner == 'maidsafe' &&
+      startsWith(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - shell: bash
+        id: versioning
+        run: |
+          ./resources/scripts/output_versioning_info.sh
+      - name: cargo login
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+      - name: cargo publish
+        run: |
+          commit_message="${{ github.event.head_commit.message }}"
+          if [[ $commit_message == *"sn_cli"* ]]; then
+            # The sn_cli crate is dependent on sn_api and sometimes the new version doesn't
+            # become available on crates.io immediately, so this script will use a retry loop.
+            ./resources/scripts/publish_crate.sh \
+              "sn_cli" "${{ steps.versioning.outputs.sn_api_version }}" "sn_api"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     env:
-      AWS_ACCESS_KEY_ID: AKIAVVODCRMSJ5MV63VB
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: eu-west-2
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
@@ -84,8 +81,9 @@ jobs:
           path: artifacts/prod/aarch64-unknown-linux-musl/release
 
       - shell: bash
+        name: package artifacts for release
         run: |
-          make clean-deploy
+          make deploy-directories
           make safe_network-package-version-artifacts-for-release
           make sn_cli-package-version-artifacts-for-release
 
@@ -126,179 +124,38 @@ jobs:
           prerelease: false
           body_path: release_description.md
 
-      #
-      # sn_node assets
-      #
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-unknown-linux-musl.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-unknown-linux-musl.zip
-          asset_content_type: application/zip
+      # There's an action you can use for uploading an asset to a release, but because there are so
+      # many assets, using the 'gh' CLI is much more concise. The 'gh' tool should be on an Actions
+      # build agent by default.
+      - name: upload artifacts as assets
+        shell: bash
+        run: |
+          (
+            cd deploy/prod/sn_node
+            ls | xargs gh release upload ${{ steps.versioning.outputs.gh_release_tag_name }}
+          )
+          (
+            cd deploy/prod/safe
+            ls | xargs gh release upload ${{ steps.versioning.outputs.gh_release_tag_name }}
+          )
 
-      - uses: actions/upload-release-asset@v1.0.1
+      - uses: shallwefootball/s3-upload-action@master
+        name: upload sn_node artifacts to s3
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-pc-windows-msvc.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-pc-windows-msvc.zip
-          asset_content_type: application/zip
+          aws_key_id: AKIAVVODCRMSJ5MV63VB
+          aws_secret_access_key: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
+          aws_bucket: sn-node
+          source_dir: deploy/prod/sn_node
+          destination_dir: ''
 
-      - uses: actions/upload-release-asset@v1.0.1
+      - uses: shallwefootball/s3-upload-action@master
+        name: upload safe artifacts to s3
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-apple-darwin.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-apple-darwin.zip
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-arm-unknown-linux-musleabi.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-arm-unknown-linux-musleabi.zip
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-armv7-unknown-linux-musleabihf.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-armv7-unknown-linux-musleabihf.zip
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-aarch64-unknown-linux-musl.zip
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-aarch64-unknown-linux-musl.zip
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-unknown-linux-musl.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-unknown-linux-musl.tar.gz
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-pc-windows-msvc.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-pc-windows-msvc.tar.gz
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-apple-darwin.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-x86_64-apple-darwin.tar.gz
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-arm-unknown-linux-musleabi.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-arm-unknown-linux-musleabi.tar.gz
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-armv7-unknown-linux-musleabihf.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-armv7-unknown-linux-musleabihf.tar.gz
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_node-${{ steps.versioning.outputs.sn_version }}-aarch64-unknown-linux-musl.tar.gz
-          asset_name: sn_node-${{ steps.versioning.outputs.sn_version }}-aarch64-unknown-linux-musl.tar.gz
-          asset_content_type: application/zip
-
-      #
-      # safe assets
-      #
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-unknown-linux-musl.zip
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-unknown-linux-musl.zip
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-pc-windows-msvc.zip
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-pc-windows-msvc.zip
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-apple-darwin.zip
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-apple-darwin.zip
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-arm-unknown-linux-musleabi.zip
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-arm-unknown-linux-musleabi.zip
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-armv7-unknown-linux-musleabihf.zip
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-armv7-unknown-linux-musleabihf.zip
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-aarch64-unknown-linux-musl.zip
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-aarch64-unknown-linux-musl.zip
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-unknown-linux-musl.tar.gz
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-unknown-linux-musl.tar.gz
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-pc-windows-msvc.tar.gz
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-pc-windows-msvc.tar.gz
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-apple-darwin.tar.gz
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-x86_64-apple-darwin.tar.gz
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-arm-unknown-linux-musleabi.tar.gz
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-arm-unknown-linux-musleabi.tar.gz
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-armv7-unknown-linux-musleabihf.tar.gz
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-armv7-unknown-linux-musleabihf.tar.gz
-          asset_content_type: application/zip
-
-      - uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-aarch64-unknown-linux-musl.tar.gz
-          asset_name: sn_cli-${{ steps.versioning.outputs.sn_cli_version }}-aarch64-unknown-linux-musl.tar.gz
-          asset_content_type: application/zip
+          aws_key_id: AKIAVVODCRMSJ5MV63VB
+          aws_secret_access_key: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
+          aws_bucket: sn-cli
+          source_dir: deploy/prod/safe
+          destination_dir: ''
 
   # At first glance, it seems like it would be possible to check the commit message in the `if` condition
   # for the presence of the crate name, by using `contains`. However, this doesn't work, so the commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - shell: bash
         name: package artifacts for release
         run: |
-          make deploy-directories
+          make prepare-deploy
           make safe_network-package-version-artifacts-for-release
           make sn_cli-package-version-artifacts-for-release
 

--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,11 @@ safe_network-build-artifacts-for-deploy:
 		rm safe_network-$$arch.zip; \
 	done
 
-clean-deploy:
+deploy-directories:
 	rm -f *.zip *.tar.gz
 	rm -rf ${DEPLOY_PATH}
-	mkdir -p ${DEPLOY_PROD_PATH}
+	mkdir -p ${DEPLOY_PROD_PATH}/safe
+	mkdir -p ${DEPLOY_PROD_PATH}/sn_node
 
 .ONESHELL:
 safe_network-package-version-artifacts-for-release:
@@ -102,8 +103,8 @@ safe_network-package-version-artifacts-for-release:
 		tar -C artifacts/prod/$$arch/release -zcvf sn_node-${SN_NODE_VERSION}-$$arch.tar.gz $$bin_name; \
 	done
 
-	mv *.tar.gz ${DEPLOY_PROD_PATH}
-	mv *.zip ${DEPLOY_PROD_PATH}
+	mv *.tar.gz ${DEPLOY_PROD_PATH}/sn_node
+	mv *.zip ${DEPLOY_PROD_PATH}/sn_node
 
 .ONESHELL:
 sn_cli-package-version-artifacts-for-release:
@@ -118,13 +119,11 @@ sn_cli-package-version-artifacts-for-release:
 	for arch in "$${architectures[@]}" ; do \
 		if [[ $$arch == *"windows"* ]]; then bin_name="safe.exe"; else bin_name="safe"; fi; \
 		zip -j sn_cli-${SN_CLI_VERSION}-$$arch.zip artifacts/prod/$$arch/release/$$bin_name; \
-		zip -j sn_cli-latest-$$arch.zip artifacts/prod/$$arch/release/$$bin_name; \
 		tar -C artifacts/prod/$$arch/release -zcvf sn_cli-${SN_CLI_VERSION}-$$arch.tar.gz $$bin_name; \
-		tar -C artifacts/prod/$$arch/release -zcvf sn_cli-latest-$$arch.tar.gz $$bin_name; \
 	done
 
-	mv *.tar.gz ${DEPLOY_PROD_PATH}
-	mv *.zip ${DEPLOY_PROD_PATH}
+	mv *.tar.gz ${DEPLOY_PROD_PATH}/safe
+	mv *.zip ${DEPLOY_PROD_PATH}/safe
 
 .ONESHELL:
 upload-sn_node-musl-to-s3:

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,9 @@ safe_network-build-artifacts-for-deploy:
 		rm safe_network-$$arch.zip; \
 	done
 
-deploy-directories:
+prepare-deploy:
+	find artifacts/ -name safe -exec chmod +x '{}' \;
+	find artifacts/ -name sn_node -exec chmod +x '{}' \;
 	rm -f *.zip *.tar.gz
 	rm -rf ${DEPLOY_PATH}
 	mkdir -p ${DEPLOY_PROD_PATH}/safe

--- a/resources/scripts/get_release_description.sh
+++ b/resources/scripts/get_release_description.sh
@@ -84,77 +84,77 @@ tar.gz: SN_CLI_TAR_AARCH64_CHECKSUM
 EOF
 
 sn_zip_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-x86_64-unknown-linux-musl.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 sn_zip_macos_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-x86_64-apple-darwin.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-apple-darwin.zip" | \
     awk '{ print $1 }')
 sn_zip_win_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-x86_64-pc-windows-msvc.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-pc-windows-msvc.zip" | \
     awk '{ print $1 }')
 sn_zip_arm_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-arm-unknown-linux-musleabi.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-arm-unknown-linux-musleabi.zip" | \
     awk '{ print $1 }')
 sn_zip_armv7_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-armv7-unknown-linux-musleabihf.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-armv7-unknown-linux-musleabihf.zip" | \
     awk '{ print $1 }')
 sn_zip_aarch64_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-aarch64-unknown-linux-musl.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-aarch64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 sn_tar_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-x86_64-unknown-linux-musl.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_macos_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-x86_64-apple-darwin.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-apple-darwin.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_win_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-x86_64-pc-windows-msvc.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-pc-windows-msvc.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_arm_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-arm-unknown-linux-musleabi.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-arm-unknown-linux-musleabi.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_armv7_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-armv7-unknown-linux-musleabihf.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-armv7-unknown-linux-musleabihf.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_aarch64_checksum=$(sha256sum \
-    "./deploy/prod/sn_node-$sn_version-aarch64-unknown-linux-musl.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_version-aarch64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 
 sn_cli_zip_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-unknown-linux-musl.zip" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-x86_64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 sn_cli_zip_macos_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-apple-darwin.zip" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-x86_64-apple-darwin.zip" | \
     awk '{ print $1 }')
 sn_cli_zip_win_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-pc-windows-msvc.zip" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-x86_64-pc-windows-msvc.zip" | \
     awk '{ print $1 }')
 sn_cli_zip_arm_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-arm-unknown-linux-musleabi.zip" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-arm-unknown-linux-musleabi.zip" | \
     awk '{ print $1 }')
 sn_cli_zip_armv7_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-armv7-unknown-linux-musleabihf.zip" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-armv7-unknown-linux-musleabihf.zip" | \
     awk '{ print $1 }')
 sn_cli_zip_aarch64_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-aarch64-unknown-linux-musl.zip" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-aarch64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 sn_cli_tar_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-unknown-linux-musl.tar.gz" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-x86_64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 sn_cli_tar_macos_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-apple-darwin.tar.gz" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-x86_64-apple-darwin.tar.gz" | \
     awk '{ print $1 }')
 sn_cli_tar_win_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-x86_64-pc-windows-msvc.tar.gz" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-x86_64-pc-windows-msvc.tar.gz" | \
     awk '{ print $1 }')
 sn_cli_tar_arm_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-arm-unknown-linux-musleabi.tar.gz" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-arm-unknown-linux-musleabi.tar.gz" | \
     awk '{ print $1 }')
 sn_cli_tar_armv7_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-armv7-unknown-linux-musleabihf.tar.gz" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-armv7-unknown-linux-musleabihf.tar.gz" | \
     awk '{ print $1 }')
 sn_cli_tar_aarch64_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$sn_cli_version-aarch64-unknown-linux-musl.tar.gz" | \
+    "./deploy/prod/safe/sn_cli-$sn_cli_version-aarch64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 
 release_description=$(sed "s/SN_ZIP_LINUX_CHECKSUM/$sn_zip_linux_checksum/g" <<< "$release_description")

--- a/resources/scripts/get_release_description.sh
+++ b/resources/scripts/get_release_description.sh
@@ -168,6 +168,7 @@ release_description=$(sed "s/SN_TAR_MACOS_CHECKSUM/$sn_tar_macos_checksum/g" <<<
 release_description=$(sed "s/SN_TAR_WIN_CHECKSUM/$sn_tar_win_checksum/g" <<< "$release_description")
 release_description=$(sed "s=SN_TAR_ARM_CHECKSUM=$sn_tar_arm_checksum=g" <<< "$release_description")
 release_description=$(sed "s=SN_TAR_ARMv7_CHECKSUM=$sn_tar_armv7_checksum=g" <<< "$release_description")
+release_description=$(sed "s=SN_TAR_AARCH64_CHECKSUM=$sn_tar_aarch64_checksum=g" <<< "$release_description")
 
 release_description=$(sed "s/SN_CLI_ZIP_LINUX_CHECKSUM/$sn_cli_zip_linux_checksum/g" <<< "$release_description")
 release_description=$(sed "s/SN_CLI_ZIP_MACOS_CHECKSUM/$sn_cli_zip_macos_checksum/g" <<< "$release_description")
@@ -180,7 +181,6 @@ release_description=$(sed "s/SN_CLI_TAR_MACOS_CHECKSUM/$sn_cli_tar_macos_checksu
 release_description=$(sed "s/SN_CLI_TAR_WIN_CHECKSUM/$sn_cli_tar_win_checksum/g" <<< "$release_description")
 release_description=$(sed "s=SN_CLI_TAR_ARM_CHECKSUM=$sn_cli_tar_arm_checksum=g" <<< "$release_description")
 release_description=$(sed "s=SN_CLI_TAR_ARMv7_CHECKSUM=$sn_cli_tar_armv7_checksum=g" <<< "$release_description")
-release_description=$(sed "s=SN_CLI_TAR_AARCH64_CHECKSUM=$sn_cli_tar_aarch64_checksum=g" <<< "$release_description")
 release_description=$(sed "s=SN_CLI_TAR_AARCH64_CHECKSUM=$sn_cli_tar_aarch64_checksum=g" <<< "$release_description")
 
 echo "$release_description"

--- a/resources/scripts/insert_changelog_entry.py
+++ b/resources/scripts/insert_changelog_entry.py
@@ -16,6 +16,8 @@ def get_changelog_entry(changelog_path, version):
     return sn_changelog_content[start:end].strip()
 
 def insert_changelog_entry(entry, pattern):
+    if not entry.strip():
+        entry = "No changes for this release"
     release_description = ""
     with open("release_description.md", "r") as file:
         release_description = file.read()

--- a/resources/scripts/output_versioning_info.sh
+++ b/resources/scripts/output_versioning_info.sh
@@ -1,35 +1,15 @@
 #!/usr/bin/env bash
 
 function build_release_name() {
-    if [[ $commit_message == *"safe_network"* ]]; then
-        gh_release_name="Safe Network v$sn_version/"
-    fi
-    if [[ $commit_message == *"sn_api"* ]]; then
-        gh_release_name="${gh_release_name}Safe API v$sn_api_version/"
-    fi
-    if [[ $commit_message == *"sn_cli"* ]]; then
-        gh_release_name="${gh_release_name}Safe CLI v$sn_cli_version/"
-    fi
-    gh_release_name=${gh_release_name::-1} # strip off any trailing '/' 
+    gh_release_name="Safe Network v$sn_version/"
+    gh_release_name="${gh_release_name}Safe API v$sn_api_version/"
+    gh_release_name="${gh_release_name}Safe CLI v$sn_cli_version"
 }
 
 function build_release_tag_name() {
-    # This is to avoid having a '/' in the tag name, which Github don't seem to like.
-    # If the sn crate has had changes, we'll just use that as the tag name, otherwise
-    # use sn_api, otherwise sn_cli. It doesn't really matter too much, as this is just
-    # tag for the Github Release. The actual release tags will have already been created
-    # at version bumping, and there will be a tag for each of the crates.
-    if [[ $commit_message == *"safe_network"* ]]; then
-        gh_release_tag_name="safe_network-v$sn_version"
-    elif [[ $commit_message == *"sn_api"* ]]; then
-        gh_release_tag_name="sn_api-v$sn_api_version"
-    elif [[ $commit_message == *"sn_cli"* ]]; then
-        gh_release_tag_name="sn_cli-v$sn_cli_version"
-    else
-        echo "Unable to set the tag name for the Github Release"
-        echo "The commit message doesn't contain any expected text"
-        exit 1
-    fi
+    gh_release_tag_name="v$sn_version-"
+    gh_release_tag_name="v$sn_api_version-"
+    gh_release_tag_name="v$sn_cli_version"
 }
 
 function output_version_info() {

--- a/resources/scripts/output_versioning_info.sh
+++ b/resources/scripts/output_versioning_info.sh
@@ -7,9 +7,9 @@ function build_release_name() {
 }
 
 function build_release_tag_name() {
-    gh_release_tag_name="v$sn_version-"
-    gh_release_tag_name="v$sn_api_version-"
-    gh_release_tag_name="v$sn_cli_version"
+    gh_release_tag_name="$sn_version-"
+    gh_release_tag_name="${gh_release_tag_name}$sn_api_version-"
+    gh_release_tag_name="${gh_release_tag_name}$sn_cli_version"
 }
 
 function output_version_info() {

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -74,12 +74,11 @@ features = [
     "compression-flate2",
     "compression-zip-deflate"
 ]
-optional = true
 
 [features]
 default = [ "testing", "self-update" ]
 testing = [ "sn_api/testing" ]
-self-update = [ "self_update" ]
+self-update = []
 
 [dev-dependencies]
 assert_cmd = "~2.0"

--- a/sn_cli/src/operations/helpers.rs
+++ b/sn_cli/src/operations/helpers.rs
@@ -7,8 +7,6 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-#![cfg(feature = "self-update")]
-
 use color_eyre::{eyre::eyre, eyre::WrapErr, Result};
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::PermissionsExt;

--- a/sn_cli/src/operations/node.rs
+++ b/sn_cli/src/operations/node.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::helpers::download_and_install_github_release_asset;
+use super::helpers::download_and_install_node;
 use crate::operations::config::NetworkLauncher;
 use color_eyre::{eyre::bail, eyre::eyre, eyre::WrapErr, Result};
 use sn_api::NodeConfig;
@@ -73,12 +73,8 @@ pub fn node_install(
     } else {
         node_config_dir_path
     };
-    let _ = download_and_install_github_release_asset(
-        target_dir_path,
-        SN_NODE_EXECUTABLE,
-        "safe_network",
-        version,
-    )?;
+    let _ =
+        download_and_install_node(target_dir_path, SN_NODE_EXECUTABLE, "safe_network", version)?;
     Ok(())
 }
 

--- a/sn_cli/src/operations/node.rs
+++ b/sn_cli/src/operations/node.rs
@@ -7,7 +7,6 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-#[cfg(feature = "self-update")]
 use super::helpers::download_and_install_github_release_asset;
 use crate::operations::config::NetworkLauncher;
 use color_eyre::{eyre::bail, eyre::eyre, eyre::WrapErr, Result};
@@ -64,16 +63,6 @@ pub fn node_version(node_path: Option<PathBuf>) -> Result<()> {
     }
 }
 
-#[cfg(not(feature = "self-update"))]
-pub fn node_install(
-    _node_config_dir_path: PathBuf,
-    _node_override_dir_path: Option<PathBuf>,
-    _version: Option<String>,
-) -> Result<()> {
-    Err(eyre!("Self updates are disabled"))
-}
-
-#[cfg(feature = "self-update")]
 pub fn node_install(
     node_config_dir_path: PathBuf,
     node_override_dir_path: Option<PathBuf>,

--- a/sn_cli/tests/cli_node.rs
+++ b/sn_cli/tests/cli_node.rs
@@ -33,9 +33,10 @@ fn node_install_should_install_the_latest_version() -> Result<()> {
         .arg("install")
         .assert()
         .success()
-        .stdout(
-            predicate::str::is_match(format!("Downloading sn_node version:.*{}", latest_version))?
-        );
+        .stdout(predicate::str::is_match(format!(
+            "Downloading sn_node version:.*{}",
+            latest_version
+        ))?);
     node_bin_path.assert(predicate::path::is_file());
     Ok(())
 }
@@ -56,9 +57,10 @@ fn node_install_should_install_a_specific_version() -> Result<()> {
         .arg(&version)
         .assert()
         .success()
-        .stdout(
-            predicate::str::is_match(format!("Downloading sn_node version:.*{}", version))?
-        );
+        .stdout(predicate::str::is_match(format!(
+            "Downloading sn_node version:.*{}",
+            version
+        ))?);
     node_bin_path.assert(predicate::path::is_file());
     Ok(())
 }
@@ -81,9 +83,10 @@ fn node_install_should_install_to_a_specific_location() -> Result<()> {
         .arg(&version)
         .assert()
         .success()
-        .stdout(
-            predicate::str::is_match(format!("Downloading sn_node version:.*{}", version))?
-        );
+        .stdout(predicate::str::is_match(format!(
+            "Downloading sn_node version:.*{}",
+            version
+        ))?);
     node_bin_path.assert(predicate::path::is_file());
     Ok(())
 }

--- a/sn_cli/tests/cli_node.rs
+++ b/sn_cli/tests/cli_node.rs
@@ -33,10 +33,9 @@ fn node_install_should_install_the_latest_version() -> Result<()> {
         .arg("install")
         .assert()
         .success()
-        .stdout(predicate::str::is_match(format!(
-            "Found release:.*{}",
-            latest_version
-        ))?);
+        .stdout(
+            predicate::str::is_match(format!("Downloading sn_node version:.*{}", latest_version))?
+        );
     node_bin_path.assert(predicate::path::is_file());
     Ok(())
 }
@@ -47,7 +46,7 @@ fn node_install_should_install_a_specific_version() -> Result<()> {
     let safe_dir = temp_dir.child(".safe");
     safe_dir.create_dir_all()?;
     let node_bin_path = safe_dir.child(format!("node/{}", SN_NODE_BIN_NAME));
-    let version = "0.49.0";
+    let version = "0.51.6";
 
     let mut cmd = Command::cargo_bin("safe")?;
     cmd.env("SN_CLI_CONFIG_PATH", safe_dir.path())
@@ -57,10 +56,9 @@ fn node_install_should_install_a_specific_version() -> Result<()> {
         .arg(&version)
         .assert()
         .success()
-        .stdout(predicate::str::is_match(format!(
-            "Found release:.*{}",
-            version
-        ))?);
+        .stdout(
+            predicate::str::is_match(format!("Downloading sn_node version:.*{}", version))?
+        );
     node_bin_path.assert(predicate::path::is_file());
     Ok(())
 }
@@ -72,7 +70,7 @@ fn node_install_should_install_to_a_specific_location() -> Result<()> {
     safe_dir.create_dir_all()?;
     let node_dir_path = safe_dir.child("node");
     let node_bin_path = node_dir_path.child(SN_NODE_BIN_NAME);
-    let version = "0.49.0";
+    let version = "0.51.6";
 
     let mut cmd = Command::cargo_bin("safe")?;
     cmd.arg("node")
@@ -83,10 +81,9 @@ fn node_install_should_install_to_a_specific_location() -> Result<()> {
         .arg(&version)
         .assert()
         .success()
-        .stdout(predicate::str::is_match(format!(
-            "Found release:.*{}",
-            version
-        ))?);
+        .stdout(
+            predicate::str::is_match(format!("Downloading sn_node version:.*{}", version))?
+        );
     node_bin_path.assert(predicate::path::is_file());
     Ok(())
 }

--- a/sn_cmd_test_utilities/src/lib.rs
+++ b/sn_cmd_test_utilities/src/lib.rs
@@ -440,7 +440,7 @@ pub mod util {
     fn get_version_from_release_version(release_version: &str) -> Result<String> {
         let mut parts = release_version.split('-');
         let version = parts
-            .next_back()
+            .next()
             .ok_or_else(|| {
                 eyre!(format!(
                     "Could not parse version number from {}",


### PR DESCRIPTION
- 30950813c **ci: release tag_name to include 3 crate versions**

  Rather than just having the `safe_network` crate version, the tag name field will now include the
  version numbers of the 3 crates. This will enable us to be able to install a specific version of the
  CLI. This tag name should always be unique, since there will always be at least 1 crate with a
  change in it.

  The title of the release will also include the names and versions of each of the components, even if
  one crate didn't change.

  The commit message will still just include the crates that changed, so that we know which publishing
  stages to run.

  Also fixes a little bug here with one of the asset hashes not being set correctly.

- c4fd95037 **chore: remove `self-update` feature from `node install`**

  This feature should really never have been applied to `node install`, since self update for the node
  occurs on the node binary itself. We only want to disable self update for the CLI and we still want
  the `node install` feature.

  This means that the `self-update` feature itself isn't actually tied to the `self_update` crate,
  which will still be used, because parts of its functionality are used for the `node install`
  command.

  It will now just disable the CLI itself from updating, which a separate concern from the `node`
  command.

  This also fixes a little mistake with the tag_name for the release not being assigned correctly.

- 51bfdfa9c **ci: upload artifacts to s3 buckets**

  We removed this in favour of using Github Releases as the primary mechanism for downloading the
  binaries, but this is an issue when everything is in the same repository and each release has
  binaries for both `safe` and `sn_node`. It means we can't easily retrieve specific versions of any
  individually component, which we may want to do to give users the ability to install specific
  versions of the binaries.

  For this reason, we'll also upload the binaries to S3. So when the user requests a specific version,
  we'll go to S3 to fetch it, but we can get the latest version from Github Releases.

  There's also a little refactor here to use the `gh` command line tool to upload the artifacts as
  assets to the release. Due to the fact that we have lots of artifacts, using the action is a very
  verbose way of doing the upload.

- 42f1914db **ci: fix executable permissions on binaries**

  Both the `sn_node` and `safe` binaries were not being set as executable either when they're built,
  or they are being reset by the Github archiving process. This little extension fixes that problem.

- 968d05329 **refactor: use s3 as download source for sn_node**

  Now that we've restructured the release process such that one release has all crates, it makes it
  more difficult and awkward to install specific versions of any of the binaries, when Github Releases
  are the source of the download. This is because you can't query Github releases to search for the
  version number of one component. If you want to get a particular version of something by a
  convention (like say the tag name on the release), you need to know the version number for each of
  the 3 components.

  Here the `node install` command is changed to use the Github API to get the latest version, but once
  the version is obtained, we download the binary from S3. This is so we can also support downloading
  specific versions. Using the S3 bucket, we can do this by convention, based on the version number
  and the target platform. It happens to be the case that the self update crate provides some
  functions for querying the API and also downloading and extracting a binary from a compressed tar
  archive, so we're still making use of that crate here.

- 650991551 **chore: re-introduce version arg for cli install script**

  The release process has been modified to upload all our releases to S3, so we can re-introduce the
  `--version` argument for installing specific versions. If the user supplies a version, we can get
  that from S3. Otherwise, we'll get the latest version from Github Releases.

  Also run a `cargo fmt` after a rebase with some conflicts.
