### PR TITLE
chore(release): sn_cli-v0.39.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "sn_cli"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "ansi_term 0.12.1",
  "assert_cmd",

--- a/sn_cli/CHANGELOG.md
+++ b/sn_cli/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## v0.39.2 (2021-12-21)
+
+This is a manually generated changelog, as `smart-release` seemed to have some issue detecting a change in the `sn_cli` crate.
+
+* refactor: use s3 as download source for sn_node
+* chore: remove `self-update` feature from `node install`
+
 ## v0.39.1 (2021-12-16)
 
 ### Commit Statistics

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sn_cli"
-version = "0.39.1"
+version = "0.39.2"
 description = "Safe CLI"
 authors = [
   "bochaco <gabrielviganotti@gmail.com>",


### PR DESCRIPTION
This was a manually generated commit, because smart-release didn't detect any changes in the sn_cli crate.
