### PR TITLE
fix(api): when in dry-run was still requiring a connection by some APIs

### DIFF
--- a/sn_api/src/app/files/file_system.rs
+++ b/sn_api/src/app/files/file_system.rs
@@ -11,6 +11,7 @@ use super::{metadata::get_metadata, ProcessedFiles};
 use crate::{app::consts::*, Error, Result, Safe, XorUrl};
 use bytes::Bytes;
 use log::info;
+use safe_network::client::Error as ClientError;
 use std::{collections::BTreeMap, fs, path::Path};
 use walkdir::{DirEntry, WalkDir};
 
@@ -27,20 +28,31 @@ pub(crate) async fn upload_file_to_net(
     })?;
     let data = Bytes::from(data);
 
-    let mime_type = mime_guess::from_path(&path);
-    match safe
-        .store_public_bytes(data.to_owned(), mime_type.first_raw(), dry_run)
+    let mut mime_type_for_xorurl = mime_guess::from_path(&path).first_raw();
+    let result = match safe
+        .store_public_bytes(data.to_owned(), mime_type_for_xorurl, dry_run)
         .await
     {
         Ok(xorurl) => Ok(xorurl),
-        Err(err) => {
+        Err(Error::InvalidMediaType(_)) => {
             // Let's then upload it and set media-type to be simply raw content
-            if let Error::InvalidMediaType(_) = err {
-                safe.store_public_bytes(data, None, dry_run).await
-            } else {
-                Err(err)
-            }
+            mime_type_for_xorurl = None;
+            safe.store_public_bytes(data.clone(), mime_type_for_xorurl, dry_run)
+                .await
         }
+        other_err => other_err,
+    };
+
+    // If the upload verification failed, the file could still have been uploaded successfully,
+    // thus let's report the error but providing the xorurl for the user to be aware of.
+    if let Err(Error::ClientError(ClientError::NotEnoughChunksRetrieved { .. })) = result {
+        // let's obtain the xorurl with using dry-run mode
+        let xorurl = safe
+            .store_public_bytes(data, mime_type_for_xorurl, true)
+            .await?;
+        Err(Error::ContentUploadVerificationFailed(xorurl))
+    } else {
+        result
     }
 }
 

--- a/sn_api/src/app/files/files_map.rs
+++ b/sn_api/src/app/files/files_map.rs
@@ -69,8 +69,7 @@ pub(crate) async fn add_or_update_file_item(
                 file_name.to_string(),
                 (
                     content_added_sign,
-                    // note: files have link property,
-                    //       dirs and symlinks do not
+                    // note: files have link property, dirs and symlinks do not
                     new_file_item
                         .get(PREDICATE_LINK)
                         .unwrap_or(&String::default())

--- a/sn_api/src/app/multimap.rs
+++ b/sn_api/src/app/multimap.rs
@@ -34,7 +34,7 @@ impl Safe {
         debug!("Creating a Multimap");
         let (xorname, op_batch) = self
             .safe_client
-            .create_register(name, type_tag, None, private)
+            .create_register(name, type_tag, None, private, dry_run)
             .await?;
 
         if !dry_run {
@@ -46,6 +46,7 @@ impl Safe {
         } else {
             Scope::Public
         };
+
         let xorurl = SafeUrl::encode_register(
             xorname,
             type_tag,

--- a/sn_api/src/app/register.rs
+++ b/sn_api/src/app/register.rs
@@ -27,7 +27,7 @@ impl Safe {
     ) -> Result<XorUrl> {
         let (xorname, op_batch) = self
             .safe_client
-            .create_register(name, type_tag, None, private)
+            .create_register(name, type_tag, None, private, dry_run)
             .await?;
 
         let scope = if private {

--- a/sn_api/src/errors.rs
+++ b/sn_api/src/errors.rs
@@ -9,7 +9,7 @@
 
 use super::ipc::IpcError;
 use super::nrs::NrsMap;
-use super::safeurl::{Error as UrlError, SafeUrl};
+use super::safeurl::{Error as UrlError, SafeUrl, XorUrl};
 use safe_network::client::Error as ClientError;
 use thiserror::Error;
 
@@ -108,6 +108,9 @@ pub enum Error {
     /// UnversionedContentError
     #[error("UnversionedContentError: {0}")]
     UnversionedContentError(String),
+    /// Content may have been correctly stored on the network, but verification failed
+    #[error("Content may have been correctly stored on the network, but verification failed: {0}")]
+    ContentUploadVerificationFailed(XorUrl),
     /// NotImplementedError
     #[error("NotImplementedError: {0}")]
     NotImplementedError(String),


### PR DESCRIPTION
This also improves error reported by files container api. Example output when uploading a file is uploaded but verification fails:
```
FilesContainer created at: "safe://hyryyryynzxkzkmpixzurnfyqziabtgpqc9bp6zbsdixmrf1h9paiaz9fc9myeuy?v=hgip1akd6y1eg5cnzxjfqayrb7yyyobuttozu3uwcoggpcnoq1aho"
E  README.md  <Content may have been correctly stored on the network, but verification failed: safe://hy8oyeyybd55gmbsw43438bu1zmn5xk1yqtiicdj6hce7t5rsu41om5ps6ecy> 
```