### PR TITLE
refactor(api): make ProcessedFiles to contained fully typed elements instead of simply strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,6 +3397,7 @@ name = "sn_api"
 version = "0.47.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "bincode",
  "blsttc",
  "bytes",

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -73,6 +73,7 @@ testing = [ ]
 default = [ "testing", "authenticator", "authd_client", "app" ]
 
 [dev-dependencies]
+assert_matches = "1.3"
 anyhow = "1.0.38"
 proptest = "~0.10"
 tracing-subscriber = "0.3.1"

--- a/sn_api/src/app/consts.rs
+++ b/sn_api/src/app/consts.rs
@@ -12,11 +12,6 @@ use crate::safeurl::XorUrlBase;
 // Default base encoding used for XOR URLs
 pub const DEFAULT_XORURL_BASE: XorUrlBase = XorUrlBase::Base32z;
 
-pub const CONTENT_ADDED_SIGN: &str = "+";
-pub const CONTENT_UPDATED_SIGN: &str = "*";
-pub const CONTENT_DELETED_SIGN: &str = "-";
-pub const CONTENT_ERROR_SIGN: &str = "E";
-
 pub const PREDICATE_LINK: &str = "link";
 pub const PREDICATE_TYPE: &str = "type";
 pub const PREDICATE_SIZE: &str = "size";

--- a/sn_api/src/app/files/file_system.rs
+++ b/sn_api/src/app/files/file_system.rs
@@ -139,7 +139,7 @@ pub(crate) async fn file_system_dir_walk(
                                 info!("Skipping file \"{}\". {}", normalised_path.display(), err);
                                 processed_files.insert(
                                     normalised_path,
-                                    FilesMapChange::Failed(format!("<{}>", err)),
+                                    FilesMapChange::Failed(format!("{}", err)),
                                 );
                             }
                         }
@@ -149,10 +149,8 @@ pub(crate) async fn file_system_dir_walk(
                     info!(
                         "Skipping file \"{}\" since no metadata could be read from local location: {:?}",
                         normalised_path.display(), err);
-                    processed_files.insert(
-                        normalised_path,
-                        FilesMapChange::Failed(format!("<{}>", err)),
-                    );
+                    processed_files
+                        .insert(normalised_path, FilesMapChange::Failed(format!("{}", err)));
                 }
             }
         }
@@ -205,10 +203,7 @@ pub(crate) async fn file_system_single_file(
             }
             Err(err) => {
                 info!("Skipping file \"{}\". {}", normalised_path.display(), err);
-                processed_files.insert(
-                    normalised_path,
-                    FilesMapChange::Failed(format!("<{}>", err)),
-                );
+                processed_files.insert(normalised_path, FilesMapChange::Failed(format!("{}", err)));
             }
         };
         Ok(processed_files)

--- a/sn_api/src/app/files/file_system.rs
+++ b/sn_api/src/app/files/file_system.rs
@@ -7,12 +7,15 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::{metadata::get_metadata, ProcessedFiles};
-use crate::{app::consts::*, Error, Result, Safe, XorUrl};
+use super::{metadata::get_metadata, FilesMapChange, ProcessedFiles};
+use crate::{Error, Result, Safe, XorUrl};
 use bytes::Bytes;
 use log::info;
 use safe_network::client::Error as ClientError;
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use walkdir::{DirEntry, WalkDir};
 
 const MAX_RECURSIVE_DEPTH: usize = 10_000;
@@ -73,12 +76,13 @@ pub(crate) async fn file_system_dir_walk(
 ) -> Result<ProcessedFiles> {
     let file_path = Path::new(location);
     info!("Reading files from {}", file_path.display());
+
     let (metadata, _) = get_metadata(file_path, follow_links)?;
     if metadata.is_dir() || !recursive {
         // TODO: option to enable following symlinks?
         // We now compare both FilesMaps to upload the missing files
         let max_depth = if recursive { MAX_RECURSIVE_DEPTH } else { 1 };
-        let mut processed_files = BTreeMap::new();
+        let mut processed_files = ProcessedFiles::default();
         let children_to_process = WalkDir::new(file_path)
             .follow_links(follow_links)
             .into_iter()
@@ -89,13 +93,13 @@ pub(crate) async fn file_system_dir_walk(
             let current_file_path = child.path();
             let current_path_str = current_file_path.to_str().unwrap_or("").to_string();
             info!("Processing {}...", current_path_str);
-            let normalised_path = normalise_path_separator(&current_path_str);
+            let normalised_path = PathBuf::from(normalise_path_separator(&current_path_str));
 
             let result = get_metadata(current_file_path, follow_links);
             match result {
                 Ok((metadata, _)) => {
                     if metadata.file_type().is_dir() {
-                        if idx == 0 && normalised_path.ends_with('/') {
+                        if idx == 0 && normalised_path.display().to_string().ends_with('/') {
                             // If the first directory ends with '/' then it is
                             // the root, and we are only interested in the children,
                             // so we skip it.
@@ -114,41 +118,41 @@ pub(crate) async fn file_system_dir_walk(
                         // Callers can inspect the file's metadata.
                         processed_files.insert(
                             normalised_path.clone(),
-                            (CONTENT_ADDED_SIGN.to_string(), String::default()),
+                            FilesMapChange::Added(String::default()),
                         );
                     }
+
                     if metadata.file_type().is_symlink() {
                         processed_files.insert(
                             normalised_path.clone(),
-                            (CONTENT_ADDED_SIGN.to_string(), String::default()),
+                            FilesMapChange::Added(String::default()),
                         );
                     }
+
                     if metadata.file_type().is_file() {
                         match upload_file_to_net(safe, current_file_path, dry_run).await {
                             Ok(xorurl) => {
-                                processed_files.insert(
-                                    normalised_path,
-                                    (CONTENT_ADDED_SIGN.to_string(), xorurl),
-                                );
+                                processed_files
+                                    .insert(normalised_path, FilesMapChange::Added(xorurl));
                             }
                             Err(err) => {
+                                info!("Skipping file \"{}\". {}", normalised_path.display(), err);
                                 processed_files.insert(
-                                    normalised_path.clone(),
-                                    (CONTENT_ERROR_SIGN.to_string(), format!("<{}>", err)),
+                                    normalised_path,
+                                    FilesMapChange::Failed(format!("<{}>", err)),
                                 );
-                                info!("Skipping file \"{}\". {}", normalised_path, err);
                             }
                         }
                     }
                 }
                 Err(err) => {
-                    processed_files.insert(
-                        normalised_path.clone(),
-                        (CONTENT_ERROR_SIGN.to_string(), format!("<{}>", err)),
-                    );
                     info!(
                         "Skipping file \"{}\" since no metadata could be read from local location: {:?}",
-                        normalised_path, err);
+                        normalised_path.display(), err);
+                    processed_files.insert(
+                        normalised_path,
+                        FilesMapChange::Failed(format!("<{}>", err)),
+                    );
                 }
             }
         }
@@ -187,8 +191,8 @@ pub(crate) async fn file_system_single_file(
     let (metadata, _) = get_metadata(file_path, true)?; // follows symlinks.
 
     // We now compare both FilesMaps to upload the missing files
-    let mut processed_files = BTreeMap::new();
-    let normalised_path = normalise_path_separator(file_path.to_str().unwrap_or(""));
+    let mut processed_files = ProcessedFiles::default();
+    let normalised_path = PathBuf::from(normalise_path_separator(file_path.to_str().unwrap_or("")));
     if metadata.is_dir() {
         Err(Error::InvalidInput(format!(
             "'{}' is a directory, only individual files can be added. Use files sync operation for uploading folders",
@@ -197,14 +201,14 @@ pub(crate) async fn file_system_single_file(
     } else {
         match upload_file_to_net(safe, file_path, dry_run).await {
             Ok(xorurl) => {
-                processed_files.insert(normalised_path, (CONTENT_ADDED_SIGN.to_string(), xorurl));
+                processed_files.insert(normalised_path, FilesMapChange::Added(xorurl));
             }
             Err(err) => {
+                info!("Skipping file \"{}\". {}", normalised_path.display(), err);
                 processed_files.insert(
-                    normalised_path.clone(),
-                    (CONTENT_ERROR_SIGN.to_string(), format!("{}>", err)),
+                    normalised_path,
+                    FilesMapChange::Failed(format!("<{}>", err)),
                 );
-                info!("Skipping file \"{}\". {}", normalised_path, err);
             }
         };
         Ok(processed_files)

--- a/sn_api/src/app/files/files_map.rs
+++ b/sn_api/src/app/files/files_map.rs
@@ -127,7 +127,7 @@ pub(crate) async fn add_or_update_file_item(
             info!("Skipping file \"{}\": {:?}", file_link.unwrap_or(""), err);
             processed_files.insert(
                 file_name.to_path_buf(),
-                FilesMapChange::Failed(format!("<{}>", err)),
+                FilesMapChange::Failed(format!("{}", err)),
             );
 
             false

--- a/sn_api/src/app/files/files_map.rs
+++ b/sn_api/src/app/files/files_map.rs
@@ -12,8 +12,9 @@ use super::{
     metadata::FileMeta,
     ProcessedFiles, RealPath,
 };
-use crate::{app::consts::*, Error, Result, Safe};
+use crate::{app::consts::*, Error, Result, Safe, XorUrl};
 use log::{debug, info};
+use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs, path::Path};
 
 // To use for mapping files names (with path in a flattened hierarchy) to FileInfos
@@ -21,6 +22,53 @@ pub type FilesMap = BTreeMap<String, FileInfo>;
 
 // Each FileInfo contains file metadata and the link to the file's Blob XOR-URL
 pub type FileInfo = BTreeMap<String, String>;
+
+// Type of changes made to each item of a FilesMap
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FilesMapChange {
+    Added(XorUrl),
+    Updated(XorUrl),
+    Removed(XorUrl),
+    Failed(String),
+}
+
+impl FilesMapChange {
+    pub fn is_success(&self) -> bool {
+        match self {
+            Self::Added(_) | Self::Updated(_) | Self::Removed(_) => true,
+            Self::Failed(_) => false,
+        }
+    }
+
+    pub fn link(&self) -> Option<&XorUrl> {
+        match self {
+            Self::Added(link) | Self::Updated(link) | Self::Removed(link) => Some(link),
+            Self::Failed(_) => None,
+        }
+    }
+
+    pub fn is_added(&self) -> bool {
+        match self {
+            Self::Added(_) => true,
+            Self::Updated(_) | Self::Removed(_) | Self::Failed(_) => false,
+        }
+    }
+
+    pub fn is_updated(&self) -> bool {
+        match self {
+            Self::Updated(_) => true,
+            Self::Added(_) | Self::Removed(_) | Self::Failed(_) => false,
+        }
+    }
+
+    pub fn is_removed(&self) -> bool {
+        match self {
+            Self::Removed(_) => true,
+            Self::Added(_) | Self::Updated(_) | Self::Failed(_) => false,
+        }
+    }
+}
 
 // A trait to get an key attr and return an API Result
 pub trait GetAttr {
@@ -42,7 +90,7 @@ impl GetAttr for FileInfo {
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn add_or_update_file_item(
     safe: &mut Safe,
-    file_name: &str,
+    file_name: &Path,
     file_name_for_map: &str,
     file_path: &Path,
     file_meta: &FileMeta,
@@ -55,36 +103,32 @@ pub(crate) async fn add_or_update_file_item(
     // We need to add a new FileInfo, let's generate the FileInfo first
     match gen_new_file_item(safe, file_path, file_meta, file_link, dry_run).await {
         Ok(new_file_item) => {
-            let content_added_sign = if name_exists {
-                CONTENT_UPDATED_SIGN.to_string()
+            // note: files have link property, dirs and symlinks do not
+            let xorurl = new_file_item
+                .get(PREDICATE_LINK)
+                .unwrap_or(&String::default())
+                .to_string();
+
+            let file_item_change = if name_exists {
+                FilesMapChange::Updated(xorurl)
             } else {
-                CONTENT_ADDED_SIGN.to_string()
+                FilesMapChange::Added(xorurl)
             };
 
             debug!("New FileInfo item: {:?}", new_file_item);
             debug!("New FileInfo item inserted as {:?}", file_name);
-            files_map.insert(file_name_for_map.to_string(), new_file_item.clone());
+            files_map.insert(file_name_for_map.to_string(), new_file_item);
 
-            processed_files.insert(
-                file_name.to_string(),
-                (
-                    content_added_sign,
-                    // note: files have link property, dirs and symlinks do not
-                    new_file_item
-                        .get(PREDICATE_LINK)
-                        .unwrap_or(&String::default())
-                        .to_string(),
-                ),
-            );
+            processed_files.insert(file_name.to_path_buf(), file_item_change);
 
             true
         }
         Err(err) => {
-            processed_files.insert(
-                file_name.to_string(),
-                (CONTENT_ERROR_SIGN.to_string(), format!("<{}>", err)),
-            );
             info!("Skipping file \"{}\": {:?}", file_link.unwrap_or(""), err);
+            processed_files.insert(
+                file_name.to_path_buf(),
+                FilesMapChange::Failed(format!("<{}>", err)),
+            );
 
             false
         }

--- a/sn_api/src/app/files/metadata.rs
+++ b/sn_api/src/app/files/metadata.rs
@@ -37,8 +37,8 @@ pub(crate) struct FileMeta {
 
 impl FileMeta {
     // Instantiates FileMeta from a local filesystem path.
-    pub(crate) fn from_path(path: &str, follow_links: bool) -> Result<Self> {
-        let (metadata, file_type) = get_metadata(Path::new(path), follow_links)?;
+    pub(crate) fn from_path(path: &Path, follow_links: bool) -> Result<Self> {
+        let (metadata, file_type) = get_metadata(path, follow_links)?;
 
         // created and modified may not be available on all platforms/filesystems.
         let original_created = if let Ok(time) = metadata.created() {

--- a/sn_api/src/app/files/mod.rs
+++ b/sn_api/src/app/files/mod.rs
@@ -27,7 +27,7 @@ use safe_network::types::BytesAddress;
 use std::{
     collections::{BTreeMap, HashSet},
     iter::FromIterator,
-    path::Path,
+    path::{Path, PathBuf},
     str,
 };
 
@@ -35,10 +35,10 @@ pub(crate) use files_map::{file_map_for_path, get_file_link_and_metadata};
 pub(crate) use metadata::FileMeta;
 pub(crate) use realpath::RealPath;
 
-pub use files_map::{FileInfo, FilesMap, GetAttr};
+pub use files_map::{FileInfo, FilesMap, FilesMapChange, GetAttr};
 
-// List of files uploaded with details if they were added, updated or deleted from FilesContainer
-pub type ProcessedFiles = BTreeMap<String, (String, String)>;
+// List of files uploaded with details if they were added, updated or removed from FilesContainer
+pub type ProcessedFiles = BTreeMap<PathBuf, FilesMapChange>;
 
 const ERROR_MSG_NO_FILES_CONTAINER_FOUND: &str = "No FilesContainer found at this address";
 // Type tag to use for the FilesContainer stored on Register
@@ -62,7 +62,7 @@ impl Safe {
     pub async fn files_container_create(
         &mut self,
         location: Option<&str>,
-        dest: Option<&str>,
+        dest: Option<&Path>,
         recursive: bool,
         follow_links: bool,
         dry_run: bool,
@@ -272,7 +272,7 @@ impl Safe {
         let processed_files =
             file_system_dir_walk(self, location, recursive, follow_links, true).await?;
 
-        let dest_path = Some(safe_url.path());
+        let dest_path = Path::new(safe_url.path());
 
         let (processed_files, new_files_map, success_count): (ProcessedFiles, FilesMap, u64) =
             files_map_sync(
@@ -280,7 +280,7 @@ impl Safe {
                 current_files_map,
                 location,
                 processed_files,
-                dest_path,
+                Some(dest_path),
                 delete,
                 dry_run,
                 false,
@@ -337,7 +337,7 @@ impl Safe {
         let (safe_url, current_version, current_files_map) =
             validate_files_add_params(self, source_file, url, update_nrs).await?;
 
-        let dest_path = safe_url.path();
+        let dest_path = Path::new(safe_url.path());
 
         // Let's act according to if it's a local file path or a safe:// location
         let (processed_files, new_files_map, success_count) = if source_file.starts_with("safe://")
@@ -408,7 +408,7 @@ impl Safe {
         let (safe_url, current_version, current_files_map) =
             validate_files_add_params(self, "", url, update_nrs).await?;
 
-        let dest_path = safe_url.path();
+        let dest_path = Path::new(safe_url.path());
         let new_file_xorurl = self.store_public_bytes(data, None, false).await?;
 
         // Let's act according to if it's a local file path or a safe:// location
@@ -482,7 +482,7 @@ impl Safe {
             self.fetch_files_container(&safe_url).await?;
 
         let (processed_files, new_files_map, success_count) =
-            files_map_remove_path(dest_path, files_map, recursive)?;
+            files_map_remove_path(Path::new(dest_path), files_map, recursive)?;
 
         let version = if success_count == 0 {
             current_version
@@ -702,7 +702,7 @@ async fn validate_files_add_params(
 
 // From the location path and the destination path chosen by the user, calculate
 // the destination path considering ending '/' in both the  location and dest path
-fn get_base_paths(location: &str, dest_path: Option<&str>) -> (String, String) {
+fn get_base_paths(location: &str, dest_path: Option<&Path>) -> (String, String) {
     // Let's normalise the path to use '/' (instead of '\' as on Windows)
     let location_base_path = if location == "." {
         "./".to_string()
@@ -712,10 +712,11 @@ fn get_base_paths(location: &str, dest_path: Option<&str>) -> (String, String) {
 
     let new_dest_path = match dest_path {
         Some(path) => {
-            if path.is_empty() {
+            let path_str = path.display().to_string();
+            if path_str.is_empty() {
                 "/".to_string()
             } else {
-                path.to_string()
+                path_str
             }
         }
         None => "/".to_string(),
@@ -748,7 +749,7 @@ async fn files_map_sync(
     mut current_files_map: FilesMap,
     location: &str,
     new_content: ProcessedFiles,
-    dest_path: Option<&str>,
+    dest_path: Option<&Path>,
     delete: bool,
     dry_run: bool,
     force: bool,
@@ -760,14 +761,12 @@ async fn files_map_sync(
     let mut processed_files = ProcessedFiles::new();
     let mut success_count = 0;
 
-    for (local_file_name, _) in new_content
-        .iter()
-        .filter(|(_, (change, _))| change != CONTENT_ERROR_SIGN)
-    {
+    for (local_file_name, _) in new_content.iter().filter(|(_, change)| change.is_success()) {
         let file_path = Path::new(&local_file_name);
 
         let file_name = RelativePath::new(
             &local_file_name
+                .display()
                 .to_string()
                 .replace(&location_base_path, &dest_base_path),
         )
@@ -831,7 +830,7 @@ async fn files_map_sync(
                         local_file_name,
                         &normalised_file_name,
                         file_path,
-                        &FileMeta::from_path(local_file_name, follow_links)?,
+                        &FileMeta::from_path(local_file_name.as_path(), follow_links)?,
                         None, // no xorurl link
                         true,
                         dry_run,
@@ -847,18 +846,23 @@ async fn files_map_sync(
                     updated_files_map.insert(normalised_file_name.to_string(), file_item.clone());
 
                     if !force && !compare_file_content {
-                        let comp_str = if is_modified { "different" } else { "same" };
-                        processed_files.insert(
-                            local_file_name.to_string(),
+                        let (err_type, comp_str) = if is_modified {
                             (
-                                CONTENT_ERROR_SIGN.to_string(),
-                                format!(
-                                    "File named \"{}\" with {} content already exists on target. Use the 'force' flag to replace it",
-                                    normalised_file_name, comp_str
-                                ),
-                            ),
+                                Error::FileNameConflict(normalised_file_name.clone()),
+                                "different",
+                            )
+                        } else {
+                            (
+                                Error::FileAlreadyExists(normalised_file_name.clone()),
+                                "same",
+                            )
+                        };
+
+                        processed_files.insert(
+                            local_file_name.to_path_buf(),
+                            FilesMapChange::Failed(format!("<{}>", err_type)),
                         );
-                        info!("Skipping file \"{}\" since a file named \"{}\" with {} content already exists on target. You can use the 'force' flag to replace the existing file with the new one", local_file_name, normalised_file_name, comp_str);
+                        info!("Skipping file \"{}\" since a file named \"{}\" with {} content already exists on target. You can use the 'force' flag to replace the existing file with the new one", local_file_name.display(), normalised_file_name, comp_str);
                     }
                 }
 
@@ -892,18 +896,13 @@ async fn files_map_sync(
         if !delete {
             updated_files_map.insert(file_name.to_string(), file_item.clone());
         } else {
-            processed_files.insert(
-                file_name.to_string(),
-                (
-                    CONTENT_DELETED_SIGN.to_string(),
-                    // note: files have link property,
-                    //       dirs and symlinks do not
-                    file_item
-                        .get(PREDICATE_LINK)
-                        .unwrap_or(&String::default())
-                        .to_string(),
-                ),
-            );
+            // note: files have link property, dirs and symlinks do not
+            let xorurl = file_item
+                .get(PREDICATE_LINK)
+                .unwrap_or(&String::default())
+                .to_string();
+
+            processed_files.insert(PathBuf::from(file_name), FilesMapChange::Removed(xorurl));
             success_count += 1;
         }
     });
@@ -936,18 +935,18 @@ async fn files_map_add_link(
     safe: &mut Safe,
     mut files_map: FilesMap,
     file_link: &str,
-    file_name: &str,
+    file_name: &Path,
     force: bool,
 ) -> Result<(ProcessedFiles, FilesMap, u64)> {
     let mut processed_files = ProcessedFiles::new();
     let mut success_count = 0;
     match SafeUrl::from_url(file_link) {
         Err(err) => {
-            processed_files.insert(
-                file_link.to_string(),
-                (CONTENT_ERROR_SIGN.to_string(), format!("<{}>", err)),
-            );
             info!("Skipping file \"{}\". {}", file_link, err);
+            processed_files.insert(
+                PathBuf::from(file_link),
+                FilesMapChange::Failed(format!("<{}>", err)),
+            );
             Ok((processed_files, files_map, success_count))
         }
         Ok(safe_url) => {
@@ -957,9 +956,10 @@ async fn files_map_add_link(
                 other => format!("{}", other),
             };
             let file_size = ""; // unknown
+            let file_name_str = file_name.display().to_string();
 
             // Let's update FileInfo if the link is different or it doesn't exist in the files_map
-            match files_map.get(file_name) {
+            match files_map.get(&file_name_str) {
                 Some(current_file_item) => {
                     let mut file_meta = FileMeta::from_file_item(current_file_item);
                     file_meta.file_type = file_type;
@@ -978,7 +978,7 @@ async fn files_map_add_link(
                             if add_or_update_file_item(
                                 safe,
                                 file_name,
-                                file_name,
+                                &file_name_str,
                                 file_path,
                                 &file_meta,
                                 Some(file_link),
@@ -992,28 +992,31 @@ async fn files_map_add_link(
                                 success_count += 1;
                             }
                         } else {
-                            processed_files.insert(file_name.to_string(), (CONTENT_ERROR_SIGN.to_string(), format!("File named \"{}\" already exists on target. Use the 'force' flag to replace it", file_name)));
-                            info!("Skipping file \"{}\" since a file with name \"{}\" already exists on target. You can use the 'force' flag to replace the existing file with the new one", file_link, file_name);
+                            info!("Skipping file \"{}\" since a file with name \"{}\" already exists on target. You can use the 'force' flag to replace the existing file with the new one", file_link, file_name_str);
+                            processed_files.insert(
+                                file_name.to_path_buf(),
+                                FilesMapChange::Failed(format!(
+                                    "<{}>",
+                                    Error::FileNameConflict(file_name_str)
+                                )),
+                            );
                         }
                     } else {
+                        info!("Skipping file \"{}\" since a file with name \"{}\" already exists on target with the same link", file_link, file_name_str);
                         processed_files.insert(
-                            file_link.to_string(),
-                            (
-                                CONTENT_ERROR_SIGN.to_string(),
-                                format!(
-                                    "File named \"{}\" already exists on target with same link",
-                                    file_name
-                                ),
-                            ),
+                            PathBuf::from(file_link),
+                            FilesMapChange::Failed(format!(
+                                "<{}>",
+                                Error::FileAlreadyExists(file_name_str)
+                            )),
                         );
-                        info!("Skipping file \"{}\" since a file with name \"{}\" already exists on target with the same link", file_link, file_name);
                     }
                 }
                 None => {
                     if add_or_update_file_item(
                         safe,
                         file_name,
-                        file_name,
+                        &file_name_str,
                         file_path,
                         &FileMeta::from_type_and_size(&file_type, file_size),
                         Some(file_link),
@@ -1036,7 +1039,7 @@ async fn files_map_add_link(
 
 // Remove a path from the FilesMap provided
 fn files_map_remove_path(
-    dest_path: &str,
+    dest_path: &Path,
     mut files_map: FilesMap,
     recursive: bool,
 ) -> Result<(ProcessedFiles, FilesMap, u64)> {
@@ -1044,27 +1047,22 @@ fn files_map_remove_path(
     let (success_count, new_files_map) = if recursive {
         let mut success_count = 0;
         let mut new_files_map = FilesMap::default();
-        let folder_path = if !dest_path.ends_with('/') {
-            format!("{}/", dest_path)
+        let folder_path = if !dest_path.ends_with("/") {
+            format!("{}/", dest_path.display())
         } else {
-            dest_path.to_string()
+            dest_path.display().to_string()
         };
 
         files_map.iter().for_each(|(file_path, file_item)| {
             // if the current file_path is a subfolder we remove it
             if file_path.starts_with(&folder_path) {
-                processed_files.insert(
-                    file_path.to_string(),
-                    (
-                        CONTENT_DELETED_SIGN.to_string(),
-                        // note: files have link property,
-                        //       dirs and symlinks do not
-                        file_item
-                            .get(PREDICATE_LINK)
-                            .unwrap_or(&String::default())
-                            .to_string(),
-                    ),
-                );
+                // note: files have link property, dirs and symlinks do not
+                let xorurl = file_item
+                    .get(PREDICATE_LINK)
+                    .unwrap_or(&String::default())
+                    .to_string();
+
+                processed_files.insert(PathBuf::from(file_path), FilesMapChange::Removed(xorurl));
                 success_count += 1;
             } else {
                 new_files_map.insert(file_path.to_string(), file_item.clone());
@@ -1073,23 +1071,20 @@ fn files_map_remove_path(
         (success_count, new_files_map)
     } else {
         let file_item = files_map
-            .remove(dest_path)
+            .remove(&dest_path.display().to_string())
             .ok_or_else(|| Error::ContentError(format!(
                 "No content found matching the \"{}\" path on the target FilesContainer. If you are trying to remove a folder rather than a file, you need to pass the 'recursive' flag",
-                dest_path
+                dest_path.display()
             )))?;
-        processed_files.insert(
-            dest_path.to_string(),
-            (
-                CONTENT_DELETED_SIGN.to_string(),
-                // note: files have link property,
-                //       dirs and symlinks do not
-                file_item
-                    .get(PREDICATE_LINK)
-                    .unwrap_or(&String::default())
-                    .to_string(),
-            ),
-        );
+
+        // note: files have link property, dirs and symlinks do not
+        let xorurl = file_item
+            .get(PREDICATE_LINK)
+            .unwrap_or(&String::default())
+            .to_string();
+
+        processed_files.insert(dest_path.to_path_buf(), FilesMapChange::Removed(xorurl));
+
         (1, files_map)
     };
 
@@ -1102,7 +1097,7 @@ async fn files_map_create(
     safe: &mut Safe,
     content: &mut ProcessedFiles,
     location: &str,
-    dest_path: Option<&str>,
+    dest_path: Option<&Path>,
     follow_links: bool,
     dry_run: bool,
 ) -> Result<FilesMap> {
@@ -1115,16 +1110,18 @@ async fn files_map_create(
     // Rust doesn't allow that exactly, but we can get the keys
     // to iterate over instead.  Cloning the keys isn't ideal
     // either, but is much less data.  Is there a more efficient way?
-    let keys = content.keys().cloned().collect::<Vec<_>>();
-    for file_name in keys {
-        let (change, link) = &content[&file_name].clone();
-
-        if change == CONTENT_ERROR_SIGN {
-            continue;
-        }
+    let names = content.keys().cloned().collect::<Vec<_>>();
+    for file_name in names {
+        let link = match &content[&file_name] {
+            FilesMapChange::Failed(_) => continue,
+            FilesMapChange::Added(link)
+            | FilesMapChange::Updated(link)
+            | FilesMapChange::Removed(link) => link.clone(),
+        };
 
         let new_file_name = RelativePath::new(
             &file_name
+                .display()
                 .to_string()
                 .replace(&location_base_path, &dest_base_path),
         )
@@ -1142,9 +1139,9 @@ async fn files_map_create(
             safe,
             &file_name,
             &final_name,
-            Path::new(&file_name),
+            &file_name,
             &FileMeta::from_path(&file_name, follow_links)?,
-            if link.is_empty() { None } else { Some(link) },
+            if link.is_empty() { None } else { Some(&link) },
             false,
             dry_run,
             &mut files_map,
@@ -1163,13 +1160,13 @@ mod tests {
         retry_loop, retry_loop_for_pattern,
     };
     use anyhow::{anyhow, bail, Result};
+    use assert_matches::assert_matches;
     use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
     const TEST_DATA_FOLDER: &str = "./testdata/";
     const TEST_DATA_FOLDER_NO_SLASH: &str = "./testdata";
 
-    // make some constants for these, in case entries in the
-    // testdata folder change.
+    // make some constants for these, in case entries in the testdata folder change.
     const TESTDATA_PUT_FILEITEM_COUNT: usize = 11;
     const TESTDATA_PUT_FILESMAP_COUNT: usize = 10; // TODO: review case of empty folder and empty file
     const TESTDATA_NO_SLASH_PUT_FILEITEM_COUNT: usize = 12;
@@ -1205,18 +1202,18 @@ mod tests {
         let second_xorurl = SafeUrl::from_url("safe://second_xorurl")?.to_xorurl_string();
 
         processed_files.insert(
-            "./testdata/test.md".to_string(),
-            (CONTENT_ADDED_SIGN.to_string(), first_xorurl.clone()),
+            PathBuf::from("./testdata/test.md"),
+            FilesMapChange::Added(first_xorurl.clone()),
         );
         processed_files.insert(
-            "./testdata/subfolder/subexists.md".to_string(),
-            (CONTENT_ADDED_SIGN.to_string(), second_xorurl.clone()),
+            PathBuf::from("./testdata/subfolder/subexists.md"),
+            FilesMapChange::Added(second_xorurl.clone()),
         );
         let files_map = files_map_create(
             &mut safe,
             &mut processed_files,
             TEST_DATA_FOLDER_NO_SLASH,
-            Some(""),
+            Some(Path::new("")),
             true,
             false,
         )
@@ -1258,11 +1255,11 @@ mod tests {
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), 1);
 
-        let filename = "./testdata/test.md";
-        assert_eq!(new_processed_files[filename].0, CONTENT_ADDED_SIGN);
+        let filename = Path::new("./testdata/test.md");
+        assert!(new_processed_files[filename].is_added());
         assert_eq!(
-            new_processed_files[filename].1,
-            new_files_map["/test.md"][PREDICATE_LINK]
+            new_processed_files[filename].link(),
+            Some(&new_files_map["/test.md"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -1287,19 +1284,24 @@ mod tests {
     #[tokio::test]
     async fn test_files_container_create_file() -> Result<()> {
         let mut safe = new_safe_instance().await?;
-        let filename = "./testdata/test.md";
+        let filename = Path::new("./testdata/test.md");
         let (xorurl, processed_files, files_map) = safe
-            .files_container_create(Some(filename), None, false, false, false)
+            .files_container_create(
+                Some(&filename.display().to_string()),
+                None,
+                false,
+                false,
+                false,
+            )
             .await?;
 
         assert!(xorurl.starts_with("safe://"));
         assert_eq!(processed_files.len(), 1);
         assert_eq!(files_map.len(), 1);
-        let file_path = "/test.md";
-        assert_eq!(processed_files[filename].0, CONTENT_ADDED_SIGN);
+        assert!(processed_files[filename].is_added());
         assert_eq!(
-            processed_files[filename].1,
-            files_map[file_path][PREDICATE_LINK]
+            processed_files[filename].link(),
+            Some(&files_map["/test.md"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -1312,40 +1314,40 @@ mod tests {
             .files_container_create(Some(TEST_DATA_FOLDER), None, true, false, true)
             .await?;
 
-        assert!(!xorurl.is_empty());
+        assert!(xorurl.starts_with("safe://"));
         assert_eq!(processed_files.len(), TESTDATA_PUT_FILEITEM_COUNT);
         assert_eq!(files_map.len(), TESTDATA_PUT_FILESMAP_COUNT);
 
-        let filename1 = "./testdata/test.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
-        assert!(!processed_files[filename1].1.is_empty());
+        let filename1 = Path::new("./testdata/test.md");
+        assert!(processed_files[filename1].is_added());
+        assert_matches!(processed_files[filename1].link(), Some(link) if !link.is_empty());
         assert_eq!(
-            processed_files[filename1].1,
-            files_map["/test.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&files_map["/test.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/another.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
-        assert!(!processed_files[filename2].1.is_empty());
+        let filename2 = Path::new("./testdata/another.md");
+        assert!(processed_files[filename2].is_added());
+        assert_matches!(processed_files[filename2].link(), Some(link) if !link.is_empty());
         assert_eq!(
-            processed_files[filename2].1,
-            files_map["/another.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&files_map["/another.md"][PREDICATE_LINK])
         );
 
-        let filename3 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename3].0, CONTENT_ADDED_SIGN);
-        assert!(!processed_files[filename3].1.is_empty());
+        let filename3 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename3].is_added());
+        assert_matches!(processed_files[filename3].link(), Some(link) if !link.is_empty());
         assert_eq!(
-            processed_files[filename3].1,
-            files_map["/subfolder/subexists.md"][PREDICATE_LINK]
+            processed_files[filename3].link(),
+            Some(&files_map["/subfolder/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename4 = "./testdata/noextension";
-        assert_eq!(processed_files[filename4].0, CONTENT_ADDED_SIGN);
-        assert!(!processed_files[filename4].1.is_empty());
+        let filename4 = Path::new("./testdata/noextension");
+        assert!(processed_files[filename4].is_added());
+        assert_matches!(processed_files[filename4].link(), Some(link) if !link.is_empty());
         assert_eq!(
-            processed_files[filename4].1,
-            files_map["/noextension"][PREDICATE_LINK]
+            processed_files[filename4].link(),
+            Some(&files_map["/noextension"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -1366,32 +1368,32 @@ mod tests {
         assert_eq!(processed_files.len(), TESTDATA_NO_SLASH_PUT_FILEITEM_COUNT);
         assert_eq!(files_map.len(), TESTDATA_NO_SLASH_PUT_FILESMAP_COUNT);
 
-        let filename1 = "./testdata/test.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/test.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            files_map["/testdata/test.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&files_map["/testdata/test.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/another.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
+        let filename2 = Path::new("./testdata/another.md");
+        assert!(processed_files[filename2].is_added());
         assert_eq!(
-            processed_files[filename2].1,
-            files_map["/testdata/another.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&files_map["/testdata/another.md"][PREDICATE_LINK])
         );
 
-        let filename3 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename3].0, CONTENT_ADDED_SIGN);
+        let filename3 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename3].is_added());
         assert_eq!(
-            processed_files[filename3].1,
-            files_map["/testdata/subfolder/subexists.md"][PREDICATE_LINK]
+            processed_files[filename3].link(),
+            Some(&files_map["/testdata/subfolder/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename4 = "./testdata/noextension";
-        assert_eq!(processed_files[filename4].0, CONTENT_ADDED_SIGN);
+        let filename4 = Path::new("./testdata/noextension");
+        assert!(processed_files[filename4].is_added());
         assert_eq!(
-            processed_files[filename4].1,
-            files_map["/testdata/noextension"][PREDICATE_LINK]
+            processed_files[filename4].link(),
+            Some(&files_map["/testdata/noextension"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -1402,32 +1404,32 @@ mod tests {
         let mut safe = new_safe_instance().await?;
         let (_, processed_files, files_map) = new_files_container_from_testdata(&mut safe).await?;
 
-        let filename1 = "./testdata/test.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/test.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            files_map["/test.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&files_map["/test.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/another.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
+        let filename2 = Path::new("./testdata/another.md");
+        assert!(processed_files[filename2].is_added());
         assert_eq!(
-            processed_files[filename2].1,
-            files_map["/another.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&files_map["/another.md"][PREDICATE_LINK])
         );
 
-        let filename3 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename3].0, CONTENT_ADDED_SIGN);
+        let filename3 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename3].is_added());
         assert_eq!(
-            processed_files[filename3].1,
-            files_map["/subfolder/subexists.md"][PREDICATE_LINK]
+            processed_files[filename3].link(),
+            Some(&files_map["/subfolder/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename4 = "./testdata/noextension";
-        assert_eq!(processed_files[filename4].0, CONTENT_ADDED_SIGN);
+        let filename4 = Path::new("./testdata/noextension");
+        assert!(processed_files[filename4].is_added());
         assert_eq!(
-            processed_files[filename4].1,
-            files_map["/noextension"][PREDICATE_LINK]
+            processed_files[filename4].link(),
+            Some(&files_map["/noextension"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -1439,7 +1441,7 @@ mod tests {
         let (xorurl, processed_files, files_map) = safe
             .files_container_create(
                 Some(TEST_DATA_FOLDER_NO_SLASH),
-                Some("/myroot"),
+                Some(Path::new("/myroot")),
                 true,
                 true,
                 false,
@@ -1450,32 +1452,32 @@ mod tests {
         assert_eq!(processed_files.len(), TESTDATA_NO_SLASH_PUT_FILEITEM_COUNT);
         assert_eq!(files_map.len(), TESTDATA_NO_SLASH_PUT_FILESMAP_COUNT);
 
-        let filename1 = "./testdata/test.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/test.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            files_map["/myroot/test.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&files_map["/myroot/test.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/another.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
+        let filename2 = Path::new("./testdata/another.md");
+        assert!(processed_files[filename2].is_added());
         assert_eq!(
-            processed_files[filename2].1,
-            files_map["/myroot/another.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&files_map["/myroot/another.md"][PREDICATE_LINK])
         );
 
-        let filename3 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename3].0, CONTENT_ADDED_SIGN);
+        let filename3 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename3].is_added());
         assert_eq!(
-            processed_files[filename3].1,
-            files_map["/myroot/subfolder/subexists.md"][PREDICATE_LINK]
+            processed_files[filename3].link(),
+            Some(&files_map["/myroot/subfolder/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename4 = "./testdata/noextension";
-        assert_eq!(processed_files[filename4].0, CONTENT_ADDED_SIGN);
+        let filename4 = Path::new("./testdata/noextension");
+        assert!(processed_files[filename4].is_added());
         assert_eq!(
-            processed_files[filename4].1,
-            files_map["/myroot/noextension"][PREDICATE_LINK]
+            processed_files[filename4].link(),
+            Some(&files_map["/myroot/noextension"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -1487,7 +1489,7 @@ mod tests {
         let (xorurl, processed_files, files_map) = safe
             .files_container_create(
                 Some(TEST_DATA_FOLDER_NO_SLASH),
-                Some("/myroot/"),
+                Some(Path::new("/myroot/")),
                 true,
                 true,
                 false,
@@ -1498,32 +1500,32 @@ mod tests {
         assert_eq!(processed_files.len(), TESTDATA_NO_SLASH_PUT_FILEITEM_COUNT);
         assert_eq!(files_map.len(), TESTDATA_NO_SLASH_PUT_FILESMAP_COUNT);
 
-        let filename1 = "./testdata/test.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/test.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            files_map["/myroot/testdata/test.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&files_map["/myroot/testdata/test.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/another.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
+        let filename2 = Path::new("./testdata/another.md");
+        assert!(processed_files[filename2].is_added());
         assert_eq!(
-            processed_files[filename2].1,
-            files_map["/myroot/testdata/another.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&files_map["/myroot/testdata/another.md"][PREDICATE_LINK])
         );
 
-        let filename3 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename3].0, CONTENT_ADDED_SIGN);
+        let filename3 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename3].is_added());
         assert_eq!(
-            processed_files[filename3].1,
-            files_map["/myroot/testdata/subfolder/subexists.md"][PREDICATE_LINK]
+            processed_files[filename3].link(),
+            Some(&files_map["/myroot/testdata/subfolder/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename4 = "./testdata/noextension";
-        assert_eq!(processed_files[filename4].0, CONTENT_ADDED_SIGN);
+        let filename4 = Path::new("./testdata/noextension");
+        assert!(processed_files[filename4].is_added());
         assert_eq!(
-            processed_files[filename4].1,
-            files_map["/myroot/testdata/noextension"][PREDICATE_LINK]
+            processed_files[filename4].link(),
+            Some(&files_map["/myroot/testdata/noextension"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -1555,46 +1557,46 @@ mod tests {
             TESTDATA_PUT_FILESMAP_COUNT + SUBFOLDER_PUT_FILEITEM_COUNT
         );
 
-        let filename1 = "./testdata/test.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/test.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            new_files_map["/test.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&new_files_map["/test.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/another.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
+        let filename2 = Path::new("./testdata/another.md");
+        assert!(processed_files[filename2].is_added());
         assert_eq!(
-            processed_files[filename2].1,
-            new_files_map["/another.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&new_files_map["/another.md"][PREDICATE_LINK])
         );
 
-        let filename3 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename3].0, CONTENT_ADDED_SIGN);
+        let filename3 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename3].is_added());
         assert_eq!(
-            processed_files[filename3].1,
-            new_files_map["/subfolder/subexists.md"][PREDICATE_LINK]
+            processed_files[filename3].link(),
+            Some(&new_files_map["/subfolder/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename4 = "./testdata/noextension";
-        assert_eq!(processed_files[filename4].0, CONTENT_ADDED_SIGN);
+        let filename4 = Path::new("./testdata/noextension");
+        assert!(processed_files[filename4].is_added());
         assert_eq!(
-            processed_files[filename4].1,
-            new_files_map["/noextension"][PREDICATE_LINK]
+            processed_files[filename4].link(),
+            Some(&new_files_map["/noextension"][PREDICATE_LINK])
         );
 
-        let filename5 = "./testdata/subfolder/subexists.md";
-        assert_eq!(new_processed_files[filename5].0, CONTENT_ADDED_SIGN);
+        let filename5 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(new_processed_files[filename5].is_added());
         assert_eq!(
-            new_processed_files[filename5].1,
-            new_files_map["/subexists.md"][PREDICATE_LINK]
+            new_processed_files[filename5].link(),
+            Some(&new_files_map["/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename6 = "./testdata/subfolder/sub2.md";
-        assert_eq!(new_processed_files[filename6].0, CONTENT_ADDED_SIGN);
+        let filename6 = Path::new("./testdata/subfolder/sub2.md");
+        assert!(new_processed_files[filename6].is_added());
         assert_eq!(
-            new_processed_files[filename6].1,
-            new_files_map["/sub2.md"][PREDICATE_LINK]
+            new_processed_files[filename6].link(),
+            Some(&new_files_map["/sub2.md"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -1624,48 +1626,48 @@ mod tests {
             TESTDATA_PUT_FILESMAP_COUNT + SUBFOLDER_PUT_FILEITEM_COUNT
         );
 
-        let filename1 = "./testdata/test.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/test.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            new_files_map["/test.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&new_files_map["/test.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/another.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
+        let filename2 = Path::new("./testdata/another.md");
+        assert!(processed_files[filename2].is_added());
         assert_eq!(
-            processed_files[filename2].1,
-            new_files_map["/another.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&new_files_map["/another.md"][PREDICATE_LINK])
         );
 
-        let filename3 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename3].0, CONTENT_ADDED_SIGN);
+        let filename3 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename3].is_added());
         assert_eq!(
-            processed_files[filename3].1,
-            new_files_map["/subfolder/subexists.md"][PREDICATE_LINK]
+            processed_files[filename3].link(),
+            Some(&new_files_map["/subfolder/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename4 = "./testdata/noextension";
-        assert_eq!(processed_files[filename4].0, CONTENT_ADDED_SIGN);
+        let filename4 = Path::new("./testdata/noextension");
+        assert!(processed_files[filename4].is_added());
         assert_eq!(
-            processed_files[filename4].1,
-            new_files_map["/noextension"][PREDICATE_LINK]
+            processed_files[filename4].link(),
+            Some(&new_files_map["/noextension"][PREDICATE_LINK])
         );
 
-        let filename5 = "./testdata/subfolder/subexists.md";
-        assert_eq!(new_processed_files[filename5].0, CONTENT_ADDED_SIGN);
-        assert!(!new_processed_files[filename5].1.is_empty());
+        let filename5 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(new_processed_files[filename5].is_added());
+        assert_matches!(new_processed_files[filename5].link(), Some(link) if !link.is_empty());
         assert_eq!(
-            new_processed_files[filename5].1,
-            new_files_map["/subexists.md"][PREDICATE_LINK]
+            new_processed_files[filename5].link(),
+            Some(&new_files_map["/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename6 = "./testdata/subfolder/sub2.md";
-        assert_eq!(new_processed_files[filename6].0, CONTENT_ADDED_SIGN);
-        assert!(!new_processed_files[filename6].1.is_empty());
+        let filename6 = Path::new("./testdata/subfolder/sub2.md");
+        assert!(new_processed_files[filename6].is_added());
+        assert_matches!(new_processed_files[filename6].link(), Some(link) if !link.is_empty());
         assert_eq!(
-            new_processed_files[filename6].1,
-            new_files_map["/sub2.md"][PREDICATE_LINK]
+            new_processed_files[filename6].link(),
+            Some(&new_files_map["/sub2.md"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -1699,17 +1701,17 @@ mod tests {
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), 1);
 
-        let filename1 = "./testdata/test.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/test.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            files_map["/test.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&files_map["/test.md"][PREDICATE_LINK])
         );
-        let filename2 = "./testdata/.subhidden/test.md";
-        assert_eq!(new_processed_files[filename2].0, CONTENT_UPDATED_SIGN);
+        let filename2 = Path::new("./testdata/.subhidden/test.md");
+        assert!(new_processed_files[filename2].is_updated());
         assert_eq!(
-            new_processed_files[filename2].1,
-            new_files_map["/test.md"][PREDICATE_LINK]
+            new_processed_files[filename2].link(),
+            Some(&new_files_map["/test.md"][PREDICATE_LINK])
         );
 
         // check sizes are the same but links are different
@@ -1787,40 +1789,40 @@ mod tests {
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT);
 
         // first check all previous files were removed
-        let file_path1 = "/test.md";
-        assert_eq!(new_processed_files[file_path1].0, CONTENT_DELETED_SIGN);
+        let file_path1 = Path::new("/test.md");
+        assert!(new_processed_files[file_path1].is_removed());
         assert_eq!(
-            new_processed_files[file_path1].1,
-            files_map[file_path1][PREDICATE_LINK]
+            new_processed_files[file_path1].link(),
+            Some(&files_map[&file_path1.display().to_string()][PREDICATE_LINK])
         );
 
-        let file_path2 = "/another.md";
-        assert_eq!(new_processed_files[file_path2].0, CONTENT_DELETED_SIGN);
+        let file_path2 = Path::new("/another.md");
+        assert!(new_processed_files[file_path2].is_removed());
         assert_eq!(
-            new_processed_files[file_path2].1,
-            files_map[file_path2][PREDICATE_LINK]
+            new_processed_files[file_path2].link(),
+            Some(&files_map[&file_path2.display().to_string()][PREDICATE_LINK])
         );
 
-        let file_path3 = "/subfolder/subexists.md";
-        assert_eq!(new_processed_files[file_path3].0, CONTENT_DELETED_SIGN);
+        let file_path3 = Path::new("/subfolder/subexists.md");
+        assert!(new_processed_files[file_path3].is_removed());
         assert_eq!(
-            new_processed_files[file_path3].1,
-            files_map[file_path3][PREDICATE_LINK]
+            new_processed_files[file_path3].link(),
+            Some(&files_map[&file_path3.display().to_string()][PREDICATE_LINK])
         );
 
-        let file_path4 = "/noextension";
-        assert_eq!(new_processed_files[file_path4].0, CONTENT_DELETED_SIGN);
+        let file_path4 = Path::new("/noextension");
+        assert!(new_processed_files[file_path4].is_removed());
         assert_eq!(
-            new_processed_files[file_path4].1,
-            files_map[file_path4][PREDICATE_LINK]
+            new_processed_files[file_path4].link(),
+            Some(&files_map[&file_path4.display().to_string()][PREDICATE_LINK])
         );
 
         // and finally check the synced file was added
-        let filename5 = "./testdata/subfolder/subexists.md";
-        assert_eq!(new_processed_files[filename5].0, CONTENT_ADDED_SIGN);
+        let filename5 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(new_processed_files[filename5].is_added());
         assert_eq!(
-            new_processed_files[filename5].1,
-            new_files_map["/subexists.md"][PREDICATE_LINK]
+            new_processed_files[filename5].link(),
+            Some(&new_files_map["/subexists.md"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -1984,40 +1986,40 @@ mod tests {
             TESTDATA_PUT_FILESMAP_COUNT + SUBFOLDER_NO_SLASH_PUT_FILEITEM_COUNT
         );
 
-        let filename1 = "./testdata/test.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/test.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            new_files_map["/test.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&new_files_map["/test.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/another.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
+        let filename2 = Path::new("./testdata/another.md");
+        assert!(processed_files[filename2].is_added());
         assert_eq!(
-            processed_files[filename2].1,
-            new_files_map["/another.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&new_files_map["/another.md"][PREDICATE_LINK])
         );
 
-        let filename3 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename3].0, CONTENT_ADDED_SIGN);
+        let filename3 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename3].is_added());
         assert_eq!(
-            processed_files[filename3].1,
-            new_files_map["/subfolder/subexists.md"][PREDICATE_LINK]
+            processed_files[filename3].link(),
+            Some(&new_files_map["/subfolder/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename4 = "./testdata/noextension";
-        assert_eq!(processed_files[filename4].0, CONTENT_ADDED_SIGN);
+        let filename4 = Path::new("./testdata/noextension");
+        assert!(processed_files[filename4].is_added());
         assert_eq!(
-            processed_files[filename4].1,
-            new_files_map["/noextension"][PREDICATE_LINK]
+            processed_files[filename4].link(),
+            Some(&new_files_map["/noextension"][PREDICATE_LINK])
         );
 
         // and finally check the synced file is there
-        let filename5 = "./testdata/subfolder/subexists.md";
-        assert_eq!(new_processed_files[filename5].0, CONTENT_ADDED_SIGN);
+        let filename5 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(new_processed_files[filename5].is_added());
         assert_eq!(
-            new_processed_files[filename5].1,
-            new_files_map["/path/when/sync/subexists.md"][PREDICATE_LINK]
+            new_processed_files[filename5].link(),
+            Some(&new_files_map["/path/when/sync/subexists.md"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -2050,40 +2052,40 @@ mod tests {
             TESTDATA_PUT_FILESMAP_COUNT + SUBFOLDER_NO_SLASH_PUT_FILEITEM_COUNT
         );
 
-        let filename1 = "./testdata/test.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/test.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            new_files_map["/test.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&new_files_map["/test.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/another.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
+        let filename2 = Path::new("./testdata/another.md");
+        assert!(processed_files[filename2].is_added());
         assert_eq!(
-            processed_files[filename2].1,
-            new_files_map["/another.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&new_files_map["/another.md"][PREDICATE_LINK])
         );
 
-        let filename3 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename3].0, CONTENT_ADDED_SIGN);
+        let filename3 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename3].is_added());
         assert_eq!(
-            processed_files[filename3].1,
-            new_files_map["/subfolder/subexists.md"][PREDICATE_LINK]
+            processed_files[filename3].link(),
+            Some(&new_files_map["/subfolder/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename4 = "./testdata/noextension";
-        assert_eq!(processed_files[filename4].0, CONTENT_ADDED_SIGN);
+        let filename4 = Path::new("./testdata/noextension");
+        assert!(processed_files[filename4].is_added());
         assert_eq!(
-            processed_files[filename4].1,
-            new_files_map["/noextension"][PREDICATE_LINK]
+            processed_files[filename4].link(),
+            Some(&new_files_map["/noextension"][PREDICATE_LINK])
         );
 
         // and finally check the synced file is there
-        let filename5 = "./testdata/subfolder/subexists.md";
-        assert_eq!(new_processed_files[filename5].0, CONTENT_ADDED_SIGN);
+        let filename5 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(new_processed_files[filename5].is_added());
         assert_eq!(
-            new_processed_files[filename5].1,
-            new_files_map["/path/when/sync/subfolder/subexists.md"][PREDICATE_LINK]
+            new_processed_files[filename5].link(),
+            Some(&new_files_map["/path/when/sync/subfolder/subexists.md"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -2164,10 +2166,10 @@ mod tests {
         assert_eq!(version, version0);
         assert_eq!(files_map, v0_files_map);
         // let's check that one of the files in v1 is still there
-        let file_path1 = "/test.md";
+        let file_path1 = Path::new("/test.md");
         assert_eq!(
-            files_map[file_path1][PREDICATE_LINK],
-            v0_files_map[file_path1][PREDICATE_LINK]
+            files_map[&file_path1.display().to_string()][PREDICATE_LINK],
+            v0_files_map[&file_path1.display().to_string()][PREDICATE_LINK]
         );
 
         // let's fetch version1
@@ -2178,13 +2180,21 @@ mod tests {
         assert_eq!(version, version1);
         assert_eq!(new_files_map, v1_files_map);
         // let's check that some of the files are no in v2 anymore
-        let file_path2 = "/another.md";
-        let file_path3 = "/subfolder/subexists.md";
-        let file_path4 = "/noextension";
-        assert!(v1_files_map.get(file_path1).is_none());
-        assert!(v1_files_map.get(file_path2).is_none());
-        assert!(v1_files_map.get(file_path3).is_none());
-        assert!(v1_files_map.get(file_path4).is_none());
+        let file_path2 = Path::new("/another.md");
+        let file_path3 = Path::new("/subfolder/subexists.md");
+        let file_path4 = Path::new("/noextension");
+        assert!(v1_files_map
+            .get(&file_path1.display().to_string())
+            .is_none());
+        assert!(v1_files_map
+            .get(&file_path2.display().to_string())
+            .is_none());
+        assert!(v1_files_map
+            .get(&file_path3.display().to_string())
+            .is_none());
+        assert!(v1_files_map
+            .get(&file_path4.display().to_string())
+            .is_none());
 
         // let's fetch invalid version
         safe_url.set_content_version(Some(VersionHash::default()));
@@ -2317,25 +2327,25 @@ mod tests {
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT + 1);
 
-        let filename1 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            new_files_map["/subexists.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&new_files_map["/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/subfolder/sub2.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
+        let filename2 = Path::new("./testdata/subfolder/sub2.md");
+        assert!(processed_files[filename2].is_added());
         assert_eq!(
-            processed_files[filename2].1,
-            new_files_map["/sub2.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&new_files_map["/sub2.md"][PREDICATE_LINK])
         );
 
-        let filename3 = "./testdata/test.md";
-        assert_eq!(new_processed_files[filename3].0, CONTENT_ADDED_SIGN);
+        let filename3 = Path::new("./testdata/test.md");
+        assert!(new_processed_files[filename3].is_added());
         assert_eq!(
-            new_processed_files[filename3].1,
-            new_files_map["/new_filename_test.md"][PREDICATE_LINK]
+            new_processed_files[filename3].link(),
+            Some(&new_files_map["/new_filename_test.md"][PREDICATE_LINK])
         );
         Ok(())
     }
@@ -2385,16 +2395,16 @@ mod tests {
         assert_eq!(new_processed_files.len(), new_processed_files2.len());
         assert_eq!(new_files_map.len(), new_files_map2.len());
 
-        let filename = "./testdata/test.md";
-        assert_eq!(new_processed_files[filename].0, CONTENT_ADDED_SIGN);
-        assert_eq!(new_processed_files2[filename].0, CONTENT_ADDED_SIGN);
+        let filename = Path::new("./testdata/test.md");
+        assert!(new_processed_files[filename].is_added());
+        assert!(new_processed_files2[filename].is_added());
         assert_eq!(
-            new_processed_files[filename].1,
-            new_files_map["/new_filename_test.md"][PREDICATE_LINK]
+            new_processed_files[filename].link(),
+            Some(&new_files_map["/new_filename_test.md"][PREDICATE_LINK])
         );
         assert_eq!(
-            new_processed_files2[filename].1,
-            new_files_map2["/new_filename_test.md"][PREDICATE_LINK]
+            new_processed_files2[filename].link(),
+            Some(&new_files_map2["/new_filename_test.md"][PREDICATE_LINK])
         );
 
         Ok(())
@@ -2462,9 +2472,10 @@ mod tests {
         url_with_path.set_path("/sub2.md");
 
         // let's try to add a file with same target name and same content, it should fail
+        let filename1 = Path::new("./testdata/subfolder/sub2.md");
         let (version1, new_processed_files, new_files_map) = safe
             .files_container_add(
-                "./testdata/subfolder/sub2.md",
+                &filename1.display().to_string(),
                 &url_with_path.to_string(),
                 false,
                 false,
@@ -2476,15 +2487,16 @@ mod tests {
         assert_eq!(version1, version0);
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT);
-        assert_eq!(
-            new_processed_files["./testdata/subfolder/sub2.md"].1,
-            "File named \"/sub2.md\" with same content already exists on target. Use the \'force\' flag to replace it"
+        assert_matches!(
+            &new_processed_files[filename1],
+            FilesMapChange::Failed(msg) if msg == &format!("<{}>", Error::FileAlreadyExists("/sub2.md".to_string()))
         );
         assert_eq!(files_map, new_files_map);
 
         // let's try to add a file with same target name but with different content, it should still fail
+        let filename2 = Path::new("./testdata/test.md");
         let (version2, new_processed_files, new_files_map) = retry_loop!(safe.files_container_add(
-            "./testdata/test.md",
+            &filename2.display().to_string(),
             &url_with_path.to_string(),
             false,
             false,
@@ -2495,15 +2507,15 @@ mod tests {
         assert_eq!(version2, version0);
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT);
-        assert_eq!(
-            new_processed_files["./testdata/test.md"].1,
-            "File named \"/sub2.md\" with different content already exists on target. Use the \'force\' flag to replace it"
+        assert_matches!(
+            &new_processed_files[filename2],
+            FilesMapChange::Failed(msg) if msg == &format!("<{}>", Error::FileNameConflict("/sub2.md".to_string()))
         );
         assert_eq!(files_map, new_files_map);
 
         // let's now force it
         let (version3, new_processed_files, new_files_map) = retry_loop!(safe.files_container_add(
-            "./testdata/test.md",
+            &filename2.display().to_string(),
             &url_with_path.to_string(),
             true, //force it
             false,
@@ -2514,13 +2526,10 @@ mod tests {
         assert!(version3 != version0);
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT);
+        assert!(new_processed_files[filename2].is_updated());
         assert_eq!(
-            new_processed_files["./testdata/test.md"].0,
-            CONTENT_UPDATED_SIGN
-        );
-        assert_eq!(
-            new_processed_files["./testdata/test.md"].1,
-            new_files_map["/sub2.md"]["link"]
+            new_processed_files[filename2].link(),
+            Some(&new_files_map["/sub2.md"]["link"])
         );
 
         Ok(())
@@ -2610,10 +2619,10 @@ mod tests {
 
         let data = Bytes::from("0123456789");
         let file_xorurl = retry_loop!(safe.store_public_bytes(data.clone(), None, false));
-        let new_filename = "/new_filename_test.md";
+        let new_filename = Path::new("/new_filename_test.md");
 
         let mut url_with_path = SafeUrl::from_xorurl(&xorurl)?;
-        url_with_path.set_path(new_filename);
+        url_with_path.set_path(&new_filename.display().to_string());
 
         let (version1, new_processed_files, new_files_map) = retry_loop!(safe.files_container_add(
             &file_xorurl,
@@ -2628,26 +2637,29 @@ mod tests {
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT + 1);
 
-        let filename1 = "./testdata/subfolder/subexists.md";
-        assert_eq!(processed_files[filename1].0, CONTENT_ADDED_SIGN);
+        let filename1 = Path::new("./testdata/subfolder/subexists.md");
+        assert!(processed_files[filename1].is_added());
         assert_eq!(
-            processed_files[filename1].1,
-            new_files_map["/subexists.md"][PREDICATE_LINK]
+            processed_files[filename1].link(),
+            Some(&new_files_map["/subexists.md"][PREDICATE_LINK])
         );
 
-        let filename2 = "./testdata/subfolder/sub2.md";
-        assert_eq!(processed_files[filename2].0, CONTENT_ADDED_SIGN);
+        let filename2 = Path::new("./testdata/subfolder/sub2.md");
+        assert!(processed_files[filename2].is_added());
         assert_eq!(
-            processed_files[filename2].1,
-            new_files_map["/sub2.md"][PREDICATE_LINK]
+            processed_files[filename2].link(),
+            Some(&new_files_map["/sub2.md"][PREDICATE_LINK])
         );
 
-        assert_eq!(new_processed_files[new_filename].0, CONTENT_ADDED_SIGN);
+        assert!(new_processed_files[new_filename].is_added());
         assert_eq!(
-            new_processed_files[new_filename].1,
-            new_files_map[new_filename][PREDICATE_LINK]
+            new_processed_files[new_filename].link(),
+            Some(&new_files_map[&new_filename.display().to_string()][PREDICATE_LINK])
         );
-        assert_eq!(new_files_map[new_filename][PREDICATE_LINK], file_xorurl);
+        assert_eq!(
+            new_files_map[&new_filename.display().to_string()][PREDICATE_LINK],
+            file_xorurl
+        );
 
         // let's add another file but with the same name
         let data = Bytes::from("9876543210");
@@ -2665,13 +2677,13 @@ mod tests {
         assert_ne!(version2, version1);
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT + 1);
-        assert_eq!(new_processed_files[new_filename].0, CONTENT_UPDATED_SIGN);
+        assert!(new_processed_files[new_filename].is_updated());
         assert_eq!(
-            new_processed_files[new_filename].1,
-            new_files_map[new_filename][PREDICATE_LINK]
+            new_processed_files[new_filename].link(),
+            Some(&new_files_map[&new_filename.display().to_string()][PREDICATE_LINK])
         );
         assert_eq!(
-            new_files_map[new_filename][PREDICATE_LINK],
+            new_files_map[&new_filename.display().to_string()][PREDICATE_LINK],
             other_file_xorurl
         );
 
@@ -2694,10 +2706,10 @@ mod tests {
         let (version0, _) = retry_loop!(safe.files_container_get(&xorurl));
 
         let data = Bytes::from("0123456789");
-        let new_filename = "/new_filename_test.md";
+        let new_filename = Path::new("/new_filename_test.md");
 
         let mut url_with_path = SafeUrl::from_xorurl(&xorurl)?;
-        url_with_path.set_path(new_filename);
+        url_with_path.set_path(&new_filename.display().to_string());
 
         let (version1, new_processed_files, new_files_map) = retry_loop!(safe
             .files_container_add_from_raw(
@@ -2713,10 +2725,10 @@ mod tests {
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT + 1);
 
-        assert_eq!(new_processed_files[new_filename].0, CONTENT_ADDED_SIGN);
+        assert!(new_processed_files[new_filename].is_added());
         assert_eq!(
-            new_processed_files[new_filename].1,
-            new_files_map[new_filename][PREDICATE_LINK]
+            new_processed_files[new_filename].link(),
+            Some(&new_files_map[&new_filename.display().to_string()][PREDICATE_LINK])
         );
 
         // let's add another file but with the same name
@@ -2735,10 +2747,10 @@ mod tests {
         assert_ne!(version2, version1);
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT + 1);
-        assert_eq!(new_processed_files[new_filename].0, CONTENT_UPDATED_SIGN);
+        assert!(new_processed_files[new_filename].is_updated());
         assert_eq!(
-            new_processed_files[new_filename].1,
-            new_files_map[new_filename][PREDICATE_LINK]
+            new_processed_files[new_filename].link(),
+            Some(&new_files_map[&new_filename.display().to_string()][PREDICATE_LINK])
         );
         Ok(())
     }
@@ -2762,11 +2774,11 @@ mod tests {
         assert_eq!(new_processed_files.len(), 1);
         assert_eq!(new_files_map.len(), TESTDATA_PUT_FILESMAP_COUNT - 1);
 
-        let filepath = "/test.md";
-        assert_eq!(new_processed_files[filepath].0, CONTENT_DELETED_SIGN);
+        let filepath = Path::new("/test.md");
+        assert!(new_processed_files[filepath].is_removed());
         assert_eq!(
-            new_processed_files[filepath].1,
-            files_map[filepath][PREDICATE_LINK]
+            new_processed_files[filepath].link(),
+            Some(&files_map[&filepath.display().to_string()][PREDICATE_LINK])
         );
 
         // let's remove an entire folder now with recursive flag
@@ -2783,18 +2795,18 @@ mod tests {
             TESTDATA_PUT_FILESMAP_COUNT - SUBFOLDER_PUT_FILEITEM_COUNT - 1
         );
 
-        let filename1 = "/subfolder/subexists.md";
-        assert_eq!(new_processed_files[filename1].0, CONTENT_DELETED_SIGN);
+        let filename1 = Path::new("/subfolder/subexists.md");
+        assert!(new_processed_files[filename1].is_removed());
         assert_eq!(
-            new_processed_files[filename1].1,
-            files_map[filename1][PREDICATE_LINK]
+            new_processed_files[filename1].link(),
+            Some(&files_map[&filename1.display().to_string()][PREDICATE_LINK])
         );
 
-        let filename2 = "/subfolder/sub2.md";
-        assert_eq!(new_processed_files[filename2].0, CONTENT_DELETED_SIGN);
+        let filename2 = Path::new("/subfolder/sub2.md");
+        assert!(new_processed_files[filename2].is_removed());
         assert_eq!(
-            new_processed_files[filename2].1,
-            files_map[filename2][PREDICATE_LINK]
+            new_processed_files[filename2].link(),
+            Some(&files_map[&filename2.display().to_string()][PREDICATE_LINK])
         );
 
         Ok(())

--- a/sn_api/src/app/files/mod.rs
+++ b/sn_api/src/app/files/mod.rs
@@ -860,7 +860,7 @@ async fn files_map_sync(
 
                         processed_files.insert(
                             local_file_name.to_path_buf(),
-                            FilesMapChange::Failed(format!("<{}>", err_type)),
+                            FilesMapChange::Failed(format!("{}", err_type)),
                         );
                         info!("Skipping file \"{}\" since a file named \"{}\" with {} content already exists on target. You can use the 'force' flag to replace the existing file with the new one", local_file_name.display(), normalised_file_name, comp_str);
                     }
@@ -945,7 +945,7 @@ async fn files_map_add_link(
             info!("Skipping file \"{}\". {}", file_link, err);
             processed_files.insert(
                 PathBuf::from(file_link),
-                FilesMapChange::Failed(format!("<{}>", err)),
+                FilesMapChange::Failed(format!("{}", err)),
             );
             Ok((processed_files, files_map, success_count))
         }
@@ -2489,7 +2489,7 @@ mod tests {
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT);
         assert_matches!(
             &new_processed_files[filename1],
-            FilesMapChange::Failed(msg) if msg == &format!("<{}>", Error::FileAlreadyExists("/sub2.md".to_string()))
+            FilesMapChange::Failed(msg) if msg == &format!("{}", Error::FileAlreadyExists("/sub2.md".to_string()))
         );
         assert_eq!(files_map, new_files_map);
 
@@ -2509,7 +2509,7 @@ mod tests {
         assert_eq!(new_files_map.len(), SUBFOLDER_PUT_FILEITEM_COUNT);
         assert_matches!(
             &new_processed_files[filename2],
-            FilesMapChange::Failed(msg) if msg == &format!("<{}>", Error::FileNameConflict("/sub2.md".to_string()))
+            FilesMapChange::Failed(msg) if msg == &format!("{}", Error::FileNameConflict("/sub2.md".to_string()))
         );
         assert_eq!(files_map, new_files_map);
 

--- a/sn_api/src/errors.rs
+++ b/sn_api/src/errors.rs
@@ -72,9 +72,12 @@ pub enum Error {
     /// EntryNotFound
     #[error("EntryNotFound: {0}")]
     EntryNotFound(String),
-    /// EntryExists
-    #[error("EntryExists: {0}")]
-    EntryExists(String),
+    /// A file with same name already exists on target FilesContainer with same link"
+    #[error("File named \"{0}\" already exists on target with same link.")]
+    FileAlreadyExists(String),
+    /// A file with same name already exists on target FilesContainer with same link"
+    #[error("File named \"{0}\" already exists on target. Use the 'force' flag to replace it.")]
+    FileNameConflict(String),
     /// InvalidAmount
     #[error("InvalidAmount: {0}")]
     InvalidAmount(String),

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -11,7 +11,7 @@ use super::{
     files_get::{process_get_command, FileExistsAction, ProgressIndicator},
     helpers::{
         gen_processed_files_table, get_from_arg_or_stdin, get_from_stdin, if_tty, notice_dry_run,
-        parse_stdin_arg, pluralize, serialise_output,
+        parse_stdin_arg, pluralize, processed_files_err_report, serialise_output,
     },
     OutputFmt,
 };
@@ -21,14 +21,14 @@ use color_eyre::{eyre::bail, eyre::eyre, Result};
 use prettytable::{format::FormatBuilder, Table};
 use serde::Serialize;
 use sn_api::{
-    files::{FilesMap, ProcessedFiles},
+    files::{FilesMap, FilesMapChange, ProcessedFiles},
     nrs::VersionHash,
     resolver::SafeData,
     Safe, SafeUrl, XorUrl,
 };
 use std::{
     collections::{BTreeMap, HashMap},
-    path::{Component, Path},
+    path::{Component, Path, PathBuf},
 };
 use structopt::StructOpt;
 use tracing::debug;
@@ -104,7 +104,7 @@ pub enum FilesSubCommands {
         /// The source file/folder local path
         location: String,
         /// The destination path (in the FilesContainer) for the uploaded files and folders (default is '/')
-        dest: Option<String>,
+        dest: Option<PathBuf>,
         /// Recursively upload folders and files found in the source location
         #[structopt(short = "r", long = "recursive")]
         recursive: bool,
@@ -217,7 +217,7 @@ pub async fn files_commander(
             if dry_run && OutputFmt::Pretty == output_fmt {
                 notice_dry_run();
             }
-            let (files_container_xorurl, processed_files, _files_map) = safe
+            let (files_, processed_files, _) = safe
                 .files_container_create(
                     Some(&location),
                     dest.as_deref(),
@@ -232,7 +232,7 @@ pub async fn files_commander(
                 if dry_run {
                     println!("FilesContainer not created since running in dry-run mode");
                 } else {
-                    println!("FilesContainer created at: \"{}\"", files_container_xorurl);
+                    println!("FilesContainer created at: \"{}\"", files_);
                 }
                 let mut table = Table::new();
                 let format = FormatBuilder::new()
@@ -240,15 +240,26 @@ pub async fn files_commander(
                     .padding(0, 1)
                     .build();
                 table.set_format(format);
-                for (file_name, (change, link)) in processed_files.iter() {
-                    table.add_row(row![change, file_name, link]);
+                for (file_name, change) in processed_files.iter() {
+                    match change {
+                        FilesMapChange::Failed(err) => {
+                            let (change_sign, msg) = processed_files_err_report(err);
+                            table.add_row(row![change_sign, file_name.display(), msg])
+                        }
+                        FilesMapChange::Added(link) => {
+                            table.add_row(row!["+", file_name.display(), link])
+                        }
+                        FilesMapChange::Updated(link) => {
+                            table.add_row(row!["*", file_name.display(), link])
+                        }
+                        FilesMapChange::Removed(link) => {
+                            table.add_row(row!["-", file_name.display(), link])
+                        }
+                    };
                 }
                 table.printstd();
             } else {
-                println!(
-                    "{}",
-                    serialise_output(&(files_container_xorurl, processed_files), output_fmt)
-                );
+                print_serialized_output(files_, None, &processed_files, output_fmt);
             }
 
             Ok(())
@@ -266,7 +277,7 @@ pub async fn files_commander(
                 notice_dry_run();
             }
             // Update the FilesContainer on the Network
-            let (version, processed_files, _files_map) = safe
+            let (version, processed_files, _) = safe
                 .files_container_sync(
                     &location,
                     &target,
@@ -279,8 +290,8 @@ pub async fn files_commander(
                 .await?;
 
             // Now let's just print out a list of the files synced/processed
+            let (table, success_count) = gen_processed_files_table(&processed_files, true);
             if OutputFmt::Pretty == output_fmt {
-                let (table, success_count) = gen_processed_files_table(&processed_files, true);
                 if success_count > 0 {
                     let url = match SafeUrl::from_url(&target) {
                         Ok(mut safeurl) => {
@@ -306,7 +317,7 @@ pub async fn files_commander(
                     println!("No changes were required, source location is already in sync with FilesContainer (version {}) at: \"{}\"", version, target);
                 }
             } else {
-                print_serialized_output(target, Some(version), processed_files, output_fmt);
+                print_serialized_output(target, Some(version), &processed_files, output_fmt);
             }
             Ok(())
         }
@@ -330,7 +341,7 @@ pub async fn files_commander(
                 notice_dry_run();
             }
 
-            let (version, processed_files, _files_map) =
+            let (version, processed_files, _) =
                 // If location is empty then we read arg from STDIN, which can still be a safe:// URL
                 if location.is_empty() {
                     let file_content = get_from_stdin(Some("...awaiting file's content to add from STDIN"))?;
@@ -342,7 +353,7 @@ pub async fn files_commander(
                 };
 
             // Now let's just print out a list of the files synced/processed
-            output_processed_files_list(output_fmt, processed_files, Some(version), target_url);
+            output_processed_files_list(output_fmt, &processed_files, Some(version), target_url);
             Ok(())
         }
         FilesSubCommands::Rm {
@@ -358,12 +369,12 @@ pub async fn files_commander(
             }
 
             // Update the FilesContainer on the Network
-            let (version, processed_files, _files_map) = safe
+            let (version, processed_files, _) = safe
                 .files_container_remove_path(&target_url, recursive, update_nrs, dry_run)
                 .await?;
 
             // Now let's just print out a list of the files removed
-            output_processed_files_list(output_fmt, processed_files, Some(version), target_url);
+            output_processed_files_list(output_fmt, &processed_files, Some(version), target_url);
             Ok(())
         }
         FilesSubCommands::Ls { target } => {
@@ -480,7 +491,7 @@ async fn process_tree_command(
 fn print_serialized_output(
     xorurl: XorUrl,
     version: Option<VersionHash>,
-    processed_files: BTreeMap<String, (String, String)>,
+    processed_files: &ProcessedFiles,
     output_fmt: OutputFmt,
 ) {
     let url = match SafeUrl::from_url(&xorurl) {
@@ -495,12 +506,12 @@ fn print_serialized_output(
 
 fn output_processed_files_list(
     output_fmt: OutputFmt,
-    processed_files: ProcessedFiles,
+    processed_files: &ProcessedFiles,
     version: Option<VersionHash>,
     target_url: String,
 ) {
     if OutputFmt::Pretty == output_fmt {
-        let (table, success_count) = gen_processed_files_table(&processed_files, true);
+        let (table, success_count) = gen_processed_files_table(processed_files, true);
         if success_count > 0 {
             let url = match SafeUrl::from_url(&target_url) {
                 Ok(mut safeurl) => {

--- a/sn_cli/src/subcommands/helpers.rs
+++ b/sn_cli/src/subcommands/helpers.rs
@@ -148,10 +148,7 @@ pub fn gen_processed_files_table(
         if show_change_sign {
             table.add_row(row![change_sign, file_name.display(), link]);
         } else {
-            table.add_row(row![
-                file_name.display(),
-                change.link().unwrap_or(&String::default())
-            ]);
+            table.add_row(row![file_name.display(), link]);
         }
     }
     (table, success_count)

--- a/sn_cli/tests/cli_cat.rs
+++ b/sn_cli/tests/cli_cat.rs
@@ -41,7 +41,7 @@ fn calling_safe_cat_using_spot_file() -> Result<()> {
         "cat",
         processed_files[Path::new("../resources/testdata/test.md")]
             .link()
-            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?,
+            .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?,
     ])
     .assert()
     .stdout(predicate::str::contains(TEST_FILE_CONTENT))
@@ -50,7 +50,7 @@ fn calling_safe_cat_using_spot_file() -> Result<()> {
     let safeurl = safeurl_from(
         processed_files[Path::new("../resources/testdata/test.md")]
             .link()
-            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?,
+            .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?,
     )?;
     assert_eq!(
         safeurl.content_type(),
@@ -81,7 +81,7 @@ fn calling_safe_cat_using_blob_file() -> Result<()> {
         "cat",
         processed_files[Path::new("../resources/testdata/large_markdown_file.md")]
             .link()
-            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?,
+            .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?,
     ])
     .assert()
     .stdout(predicate::str::contains(content))
@@ -90,7 +90,7 @@ fn calling_safe_cat_using_blob_file() -> Result<()> {
     let safeurl = safeurl_from(
         processed_files[Path::new("../resources/testdata/large_markdown_file.md")]
             .link()
-            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?,
+            .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?,
     )?;
     assert_eq!(
         safeurl.content_type(),
@@ -130,7 +130,7 @@ fn calling_safe_cat_on_relative_file_from_id_fails() -> Result<()> {
         "{}/something_relative.wasm",
         &processed_files[Path::new(TEST_FILE)]
             .link()
-            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?
+            .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?
     );
     cmd.args(&vec!["cat", &relative_url])
         .assert()
@@ -150,7 +150,7 @@ fn calling_safe_cat_hexdump() -> Result<()> {
         "--hexdump",
         processed_files[Path::new(TEST_FILE)]
             .link()
-            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?,
+            .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?,
     ])
     .assert()
     .stdout(predicate::str::contains(TEST_FILE_HEXDUMP_CONTENT))
@@ -159,7 +159,7 @@ fn calling_safe_cat_hexdump() -> Result<()> {
     let safeurl = safeurl_from(
         processed_files[Path::new(TEST_FILE)]
             .link()
-            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?,
+            .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?,
     )?;
     assert_eq!(
         safeurl.content_type(),

--- a/sn_cli/tests/cli_dog.rs
+++ b/sn_cli/tests/cli_dog.rs
@@ -19,7 +19,7 @@ const TEST_FILE: &str = "../resources/testdata/test.md";
 #[test]
 fn calling_safe_dog_files_container_nrsurl() -> Result<()> {
     let content = safe_cmd_stdout(["files", "put", TEST_FILE, "--json"], Some(0))?;
-    let (container_xorurl, _files_map) = parse_files_put_or_sync_output(&content)?;
+    let (container_xorurl, _) = parse_files_put_or_sync_output(&content)?;
 
     let nrsurl = get_random_nrs_string();
     safe_cmd(
@@ -43,7 +43,7 @@ fn calling_safe_dog_files_container_nrsurl() -> Result<()> {
 #[test]
 fn calling_safe_dog_files_container_nrsurl_jsoncompact() -> Result<()> {
     let content = safe_cmd_stdout(["files", "put", TEST_FILE, "--output=jsoncompact"], Some(0))?;
-    let (container_xorurl, _files_map) = parse_files_put_or_sync_output(&content)?;
+    let (container_xorurl, _) = parse_files_put_or_sync_output(&content)?;
 
     let nrsurl = get_random_nrs_string();
     safe_cmd(
@@ -67,7 +67,7 @@ fn calling_safe_dog_files_container_nrsurl_jsoncompact() -> Result<()> {
 #[test]
 fn calling_safe_dog_files_container_nrsurl_yaml() -> Result<()> {
     let content = safe_cmd_stdout(["files", "put", TEST_FILE, "--json"], Some(0))?;
-    let (container_xorurl, _files_map) = parse_files_put_or_sync_output(&content)?;
+    let (container_xorurl, _) = parse_files_put_or_sync_output(&content)?;
 
     let nrsurl = get_random_nrs_string();
     let _ = safe_cmd_stdout(

--- a/sn_cli/tests/cli_files.rs
+++ b/sn_cli/tests/cli_files.rs
@@ -77,7 +77,7 @@ fn calling_safe_files_put_dry_run() -> Result<()> {
         "cat",
         processed_files[Path::new(TEST_FILE_RANDOM_CONTENT)]
             .link()
-            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?,
+            .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?,
     ])
     .assert()
     .failure();
@@ -89,7 +89,7 @@ fn calling_safe_files_put_recursive() -> Result<()> {
     let mut cmd = Command::cargo_bin(CLI).map_err(|e| eyre!(e.to_string()))?;
     cmd.args(&vec!["files", "put", TEST_FOLDER, "--recursive", "--json"])
         .assert()
-        .stdout(predicate::str::contains(r#"+"#).count(12))
+        .stdout(predicate::str::contains(r#"Added"#).count(12))
         .stdout(predicate::str::contains("../resources/testdata/test.md").count(1))
         .stdout(predicate::str::contains("../resources/testdata/another.md").count(1))
         .stdout(predicate::str::contains("../resources/testdata/subfolder/subexists.md").count(1))
@@ -292,7 +292,7 @@ fn calling_safe_files_sync_dry_run() -> Result<()> {
         "cat",
         processed_files[Path::new(TEST_FILE_RANDOM_CONTENT)]
             .link()
-            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?,
+            .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?,
     ])
     .assert()
     .failure();
@@ -656,7 +656,7 @@ fn calling_safe_files_add_a_url() -> Result<()> {
     safeurl.set_path("/new_test.md");
     let link = processed_files[Path::new(TEST_FILE)]
         .link()
-        .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?;
+        .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?;
     safe_cmd(
         ["files", "add", link, &safeurl.to_string(), "--json"],
         Some(0),

--- a/sn_cli/tests/cli_files.rs
+++ b/sn_cli/tests/cli_files.rs
@@ -19,7 +19,7 @@ use sn_cmd_test_utilities::util::{
     safeurl_from, test_symlinks_are_valid, upload_path, upload_test_symlinks_folder,
     upload_testfolder_trailing_slash, CLI, SAFE_PROTOCOL,
 };
-use std::{process::Command, str::FromStr};
+use std::{path::Path, process::Command, str::FromStr};
 
 const PRETTY_FILES_CREATION_RESPONSE: &str = "FilesContainer created at: ";
 const TEST_FILE: &str = "../resources/testdata/test.md";
@@ -71,11 +71,16 @@ fn calling_safe_files_put_dry_run() -> Result<()> {
         Some(0),
     )?;
 
-    let (_container_xorurl, map) = parse_files_put_or_sync_output(&content)?;
+    let (_, processed_files) = parse_files_put_or_sync_output(&content)?;
     let mut cmd = Command::cargo_bin(CLI).map_err(|e| eyre!(e.to_string()))?;
-    cmd.args(&vec!["cat", &map[TEST_FILE_RANDOM_CONTENT].1])
-        .assert()
-        .failure();
+    cmd.args(&vec![
+        "cat",
+        processed_files[Path::new(TEST_FILE_RANDOM_CONTENT)]
+            .link()
+            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?,
+    ])
+    .assert()
+    .failure();
     Ok(())
 }
 
@@ -281,11 +286,16 @@ fn calling_safe_files_sync_dry_run() -> Result<()> {
         ],
         Some(0),
     )?;
-    let (_, map) = parse_files_put_or_sync_output(&sync_content)?;
+    let (_, processed_files) = parse_files_put_or_sync_output(&sync_content)?;
     let mut cmd = Command::cargo_bin(CLI).map_err(|e| eyre!(e.to_string()))?;
-    cmd.args(&vec!["cat", &map[TEST_FILE_RANDOM_CONTENT].1])
-        .assert()
-        .failure();
+    cmd.args(&vec![
+        "cat",
+        processed_files[Path::new(TEST_FILE_RANDOM_CONTENT)]
+            .link()
+            .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?,
+    ])
+    .assert()
+    .failure();
     Ok(())
 }
 
@@ -475,7 +485,7 @@ fn calling_files_sync_and_fetch_with_nrsurl_and_nrs_update() -> Result<()> {
         ],
         Some(0),
     )?;
-    let (nrs_xorurl, _files_map) = parse_nrs_register_output(&output)?;
+    let (nrs_xorurl, _) = parse_nrs_register_output(&output)?;
     let nrs_version = nrs_xorurl
         .content_version()
         .ok_or_else(|| eyre!("failed to get content version from xorurl"))?;
@@ -644,15 +654,11 @@ fn calling_safe_files_add_a_url() -> Result<()> {
     let mut safeurl = safeurl_from(&files_container_xor)?;
     safeurl.set_content_version(None);
     safeurl.set_path("/new_test.md");
-    println!("data type: {}", safeurl.data_type());
+    let link = processed_files[Path::new(TEST_FILE)]
+        .link()
+        .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?;
     safe_cmd(
-        [
-            "files",
-            "add",
-            &processed_files[TEST_FILE].1,
-            &safeurl.to_string(),
-            "--json",
-        ],
+        ["files", "add", link, &safeurl.to_string(), "--json"],
         Some(0),
     )?;
 
@@ -696,20 +702,20 @@ fn calling_files_ls() -> Result<()> {
     assert_eq!(xorurl, container_xorurl_no_version);
     assert_eq!(files_map.len(), 8);
     assert_eq!(
-        files_map[".hidden.txt"]["link"],
-        processed_files[&format!("{}.hidden.txt", TEST_FOLDER)].1
+        processed_files[Path::new(&format!("{}.hidden.txt", TEST_FOLDER))].link(),
+        Some(&files_map[".hidden.txt"]["link"]),
     );
     assert_eq!(
-        files_map["another.md"]["link"],
-        processed_files[&format!("{}another.md", TEST_FOLDER)].1
+        processed_files[Path::new(&format!("{}another.md", TEST_FOLDER))].link(),
+        Some(&files_map["another.md"]["link"]),
     );
     assert_eq!(
-        files_map["noextension"]["link"],
-        processed_files[&format!("{}noextension", TEST_FOLDER)].1
+        processed_files[Path::new(&format!("{}noextension", TEST_FOLDER))].link(),
+        Some(&files_map["noextension"]["link"]),
     );
     assert_eq!(
-        files_map["test.md"]["link"],
-        processed_files[&format!("{}test.md", TEST_FOLDER)].1
+        processed_files[Path::new(&format!("{}test.md", TEST_FOLDER))].link(),
+        Some(&files_map["test.md"]["link"]),
     );
 
     let subfolder_len = get_directory_len(TEST_FOLDER_SUBFOLDER)?;
@@ -724,15 +730,15 @@ fn calling_files_ls() -> Result<()> {
     assert_eq!(xorurl, subfolder_path);
     assert_eq!(files_map.len(), 2);
     assert_eq!(
-        files_map["sub2.md"]["link"],
-        processed_files[&format!("{}sub2.md", TEST_FOLDER_SUBFOLDER)].1
+        processed_files[Path::new(&format!("{}sub2.md", TEST_FOLDER_SUBFOLDER))].link(),
+        Some(&files_map["sub2.md"]["link"]),
     );
 
     let sub2_len = get_file_len(&format!("{}/{}", TEST_FOLDER_SUBFOLDER, "sub2.md"))?;
     assert_eq!(files_map["sub2.md"]["size"], sub2_len.to_string());
     assert_eq!(
-        files_map["subexists.md"]["link"],
-        processed_files[&format!("{}subexists.md", TEST_FOLDER_SUBFOLDER)].1
+        processed_files[Path::new(&format!("{}subexists.md", TEST_FOLDER_SUBFOLDER))].link(),
+        Some(&files_map["subexists.md"]["link"]),
     );
 
     let subexists_len = get_file_len(&format!("{}/{}", TEST_FOLDER_SUBFOLDER, "subexists.md"))?;

--- a/sn_cli/tests/cli_nrs.rs
+++ b/sn_cli/tests/cli_nrs.rs
@@ -73,8 +73,12 @@ fn nrs_register_should_register_a_topname_with_an_immutable_content_link() -> Re
         .iter()
         .last()
         .ok_or_else(|| eyre!("list of processed files unexpectedly empty"))?;
-    let test_md_blob_link = test_md_entry.1.to_owned().1;
-    let url = SafeUrl::from_url(&test_md_blob_link)?;
+    let test_md_blob_link = test_md_entry
+        .1
+        .to_owned()
+        .link()
+        .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?;
+    let url = SafeUrl::from_url(test_md_blob_link)?;
     println!("processed_files = {:?}", processed_files);
 
     let topname = get_random_nrs_string();
@@ -215,8 +219,12 @@ fn nrs_add_should_add_a_subname_to_immutable_content() -> Result<()> {
         .iter()
         .last()
         .ok_or_else(|| eyre!("list of processed files unexpectedly empty"))?;
-    let test_md_blob_link = test_md_entry.1.to_owned().1;
-    let url = SafeUrl::from_url(&test_md_blob_link)?;
+    let test_md_blob_link = test_md_entry
+        .1
+        .to_owned()
+        .link()
+        .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?;
+    let url = SafeUrl::from_url(test_md_blob_link)?;
 
     let test_name = get_random_nrs_string();
     let public_name = format!("test.{}", &test_name);

--- a/sn_cli/tests/cli_nrs.rs
+++ b/sn_cli/tests/cli_nrs.rs
@@ -77,7 +77,7 @@ fn nrs_register_should_register_a_topname_with_an_immutable_content_link() -> Re
         .1
         .to_owned()
         .link()
-        .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?;
+        .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?;
     let url = SafeUrl::from_url(test_md_blob_link)?;
     println!("processed_files = {:?}", processed_files);
 
@@ -223,7 +223,7 @@ fn nrs_add_should_add_a_subname_to_immutable_content() -> Result<()> {
         .1
         .to_owned()
         .link()
-        .ok_or_else(|| eyre!("Missing xorurl link or uploaded test file"))?;
+        .ok_or_else(|| eyre!("Missing xorurl link of uploaded test file"))?;
     let url = SafeUrl::from_url(test_md_blob_link)?;
 
     let test_name = get_random_nrs_string();


### PR DESCRIPTION
BREAKING CHANGE: change in sn-api ProcessedFiles which is part of public API.
