### PR TITLE
docs: align cli user guide with current features

### DIFF
--- a/sn_cli/README.md
+++ b/sn_cli/README.md
@@ -5,158 +5,133 @@
 
 ## Table of contents
 
-- [Safe Network CLI](#safe-network-cli)
-  - [Table of contents](#table-of-contents)
-  - [Description](#description)
-  - [Download](#download)
-    - [Linux and Mac](#linux-and-mac)
-    - [Windows](#windows)
-  - [Build](#build)
-  - [Using the CLI](#using-the-cli)
-      - [`--help`](#--help)
-    - [Networks](#networks)
-      - [Node install](#node-install)
-      - [Run a local network](#run-a-local-network)
-        - [Run a local network for testing: `--test`](#run-a-local-network-for-testing---test)
-      - [Connect to a shared network](#connect-to-a-shared-network)
-      - [Switch networks](#switch-networks)
-      - [Set network bootstrap address](#set-network-bootstrap-address)
-      - [Node update](#node-update)
-    - [Auth](#auth)
-      - [The Authenticator daemon (authd)](#the-authenticator-daemon-authd)
-      - [Auth install](#auth-install)
-      - [Auth start](#auth-start)
-      - [Auth status](#auth-status)
-      - [Auth create](#auth-create)
-      - [Auth unlock](#auth-unlock)
-        - [Passing credentials from a config file](#passing-credentials-from-a-config-file)
-        - [Using environment variables](#using-environment-variables)
-      - [Auth reqs](#auth-reqs)
-      - [Auth allow/deny](#auth-allowdeny)
-        - [Self authorising the CLI application](#self-authorising-the-cli-application)
-      - [Auth update](#auth-update)
-    - [The interactive shell](#the-interactive-shell)
-    - [SafeKeys](#safekeys)
-      - [SafeKeys Creation](#safekeys-creation)
-      - [SafeKey's Balance](#safekeys-balance)
-      - [SafeKeys Transfer](#safekeys-transfer)
-    - [Wallet](#wallet)
-      - [Wallet Creation](#wallet-creation)
-      - [Wallet Balance](#wallet-balance)
-      - [Wallet Insert](#wallet-insert)
-      - [Wallet Transfer](#wallet-transfer)
-    - [Files](#files)
-      - [[ Warning: Underlying API to be deprecated ]](#-warning-underlying-api-to-be-deprecated-)
-      - [Files...](#files-1)
-      - [Files Put](#files-put)
-        - [Base path of files in a FilesContainer](#base-path-of-files-in-a-filescontainer)
-      - [Files Sync](#files-sync)
-      - [Files Add](#files-add)
-      - [Files Ls](#files-ls)
-      - [Files Get](#files-get)
-        - [Example: retrieving contents of a file container to local working directory](#example-retrieving-contents-of-a-file-container-to-local-working-directory)
-        - [Example: retrieving subfolder in a file container to an existing local directory.](#example-retrieving-subfolder-in-a-file-container-to-an-existing-local-directory)
-        - [Example: retrieving subfolder in a file container to a non-existent local directory (rename)](#example-retrieving-subfolder-in-a-file-container-to-a-non-existent-local-directory-rename)
-        - [Example: Retrieving individual file to an existing directory](#example-retrieving-individual-file-to-an-existing-directory)
-        - [Example: Retrieving individual file to a new filename](#example-retrieving-individual-file-to-a-new-filename)
-        - [A performance note about very large FileContainers](#a-performance-note-about-very-large-filecontainers)
-      - [Files Tree](#files-tree)
-      - [Files Rm](#files-rm)
-    - [Xorurl](#xorurl)
-      - [Xorurl decode](#xorurl-decode)
-    - [Cat](#cat)
-      - [Retrieving binary files with --hexdump](#retrieving-binary-files-with---hexdump)
-      - [Retrieving older versions of content](#retrieving-older-versions-of-content)
-    - [NRS (Name Resolution System)](#nrs-name-resolution-system)
-      - [NRS Create](#nrs-create)
-        - [Sub Names](#sub-names)
-      - [NRS Add](#nrs-add)
-      - [NRS Remove](#nrs-remove)
-    - [Safe-URLs](#safe-urls)
-      - [Symlinks](#symlinks)
-    - [Dog](#dog)
-    - [Seq (Sequence)](#seq-sequence)
-      - [Seq Store](#seq-store)
-        - [Private Sequence](#private-sequence)
-      - [Seq Append](#seq-append)
-    - [Shell Completions](#shell-completions)
-      - [Bash Completions](#bash-completions)
-      - [Windows PowerShell Completions](#windows-powershell-completions)
-    - [Update](#update)
-  - [Further Help](#further-help)
-  - [License](#license)
-  - [Contributing](#contributing)
+- [Description](#description)
+- [Quick Start](#quick-start)
+- [Installation and Setup](#installation-and-setup)
+- [Prerequisites](#prerequisites)
+- [Install Script](#install-script)
+  - [Linux and macOS](#linux-and-macos)
+  - [Windows](#linux-and-macos)
+- [Binaries](#binaries)
+- [Build from Source](#build-from-source)
+- [Using the CLI](#using-the-cli)
+- [Getting Help](#getting-help)
+- [Networks](#networks)
+- [Node Management](#node-management)
+- [Run a Local Network](#run-a-local-network)
+- [Connect to a Remote Network](#connect-to-a-remote-network)
+  - [Connection Info via HTTP](#connection-info-via-http)
+  - [Direct Connection Info](#direct-connection-info)
+  - [Provide a Node](#provide-a-node)
+- [Files](#files)
+  - [Put](#put)
+    - [Base Path](#base-path)
+  - [Add](#files-add)
+  - [Ls](#files-ls)
+  - [Get](#files-get)
+    - [Example: retrieving contents of a file container to local working directory](#example-retrieving-contents-of-a-file-container-to-local-working-directory)
+    - [Example: retrieving subfolder in a file container to an existing local directory.](#example-retrieving-subfolder-in-a-file-container-to-an-existing-local-directory)
+    - [Example: retrieving subfolder in a file container to a non-existent local directory (rename)](#example-retrieving-subfolder-in-a-file-container-to-a-non-existent-local-directory-rename)
+    - [Example: retrieving individual file to an existing directory](#example-retrieving-individual-file-to-an-existing-directory)
+    - [Example: retrieving individual file to a new filename](#example-retrieving-individual-file-to-a-new-filename)
+    - [Performance](#performance)
+  - [Tree](#files-tree)
+  - [Rm](#files-rm)
+- [Xorurl](#xorurl)
+- [Xorurl decode](#xorurl-decode)
+- [Cat](#cat)
+  - [Retrieving Binary Files](#retrieving-binary-files)
+  - [Retrieving Older Versions](#retrieving-older-versions)
+- [Safe-URLs](#safe-urls)
+  - [Symlinks](#symlinks)
+- [Dog](#dog)
+- [Shell Completions](#shell-completions)
+  - [Bash Completions](#bash-completions)
+  - [Windows PowerShell Completions](#windows-powershell-completions)
+- [Further Help](#further-help)
+- [License](#license)
+- [Contributing](#contributing)
 
 ## Description
 
 This crate implements a CLI (Command Line Interface) for the Safe Network.
 
-The Safe CLI provides all the tools necessary to interact with the Safe Network, including storing and browsing data of any kind, following links that are contained in the data and using their addresses on the network, using safecoin wallets, and much more. Using the CLI, users have access to any type of operation that can be made on the Safe Network and the data stored on it, allowing them to also use it for automated scripts and piped chain of commands.
+The Safe CLI provides all the tools necessary to interact with the Safe Network, including storing and browsing data of any kind, following links contained in the data, using their addresses on the network, and much more. Using the CLI, users have access to any type of operation that can be made on the Safe Network and the data stored on it. Due to it being a CLI, it can also be used in automated scripts and Unix-style piping and redirection.
 
-## Download
+## Quick Start
 
-The latest version of the Safe CLI can be downloaded and installed using the [install script](https://sn-api.s3.amazonaws.com/install.sh).
-
-The [install script](https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh) will not only download the latest Safe CLI, but it will also unpack the CLI binary into the `~/.safe/cli/` folder (`C:\Users\<user>\.safe\cli` in Windows), as well as set it in the PATH, so you can run the `safe` binary from any location when opening a console.
-
-### Linux and Mac
-
-Open a new console and run either of the following `curl` or `wget` commands:
+If you're a Linux or macOS user, you can simply run the following in your terminal:
 ```
 $ curl -so- https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh | bash
 ```
-or
+
+This will make the latest version of `safe` available. If you can successfully run `safe --version`, you can now skip to [Using the CLI](#using-the-cli).
+
+At the moment we don't have a quick start mechanism for Windows, but this will be coming soon.
+
+## Installation and Setup
+
+If you want more detail or alternative setup options, continue reading this section.
+
+### Prerequisites
+
+The Safe CLI is written in Rust and distributed as a single binary, so it has almost no prerequisites. For Linux, we build using [musl](https://musl.libc.org/), meaning we don't need different builds for particular distributions. There is no other setup required. You simply get a copy of the binary and run it.
+
+If you are a Windows user, you need to install the [Visual C++ Redistributable for Visual Studio](https://www.microsoft.com/en-in/download/details.aspx?id=48145), otherwise attempting to run the CLI will result in errors such as:
+```
+error while loading shared libraries: api-ms-win-crt-locale-l1-1-0.dll: cannot open shared object file: No such file or directory`
+```
+
+If you use Visual Studio, you may already have these libraries installed.
+
+### Install Script
+
+#### Linux and macOS
+
+The [install script](https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh) will download the latest Safe CLI binary, unpack it to `~/.safe/cli/`, and extend your `PATH` variable with that location. When using a terminal, you can then refer to the `safe` binary from any location.
+
+Run either of the following commands from a terminal:
+```
+$ curl -so- https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh | bash
+```
 ```
 $ wget -qO- https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh | bash
 ```
 
-### Windows
-
-If you are a Windows user, you will need to download and install the [Visual C++ Redistributable for Visual Studio](https://www.microsoft.com/en-in/download/details.aspx?id=48145) if not already installed on your machine, otherwise attempting to run the CLI will result in errors such as:
-`error while loading shared libraries: api-ms-win-crt-locale-l1-1-0.dll: cannot open shared object file: No such file or directory`
-
-You may already have these Visual C++ libraries on your machine if you already use Visual Studio.
-
-Next, you'll need to open a [Git BASH](https://gitforwindows.org) console with admin permissions.
-
-Click the "Start" button and type "git-bash" in the search bar, then press the **Shift+Ctrl+Enter** keys to reach Git-Bash console. The Git-Bash icon may also be in the Start Menu. You can [download Git Bash from here](https://gitforwindows.org/) if you don't already have installed on your PC.
-
-Once you have an admin Git Bash console running, just run the above `curl` command to download and execute our install script:
-```
-$ curl -so- https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh | bash
-```
-
-Should it be required, on all platforms, it's also possible to install a specific version:
+The install script also has a `--version` argument to enable retrieval of a specific version:
 ```
 $ curl -so- https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh | bash -s - --version=0.32.0
 ```
 
-Once the Safe CLI is downloaded and installed on your system, you can follow the steps in this User Guide by starting from the [Using the CLI](#using-the-cli) section below in this document.
+#### Windows
 
-Alternatively, you can download the latest version of the Safe CLI from the [releases page](https://github.com/maidsafe/sn_cli/releases/latest) and install it manually on your system.
+On Windows you can run the Bash install script using Bash emulation like [Git Bash](https://gitforwindows.org). You'll need to run it as an administrative user. The script can be run using the same commands as per the above section. The install script detects that it's running in emulation and will install a native Windows binary.
 
-If you prefer to build the Safe CLI from source code, please follow the instructions in the [Build](#build) section below.
+You can also run the install script from [WSL](https://docs.microsoft.com/en-us/windows/wsl/about), though this will install a Linux-based binary inside the Linux emulation.
 
-## Build
+We hope to make things much easier for Windows users by having a Powershell script that does something similar to the Bash script.
 
-In order to build this CLI from source code you need to make sure you have `rustc v1.48.0` (or higher) installed. Please take a look at this [notes about Rust installation](https://www.rust-lang.org/tools/install) if you need help with installing it. We recommend you install it with `rustup` which will install the `cargo` tool which this guide makes use of.
+### Binaries
 
-Once Rust and its toolchain are installed, run the following commands to clone this repository and build the `sn_cli` (the build process may take several minutes the first time you run it on this crate):
-```shell
-$ git clone https://github.com/maidsafe/sn_cli.git
-$ cd sn_cli
-$ cargo build
+If you would prefer, you can obtain binaries for all available platforms from the [releases page](https://github.com/maidsafe/sn_cli/releases/latest). You are free to download and extract these to any location you wish. It's advisable to put them in a location that's on your system's `PATH` variable, or extend the variable to include the new location.
+
+### Build from Source
+
+To build from source, you need to have `rustc v1.56.1` (or higher) installed. Please refer to [this guide](https://www.rust-lang.org/tools/install) for setting up a Rust environment. We recommend installation with `rustup`, which will install the `cargo` build system.
+
+Once Rust and its toolchain are installed, run the following commands to clone this repository and build the CLI:
+```
+$ git clone https://github.com/maidsafe/safe_network.git
+$ cargo build --bin safe
 ```
 
-Since this project has a cargo workspace with the `sn_cli` as the default crate, when building from the root location it will build the Safe CLI. Once it's built, you can find the `safe` executable at `target/debug/`, or `target/release` if you built it with the `--release` flag.
+Once built, you can find the `safe` executable at `target/debug/`, or `target/release/` if you used the `--release` flag.
 
 ## Using the CLI
 
 Right now the CLI is under active development. Here we're listing commands ready to be tested.
 
-In this guide we will assume from now on that you have used the install script and so have the CLI binary added to your system PATH, or you have navigated your terminal to the directory where the `safe` executable file you downloaded or built for your platform is located.
-
-The base command, once built, is `$ safe`, or all commands can be run via `$ cargo run -- <command>`.
+In this guide, from this point we'll assume you have the `safe` binary installed and available on your system PATH.
 
 Various global flags are available:
 
@@ -170,551 +145,261 @@ Various global flags are available:
                            (default), base32 and base64
 ```
 
-#### `--help`
+### Getting Help
 
-All commands have a `--help` function which lists args, options and subcommands.
+All commands have a `--help` argument, which lists and describes arguments, options and subcommands.
 
-### Networks
+Sometimes it can also be useful to increase the level of output from the CLI. It may look like it isn't doing anything when it's actually retrying or waiting on something. More verbose output can help with identifying potential issues. You can control the output using the `RUST_LOG` environment variable. Here's an example:
+```
+export RUST_LOG=safe=debug,sn_api=debug,safe_network=debug
+```
 
-The CLI, like any other Safe application, can connect to different Safe networks that may be available. As the project advances several networks may coexist with the main Safe Network, there could be Safe networks available for testing upcoming features, or networks that are local to the user in their own computer or WAN/LAN.
+Logging is available from 3 sources: `safe`, `sn_api` and `safe_network`. Possible values for levels are `info`, `debug` and `trace`, each of those increasing in detail. You can try varying these to get the level you want.
 
-The way Safe applications currently connect to a Safe network is by reading the connection information from a specific location in the system: `~/.safe/node/node_connection_info.config`
+If you experience the CLI taking a long time to respond, you can try decreasing its timeout duration. This is controlled using the `SN_CLI_QUERY_TIMEOUT` environment variable. The units of this variable is in seconds. So for example, you may try `export SN_CLI_QUERY_TIMEOUT=30`.
 
-Currently, there is a public test network accessible to anyone. Users may also have local nodes running in their own environment creating a local network. The CLI allows users to easily create a list of different Safe networks in its config settings, to then be able to switch between them with just a simple command.
+## Networks
 
-#### Node install
+We can connect to different Safe networks that may be available. As the project advances, several networks may coexist with the main Safe Network; there could be networks available for testing upcoming features, or networks local to the user in their own computer or WAN/LAN.
 
-Let's first look at how to run a local Safe network using the CLI. A local network is bootstrapped by running several Safe Network nodes which automatically interconnect forming a network. We therefore first need to install the Safe Network node in our system:
-```shell
+The CLI enables users to easily maintain different networks and switch between them.
+
+The first thing we'll do is create a local network and connect to it, but in order to do so, we need to setup a node.
+
+### Node Management
+
+Before we can create a local network, we need to obtain the `sn_node` binary. 
+
+We can get the latest version using the `node install` command:
+```
 $ safe node install
-Latest release found: sn_node v0.25.14
-Downloading https://sn-node.s3.eu-west-2.amazonaws.com/sn_node-0.25.14-x86_64-unknown-linux-musl.zip...
-[00:00:08] [========================================] 9.34MB/9.34MB (0s) Done
-Installing sn_node binary at ~/.safe/node ...
-Setting execution permissions to installed binary '~/.safe/node/sn_node'...
+Downloading sn_node version: 0.52.0
+Downloading https://sn-node.s3.eu-west-2.amazonaws.com/sn_node-0.52.0-x86_64-unknown-linux-musl.tar.gz...
+[00:00:01] [========================================] 10.49MB/10.49MB (0s) Done
+Creating '/home/chris/.safe/node' folder
+Installing sn_node binary at /home/chris/.safe/node ...
+Setting execution permissions to installed binary '/home/chris/.safe/node/sn_node'...
 Done!
 ```
 
-#### Run a local network
+If for some reason you want a specific version, or you want it placed at another location, the command has `--version` and `--node-path` arguments.
 
-At the current state of the Safe project, a single-section Safe network can be launched locally in our system. If the Safe Network node was installed in the system using the CLI as described in the previous section we can then launch it with a simple command:
-```shell
+The node can be updated to the latest available version using the `node update` command.
+
+After prompting to confirm if you want to take the latest version, it will be downloaded and the binary will be updated. By default it will assume `sn_node` is at `~/.safe/node/`, but you can override that path by using the `--node-path` argument.
+
+### Run a Local Network
+
+Let's first look at how to run a local Safe network with a single section.
+
+A local network is bootstrapped by running several nodes which automatically interconnect to form a network. If the node was installed as described in the previous section, we can then create the network with a simple command:
+```
 $ safe node run-baby-fleming
-Creating '~/.safe/node/baby-fleming-nodes' folder
-Storing nodes' generated data at ~/.safe/node/baby-fleming-nodes
-Launching local Safe network...
-Launching with node executable from: ~/.safe/node/sn_node
-Version: sn_node 0.26.8
-Network size: 11 nodes
-Launching genesis node (#1)...
-Connection info directory: ~/.safe/node/node_connection_info.config
-Genesis node contact info: ["127.0.0.1:12000"]
-Common node args for launching the network: ["-vv", "--idle-timeout-msec", "5500", "--keep-alive-interval-msec", "4000", "--local"]
-No RUST_LOG override provided
-Launching node #2...
-Launching node #3...
-Launching node #4...
-Launching node #5...
-Launching node #6...
-Launching node #7...
-Launching node #8...
-Launching node #9...
-Launching node #10...
-Launching node #11...
-Done!
+Storing nodes' generated data at /home/chris/.safe/node/baby-fleming-nodes
+Starting a node to join a Safe network...
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-genesis"
+Node PID: 1025110, prefix: Prefix(), name: 799ac7(01111001).., age: 255, connection info:
+"127.0.0.1:41904"
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-2"
+Node PID: 1025149, prefix: Prefix(), name: 8e9b93(10001110).., age: 98, connection info:
+"127.0.0.1:49538"
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-3"
+Node PID: 1025186, prefix: Prefix(), name: 0c9ce6(00001100).., age: 96, connection info:
+"127.0.0.1:40617"
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-4"
+Node PID: 1025224, prefix: Prefix(), name: f7a2ff(11110111).., age: 94, connection info:
+"127.0.0.1:57710"
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-5"
+Node PID: 1025261, prefix: Prefix(), name: 75a2c1(01110101).., age: 92, connection info:
+"127.0.0.1:49860"
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-6"
+Node PID: 1025299, prefix: Prefix(), name: b6f79c(10110110).., age: 90, connection info:
+"127.0.0.1:32819"
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-7"
+Node PID: 1025336, prefix: Prefix(), name: 3444f0(00110100).., age: 88, connection info:
+"127.0.0.1:51381"
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-8"
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-9"
+Node PID: 1025379, prefix: Prefix(), name: 653f38(01100101).., age: 76, connection info:
+"127.0.0.1:60200"
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-10"
+Node PID: 1025399, prefix: Prefix(), name: a76137(10100111).., age: 74, connection info:
+"127.0.0.1:52562"
+Starting logging to file: "/home/chris/.safe/node/baby-fleming-nodes/sn-node-11"
+Node PID: 1025437, prefix: Prefix(), name: 260ca3(00100110).., age: 72, connection info:
+"127.0.0.1:48606"
+Node PID: 1025475, prefix: Prefix(), name: c5feb4(11000101).., age: 70, connection info:
+"127.0.0.1:42312"
+Creating '/home/chris/.safe/cli/networks' folder for networks connection info cache
+Caching current network connection information into '/home/chris/.safe/cli/networks/baby-fleming_node_connection_info.config'
 ```
 
-Once the local network is running, the connection configuration file will be already in the correct place for the CLI to connect to it. Thus from this point on, you can simply use the CLI to connect to your local network.
+If you now run `safe networks`, you will see the newly created network in your networks list:
+```
++----------+--------------+-------------------------------------------------------------------------+
+| Networks |              |                                                                         |
++----------+--------------+-------------------------------------------------------------------------+
+| Current  | Network name | Connection info                                                         |
++----------+--------------+-------------------------------------------------------------------------+
+| *        | baby-fleming | /home/chris/.safe/cli/networks/baby-fleming_node_connection_info.config |
++----------+--------------+-------------------------------------------------------------------------+
+```
 
-In order to shutdown a running local network, the following CLI command can be invoked to kill all running sn_node processes:
-```shell
+The local network is set as the current network, so any `safe` commands will now run against that. This network consists of 11 `sn_node` processes running on the local machine.
+
+Before attempting to connect to a remote network, you may want to play around with this local network by issuing some commands against it. You could try storing some files with the `files put` command, then you could retrieve them using the `cat` command. You could also create some NRS entries. To get an idea of what you could do, you can read those sections of this guide, then come back here.
+
+When you're satisfied with your local experimentation, you can stop the local network using the following command:
+```
 $ safe node killall
 Success, all processes instances of sn_node were stopped!
 ```
 
-##### Run a local network for testing: `--test`
+However, you can feel free to keep this network running but still connect to another network. We'll do this in our examples here.
 
-The `run-baby-fleming` command accepts a `--test` or `-t` flag to automatically create a new Safe and authorise the CLI for test purposes. This requires that the `sn_node`, `sn_authd` and CLI themselves be installed in the correct locations on the system
+### Connect to a Remote Network
 
-#### Connect to a shared network
+We'll describe the process for connecting to a remote network using a couple of example networks created by our [testnet tool](https://github.com/maidsafe/sn_testnet_tool). We'll call these networks 'alpha' and 'beta'.
 
-Ready to play your part in a shared network by adding your node from home to a single section with other people's nodes? Keep reading...
+To connect to a network, we need to obtain its node connection information. This can be provided using different mechanisms. Contact the owner(s)/administrator(s) of the network you're trying to connect to and ask them to provide you with the connection info.
 
-MaidSafe are currently hosting some bootstrap nodes on Digital Ocean to kickstart a single section, you can bootstrap using these nodes as hardcoded contacts, then watch the logs as your node joins the network, progresses to Adult status, and plays its part in hosting Immutable Data Chunks. Of course you will also be able to create a Safe on this network, unlock it, upload data, create keys and wallets, and all the other commands described in this user guide. This guide will take you through connecting to this MaidSafe started network, but of course it can be applied to connecting to any shared section, hosted by anyone.
+#### Connection Info via HTTP
 
-You will need the network configuration containing the details of the hardcoded contacts that will bootstrap you to the shared section. If you have connected to this or previous iterations of the MaidSafe shared section then you may already have a `maidsafe-testnet` network profile saved on your machine. You can confirm this and update it to the latest configuration using `safe networks check`:
-```shell
-$ safe networks check
-Checking current setup network connection information...
-Fetching 'my-network' network connection information from '~/.config/sn_cli/networks/my-network_node_connection_info.config' ...
-Fetching 'maidsafe-testnet' network connection information from 'https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config' ...
-
-'maidsafe-testnet' network matched!
-Current set network connection information at '~/.config/sn_node/node_connection_info.config' matches 'maidsafe-testnet' network as per current config
+People who run networks can keep a copy of the connection info at some http location. In our case, we have this connection information hosted in an S3 bucket, and this is available via http. We can add a new network and use this http location for the connection info:
+```
+$ safe networks add alpha https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/alpha-node_connection_info.config
+Network 'alpha' was added to the list. Connection information is located at 'https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/alpha-node_connection_info.config'
 ```
 
-If you don't have a configuration in your results which points to the exact [S3 location](https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config) listed in the results above, you can add using `safe networks add`:
-```shell
-$ safe networks add maidsafe-testnet https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config
-Network 'maidsafe-testnet' was added to the list. Connection information is located at 'https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config'
+We've given this network the name 'alpha', but it can be named however you wish to refer to it. Run `safe networks` to see it in the networks list:
 ```
-
-Now you need to ensure you are set to use this `maidsafe-testnet` configuration that we have updated/added, we can use `safe networks switch maidsafe-testnet` for this:
-```shell
-$ safe networks switch maidsafe-testnet
-Switching to 'maidsafe-testnet' network...
-Fetching 'maidsafe-testnet' network connection information from 'https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config' ...
-Successfully switched to 'maidsafe-testnet' network in your system!
-If you need write access to the 'maidsafe-testnet' network, you'll need to restart authd (safe auth restart), unlock a Safe and re-authorise the CLI again
-```
-
-We're now ready to launch our node and add it as a node. This is achieved using `safe node join` as follows:
-```shell
-$ safe node join
-Joining network with contacts {161.35.36.185:12000}...
-Creating '~/.safe/node/local-node' folder
-Storing nodes' generated data at ~/.safe/node/local-node
-Starting a node to join a Safe network...
-Launching with node executable from: ~/.safe/node/sn_node
-Version: sn_node 0.26.8
-Node to be started with contact(s): ["161.35.36.185:12000"]
-Launching node...
-Node logs are being stored at: ~/.safe/node/local-node/sn_node.log
-```
-
-Your node will now launch and attempt to connect to the shared network. You can keep an eye on its progress via its logs, which can be found at `~/.safe/node/local-node/sn_node.log`.
-
-Note that at the time of writing nodes from home is being restricted to those with home routers which correctly implement [IGD](https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol). This will be expanded imminently to include those with routers which don't support IGD, with instructions added here for manual port forwarding at that point. If your log file states `Automatic Port forwarding Failed` then be on stand by for the next iteration.
-
-#### Switch networks
-
-MaidSafe currently hosts a test network for those who don't want to run a local network but still have a go at using the CLI and client applications. It's very common for users testing and experimenting with CLI and Safe applications to have a local network running, but switching to use the MaidSafe hosted network, back and forth, is also quite common.
-
-The CLI allows you to set up a list of networks in its config settings for easily switching to connect to them. If you just launched a local network, you can keep current connection information as a configured network on CLI with the following command:
-```shell
-$ safe networks add my-network
-Caching current network connection information into: ~/.config/sn_cli/networks/my-network_node_connection_info.config
-Network 'my-network' was added to the list. Connection information is located at '~/.config/sn_cli/networks/my-network_node_connection_info.config'
-```
-
-If you also would like to connect to the MaidSafe hosted test network, you would need to set it up in CLI settings as another network, specifying the URL where to fetch latest connection information from:
-```shell
-$ safe networks add maidsafe-testnet https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config
-Network 'maidsafe-testnet' was added to the list
-```
-
-We can also retrieve the list of the different networks that were set up in the CLI config:
-```shell
 $ safe networks
-+----------+------------------+------------------------------------------------------------------------------------------------+
-| Networks |                  |                                                                                                |
-+----------+------------------+------------------------------------------------------------------------------------------------+
-| Current  | Network name     | Connection info                                                                                |
-+----------+------------------+------------------------------------------------------------------------------------------------+
-|          | maidsafe-testnet | https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config                  |
-+----------+------------------+------------------------------------------------------------------------------------------------+
-| *        | my-network       | ~/.safe/cli/networks/my-network_node_connection_info.config                                    |
-+----------+------------------+------------------------------------------------------------------------------------------------+
++----------+--------------+----------------------------------------------------------------------------------------+
+| Networks |              |                                                                                        |
++----------+--------------+----------------------------------------------------------------------------------------+
+| Current  | Network name | Connection info                                                                        |
++----------+--------------+----------------------------------------------------------------------------------------+
+|          | alpha        | https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/alpha-node_connection_info.config |
++----------+--------------+----------------------------------------------------------------------------------------+
+| *        | baby-fleming | /home/chris/.safe/cli/networks/baby-fleming_node_connection_info.config                |
++----------+--------------+----------------------------------------------------------------------------------------+
+
 ```
 
-Once we have them in the CLI settings, we can use the CLI to automatically fetch the connection information data using the configured location, and place it at the right location in the system for Safe applications to connect to the selected network. E.g. let's switch to the 'maidsafe-testnet' network we previously configured:
-```shell
-$ safe networks switch maidsafe-testnet
-Switching to 'maidsafe-testnet' network...
-Fetching 'maidsafe-testnet' network connection information from 'https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config' ...
-Successfully switched to 'maidsafe-testnet' network in your system!
-If you need write access to the 'maidsafe-testnet' network, you'll need to restart authd (safe auth restart), unlock a Safe and re-authorise the CLI again
+Notice our new network isn't set as the current network, meaning any `safe` commands we run will still run against our local network. Make the remote network current by using the `switch` command:
+```
+$ safe networks switch alpha
+Switching to 'alpha' network...
+Fetching 'alpha' network connection information from 'https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/alpha-node_connection_info.config' ...
+Successfully switched to 'alpha' network in your system!
 ```
 
-Remember that every time you launch a local network the connection configuration in your system is automatically overwritten with new connection information. Also, if the test network was restarted by MaidSafe, the new connection information is published in the same URL and needs to be updated in your system to be able to successfully connect to it. Thus if you want to make sure your current setup network matches any of those set up in the CLI config, you can use the `check` subcommand:
-```shell
-$ safe networks check
-Checking current setup network connection information...
-Fetching 'my-network' network connection information from '~/.config/sn_cli/networks/my-network_node_connection_info.config' ...
-Fetching 'maidsafe-testnet' network connection information from 'https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config' ...
-
-'maidsafe-testnet' network matched!
-Current set network connection information at '~/.config/sn_node/node_connection_info.config' matches 'maidsafe-testnet' network as per current config
+You can then run `safe networks` to see the current network has changed:
+```
++----------+--------------+----------------------------------------------------------------------------------------+
+| Networks |              |                                                                                        |
++----------+--------------+----------------------------------------------------------------------------------------+
+| Current  | Network name | Connection info                                                                        |
++----------+--------------+----------------------------------------------------------------------------------------+
+| *        | alpha        | https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/alpha-node_connection_info.config |
++----------+--------------+----------------------------------------------------------------------------------------+
+|          | baby-fleming | /home/chris/.safe/cli/networks/baby-fleming_node_connection_info.config                |
++----------+--------------+----------------------------------------------------------------------------------------+
 ```
 
-Note that in the scenario that your current network is set to be the MaidSafe test network, and that is restarted by MaidSafe (which causes new connection information to be published at the same URL), you then only need to re-run the `networks switch` command with the corresponding network name to update your system with the new connection information.
+At this point, you can now start using this network. Try uploading some files and retrieving them.
 
-#### Set network bootstrap address
+#### Direct Connection Info
 
-Another way to add a network to the CLI config settings is by directly mapping a network name to its bootstrapping address/es (IPs and ports). This can be achieved by using the `networks set` subcommand:
-```shell
-$ safe networks set community-network 161.35.36.112:15000
-Network 'community-network' was added to the list. Contacts: '{161.35.36.112:15000}'
+If for some reason connection info isn't available via http, the network owner can directly provide the network's genesis key and the list of IP and port pairs for each node. These can then be added as a network using the `networks set` command:
+```
+$ safe networks set beta \
+    a857bf4e8cce3ab97a6e6c27c2308eebe640ccf57e0447182b732b41f6b04a9796edce5bf151fbfa522b01bcfbbfefa0 \
+    178.62.57.53:12000 167.99.88.95:12000 178.128.41.85:12000 206.189.23.17:12000 \
+    178.128.42.138:12000 178.128.173.109:12000 167.99.199.158:12000 142.93.41.250:12000 \
+    206.189.117.149:12000 209.97.191.137:12000 104.248.171.51:12000 142.93.41.143:12000 \
+    167.99.199.11:12000 104.248.174.35:12000 178.128.162.247:12000 209.97.189.244:12000
+Network 'beta' was added to the list. Contacts: '(PublicKey(0857..aa81), {104.248.171.51:12000, 104.248.174.35:12000, 142.93.41.143:12000, 142.93.41.250:12000, 167.99.88.95:12000, 167.99.199.11:12000, 167.99.199.158:12000, 178.62.57.53:12000, 178.128.41.85:12000, 178.128.42.138:12000, 178.128.162.247:12000, 178.128.173.109:12000, 206.189.23.17:12000, 206.189.117.149:12000, 209.97.189.244:12000, 209.97.191.137:12000})'
 ```
 
-And as we did before, we could then switch to use this network using its name:
-```shell
-$ safe networks switch community-network
-Switching to 'community-network' network...
-Successfully switched to 'community-network' network in your system!
-If you need write access to the 'community-network' network, you'll need to restart authd (safe auth restart), unlock a Safe and re-authorise the CLI again
+As can be seen, this method isn't as convenient as http, but nonetheless, it's available if need be.
+
+If you run `safe networks`, you'll now see 'beta' in the networks list, and you can run `safe networks switch beta` to start using this network.
+
+Perhaps give that a try by uploading some files, then switch between each network.
+
+### Provide a Node
+
+With the remote networks added, we have the opportunity to launch our own node and participate in either of those networks. This will provide more storage space to the network. Let's join the 'alpha' network. We can do so using the `node join` command.
+
+Successfully joining a remote network depends on your networking and routing configuration. The node implements automated port forwarding according to the [IGD Protocol](https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol). If your router is IGD compatible, you should be able to join the network with no further configuration.
+
+Try the `safe node join` command and see what happens. If this command runs without error and the node starts, you've sent a join request. If there's an error, it's likely to be related to UPnP port forwarding. If so, run `safe node join --skip-auto-port-forwarding`. Again, this may successfully start the node and send a join request, but the request could be rejected.
+
+We need to inspect the node log to see the status of the join request. The CLI will tell you the location of the log, but it's usually under the `~/.safe/node/local-node` directory. If the join request is rejected, you would see something similar to the following:
+```
+➤ Node cannot join the network since it is not externally reachable: X.X.X.X:38854
+Unfortunately we are unable to establish a connection to your machine (X.X.X.X:38854) either through a public IP address, or via IGD on your router. Please ensure that IGD is enabled on your router - if it is and you are still unable to add your node to the testnet, then skip adding a node for this testnet iteration. You can still use the testnet as a client, uploading and downloading content, etc. https://safenetforum.org/
 ```
 
-If now check the list of networks we have in the CLI config settings we can see the 'community-network' is listed as the one currently set:
-```shell
-$ safe networks
-+----------+-------------------+------------------------------------------------------------------------------------------------+
-| Networks |                   |                                                                                                |
-+----------+-------------------+------------------------------------------------------------------------------------------------+
-| Current  | Network name      | Connection info                                                                                |
-+----------+-------------------+------------------------------------------------------------------------------------------------+
-| *        | community-network | {161.35.36.112:15000}                                                                          |
-+----------+-------------------+------------------------------------------------------------------------------------------------+
-|          | maidsafe-testnet  | https://sn-node.s3.eu-west-2.amazonaws.com/config/node_connection_info.config                  |
-+----------+-------------------+------------------------------------------------------------------------------------------------+
-|          | my-network        | ~/.safe/cli/networks/my-network_node_connection_info.config                                    |
-+----------+-------------------+------------------------------------------------------------------------------------------------+
+The Xs will be your internet public IP address. If this is the case, you most likely need to configure port forwarding on your router. Obviously, this is something that varies depending on the router, so a step-by-step guide is beyond the scope of this document. However, we can say broadly, you need to access the admin console for your router and find a section on access control and port forwarding. What you want to do is add a UDP rule to forward any external requests on a port of your choosing, to an internal network address and port. The internal address will be the address of the machine where the node is running, and most likely in the form 192.168.X.X. The node uses port 12000 by default, so that's a good one to go with. The rule would look something like this:
+```
++----------+---------------+---------------+---------------+---------------+
+| Protocol | External Host | Internal Host | External Port | Internal Port |
++----------+---------------+---------------+---------------+---------------+
+| UDP      | *             | 192.168.X.X   | 12000         | 12000         |
++----------+---------------+---------------+---------------+---------------+
 ```
 
-#### Node update
+With this configuration in place, you can try joining the network using the following command:
+```
+$ safe node join --public-addr <internet public IP>:12000 --local-addr <node device IP>:12000 --skip-auto-port-forwarding
 
-The node binary can be updated to the latest available version:
-```shell
-$ safe node update
 ```
 
-This command will check if a newer sn_node release is available on [GitHub](https://github.com/maidsafe/sn_node/releases). After prompting to confirm if you want to take the latest version, it will be downloaded and the binary will be updated. By default it will assume the sn_node binary is at `~/.safe/node/`, but you can override that path by providing `--node-path <path>` argument to the above command.
-
-### Auth
-
-The CLI is just another client Safe application, therefore it needs to be authorised by the user to gain access to the Safe Network on behalf of the user. The `auth` command allows us to obtain such authorisation from the user via the Safe Authenticator.
-
-This command simply sends an authorisation request to the Authenticator available, e.g. the `sn_authd` daemon (see further below for an explanation of how to run it), and it then stores the authorisation response (credentials) in the user's `~/.safe/cli/credentials` file. Any subsequent CLI command will read this file to obtain the credentials and connect to the Safe Network for the corresponding operation.
-
-#### The Authenticator daemon (authd)
-
-In order to be able to allow any Safe application to connect to the Network and have access to your data, we need to start the Safe Authenticator daemon (authd). This application exposes an interface as a [QUIC (Quick UDP Internet Connections)](https://en.wikipedia.org/wiki/QUIC) endpoint, which Safe applications will communicate with to request for access permissions. These permissions need to be reviewed by the user and approved, which can be all done with the Safe CLI as we'll see in this guide.
-
-The Safe Authenticator, which runs as a daemon, can be started and managed with the Safe CLI if the `sn_authd`/`sn_authd.exe` binary is properly installed in the system.
-
-#### Auth install
-
-Downloading and installing the Authenticator daemon is very simple:
-```shell
-$ safe auth install
-Latest release found: sn_authd v0.0.3
-Downloading https://sn-api.s3.eu-west-2.amazonaws.com/sn_authd-0.0.3-x86_64-unknown-linux-musl.tar.gz...
-[00:00:25] [========================================] 6.16MB/6.16MB (0s) Done
-Installing sn_authd binary at ~/.safe/authd ...
-Setting execution permissions to installed binary '~/.safe/authd/sn_authd'...
-Done!
+Regardless of which `join` command you used, if the join request is successful, the log should contain something similar to the following:
+```
+ INFO 2021-12-24T00:52:18.319227Z [sn/src/routing/routing_api/mod.rs:L196]:
+	 ➤ 59dc1f.. Joined the network!
+ INFO 2021-12-24T00:52:18.319254Z [sn/src/routing/routing_api/mod.rs:L197]:
+	 ➤ Our AGE: 5
+ INFO 2021-12-24T00:52:18.319284Z [sn/src/routing/routing_api/dispatcher.rs:L87]:
+	 ➤ Starting to probe network
+ INFO 2021-12-24T00:52:18.319291Z [sn/src/routing/routing_api/dispatcher.rs:L115]:
+	 ➤ Writing our PrefixMap to disk
+ INFO 2021-12-24T00:52:18.319312Z [sn/src/routing/core/mod.rs:L212]:
+	 ➤ Writing our latest PrefixMap to disk
+ INFO 2021-12-24T00:52:18.319659Z [sn/src/node/node_api/mod.rs:L87]:
+	 ➤ Node PID: 1065146, prefix: Prefix(0), name: 59dc1f(01011001).., age: 5, connection info: "79.71.42.38:12000"
 ```
 
-#### Auth start
+It's also possible to join a network without adding a network to the networks list. You can use the `--contact-list` and `--genesis-key` arguments. Run `safe node join --help` for more details.
 
-In order to start the `Safe Authenticator daemon (sn_authd)` so it can start receiving requests we simply need to run the following command:
-```shell
-$ safe auth start
-Starting Safe Authenticator daemon (sn_authd)...
-sn_authd started (PID: <pid>)
+## Files
+
+We can use the CLI to upload files and folders and keep them in sync with local modifications.
+
+Files are uploaded and stored as a `Blob`. When we upload a directory, its hierarchy is flattened and represented in a map, with each file's path mapped to a `Blob` XOR-URL. This map is maintained in a special container called `FilesContainer`. The data representation in the `FilesContainer` is planned to be implemented with [RDF](https://en.wikipedia.org/wiki/Resource_Description_Framework), and the corresponding `FilesContainer` RFC will be submitted; however, at this stage, the implementation is a simple serialised structure.
+
+For brevity, in the rest of this section we'll refer to the `FilesContainer` just using the term "container".
+
+### Warning
+
+At some point, the underlying files APIs used in the CLI (and perhaps much else of the CLI) will be deprecated to use [`sn_fs`](https://github.com/maidsafe/sn_fs). This is a POSIX-based filesystem which is more comprehensive and performant. The impact this may have, if any, on CLI commands, is not yet known. But if you're interested in a filesystem on Safe, `sn_fs` is most definitely where you should look.
+
+### Put
+
+The simplest thing we can do is upload a file using the `files put` command:
+```
+$ safe files put ./to-upload/myfile.txt
+FilesContainer created at: "safe://bbkulca25xhzwo6mcxlji7ocf5tm5hgn2x3mxtg62qzycculur4aixeywm"
++  ./to-upload/myfile.txt  safe://bbkulcbxk23cfnj7gz3r4y7624kpb5spwf4b7jogu2rofhuj5xiqa5huh7
 ```
 
-#### Auth status
+This will create a container with a single file. The `safe://` URLs assigned here refer to the container and the file, respectively.
 
-Once we started the `authd`, it should be running in the background and ready to receive requests, we can send a status request to check it's up and running:
-```shell
-$ safe auth status
-Sending request to authd to obtain a status report...
-+------------------------------------------+-------+
-| Safe Authenticator status                |       |
-+------------------------------------------+-------+
-| Authenticator daemon version             | 0.0.3 |
-+------------------------------------------+-------+
-| Is there a Safe currently unlocked?      | No    |
-+------------------------------------------+-------+
-| Number of pending authorisation requests | 0     |
-+------------------------------------------+-------+
-| Number of notifications subscribers      | 0     |
-+------------------------------------------+-------+
+We can also recursively upload everything in a local directory, obtaining the XOR-URLs of the newly created container and each uploaded file:
 ```
-
-#### Auth create
-
-Since we now have our Safe Authenticator running and ready to accept requests, we can start interacting with it by using other Safe CLI `auth` subcommands.
-
-In order to create a Safe on the network, we need some `safecoins` to pay with. Since this is still under development, we can have the CLI to generate some test-coins and use them for paying the cost of creating a Safe. We can do so by passing `--test-coins` flag to the `create` subcommand. The CLI will request us to enter a passphrase and password for the new account to be created:
-```shell
-$ safe auth create --test-coins
-Passphrase:
-Password:
-Sending request to authd to create a Safe...
-Safe was created successfully!
-```
-
-Alternatively, if we own some safecoins on a `SafeKey` already (see [`SafeKeys` section](#safekeys) for details about `SafeKey`s), we can provide the corresponding secret key to the safe CLI to use it for paying the cost of creating the account, as well as setting it as the default `SafeKey` for the account being created:
-```shell
-$ safe auth create
-Passphrase:
-Password:
-Enter SafeKey's secret key to pay with:
-Sending request to authd to create a Safe...
-Safe was created successfully!
-```
-
-#### Auth unlock
-
-When a new Safe is created with CLI, as we've seen above, we can unlock it using the following command:
-```shell
-$ safe auth unlock
-Passphrase:
-Password:
-Sending action request to authd to unlock the Safe...
-Safe unlocked successfully
-```
-
-If we now send a status report request to `authd`, it should now show that a Safe is currently unlocked:
-```shell
-$ safe auth status
-Sending request to authd to obtain a status report...
-+------------------------------------------+-------+
-| Safe Authenticator status                |       |
-+------------------------------------------+-------+
-| Authenticator daemon version             | 0.0.3 |
-+------------------------------------------+-------+
-| Is there a Safe currently unlocked?      | Yes   |
-+------------------------------------------+-------+
-| Number of pending authorisation requests | 0     |
-+------------------------------------------+-------+
-| Number of notifications subscribers      | 0     |
-+------------------------------------------+-------+
-```
-
-The Safe Authenticator is now ready to receive authorisation requests from any Safe application, including the Safe CLI which needs to also get permissions to perform any data operations on behalf of our account.
-
-##### Passing credentials from a config file
-
-It's possible (though not secure) to use a simple json file to pass the passphrase and password to the auth commands, and so avoid having to manually input both, either when creating a Safe or when unlocking it. E.g., having a file named `my-config.json` with:
-```
-{
-  "passphrase": "mypassphrase",
-  "password": "mypassword"
-}
-```
-And so you can unlock the Safe with:
-```shell
-$ safe auth unlock --config ./my-config.json
-Sending action request to authd to unlock the Safe...
-Safe unlocked successfully
-```
-
-##### Using environment variables
-
-Another method for passing passphrase/password involves using the environment variables `SAFE_AUTH_PASSPHRASE` and `SAFE_AUTH_PASSWORD`.
-
-With those set (eg, on Linux/macOS: `export SAFE_AUTH_PASSPHRASE="<your passphrase>;"`, and `export SAFE_AUTH_PASSWORD="<your password>"`), you can then unlock a Safe without needing to enter this information, or pass a config file:
-```shell
-$ safe auth unlock
-Sending action request to authd to unlock the Safe...
-Safe unlocked successfully
-```
-Or, you can choose to pass the environment variables to the command directly (though this can be insecure):
-```shell
-$ SAFE_AUTH_PASSPHRASE="<passphrase>" SAFE_AUTH_PASSWORD="<password>" safe auth unlock
-Sending action request to authd to unlock the Safe...
-Safe unlocked successfully
-```
-Please note, that both the passphrase and password environment variables must be set to use this method. If only one is set, an error will be thrown.
-
-#### Auth reqs
-
-Now that the Authenticator is running and ready to authorise applications, we can try to authorise the CLI application.
-
-In a normal scenario, an Authenticator GUI would be using `authd` as its backend process, e.g. the [Safe Network Application](https://github.com/maidsafe/sn_app) provides such a GUI to review authorisation requests and allow the permissions requested to be granted.
-
-For the purpose of making this guide self-contained with the Safe CLI application, we will now use also the CLI on a second console to review and allow/deny authorisation requests.
-
-Let's first send an authorisation request from the current console by simply invoking the `auth` command with no subcommands:
-```shell
-$ safe auth
-Authorising CLI application...
-```
-
-The CLI application is now waiting for an authorisation response from the `authd`.
-
-We can now open a second console which we'll use to query `authd` for pending authorisation requests, and also to allow/deny them (remember the following steps wouldn't be needed if we had any other Authenticator UI running, like the `Safe Network App`).
-
-Once we have a second console, we can start by fetching from `authd` the list of authorisation requests pending for approval/denial:
-```shell
-$ safe auth reqs
-Requesting list of pending authorisation requests from authd...
-+--------------------------------+------------------+----------+------------------+-------------------------+
-| Pending Authorisation requests |                  |          |                  |                         |
-+--------------------------------+------------------+----------+------------------+-------------------------+
-| Request Id                     | App Id           | Name     | Vendor           | Permissions requested   |
-+--------------------------------+------------------+----------+------------------+-------------------------+
-| 584798987                      | net.maidsafe.cli | Safe CLI | MaidSafe.net Ltd | Own container: No       |
-|                                |                  |          |                  | Transfer coins: Yes     |
-|                                |                  |          |                  | Mutations: Yes          |
-|                                |                  |          |                  | Read coin balance: Yes  |
-|                                |                  |          |                  | Containers: None        |
-+--------------------------------+------------------+----------+------------------+-------------------------+
-```
-
-We see there is one authorisation request pending for approval/denial, which is the one requested by the CLI application from the other console.
-
-#### Auth allow/deny
-
-In order to allow any pending authorisation request we use its request ID (e.g. '584798987' from above), the `authd` will then proceed to send a response back to the CLI with the corresponding credentials it can use to connect directly with the Network:
-```shell
-$ safe auth allow 584798987
-Sending request to authd to allow an authorisation request...
-Authorisation request was allowed.
-```
-
-Note we could have otherwise decided to deny this authorisation request and invoke `$ safe auth deny 584798987` instead, but let's allow it so we can continue with the next steps of this guide.
-
-If we now switch back to our previous console, the one where we sent the authorisation request with `$ safe auth` command from, we will see the Safe CLI receiving the response from `authd`. You should see in that console a message like the following:
-```shell
-Safe CLI app was successfully authorised
-Credentials were stored in ~/.safe/cli/credentials
-```
-
-We are now ready to start using the CLI to operate with the network, via its commands and supported operations!.
-
-##### Self authorising the CLI application
-
-It could be the case the Safe CLI is the only Safe application that the user is intended to use to interact with the Safe Network. In such a case authorising the CLI application as explained above (when there is no other UI for the `authd`) using another instance of the CLI in a second console is not that comfortable.
-
-Therefore there is an option which allows the Safe CLI to automatically self authorise when the user unlocks a Safe using the CLI, which is as simple as:
-```shell
-$ safe auth unlock --self-auth
-Passphrase:
-Password:
-Sending action request to authd to unlock the Safe...
-Safe unlocked successfully
-Authorising CLI application...
-Safe CLI app was successfully authorised
-Credentials were stored in ~/.safe/cli/credentials
-```
-
-#### Auth update
-
-The Authenticator binary (`sn_authd`/`sn_authd.exe`) can be updated to the latest available version using the CLI:
-```shell
-$ safe auth update
-```
-It will check if a newer release is available on [Amazon S3](https://sn-api.s3.eu-west-2.amazonaws.com). After prompting to confirm if you want to take the latest version, it will be downloaded and the sn_authd binary will be updated.
-
-After the sn_authd was updated, you'll need to restart it to start using new version:
-```shell
-$ safe auth restart
-Stopping Safe Authenticator daemon (sn_authd)...
-Success, sn_authd (PID: <pid>) stopped!
-Starting Safe Authenticator daemon (sn_authd)...
-sn_authd started (PID: <new pid>)
-Success, sn_authd restarted!
-```
-
-### The interactive shell
-
-When the CLI is invoked without any command, it enters into an interactive shell, which allows the user to run commands within a shell:
-```shell
-$ safe
-
-Welcome to Safe CLI interactive shell!
-Type 'help' for a list of supported commands
-Pass '--help' flag to any top level command for a complete list of supported subcommands and arguments
-Type 'quit' to exit this shell. Enjoy it!
-
->
-```
-
-The interactive shell supports all the same commands and operations that can be performed in the command line. E.g., we can use the `auth status` command to retrieve a status report from the `authd`:
-```shell
-> auth status
-Sending request to authd to obtain a status report...
-+------------------------------------------+-------+
-| Safe Authenticator status                |       |
-+------------------------------------------+-------+
-| Authenticator daemon version             | 0.0.3 |
-+------------------------------------------+-------+
-| Is there a Safe currently unlocked?      | No    |
-+------------------------------------------+-------+
-| Number of pending authorisation requests | 0     |
-+------------------------------------------+-------+
-| Number of notifications subscribers      | 0     |
-+------------------------------------------+-------+
-```
-
-As you can see, the commands operate in an analogous way as when they are invoked outside of the interactive shell. Although there are some operations which are only possible when they are executed from the interactive shell, one nice example is the possibility to subscribe to receive authorisation request notifications, let's see how that works.
-
-In the previous section we've used the `safe auth reqs` command to obtain a list of the authorisation requests which are waiting for approval/denial. We could instead use the interactive shell to subscribe it as an endpoint to receive notifications when this authorisation requests are sent to the `authd`:
-```shell
-> auth subscribe
-Sending request to subscribe...
-Subscribed successfully
-Keep this shell session open to receive the notifications
-```
-
-This is telling us that as long as we keep this session of the interactive shell open, we will be notified of any new authorisation request, such notifications are being sent by the `authd` to our interactive shell session. Thus if we have any other Safe app which is sending an authorisation request to `authd`, e.g. the Safe Browser, a `safe auth` command invoked from another instance of the CLI, etc., we will be notified by the interactive shell:
-```shell
->
-A new application authorisation request was received:
-+------------+------------------+---------+---------+-------------------------+
-| Request Id | App Id           | Name    | Vendor  | Permissions requested   |
-+------------+------------------+---------+---------+-------------------------+
-| 754801191  | net.maidsafe.cli | Unknown | Unknown | Own container: No       |
-|            |                  |         |         | Transfer coins: Yes     |
-|            |                  |         |         | Mutations: Yes          |
-|            |                  |         |         | Read coin balance: Yes  |
-|            |                  |         |         | Containers: None        |
-+------------+------------------+---------+---------+-------------------------+
-You can use "auth allow"/"auth deny" commands to allow/deny the request respectively, e.g.: auth allow 754801191
-Press Enter to continue
-```
-
-The notification message contains the same information we can obtain with `safe auth reqs` command. We can now do the same as before and allow/deny such a request using its ID, in this case '754801191':
-```shell
-> auth allow 754801191
-Sending request to authd to allow an authorisation request...
-Authorisation request was allowed
-```
-
-The interactive shell will be expanded to support many more operations, and especially to cover the use cases which are not possible to cover with the non-interactive shell, like the use case we've seen of receiving notifications from `authd`.
-
-It enables the possibility to also have a state in the session, e.g. allowing the user to set a wallet to be used for all operations within that session instead of using the default wallet from the account, ...or several other use cases and features we'll be adding as we move forward in its development.
-
-### SafeKeys
-
-`SafeKey` management allows users to generate sign/encryption key pairs that can be used for different types of operations, like choosing which sign key to use for uploading files (and therefore paying for the storage used), or signing a message posted on some social application when a `SafeKey` is linked from a public profile (e.g. a WebID/SAFE-ID), or even for encrypting messages that are privately sent to another party so it can verify the authenticity of the sender.
-
-Users can record `SafeKey`s in a `Wallet` (see further below for more details about `Wallet`s), having friendly names to refer to them, but they can also be created as throw away `SafeKey`s which are not linked from any `Wallet`, container, or any other type of data on the network.
-
-Note that the key pair is automatically generated by the CLI, although `SafeKey`s don’t hold the secret key on the network but just represent the public key. `SafeKey`s can also be used for safecoin transfers. In this sense, a `SafeKey` can be compared to a Bitcoin address, it has a coin balance associated to it, such balance can be only queried using the secret key, and in order to spend its balance the corresponding secret key needs to be provided in the `transfer` request to the network. The secret key can be provided by the user, or retrieved from a `Wallet`, at the moment of creating the transfer (again, see the [`Wallet` section](#wallet) below for more details).
-
-#### SafeKeys Creation
-
-To generate a `SafeKey`:
-```shell
-$ safe keys create 
-New SafeKey created: "safe://bbkulcbnrmdzhdkrfb6zbbf7fisbdn7ggztdvgcxueyq2iys272koaplks"
-Key pair generated:
-Public Key = b62c1e4e3544a1f64212fca89046df98d998ea615e84c4348c4b5fd29c07ad52a970539df819e31990c1edf09b882e61
-Secret Key = c4cc596d7321a3054d397beff82fe64f49c3896a07a349d31f29574ac9f56965
-```
-
-
-### Files
-
-#### [ Warning: Underlying API to be deprecated ]
-
-The underlying files APIs used in the CLI, and perhaps much of the CLI will be deprecated in order to use [`sn_fs`](https://github.com/maidsafe/sn_fs) at some point. This is a POSIX based filesystem which is much more comprehensive and performant. It's not yet known the impact (if any) this will have on the CLI commands. But if you're interested in a filesystem on Safe, `sn_fs` is most definitely where you should be looking at the moment.
-
-#### Files...
-
-Uploading files and folders onto the network is also possible with the CLI application, and as we'll see here it's extremely simple to not just upload them but also keep them in sync with any modifications made locally to the folders and files.
-
-Files are uploaded on the Network and stored as `Public Blob` files, and the folders and sub-folders hierarchy is flattened out and stored in a container mapping each file's path with the corresponding `Blob` XOR-URL. This map is maintained on the Network in a special container called `FilesContainer`, which is stored as `Public Sequence` data. The data representation in the `FilesContainer` is planned to be implemented with [RDF](https://en.wikipedia.org/wiki/Resource_Description_Framework) and the corresponding `FilesContainer` RFC will be submitted, but at this stage this is being done only using a simple serialised structure.
-
-#### Files Put
-
-The most simple scenario is to upload all files and subfolders found within a local `./to-upload/` directory, recursively, onto a `FilesContainer` on the Network, obtaining the XOR-URL of the newly created container, as well as the XOR-URL of each of the files uploaded:
-```shell
 $ safe files put ./to-upload/ --recursive
 FilesContainer created at: "safe://bbkulcb5hsl2zbsia4af5i7myv2ujbet7di4gx5bstduikwgobru67esqu"
 +  ./to-upload/index.html          safe://bbkulcax6ulw7ovqhpsindkybsum4tusmvuc7ovtr2bu5gj6m4ugtu7euh
@@ -722,96 +407,61 @@ FilesContainer created at: "safe://bbkulcb5hsl2zbsia4af5i7myv2ujbet7di4gx5bstdui
 +  ./to-upload/img.jpeg            safe://bbkulcbtiq3vg4xehqbrjd2gz4kljguqtds5ko5khexya3v3k7scymcphj
 ```
 
-Note that the `+` sign means the files were all added to the `FilesContainer`, which will make more sense later on when we see how to use the `files sync` command to update and/or delete files.
+**Note**: the `+` sign indicates the files were _added_ to the container, as opposed to _updated_ or _deleted_. This will be elaborated further when discussing the `files sync` command.
 
-A single file can also be uploaded using the `files put` command, which will create a `FilesContainer` as well but this time only a single file will be added to the map:
-```shell
-$ safe files put ./to-upload/myfile.txt
-FilesContainer created at: "safe://bbkulca25xhzwo6mcxlji7ocf5tm5hgn2x3mxtg62qzycculur4aixeywm"
-+  ./to-upload/myfile.txt  safe://bbkulcbxk23cfnj7gz3r4y7624kpb5spwf4b7jogu2rofhuj5xiqa5huh7
+#### Base Path
+
+When uploading files to a container, its base path is set to `/`. The source files are published with an absolute path stemming from the container's base.
+
+To illustrate, consider the following source directory:
+```
+to-upload/
+├── file1.txt
+├── myfolder
+│   └── file2.txt
+└── myotherfolder
+    └── subfolder
+        └── file3.txt
 ```
 
-##### Base path of files in a FilesContainer
-
-When uploading files onto a `FilesContainer` with the CLI, the base path for the files in the container is set by default to be `/`. All the files at the source are published on the `FilesContainer` with an absolute path with base `/` path.
-
-As an example, if we upload three files, which at source are located at `/to-upload/file1.txt`, `/to-upload/myfolder/file2.txt`, and `/to-upload/myotherfolder/subfolder/file3.txt`, the files will be published on the `FilesContainer` with paths `/file1.txt`, `/myfolder/file2.txt`, and `/myotherfolder/subfolder/file3.txt` respectively.
-
-We can additionally pass a destination path argument to set a base path for each of the paths in the `FilesContainer`, e.g. if we provide `/mychosenroot/` destination path argument to the `files put` command when uploading the above files, they will be published on the `FilesContainer` with paths `/mychosenroot/file1.txt`, `/mychosenroot/myfolder/file2.txt`, and `/mychosenroot/myotherfolder/subfolder/file3.txt` respectively. This can be verified by querying the `FilesContainer` content with the `safe cat` command, please see further below for details of how this command works.
-
-#### Files Sync
-
-Once a set of files, folders and subfolders, have been uploaded to the Network onto a `FilesContainer` using the `files put` command, local changes made to those files and folders can be easily synced up using the `files sync` command. This command takes care of finding the differences/changes on the local files and folders, creating new `Public Blob` files as necessary, and updating the `FilesContainer` by publishing a new version of it at the same location on the Network.
-
-The `files sync` command follows a very similar logic to the well known `rsync` command, supporting a subset of its functionality. This subset will gradually be expanded with more supported features. Users knowing how to use `rsync` can easily start using the Safe CLI and the Safe Network for uploading files and folders, making it also easy to integrate existing automated systems which are currently making use of `rsync`.
-
-As an example, let's suppose we upload all files and subfolders found within the `./to-upload/` local directory, recursively, using `files put` command:
-```shell
-$ safe files put ./to-upload/ --recursive
-FilesContainer created at: "safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc"
-+  ./to-upload/another.md              safe://hbhyrydt5b95dmumcm8yig4u1keuuh8hgsr5yx39xn4mqikp91sbdhbpwp
-+  ./to-upload/subfolder/subexists.md  safe://hbhyryn9uodh1ju5uzyti3gmmtwburrssd89rcwcy3rzofdpypwomrzzte
-+  ./to-upload/subfolder/note.md       safe://hbhyryncjzga5uqp3ogeadqctigyaurpju8yauqptzgh5uyctogh3dkcbt
-+  ./to-upload/test.md                 safe://hbhyrydpan7d94mwp1bun3mxfnrfrui131an7ihu11wsn8dkr8odab9qwn
+If uploaded using `safe files put --recursive to-upload/`, this maps to:
+```
+/file1.txt
+/myfolder/file2.txt
+/myotherfolder/subfolder/file3.txt
 ```
 
-All the content of the `./to-upload/` local directory is now stored and published on the Safe Network. Now, let's say we make the following changes to our local files within the `./to-upload/` folder:
-- We edit `./to-upload/another.md` and change its content
-- We create a new file at `./to-upload/new.md`
-- And we remove the file `./to-upload/test.md`
-
-We can now sync up all the changes we just made, recursively, with the `FilesContainer` we previously created:
-```shell
-$ safe files sync ./to-upload/ safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc --recursive --delete
-FilesContainer synced up (version 1): "safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc?v=1"
-*  ./to-upload/another.md  safe://hbhyrynyr3osimhxa3mfqok7tto6cf3hhjy4sp3wdri6ee46x8xg68r9mj
-+  ./to-upload/new.md      safe://hbhyrydky3ga3xgkneiy1y5o6513rq6wdipqthkhd3ujqci9qmy8weihom
--  /test.md                safe://hbhyrydpan7d94mwp1bun3mxfnrfrui131an7ihu11wsn8dkr8odab9qwn
+If desired, we could use `safe files put --recursive to-upload/ /mychosenroot` and this would map to:
+```
+/mychosenroot/file1.txt
+/mychosenroot/myfolder/file2.txt
+/mychosenroot/myotherfolder/subfolder/file3.txt
 ```
 
-The `*`, `+` and `-` signs mean that the files were updated, added, and removed respectively.
+You can try this yourself, then use the `files ls` command to see the result.
 
-Also, please note we provided the optional `--delete` flag to the command above which forces the deletion of the files found at the targeted `FilesContainer` that are not found in the source location, like the case of `./to-upload/test.md` file in our example above. If we didn't provide such flag, only the modification and creation of files would have been updated on the `FilesContainer`, like the case of `./to-upload/another.md` and `./to-upload/new` files in our example above. Note that `--delete` is only allowed if the `--recursive` flag is also provided.
+### Add
 
-The `files sync` command also supports to be passed a destination path as the `files put` command, but in this case the destination path needs to be provided as part of the target XOR-URL. E.g., we can sync a `FilesContainer` using the local path and provide a specific destination path `new-files` in the target XOR-URL:
-```shell
-$ safe files sync ./other-folder/ safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc/new-files
-FilesContainer synced up (version 2): "safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc?v=2"
-+  ./other-folder/file1.txt  safe://hbhydyn6b5x9nqxt5escpuzy3axrcqb9dgs7p74izmpfkmmquwrdgjig4k
+We may simply want to add a file to an existing container rather than perform a full sync. We can use the `files add` command for this:
 ```
-
-The `./other-folder/file1.txt` file will be uploaded and published in the `FilesContainer` with path `/new-files/file1.txt`.
-
-One more thing to note about `files sync` command is the use of the `--update-nrs` flag. When syncing content using an NRS-URL (see [NRS section](#nrs-name-resolution-system) below for more information about NRS names and commands), if you want to update the NRS name to the new version generated after syncing the target `FilesContainer`, then it can be specified using the `--update-nrs` flag:
-```shell
-$ safe files sync ./to-upload/ safe://mywebsite --update-nrs
-FilesContainer synced up (version 1): "safe://mywebsite"
-*  ./to-upload/another.md  safe://hbhyrynyr3osimhxa3mfqok7tto6cf3hhjy4sp3wdri6ee46x8xg68r9mj
-+  ./to-upload/new.md      safe://hbhyrydky3ga3xgkneiy1y5o6513rq6wdipqthkhd3ujqci9qmy8weihom
-```
-
-#### Files Add
-
-It could be desirable in some scenarios to simply add a file to a `FilesContainer` rather than having the CLI to sync up a complete local folder, so the `files add` command could be used in such cases.
-
-We can add a single file from a local path, let's say `./some-other-folder/file.txt`, to our existing `FilesContainer` on the Safe Network with the following command:
-```shell
-$ safe files add ./some-other-folder/file.txt safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc/files-added/just-a-file.txt
+$ safe files add ./some-other-folder/file.txt \
+    safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc
 FilesContainer updated (version 3): "safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc?v=3"
 +  ./some-other-folder/file.txt  safe://hbhydynx64dxu5594yunsu41dykxt3nu1be81cy9igqzz3qtqrq1w3y6d9
 ```
 
-If we have previously uploaded a file to the network, we can also add it to any existing `FilesContainer` by providing its XOR-URL as the `<location>` argument to the `files add` command. Let's add a file (the same file we uploaded in the previous command) to our `FilesContainer` again, but choosing a new destination filename, e.g. `/files-added/same-file.txt`:
-```shell
-$ safe files add safe://hbhydynx64dxu5594yunsu41dykxt3nu1be81cy9igqzz3qtqrq1w3y6d9 safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc/files-added/same-file.txt
+If we have previously uploaded a file, we can add it to another container by providing its XOR-URL as the `<location>` argument:
+```
+$ safe files add safe://hbhydynx64dxu5594yunsu41dykxt3nu1be81cy9igqzz3qtqrq1w3y6d9 \
+    safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc/files-added/same-file.txt
 FilesContainer updated (version 4): "safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc?v=4"
 +  /files-added/same-file.txt  safe://hbhydynx64dxu5594yunsu41dykxt3nu1be81cy9igqzz3qtqrq1w3y6d9
 ```
 
-#### Files Ls
+### Ls
 
-We can list the files from a `FilesContainer` using the `files ls` command:
-```shell
+We can list the files in a container using the `files ls` command:
+```
 $ safe files ls safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc
 Files of FilesContainer (version 4) at "safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc":
 Total: 6
@@ -823,10 +473,10 @@ SIZE  CREATED               MODIFIED              NAME
 23    2020-01-28T20:26:05Z  2020-01-28T20:26:05Z  subfolder/
 ```
 
-Note the size displayed for a subfolder is its total size taking into account all files contained within it.
+**Note**: the size of the subfolder is the sum of the sizes of all its files.
 
-If we provide a path to a subfolder of the `FilesContainer`, this command will resolve the path and list only those files which paths are a child of the provided path:
-```shell
+You can also list a subfolder within a container:
+```
 $ safe files ls safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc/subfolder
 Files of FilesContainer (version 4) at "safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc/subfolder":
 Total: 1
@@ -835,38 +485,37 @@ SIZE  CREATED               MODIFIED              NAME
 8     2020-01-28T20:26:05Z  2020-01-28T20:26:05Z  note.md
 ```
 
-#### Files Get
+### Get
 
 The `files get` command copies file(s) from the network to the local filesystem.
 
 This command works similarly to Unix `cp` or `scp` or the windows `copy` command.  It accepts two arguments:
 
-```shell
+```
 <source>  The target FilesContainer to retrieve from, optionally including the path to the directory or file within
 <dest>    The local destination path for the retrieved files and folders (default is '.')
 ```
 
-note: Wildcards (eg, *.txt) and set/range expansion (eg photo{1-3}.jpg, photo{1,3,5}.jpg ) in
+**Note**: Wildcards (e.g. *.txt) and set/range expansion (e.g. photo{1-3}.jpg, photo{1,3,5}.jpg) in
 the source URL path are not supported at this time, but are planned for a future release.
-
 
 It also accepts some unique flags/options:
 
-```shell
+```
 -e, --exists <exists>         How to handle pre-existing files [default: ask]  [possible values: ask, preserve, overwrite]
 -i, --progress <progress>     How to display progress [default: bars]  [possible values: bars, text, none]
 ```
 
-##### Example: retrieving contents of a file container to local working directory
-```shell
+#### Example: retrieving contents of a file container to local working directory
+```
 $ safe files get safe://hnyynywwu865s4zgxj5z9gdjynpz9z93n8ru68931odfio7ogkjco7er7abnc
 [00:00:00] [########################################] 45B/45B (329B/s, 0s) Transfer
 Done. Retrieved 5 files to .
 ```
 
-##### Example: retrieving subfolder in a file container to an existing local directory.
+#### Example: retrieving subfolder in a file container to an existing local directory
 
-```shell
+```
 $ safe files get safe://hnyynywwu865s4zgxj5z9gdjynpz9z93n8ru68931odfio7ogkjco7er7abnc/testdata/subfolder existing_dir
 [00:00:00] [########################################] 27B/27B (425B/s, 0s) Transfer
 Done. Retrieved 2 files to existing_dir
@@ -874,7 +523,7 @@ Done. Retrieved 2 files to existing_dir
 
 We see that `subfolder` has been placed inside `existing_dir`.
 
-```shell
+```
 $ tree existing_dir
 existing_dir
 └── subfolder
@@ -882,9 +531,9 @@ existing_dir
     └── subexists.md
 ```
 
-##### Example: retrieving subfolder in a file container to a non-existent local directory (rename)
+#### Example: retrieving subfolder in a file container to a non-existent local directory (rename)
 
-```shell
+```
 $ safe files get safe://hnyynywwu865s4zgxj5z9gdjynpz9z93n8ru68931odfio7ogkjco7er7abnc/testdata/subfolder nonexistent_dir
 [00:00:00] [########################################] 27B/27B (425B/s, 0s) Transfer
 Done. Retrieved 2 files to nonexistent_dir
@@ -892,16 +541,16 @@ Done. Retrieved 2 files to nonexistent_dir
 
 We see that `subfolder` has been renamed to `nonexistent_dir`.
 
-```shell
+```
 $ tree nonexistent_dir
 nonexistent_dir
 ├── sub2.md
 └── subexists.md
 ```
 
-##### Example: Retrieving individual file to an existing directory
+#### Example: retrieving individual file to an existing directory
 
-```shell
+```
 $ safe files get safe://hnyynywwu865s4zgxj5z9gdjynpz9z93n8ru68931odfio7ogkjco7er7abnc/testdata/subfolder/sub2.md existing_dir/
 [00:00:00] [########################################] 4B/4B (378B/s, 0s) Transfer
 Done. Retrieved 1 files to existing_dir/
@@ -909,15 +558,15 @@ Done. Retrieved 1 files to existing_dir/
 
 We see that the file is now inside `existing_dir`.
 
-```shell
+```
 $ tree existing_dir
 existing_dir
 └── sub2.md
 ```
 
-##### Example: Retrieving individual file to a new filename
+#### Example: retrieving individual file to a new filename
 
-```shell
+```
 $ safe files get safe://hnyynywwu865s4zgxj5z9gdjynpz9z93n8ru68931odfio7ogkjco7er7abnc/testdata/subfolder/sub2.md existing_dir/new_filename
 [00:00:00] [########################################] 4B/4B (374B/s, 0s) Transfer
 Done. Retrieved 1 files to existing_dir/new_filename
@@ -925,28 +574,25 @@ Done. Retrieved 1 files to existing_dir/new_filename
 
 We see that `new_filename` is now inside `existing_dir`.
 
-```shell
+```
 $ tree existing_dir
 existing_dir
 └── new_filename
 ```
 
-##### A performance note about very large FileContainers
+#### Performance
 
-Subfolder or single-file downloads from a FileContainer with thousands of files
-may be slower than expected.
+Subfolder or single-file downloads from a container with thousands of files may be slower than expected.
 
-This is because the entire FileContainer is fetched and locally filtered to
-obtain the XorUrl for each file that matches the source URL path.
+This is because the entire container is fetched and locally filtered to obtain the XorUrl for each file that matches the source URL path.
 
 Future releases may operate differently.
 
-
-#### Files Tree
+### Tree
 
 The `files tree` command displays a visual representation of an entire directory tree.
 
-```shell
+```
 $ safe files tree safe://hnyynyiodw4extpc7xh3dncfgsg4sjzsygru9k8omo988brz688oxkxhxgbnc
 safe://hnyynyiodw4extpc7xh3dncfgsg4sjzsygru9k8omo988brz688oxkxhxgbnc
 └── testdata
@@ -960,9 +606,9 @@ safe://hnyynyiodw4extpc7xh3dncfgsg4sjzsygru9k8omo988brz688oxkxhxgbnc
 2 directories, 5 files
 ```
 
-If we provide a path to a subfolder of the `FilesContainer`, this command will resolve the path and list only those files which paths are a child of the provided path:
+If we provide a path to a subfolder, this command will resolve the path and list only children of the provided path:
 
-```shell
+```
 $ safe files tree safe://hnyynyiodw4extpc7xh3dncfgsg4sjzsygru9k8omo988brz688oxkxhxgbnc/testdata/subfolder
 safe://hnyynyiodw4extpc7xh3dncfgsg4sjzsygru9k8omo988brz688oxkxhxgbnc/testdata/subfolder
 ├── sub2.md
@@ -973,7 +619,7 @@ safe://hnyynyiodw4extpc7xh3dncfgsg4sjzsygru9k8omo988brz688oxkxhxgbnc/testdata/su
 
 File details can be displayed with the `--details` flag:
 
-```shell
+```
 $ safe files tree --details safe://hnyynyiodw4extpc7xh3dncfgsg4sjzsygru9k8omo988brz688oxkxhxgbnc/testdata
 SIZE  CREATED               MODIFIED              NAME
                                                   safe://hnyynyiodw4extpc7xh3dncfgsg4sjzsygru9k8omo988brz688oxkxhxgbnc/testdata
@@ -987,26 +633,26 @@ SIZE  CREATED               MODIFIED              NAME
 1 directory, 5 files
 ```
 
-#### Files Rm
+### Rm
 
-Removing files from a `FilesContainer` which is in sync with a folder in the local file system can be done by simply removing them locally followed by a call to `files sync` command. If we otherwise are not in such a scenario and would like to remove files directly from a `FilesContainer` we can achieve it with the `file rm` command.
+Removing files from a container which is in sync with a local folder can be done by removing them locally followed by a call to the `files sync` command.
 
-As an example, we can remove single file to our existing `FilesContainer` on the Safe Network with the following command:
-```shell
+However, if you would like to remove files directly from the container, we can use the `files rm` command:
+```
 $ safe files rm safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc/another.md
 FilesContainer updated (version 5): "safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc?v=5"
 -  /another.md  safe://hbhyrynyr3osimhxa3mfqok7tto6cf3hhjy4sp3wdri6ee46x8xg68r9mj
 ```
 
-Removing an entire subfolder from a `FilesContainer` rather than a single file is also possible, we just need to pass the `--recursive` flag and the path to the subfolder we would like to remove:
-```shell
+We can also use the `--recursive` flag to remove a subfolder in the container: 
+```
 $ safe files rm safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc/subfolder --recursive
 FilesContainer updated (version 6): "safe://hnyynyi6tgumo67yoauewe3ee3ojh37sbyr7rnh3nd6kkqhbo9decpjk64bnc?v=6"
 -  /subfolder/subexists.md  safe://hbhyryn9uodh1ju5uzyti3gmmtwburrssd89rcwcy3rzofdpypwomrzzte
 -  /subfolder/note.md       safe://hbhyryncjzga5uqp3ogeadqctigyaurpju8yauqptzgh5uyctogh3dkcbt
 ```
 
-### Xorurl
+## Xorurl
 
 As we've seen, when uploading files to the network, each file is uploaded as an `Blob` using the [self-encryption algorithm](https://github.com/maidsafe/self_encryption) in the client, splitting the files into encrypted chunks, and the resulting file's XOR-URL is linked from a `FilesContainer`.
 
@@ -1031,7 +677,7 @@ $ safe xorurl ./to-upload/ --recursive
 +  ./to-upload/test.md                 safe://hoxibhqth9awkjgi35sz73u35wyyscuht65m3ztrznb6thd5z8hepx
 ```
 
-#### Xorurl decode
+### Decode
 
 XOR-URLs encode not only information about the location of the content, but also about the content type, native data type the data is being held on, etc.
 
@@ -1047,7 +693,7 @@ Sub names: []
 Content version: latest
 ```
 
-### Cat
+## Cat
 
 The `cat` command is probably the most straight forward command, it allows users to fetch data from the Network using a URL, and render it according to the type of data being fetched:
 ```shell
@@ -1092,22 +738,9 @@ $ safe cat safe://hnyynyixxj9uewuhh64rgg9zsdhaynwhc88mpyfpor5carg8xx6qs6jknnbnc/
 hello tests!
 ```
 
-A `Wallet` can be also fetched with `cat` to inspect its content, the list of spendable balances it holds will be listed, and we can see which of them is currently the default to be used in a transfer operation:
-```shell
-$ safe cat safe://hnyybyqbp8d4u79f9sqhcxtdczgb76iif74cdsjif1wegik9t38diuk1yny9e
-Spendable balances of Wallet at "safe://hnyybyqbp8d4u79f9sqhcxtdczgb76iif74cdsjif1wegik9t38diuk1yny9e":
-+---------+-------------------------+-------------------------------------------------------------------+
-| Default | Friendly Name           | SafeKey URL                                                       |
-+---------+-------------------------+-------------------------------------------------------------------+
-| *       | my-default-balance      | safe://hbyyyybffgc3smq1ynjewsbtqkm5h9rq367n6krzd9rz65p8684x9wy81m |
-+---------+-------------------------+-------------------------------------------------------------------+
-|         | first-spendable-balance | safe://hbyyyybqk69tpm67ecnzjg66tcrja3ugq81oh6gfaffwaty614rmttmyeu |
-+---------+-------------------------+-------------------------------------------------------------------+
-```
-
 As seen above, the `safe cat` command can be used to fetch any type of content from the Safe Network. At this point it only supports files (`Blob`), `FilesContainer`s, `Wallet`s, and `NRS-Container`s (see further below about NRS Containers and commands), but it will be expanded as more types are supported by the CLI and its API.
 
-#### Retrieving binary files with --hexdump
+### Retrieving Binary Files
 
 By default, binary files are treated just like a plaintext file and will typically display unreadable garbage on the screen unless the output is redirected to a file, eg:
 
@@ -1131,7 +764,7 @@ Length: 1406 (0x57e) bytes
 0080:   34 00 fe fa  f6 00 bf 87  5b 00 b1 6b  50 00 dd 82   4.......[..kP...
 ```
 
-#### Retrieving older versions of content
+### Retrieving Older Versions
 
 As we've seen above, we can use `cat` command to retrieve the latest/current version of any type of content from the Network using their URL. But every change made to content that is uploaded to the Network as `Public` data is perpetual, and therefore a new version is generated when performing any amendments to it, keeping older versions also available forever.
 
@@ -1150,117 +783,7 @@ Files of FilesContainer (version 0) at "safe://hnyynyi6tgumo67yoauewe3ee3ojh37sb
 +-------------------------+------+----------------------+----------------------+-------------------------------------------------------------------+
 ```
 
-### NRS (Name Resolution System)
-
-As we've seen in all the above sections, every piece of data on the Safe Network has a unique location. Such location is determined by the XoR name given to it in the Network's XoR address space, as well as some other information which depends on the native date type, like in the case of `MutableData` data type which also has a type tag associated to it apart from its XoR address.
-
-So far all commands were using the XOR-URLs to either inform of the new data created/stored on the Network, as well as for retrieving data from the Network.
-
-While XOR-URLs are simply a way to encode Safe Network data unique location into a URL, there are some incentives for having more human-friendly URLs that can be easily remembered and recognisable when trying to share them with other people, or use them with tools and applications like the Safe CLI or the Safe Browser.
-
-This is why the Safe Network also supports having such human-friendly URLs through what it's called the `Name Resolution System (NRS)`. The NRS allows users to create friendly names that are resolvable to a unique location on the Network. These friendly names can be used in the form of a URL (NRS-URL) to share with other people the location of websites, web applications, files and folders, safecoin wallets for receiving transfers, Safe IDs, etc.
-
-In this section we will explore the CLI commands which allow users to generate, administer, and use the NRS and its NRS-URLs for publishing and retrieving data to/from the Safe Network.
-
-#### NRS Create
-
-Creating a friendly name on the Network can be achieved with the `nrs create` subcommand. This subcommand generates an NRS Container automatically linking it to any data we decide to link the friendly name to. An NRS Container is stored on the Network as a `Public Sequence` data, and it contains an NRS Map using RDF for its data representation (since this is still under development, pseudo-RDF data is now being used temporarily). This Map has a list of subnames and where each of them are being linked to, e.g. `mysubname` can be created as a subname of `mywebsite` NRS name by having `mysubname` linked to a particular `FilesContainer` XOR-URL so that it can be fetched with `safe://mysubname.mywebsite`.
-
-Let's imagine we have uploaded the files and folders of a website we want to publish on the Safe Network with `files put` command:
-```shell
-$ safe files put ./website-to-publish/ --recursive
-FilesContainer created at: "safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc"
-+  ./website-to-publish/index.html              safe://hbyyyydhp7y3mb6zcj4herpqm53ywnbycstamb54yhniud1cij7frjfe8c
-+  ./website-to-publish/image.jpg               safe://hbyyyynkt8ak5mxmbqkdt81hqceota8fu83e49gi3weszddujfc8fxcugp
-+  ./website-to-publish/contact/form.html       safe://hbyyyyd1sw4dd57k1xeeijukansatia6mthaz1h6htnb8pjoh9naskoaks
-```
-
-As we know that website is now publicly available on the Safe Network for anyone who wants to visit using its XOR-URL "safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc" with either `$ safe cat` command, or a Safe Browser. But let's now create a NRS name for it and obtain its human-friendly NRS-URL:
-```shell
-$ safe nrs create mywebsite --link "safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0"
-New NRS Map for "safe://mywebsite" created at: "safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh"
-+  mywebsite  safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0
-```
-
-Note that we provided a versioned URL to the `--link` argument in the command above, i.e. a URL which targets a specific version of the content with `?v=<version number>`. Any type of content which can have different versions (like the case of a `FilesContainer` in our example) can be mapped/linked from an NRS name/subname only if a specific version is provided in the link URL. If you are using a bash based system and want to provide a version (or any other command containing a question mark), the URL must be wrapped in double quotes or bash will interpret the link as a file path and throw an error, e.g. use `"safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0"`, not `safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobncv=0`.
-
-We can now share the NRS-URL `safe://mywebsite` to anyone who wants to visit our website. Using this NRS-URL we can now fetch the same content we would do when using the `FilesContainer` XOR-URL we linked to it, thus we can fetch it using the following command:
-```shell
-$ safe cat safe://mywebsite
-Files of FilesContainer (version 0) at "safe://mywebsite":
-+-------------------------+------+----------------------+----------------------+-------------------------------------------------------------------+
-| Name                    | Size | Created              | Modified             | Link                                                              |
-+-------------------------+------+----------------------+----------------------+-------------------------------------------------------------------+
-| /index.html             | 146  | 2019-07-24T14:31:42Z | 2019-07-24T14:31:42Z | safe://hbyyyydhp7y3mb6zcj4herpqm53ywnbycstamb54yhniud1cij7frjfe8c |
-+-------------------------+------+----------------------+----------------------+-------------------------------------------------------------------+
-| /image.jpg              | 391  | 2019-07-24T14:31:42Z | 2019-07-24T14:31:42Z | safe://hbyyyynkt8ak5mxmbqkdt81hqceota8fu83e49gi3weszddujfc8fxcugp |
-+-------------------------+------+----------------------+----------------------+-------------------------------------------------------------------+
-| /contact/form.html      | 23   | 2019-07-24T14:31:42Z | 2019-07-24T14:31:42Z | safe://hbyyyyd1sw4dd57k1xeeijukansatia6mthaz1h6htnb8pjoh9naskoaks |
-+-------------------------+------+----------------------+----------------------+-------------------------------------------------------------------+
-```
-
-In this example the `cat` simply prints out the content of the top level folder (`FilesContainer`) as we've learned from previous sections of this guide, but any other tool or application would be treating this in different ways, e.g. the Safe Browser would be automatically fetching the `index.html` file from it and rendering the website to the user.
-
-We can obviously fetch the content of any of the files published at this NRS-URL using the corresponding path:
-```shell
-$ safe cat safe://mywebsite/contact/form.html
-<!DOCTYPE html>
-<html>
-<body>
-<h2>Contact Form</h2>
-<form>
-  ...
-</form>
-</body>
-</html>
-```
-
-##### Sub Names
-
-Much like the old internet, the NRS system provides increased flexibility for those wanting to have a variety of resources available under one public name, via using `Sub Names`. This is done by creating a Public name and using a `.` (dot) character to separate it into various, individually controllable parts.
-
-For example, you may wish to have `safe://mywebsite` to be about you in general, whereas `safe://blog.mywebsite` point to a different site which is your blog.
-
-To create a public name with subnames, you need only to pass the full string with `.` separators, just like any traditional URL, to the CLI:
-```shell
-$ safe nrs create blog.mywebsite --link "safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0"
-New NRS Map for "safe://blog.mywebsite" created at: "safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh"
-+  blog.mywebsite  safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0
-```
-
-As the NRS CLI advances, you'll be able to individually add to both `blog.mywebsite`, or indeed just `mywebsite`, as well as change what the `default` resource to retrieve is for both.
-
-#### NRS Add
-
-Once a public name has been created with `nrs create` command, more sub names can be added to it using the `nrs add` command. This command expects the same arguments as `nrs create` command but it only requires and assumes that the public name already exists.
-
-Let's add `profile` sub name to the `mywebsite` NRS name we created before:
-```shell
-$ safe nrs add profile.mywebsite --link "safe://hnyynyipybem7ihnzqya3w31seezj4i6u8ckg9d7s39exz37z3nxue3cnkbnc?v=0"
-NRS Map updated (version 1): "safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh"
-+  profile.mywebsite  safe://hnyynyz8m4pkok41qrn9gkrwz35fu8zxfkwrc9xrt595wjtodacx9n8u3wbnc
-```
-
-The safe nrs add command can also be used to update subnames after they have been added to a public name.
-For example, if we have made changes to files mapped to the `profile.mywebsite` NRS subname we created before, we can use `nrs add` to update its link:
-```shell
-$ safe nrs add profile.mywebsite --link safe://hnyynyw9ru4afkbfee5m4ca4jbho4f5bj6ynep5k1pioyge6dihfqyjfrnbnc?v=0
-NRS Map updated (version 2): "safe://profile.hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh"
-+  profile.mywebsite  safe://hnyynyw9ru4afkbfee5m4ca4jbho4f5bj6ynep5k1pioyge6dihfqyjfrnbnc?v=0
-```
-
-#### NRS Remove
-
-Removing sub names from an NRS Map Container is very simple and straightforward, since the only information required to do so is just the NRS-URL. The `nrs remove` command will remove only the sub name specified in the provided NRS-URL without touching any of the other existing sub names, e.g. if the `safe://sub-b.sub-a.mypubname` NRS-URL is provided then only `sub-b` sub name will be removed from `mypubname` NRS Map Container (by creating a new version of it, remember this is all part of the perpetual web).
-
-Let's remove the `profile` sub name from the `mywebsite` NRS name we added before:
-```shell
-$ safe nrs remove profile.mywebsite
-NRS Map updated (version 3): "safe://hnyydyz7utb6npt9kg3aksgorfwmkphet8u8z3or4nsu8n3bj8yiep4a91bqh"
--  profile.mywebsite  safe://hnyynyw9ru4afkbfee5m4ca4jbho4f5bj6ynep5k1pioyge6dihfqyjfrnbnc?v=0
-```
-
-### Safe-URLs
+## Safe-URLs
 
 In previous sections of this guide we explained how we can create two types of safe:// URLs, XOR-URLs and NRS-URLs. It has been explained that safe:// URLs can contain a path as well, if they target a `FilesContainer`, and they can also be post-fixed with `v=<version>` query param in order to target a specific version of the content rather than the latest/current version when this query param is omitted.
 
@@ -1272,13 +795,13 @@ E.g. we can retrieve the content of a website with the `cat` command using eithe
 
 In both cases the NRS Map Container will be found (from above URLs) by decoding the XOR-URL or by resolving NRS public name. Once that's done, and since the content is an NRS Map, following the rules defined by NRS and the map found in it the target link will be resolved from it. In some circumstances, it may be useful to get information about the resolution of a URL, which can be obtained using the `dog` command.
 
-#### Symlinks
+## Symlinks
 
 The sn_cli supports upload and retrieval of symlinks using the above commands. It can also resolve relative symlinks in a FileContainer provided that the target exists in the FileContainer.
 
 [More Details](README-symlinks.md)
 
-### Dog
+## Dog
 
 The Safe Network relates information and content using links, as an example, just considering some of the type of content we've seen in this guide, `FilesContainer`s, `Wallet`s and `NRS Map Container`s, they are all containers with named links (Safe-URLs) to other content on the network, and depending on the abstraction they provide, each of these links are resolved following a specific set of rules for each type of container, e.g. NRS subnames are resolved with a predefined set of rules, while a file's location is resolved from a FilesContainer with another set of predefined rules.
 
@@ -1331,81 +854,13 @@ Version: 3
 
 In this case we don't only get information about the content that the URL resolves to, but also about the NRS Map Container this NRS-URL was resolved with. E.g. we see the XOR-URL of the NRS Map Container, its version, and among other data we also see the list of all NRS names defined by it with their corresponding XOR-URL links.
 
-### Seq (Sequence)
-
-As mentioned before, `FilesContainers` and `NRS Map Containers` are abstractions created on top of the network's native `Public Sequence` data type. A `Public Sequence` is a very simple data type that allows the user to only append elements to it once it has been created on the network.
-
-Mutations made to `FilesContainers` and `NRS Map Containers` are made by storing the new version as a snapshot of the content and appended as a new item into its underlying `Public Sequence`. This is how these types of content are able to keep the complete history on the network.
-
-#### Seq Store
-
-The CLI also allows us to store our own `Public Sequence` instances, with any other type of content we would like to store, instead of the data representing a `FilesContainer` or `NRS Map Container`. We can store a `Public Sequence` on the network with "my initial note" string as its first item:
-```shell
-$ safe seq store "my initial note"
-Public Sequence stored at: "safe://hnyyyyp3yb3dczuaaiwx1mb5491xir4kz1hex3d1pc34oxwicy7scm3x4ybfo"
-```
-
-We can then retrieve the content of this Sequence data, using either the `cat`/`dog` command as we do it with any other type of content:
-```shell
-$ safe cat safe://hnyyyyp3yb3dczuaaiwx1mb5491xir4kz1hex3d1pc34oxwicy7scm3x4ybfo
-Public Sequence (version 0) at "safe://hnyyyyp3yb3dczuaaiwx1mb5491xir4kz1hex3d1pc34oxwicy7scm3x4ybfo":
-my initial note
-```
-
-It's also possible to pipe the output of another command into the `seq store` command to store a new `Sequence` with the content obtained from STDIN by providing `-` as the data argument:
-```shell
-$ echo "hello from stdin" | safe seq store -
-Public Sequence stored at: "safe://hnyyyypfneksex7qxr5zuqqizdkbqbmn1tir1pmfwz1wsghb69rna76syabfo"
-
-$ safe cat safe://hnyyyypfneksex7qxr5zuqqizdkbqbmn1tir1pmfwz1wsghb69rna76syabfo
-Public Sequence (version 0) at "safe://hnyyyypfneksex7qxr5zuqqizdkbqbmn1tir1pmfwz1wsghb69rna76syabfo
-hello from stdin
-```
-
-##### Private Sequence
-
-The above CLI command will store the `Sequence` as Public by default, i.e. it's perpetually stored on the network and publicly available for other users to read it. We can otherwise store the new `Sequence` as private content, in which case, only the creator of it will have access to read and mutate. This can be simply achieved by providing the `--private` flag:
-```shell
-$ safe seq store "my initial private note" --private
-Private Sequence stored at: "safe://hnyyyytcgbrcfq5aw8myg6ihw6d8ss6bsgr9szm8y6qwjxsbiqufr8n3tebfo"
-```
-
-We can retrieve it, just as with `Public Sequence` using its XOR-URL, as long as the CLI has been authorised with the Authenticator by the same user who stored the Sequence, any other user will get an error when trying to retrieve it with the following command:
-```shell
-$ safe cat safe://hnyyyytcgbrcfq5aw8myg6ihw6d8ss6bsgr9szm8y6qwjxsbiqufr8n3tebfo
-Private Sequence (version 0) at "safe://hnyyyytcgbrcfq5aw8myg6ihw6d8ss6bsgr9szm8y6qwjxsbiqufr8n3tebfo
-my initial private note
-```
-
-#### Seq Append
-
-Once we have a `Sequence` stored on the network, either `Public` or `Private`, new items can be appended to it:
-```shell
-$ safe seq append "first update to my note" safe://hnyyyyp3yb3dczuaaiwx1mb5491xir4kz1hex3d1pc34oxwicy7scm3x4ybfo
-Data appended to the Sequence: "safe://hnyyyyp3yb3dczuaaiwx1mb5491xir4kz1hex3d1pc34oxwicy7scm3x4ybfo"
-```
-
-We can confirm the new item has been appended to the `Sequence`:
-```shell
-$ safe cat safe://hnyyyyp3yb3dczuaaiwx1mb5491xir4kz1hex3d1pc34oxwicy7scm3x4ybfo
-Public Sequence (version 1) at "safe://hnyyyyp3yb3dczuaaiwx1mb5491xir4kz1hex3d1pc34oxwicy7scm3x4ybfo":
-first update to my note
-```
-
-And we can also confirm the previous item has been kept in the `Sequence` if we provide the same XOR-URL but specifying a version (with `?v=<version>`):
-```shell
-$ safe cat safe://hnyyyyp3yb3dczuaaiwx1mb5491xir4kz1hex3d1pc34oxwicy7scm3x4ybfo?v=0
-Public Sequence (version 0) at "safe://hnyyyyp3yb3dczuaaiwx1mb5491xir4kz1hex3d1pc34oxwicy7scm3x4ybfo?v=0":
-my initial note
-```
-
-### Shell Completions
+## Shell Completions
 
 Automatic command completions via <tab> are available for popular shells such as bash and PowerShell (Windows). Completions are also provided for the shells fish, zsh, and elvish.
 
 Until an installer becomes available, these completions must be manually enabled as per below.
 
-#### Bash Completions
+### Bash Completions
 
 To enable bash completions in the current bash session, use the following command:
 ```shell
@@ -1417,7 +872,7 @@ To enable bash completions always for the current user:
 SC=~/.bash_sn_cli CL="source $SC" RC=~/.bashrc; safe setup completions bash > $SC && grep -qxF "$CL" $RC || echo $CL >> $RC
 ```
 
-#### Windows PowerShell Completions
+### Windows PowerShell Completions
 
 To enable completions in the current PowerShell session, use the following commands:
 ```shell
@@ -1426,10 +881,6 @@ sn_cli.ps1
 ```
 
 To enable PowerShell completions permanently, generate the sn_cli.ps1 file as per above and then see this [stackoverflow answer](<https://stackoverflow.com/questions/20575257/how-do-i-run-a-powershell-script-when-the-computer-starts#32189430>).
-
-### Update
-
-The CLI can update itself to the latest available version. If you run `safe update`, the application will check if a newer release is available on [GitHub](https://github.com/maidsafe/sn_cli/releases). After prompting to confirm if you want to take the latest version, it will be downloaded and the binary will be updated.
 
 ## Further Help
 


### PR DESCRIPTION
The CLI user guide hadn't been updated for some time, so I brought it it in line with current features. Where relevant so far, I also trimmed the text to make it more concise.

The following updates were made:

* Reduce the indentation levels of the whole document.
* Add a Quickstart section to get users going with a single command if they want to avoid reading lots of setup text. Windows
  was explicitly left out because having a Git Bash installation does not constitute the ability to quick start.
* Re-work the previous 'Download' section to an 'Installation and Setup' section.
* Restructure the 'Networks' section with a new example using remote networks.
* Temporarily remove the 'Interactive Shell' section. This was using a feature that didn't exist any more.
* Temporarily remove the 'SafeKeys' section, which used examples referring to removed features. This can be added back in 
but applied to currently relevant features. I didn't understand it enough to apply it at the moment.
* Trim the wordy prose in the 'Files' section. This helps the reader get to the salient issues quicker.
* Temporarily remove documentation for `files sync`. This command wasn't behaving as described currently, and I'm not sure the NRS stuff still applied. Didn't have time to go into it in detail. This section also has wordy prose that could benefit from being trimmed down. I'll do that when I add it back in.
* Temporarily remove the NRS section. This is completely out of sync with the new NRS commands and terminology and I suspect it can also be made less verbose.
* Remove the 'Auth' section, since this feature has been removed.
* Remove the 'Sequences' section, since this feature has been removed.
* Remove the 'Updates' section, since this feature is currently not enabled.
* Remove the `shell` style from the ``` code blocks since we don't need shell syntax highlighting. There's only one line of shell and the rest is showing the output of the command, which isn't shell code.

**Important note:** anywhere I've said "temporarily remove", I will address as soon as I come back from holiday, so please don't fret too much about these sections being removed. The previous `sn_cli` still has the original document, so I can base from that when I re-add the sections.
