### PR TITLE
feat(api): change files APIs to accept std::Path for path args rather than only &str

### DIFF
--- a/sn_api/src/app/nrs/mod.rs
+++ b/sn_api/src/app/nrs/mod.rs
@@ -384,6 +384,8 @@ mod tests {
     use anyhow::{anyhow, bail, Result};
     use std::{matches, str::FromStr};
 
+    const TEST_DATA_FILE: &str = "./testdata/test.md";
+
     #[tokio::test]
     async fn test_nrs_create() -> Result<()> {
         let site_name = random_nrs_name();
@@ -407,7 +409,7 @@ mod tests {
 
         // let's create an empty files container so we have a valid to link
         let (link, _, _) = safe
-            .files_container_create(None, None, true, true, false)
+            .files_container_create_from(TEST_DATA_FILE, None, false, false, false)
             .await?;
         let (version0, _) = retry_loop!(safe.files_container_get(&link));
         let mut url_v0 = SafeUrl::from_url(&link)?;
@@ -445,7 +447,7 @@ mod tests {
 
         // let's create an empty files container so we have a valid to link
         let (link, _, _) = safe
-            .files_container_create(None, None, true, true, false)
+            .files_container_create_from(TEST_DATA_FILE, None, false, false, false)
             .await?;
         let (version0, _) = retry_loop!(safe.files_container_get(&link));
         let mut url_v0 = SafeUrl::from_url(&link)?;
@@ -507,7 +509,7 @@ mod tests {
 
         // let's create an empty files container so we have a valid to link
         let (link, _, _) = safe
-            .files_container_create(None, None, true, true, false)
+            .files_container_create_from(TEST_DATA_FILE, None, false, false, false)
             .await?;
         let (version0, _) = retry_loop!(safe.files_container_get(&link));
 
@@ -565,7 +567,7 @@ mod tests {
 
         // let's create an empty files container so we have a valid to link
         let (link, _, _) = safe
-            .files_container_create(None, None, true, true, false)
+            .files_container_create_from(TEST_DATA_FILE, None, false, false, false)
             .await?;
         let (version0, _) = retry_loop!(safe.files_container_get(&link));
         let mut url_v0 = SafeUrl::from_url(&link)?;
@@ -618,7 +620,7 @@ mod tests {
 
         // let's create an empty files container so we have a valid to link
         let (link, _, _) = safe
-            .files_container_create(None, None, true, true, false)
+            .files_container_create_from(TEST_DATA_FILE, None, false, false, false)
             .await?;
         let (version0, _) = retry_loop!(safe.files_container_get(&link));
 

--- a/sn_api/src/app/resolver/mod.rs
+++ b/sn_api/src/app/resolver/mod.rs
@@ -59,7 +59,7 @@ impl Safe {
     /// # let rt = tokio::runtime::Runtime::new().unwrap();
     /// # rt.block_on(async {
     /// #   safe.connect(None, None, None).await.unwrap();
-    ///     let (xorurl, _, _) = safe.files_container_create(Some("./testdata/"), None, true, false, false).await.unwrap();
+    ///     let (xorurl, _, _) = safe.files_container_create_from("./testdata/", None, true, false, false).await.unwrap();
     ///
     ///     let safe_data = safe.fetch( &format!( "{}/test.md", &xorurl.replace("?v=0", "") ), None ).await.unwrap();
     ///     let data_string = match safe_data {
@@ -108,7 +108,7 @@ impl Safe {
     /// # rt.block_on(async {
     /// #   let mut safe = Safe::default();
     /// #   safe.connect(None, None, None).await.unwrap();
-    ///     let (container_xorurl, _, _) = safe.files_container_create(Some("./testdata/"), None, true, false, false).await.unwrap();
+    ///     let (container_xorurl, _, _) = safe.files_container_create_from("./testdata/", None, true, false, false).await.unwrap();
     ///
     ///     let inspected_content = safe.inspect( &format!( "{}/test.md", &container_xorurl.replace("?v=0", "") ) ).await.unwrap();
     ///     match &inspected_content[0] {
@@ -254,7 +254,7 @@ mod tests {
     async fn test_fetch_files_container() -> Result<()> {
         let mut safe = new_safe_instance().await?;
         let (fc_xorurl, _, original_files_map) = safe
-            .files_container_create(Some("./testdata/"), None, true, false, false)
+            .files_container_create_from("./testdata/", None, true, false, false)
             .await?;
 
         let safe_url = SafeUrl::from_url(&fc_xorurl)?;
@@ -306,7 +306,7 @@ mod tests {
 
         // create file container
         let (xorurl, _, the_files_map) = safe
-            .files_container_create(Some("./testdata/"), None, true, false, false)
+            .files_container_create_from("./testdata/", None, true, false, false)
             .await?;
         let _ = retry_loop!(safe.fetch(&xorurl, None));
         let (version0, _) = retry_loop!(safe.files_container_get(&xorurl));
@@ -365,7 +365,7 @@ mod tests {
 
         // create file container
         let (xorurl, _, _the_files_map) = safe
-            .files_container_create(Some("./testdata/"), None, true, false, false)
+            .files_container_create_from("./testdata/", None, true, false, false)
             .await?;
         let _ = retry_loop!(safe.fetch(&xorurl, None));
         let (version0, _) = retry_loop!(safe.files_container_get(&xorurl));
@@ -505,7 +505,7 @@ mod tests {
 
         // create file container
         let (xorurl, _, _files_map) = safe
-            .files_container_create(Some("./testdata/"), None, true, false, false)
+            .files_container_create_from("./testdata/", None, true, false, false)
             .await?;
         let _ = retry_loop!(safe.fetch(&xorurl, None));
         let (version0, _) = retry_loop!(safe.files_container_get(&xorurl));

--- a/sn_cli/README-symlinks.md
+++ b/sn_cli/README-symlinks.md
@@ -166,7 +166,7 @@ The JSON for a FileContainer with a single symlink looks like:
 
 A parameter `follow_links` was added to the following public APIs:
 
-* Safe::files_container_create()
+* Safe::files_container_create_from()
 * Safe::files_container_sync()
 * Safe::files_container_add()
 * Safe::files_map_sync()

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -218,8 +218,8 @@ pub async fn files_commander(
                 notice_dry_run();
             }
             let (files_container_xorurl, processed_files, _) = safe
-                .files_container_create(
-                    Some(&location),
+                .files_container_create_from(
+                    &location,
                     dest.as_deref(),
                     recursive,
                     follow_links,

--- a/sn_cli/src/subcommands/xorurl.rs
+++ b/sn_cli/src/subcommands/xorurl.rs
@@ -95,7 +95,7 @@ pub async fn xorurl_commander(
 
             // Do a dry-run on the location
             let (_version, processed_files, _) = safe
-                .files_container_create(Some(&location), None, recursive, follow_symlinks, true)
+                .files_container_create_from(&location, None, recursive, follow_symlinks, true)
                 .await?;
 
             // Now let's just print out a list of the xorurls


### PR DESCRIPTION
- Changed the `files_container_create` API to now create just an empty FilesContainer
- Adding a new `files_container_create_from` API which creates a FilesContainer with files uploaded from a local folder.
- All path args passed to files container APIs can either be &str, std::Path, or std::PathBuf

BREAKING CHANGE: changes to the files public API.