### PR TITLE
tests: add 5mb many client test

### DIFF
--- a/sn/src/client/client_api/blob_apis.rs
+++ b/sn/src/client/client_api/blob_apis.rs
@@ -382,7 +382,7 @@ mod tests {
     use futures::future::join_all;
     use rand::rngs::OsRng;
     use tokio::time::Instant;
-    use tracing::Instrument;
+    use tracing::{instrument::Instrumented, Instrument};
 
     const MIN_BLOB_SIZE: usize = self_encryption::MIN_ENCRYPTABLE_BYTES;
 
@@ -456,6 +456,58 @@ mod tests {
 
         compare(blob.bytes(), read_data)?;
 
+        Ok(())
+    }
+
+    // Test storing and reading min size blob. Try and read from many clients and ensure we do not overwelm nodes.
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "Currently nodes will not cope with this."]
+    async fn store_and_read_5mb_from_many_clients() -> Result<()> {
+        init_test_logger();
+        let _start_span = tracing::info_span!("store_and_read_3kb_from_many_clients").entered();
+
+        let client = create_test_client().await?;
+        // create Blob with random bytes 5mb
+        let blob_bytes = random_bytes(5 * 1024 * 1024);
+        let blob = Blob::new(blob_bytes)?;
+
+        // Store blob
+        let address = client
+            .upload_and_verify(blob.bytes(), Scope::Public)
+            .await?;
+
+        // Assert that the blob is stored.
+        let read_data = client.read_bytes(address).await?;
+
+        compare(blob.bytes(), read_data)?;
+
+        let mut tasks = vec![];
+
+        for i in 1..100 {
+            debug!("starting client on thread #{:?}", i);
+            let handle: Instrumented<tokio::task::JoinHandle<Result<()>>> =
+                tokio::spawn(async move {
+                    debug!("started client #{:?}", i);
+                    // use a fresh client
+                    let client = create_test_client().await?;
+                    // to grab that data
+                    let _read_data = client.read_bytes(address).await?;
+
+                    debug!("client #{:?} finished", i);
+                    Ok(())
+                })
+                .in_current_span();
+
+            tasks.push(handle);
+        }
+        let responses = join_all(tasks).await;
+
+        for res in responses {
+            debug!("a response is done");
+            let _ok = res??;
+        }
+
+        // TODO: we need to use the node log analysis to check the mem usage across nodes does not exceed X
         Ok(())
     }
 

--- a/sn/src/client/utils/test_utils/test_client.rs
+++ b/sn/src/client/utils/test_utils/test_client.rs
@@ -109,11 +109,11 @@ pub async fn create_test_client() -> Result<Client> {
 /// If no keypair is provided, a check is run that a balance has been generated for the client
 pub async fn create_test_client_with(
     optional_keypair: Option<Keypair>,
-    timeout: Option<u64>,
+    query_timeout: Option<u64>,
     read_prefix_map: bool,
 ) -> Result<Client> {
     let root_dir = tempdir().map_err(|e| eyre::eyre!(e.to_string()))?;
-    let timeout = timeout.map(Duration::from_secs);
+    let query_timeout = query_timeout.map(Duration::from_secs);
     let (genesis_key, bootstrap_nodes) = read_network_conn_info()?;
 
     let standard_wait = if read_prefix_map {
@@ -129,7 +129,7 @@ pub async fn create_test_client_with(
         None,
         genesis_key,
         None,
-        timeout,
+        query_timeout,
         standard_wait,
     )
     .await;


### PR DESCRIPTION
This adds a test to check if many many client connections will result in high mem usage at nodes.

THIS TEST WILL FAIL ON MAIN. That's okay. It's currently ignored. But it gives us a benchmark to work to fixing.

TODO: 

- [ ] Check node logs for excessive mem usage in the test itself
- [ ] Do the same via register test?