### PR TITLE
feat(node): use sn-consensus (BRB membership algorithm) to agree on members additions/removals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backoff"
@@ -317,15 +317,15 @@ dependencies = [
  "getrandom 0.2.4",
  "instant",
  "pin-project",
- "rand 0.8.4",
+ "rand 0.8.5",
  "tokio",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
@@ -460,14 +460,15 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f073f59a150a1dca74aab43d794ae5a7578d52bb1e73121e559f3ee3e6a837e"
+checksum = "acb8c0939e210397464ae1857265a7492a2957f915803d43cb9832229100636a"
 dependencies = [
  "cc",
  "glob",
  "threadpool",
  "zeroize",
+ "zeroize_derive",
 ]
 
 [[package]]
@@ -689,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f67643a7d716307ad10b3e3aef02826382acbe349a3e7605ac57556148bc87"
+checksum = "cc347c19eb5b940f396ac155822caee6662f850d97306890ac3773ed76c90c5a"
 dependencies = [
  "prost",
  "prost-types",
@@ -702,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829835c211a0247cd11e65e13cec8696b879374879c35ce162ce8098b23c90d4"
+checksum = "d7a4aa62cefeef6d5a2bfcf638818b7950329a6c3ad919f89f04d60174f217f4"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -719,7 +720,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.7",
+ "tracing-subscriber 0.3.8",
 ]
 
 [[package]]
@@ -745,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -826,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -839,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -1289,9 +1290,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1304,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1314,15 +1315,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1331,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -1352,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1363,21 +1364,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1470,15 +1471,14 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f16c88aa13d2656ef20d1c042086b8767bbe2bdb62526894275a1b062161b2e"
+checksum = "4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e"
 dependencies = [
  "futures-channel",
  "futures-core",
  "js-sys",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1609,9 +1609,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdrhistogram"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6490be71f07a5f62b564bc58e36953f675833df11c7e4a0647bee7a07ca1ec5e"
+checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -1690,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -1723,9 +1723,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1736,7 +1736,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "pin-project-lite",
  "socket2 0.4.4",
  "tokio",
@@ -1753,7 +1753,7 @@ checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.2",
+ "rustls 0.20.3",
  "tokio",
  "tokio-rustls",
 ]
@@ -1793,7 +1793,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rand 0.8.4",
+ "rand 0.8.5",
  "tokio",
  "url",
  "xmltree",
@@ -1940,9 +1940,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "linked-hash-map"
@@ -2140,9 +2140,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -2704,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "qp2p"
-version = "0.28.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2fc25e3ac9db1359413ae728b1e0bffb65ec8f7e593991378c1e3eb3fdeac4f"
+checksum = "ac73b3ff29cdc19e08e6754a73bd9b9e9ceda4b1a9f7c99ce8248381d579d690"
 dependencies = [
  "backoff",
  "bincode",
@@ -2716,7 +2716,7 @@ dependencies = [
  "quinn 0.8.0",
  "quinn-proto 0.8.0",
  "rcgen 0.8.14",
- "rustls 0.20.2",
+ "rustls 0.20.3",
  "serde",
  "thiserror",
  "tokio",
@@ -2783,7 +2783,7 @@ dependencies = [
  "fxhash",
  "quinn-proto 0.8.0",
  "quinn-udp",
- "rustls 0.20.2",
+ "rustls 0.20.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -2797,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "047aa96ec7ee6acabad7a1318dff72e9aff8994316bf2166c9b94cbec78ca54c"
 dependencies = [
  "bytes",
- "rand 0.8.4",
+ "rand 0.8.5",
  "ring",
  "rustls 0.19.1",
  "slab",
@@ -2815,9 +2815,9 @@ checksum = "063dedf7983c8d57db474218f258daa85b627de6f2dbc458b690a93b1de790e8"
 dependencies = [
  "bytes",
  "fxhash",
- "rand 0.8.4",
+ "rand 0.8.5",
  "ring",
- "rustls 0.20.2",
+ "rustls 0.20.3",
  "rustls-pemfile",
  "slab",
  "thiserror",
@@ -2873,20 +2873,19 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
  "rand_pcg",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -2949,15 +2948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3109,9 +3099,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "relative-path"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d4caf086b102ab49d0525b721594a555ab55c6556086bbe52a430ad26c3bd7"
+checksum = "a49a831dc1e13c9392b660b162333d4cb0033bbbdfe6a1687177e59e89037c86"
 
 [[package]]
 name = "remove_dir_all"
@@ -3145,7 +3135,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.2",
+ "rustls 0.20.3",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3232,7 +3222,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.4",
+ "semver 1.0.5",
 ]
 
 [[package]]
@@ -3250,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+checksum = "b323592e3164322f5b193dc4302e4e36cd8d37158a712d664efae1a5c2791700"
 dependencies = [
  "log",
  "ring",
@@ -3341,6 +3331,7 @@ dependencies = [
  "signature",
  "sled",
  "sn_launch_tool",
+ "sn_membership",
  "structopt",
  "strum",
  "strum_macros",
@@ -3354,7 +3345,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-core",
- "tracing-subscriber 0.3.7",
+ "tracing-subscriber 0.3.8",
  "uluru",
  "url",
  "walkdir",
@@ -3486,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
 
 [[package]]
 name = "semver-parser"
@@ -3540,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -3696,7 +3687,7 @@ dependencies = [
  "tiny-keccak 2.0.2",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.7",
+ "tracing-subscriber 0.3.8",
  "uhttp_uri",
  "url",
  "urlencoding",
@@ -3782,7 +3773,21 @@ dependencies = [
  "serde_json",
  "structopt",
  "tracing",
- "tracing-subscriber 0.3.7",
+ "tracing-subscriber 0.3.8",
+]
+
+[[package]]
+name = "sn_membership"
+version = "1.12.0"
+dependencies = [
+ "bincode",
+ "blsttc",
+ "hex 0.4.3",
+ "log",
+ "rand 0.7.3",
+ "serde",
+ "signature",
+ "thiserror",
 ]
 
 [[package]]
@@ -4091,9 +4096,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e99d373042c30406d317cfc5bfad7b5d604bdd31dab72cf8739abebaa64aee"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes",
  "libc",
@@ -4133,7 +4138,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
- "rustls 0.20.2",
+ "rustls 0.20.3",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -4227,7 +4232,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-stream",
@@ -4251,9 +4256,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4270,14 +4275,14 @@ checksum = "94571df2eae3ed4353815ea5a90974a594a1792d8782ff2cbcc9392d1101f366"
 dependencies = [
  "crossbeam-channel",
  "time 0.3.7",
- "tracing-subscriber 0.3.7",
+ "tracing-subscriber 0.3.8",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4286,11 +4291,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -4326,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -4358,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+checksum = "74786ce43333fcf51efe947aed9718fbe46d5c7328ec3f1029e818083966d9aa"
 dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",
@@ -4436,9 +4442,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -4484,6 +4490,12 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.4",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
@@ -4858,18 +4870,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4062c749be08d90be727e9c5895371c3a0e49b90ba2b9592dc7afda95cc2b719"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e8f13fef10b63c06356d65d416b070798ddabcadc10d3ece0c5be9b3c7eddb"
+checksum = "4eb56561c1f8f5441784ea91f52ae8b44268d920f2a59121968fec9297fa7157"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sn/Cargo.toml
+++ b/sn/Cargo.toml
@@ -44,6 +44,8 @@ base64 = "~0.10.1"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "3.1.0" }
 bls_dkg = "0.9.0"
+#sn_membership = "1.12"
+sn_membership = { path = "../../sn_membership" }
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.5.11"
 console-subscriber = { version = "0.1.0", optional = true }

--- a/sn/src/messaging/serialisation/mod.rs
+++ b/sn/src/messaging/serialisation/mod.rs
@@ -90,6 +90,7 @@ impl MsgType {
                     | SystemMsg::Relocate(_)
                     | SystemMsg::JoinRequest(_)
                     | SystemMsg::JoinAsRelocatedRequest(_)
+                    | SystemMsg::Membership(_)
                     | SystemMsg::Propose { .. }
                     | SystemMsg::StartConnectivityTest(_),
                 ..

--- a/sn/src/messaging/system/agreement.rs
+++ b/sn/src/messaging/system/agreement.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{KeyedSig, NodeState};
+use super::KeyedSig;
 use crate::messaging::SectionAuthorityProvider;
 use ed25519_dalek::{PublicKey, Signature};
 use hex_fmt::HexFmt;
@@ -86,8 +86,6 @@ impl<T: Serialize> Deref for SectionAuth<T> {
 /// This can be a result of seeing a node come online, go offline, changes to section info etc.
 /// Anything where we need section authority before action can be taken
 pub enum Proposal {
-    /// Proposal to remove a node from our section
-    Offline(NodeState),
     /// Proposal to update info about a section.
     ///
     /// It signals the completion of a DKG by the elder candidates to the current elders.
@@ -104,6 +102,4 @@ pub enum Proposal {
     /// Which we can use to update the section section authority provider and the section chain at
     /// the same time as a single atomic operation without needing to cache anything.
     NewElders(SectionAuth<SectionAuthorityProvider>),
-    /// Proposal to change whether new nodes are allowed to join our section.
-    JoinsAllowed(bool),
 }

--- a/sn/src/messaging/system/join.rs
+++ b/sn/src/messaging/system/join.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{agreement::SectionAuth, KeyedSig, NodeState, SectionPeers, SigShare};
+use super::{agreement::SectionAuth, KeyedSig, SectionPeers};
 use crate::messaging::SectionAuthorityProvider;
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Signature;
@@ -21,8 +21,6 @@ pub struct JoinRequest {
     pub section_key: BlsPublicKey,
     /// Proof of the resource proofing.
     pub resource_proof_response: Option<ResourceProofResponse>,
-    /// Aggregated approval from the Elders
-    pub aggregated: Option<SectionAuth<NodeState>>,
 }
 
 /// Joining peer's proof of resolvement of given resource proofing challenge.
@@ -71,32 +69,17 @@ pub enum JoinResponse {
     /// containing addresses of nodes that are closer (than the recipient) to the
     /// requested name. The `JoinRequest` should be re-sent to these addresses.
     Redirect(SectionAuthorityProvider),
-    /// Send a share of approval that the joining node will aggregate
-    ApprovalShare {
-        /// State of the Node at the time of sending the ApprovalShare
-        node_state: NodeState,
-        /// SignatureShare of an elder over the NodeState
-        sig_share: SigShare,
-        /// Current `SectionAuthorityProvider` of the section.
-        section_auth: SectionAuthorityProvider,
-        /// Section signature over the `SectionAuthorityProvider`.
-        section_signed: KeyedSig,
-        /// Section chain of the current section
-        section_chain: SecuredLinkedList,
-        /// Signed NodeState of section members
-        members: SectionPeers,
-    },
     /// Message sent to joining peer containing the necessary
     /// info to become a member of the section.
     Approval {
-        /// Network genesis key (needed to validate) section_chain
+        /// Network genesis key, needed to validate section_chain
         genesis_key: BlsPublicKey,
-        /// SectionAuthorityProvider Signed by (current section)
+        /// SectionAuthorityProvider signed by (current section)
         section_auth: SectionAuth<SectionAuthorityProvider>,
-        /// Current node's state
-        node_state: SectionAuth<NodeState>,
         /// Full verifiable section chain
         section_chain: SecuredLinkedList,
+        /// Complete list of section members, i.e. Elders and Adults, including the approved node
+        section_peers: SectionPeers,
     },
     /// Join was rejected
     Rejected(JoinRejectionReason),

--- a/sn/src/messaging/system/join_as_relocated.rs
+++ b/sn/src/messaging/system/join_as_relocated.rs
@@ -10,6 +10,7 @@ use super::{NodeState, SectionAuth};
 use crate::messaging::SectionAuthorityProvider;
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Signature;
+use secured_linked_list::SecuredLinkedList;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
@@ -36,4 +37,14 @@ pub enum JoinAsRelocatedResponse {
     Redirect(SectionAuthorityProvider),
     /// The requesting node is not externally reachable
     NodeNotReachable(SocketAddr),
+    /// Message sent to joining peer containing the necessary
+    /// info to become a member of the section.
+    Approval {
+        /// Section Authority over this message for validation
+        section_auth: SectionAuth<SectionAuthorityProvider>,
+        /// info on current members of the section
+        node_state: SectionAuth<NodeState>,
+        /// The secured (signed) and verifiable section chain
+        section_chain: SecuredLinkedList,
+    },
 }

--- a/sn/src/messaging/system/mod.rs
+++ b/sn/src/messaging/system/mod.rs
@@ -28,6 +28,7 @@ use bls_dkg::key_gen::message::Message as DkgMessage;
 use bytes::Bytes;
 use secured_linked_list::SecuredLinkedList;
 use serde::{Deserialize, Serialize};
+use sn_membership::{Reconfig, SignedVote};
 use std::{
     collections::{BTreeMap, BTreeSet},
     net::SocketAddr,
@@ -166,6 +167,8 @@ pub enum SystemMsg {
     /// Sent to the current elders by the DKG participants when at least majority of them observe
     /// a DKG failure.
     DkgFailureAgreement(DkgFailureSigSet),
+    /// Voting message for membership consensus protocol to add/remove peers to/from a section.
+    Membership(SignedVote<Reconfig<NodeState>>),
     /// Message containing a single `Proposal` to be aggregated in the proposal aggregator.
     Propose {
         /// The content of the proposal

--- a/sn/src/node/core/messaging/handling/agreement.rs
+++ b/sn/src/node/core/messaging/handling/agreement.rs
@@ -6,218 +6,22 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::system::{KeyedSig, MembershipState, SectionAuth};
+use crate::messaging::system::{KeyedSig, SectionAuth};
 use crate::node::{
     api::cmds::Cmd,
-    core::{relocation::ChurnId, Node, Proposal},
+    core::{Node, Proposal},
     dkg::SectionAuthUtils,
-    network_knowledge::{NodeState, SectionAuthorityProvider},
-    Event, Result, MIN_ADULT_AGE,
+    network_knowledge::SectionAuthorityProvider,
+    Result,
 };
 use crate::types::log_markers::LogMarker;
 
-use std::{cmp, collections::BTreeSet};
+use std::collections::BTreeSet;
 
 // Agreement
 impl Node {
     #[instrument(skip(self), level = "trace")]
-    pub(crate) async fn handle_general_agreements(
-        &self,
-        proposal: Proposal,
-        sig: KeyedSig,
-    ) -> Result<Vec<Cmd>> {
-        debug!("handle agreement on {:?}", proposal);
-        match proposal {
-            Proposal::Offline(node_state) => self.handle_offline_agreement(node_state, sig).await,
-            Proposal::SectionInfo(section_auth) => {
-                self.handle_section_info_agreement(section_auth, sig).await
-            }
-            Proposal::NewElders(_) => {
-                error!("Elders agreement should be handled in a separate blocking fashion");
-                Ok(vec![])
-            }
-            Proposal::JoinsAllowed(joins_allowed) => {
-                *self.joins_allowed.write().await = joins_allowed;
-                Ok(vec![])
-            }
-        }
-    }
-
-    pub(crate) async fn handle_online_agreement(
-        &self,
-        new_info: NodeState,
-        sig: KeyedSig,
-    ) -> Result<Vec<Cmd>> {
-        debug!("{}", LogMarker::AgreementOfOnline);
-        let mut cmds = vec![];
-        if let Some(old_info) = self
-            .network_knowledge
-            .is_either_member_or_archived(&new_info.name())
-            .await
-        {
-            // This node is rejoin with same name.
-            if old_info.state() != MembershipState::Left {
-                debug!(
-                    "Ignoring Online node {} - {:?} not Left.",
-                    new_info.name(),
-                    old_info.state(),
-                );
-
-                return Ok(cmds);
-            }
-
-            // We would approve and relocate it only if half its age is at least MIN_ADULT_AGE
-            let new_age = cmp::max(MIN_ADULT_AGE - 1, old_info.age() / 2);
-            if new_age >= MIN_ADULT_AGE {
-                // TODO: consider handling the relocation inside the bootstrap phase, to avoid
-                // having to send this `NodeApproval`.
-                cmds.extend(self.send_node_approval(old_info.clone()).await);
-
-                cmds.extend(
-                    self.relocate_rejoining_peer(old_info.value, new_age)
-                        .await?,
-                );
-
-                return Ok(cmds);
-            }
-        }
-
-        let new_info = SectionAuth {
-            value: new_info,
-            sig,
-        };
-
-        if !self.network_knowledge.update_member(new_info.clone()).await {
-            info!("ignore Online: {} at {}", new_info.name(), new_info.addr());
-            return Ok(vec![]);
-        }
-
-        self.add_new_adult_to_trackers(new_info.name()).await;
-
-        info!("handle Online: {} at {}", new_info.name(), new_info.addr());
-
-        // still used for testing
-        self.send_event(Event::MemberJoined {
-            name: new_info.name(),
-            previous_name: new_info.previous_name(),
-            age: new_info.age(),
-        })
-        .await;
-
-        self.log_section_stats().await;
-
-        // Do not disable node joins in first section.
-        let our_prefix = self.network_knowledge.prefix().await;
-        if !our_prefix.is_empty() {
-            // ..otherwise, switch off joins_allowed on a node joining.
-            // TODO: fix racing issues here? https://github.com/maidsafe/safe_network/issues/890
-            *self.joins_allowed.write().await = false;
-        }
-
-        let churn_id = ChurnId(new_info.sig.signature.to_bytes().to_vec());
-        let excluded_from_relocation = vec![new_info.name()].into_iter().collect();
-        cmds.extend(
-            self.relocate_peers(churn_id, excluded_from_relocation)
-                .await?,
-        );
-
-        let result = self.promote_and_demote_elders().await?;
-        if result.is_empty() {
-            // Send AE-Update to Adults of our section
-            let our_adults = self.network_knowledge.adults().await;
-            let our_section_pk = self.network_knowledge.section_key().await;
-            cmds.extend(
-                self.send_ae_update_to_nodes(our_adults, &our_prefix, our_section_pk)
-                    .await,
-            );
-        }
-
-        cmds.extend(result);
-        cmds.extend(self.send_node_approval(new_info).await);
-
-        info!("cmds in queue for Accepting node {:?}", cmds);
-
-        self.print_network_stats().await;
-
-        Ok(cmds)
-    }
-
-    #[instrument(skip(self))]
-    async fn handle_offline_agreement(
-        &self,
-        node_state: NodeState,
-        sig: KeyedSig,
-    ) -> Result<Vec<Cmd>> {
-        let mut cmds = vec![];
-        let signature = sig.signature.clone();
-
-        let signed_node_state = SectionAuth {
-            value: node_state.clone(),
-            sig,
-        };
-
-        if !self
-            .network_knowledge
-            .update_member(signed_node_state.clone())
-            .await
-        {
-            info!(
-                "ignore Offline: {} at {}",
-                node_state.name(),
-                node_state.addr()
-            );
-            return Ok(cmds);
-        }
-
-        info!(
-            "handle Offline: {} at {}",
-            node_state.name(),
-            node_state.addr()
-        );
-
-        // If this is an Offline agreement where the new node state is Relocated,
-        // we then need to send the Relocate msg to the peer attaching the signed NodeState
-        // containing the relocation details.
-        if node_state.is_relocated() {
-            cmds.push(
-                self.send_relocate(node_state.peer().clone(), signed_node_state)
-                    .await?,
-            );
-        }
-
-        let churn_id = ChurnId(signature.to_bytes().to_vec());
-        cmds.extend(self.relocate_peers(churn_id, BTreeSet::default()).await?);
-
-        let result = self.promote_and_demote_elders().await?;
-        if result.is_empty() {
-            // Send AE-Update to Adults of our section
-            let our_adults = self.network_knowledge.adults().await;
-            let our_prefix = self.network_knowledge.prefix().await;
-            let our_section_pk = self.network_knowledge.section_key().await;
-            cmds.extend(
-                self.send_ae_update_to_nodes(our_adults, &our_prefix, our_section_pk)
-                    .await,
-            );
-        }
-
-        cmds.extend(result);
-
-        self.liveness_retain_only(
-            self.network_knowledge
-                .adults()
-                .await
-                .iter()
-                .map(|peer| peer.name())
-                .collect(),
-        )
-        .await?;
-        *self.joins_allowed.write().await = true;
-
-        Ok(cmds)
-    }
-
-    #[instrument(skip(self), level = "trace")]
-    async fn handle_section_info_agreement(
+    pub(crate) async fn handle_section_info_agreement(
         &self,
         section_auth: SectionAuthorityProvider,
         sig: KeyedSig,
@@ -245,18 +49,26 @@ impl Node {
                 return Ok(vec![]);
             }
 
-            // Send the `OurElder` proposal to all of the to-be-Elders so it's aggregated by them.
+            // Send the `NewElders` proposal to all of the to-be-Elders so it's aggregated by them.
+            let proposal = Proposal::NewElders(signed_section_auth);
             let proposal_recipients = saps_candidates
                 .iter()
                 .flat_map(|info| info.elders())
                 .cloned()
                 .collect();
 
-            self.send_proposal(
-                proposal_recipients,
-                Proposal::NewElders(signed_section_auth),
-            )
-            .await
+            let section_key = self.network_knowledge.section_key().await;
+            let key_share = self
+                .section_keys_provider
+                .key_share(&section_key)
+                .await
+                .map_err(|err| {
+                    trace!("Can't propose {:?}: {:?}", proposal, err);
+                    err
+                })?;
+
+            self.send_proposal(proposal_recipients, proposal, &key_share)
+                .await
         } else {
             // Other section. We shouln't be receiving or updating a SAP for
             // a remote section here, that is done with a AE msg response.
@@ -336,6 +148,7 @@ impl Node {
             self.network_knowledge.prefix_map()
         );
 
+        self.log_section_stats().await;
         self.update_self_for_new_node_state(snapshot).await
     }
 }

--- a/sn/src/node/core/messaging/handling/dkg.rs
+++ b/sn/src/node/core/messaging/handling/dkg.rs
@@ -267,7 +267,7 @@ impl Node {
         // if so we can skip the SectionInfo agreement proposal phase.
         if self
             .network_knowledge
-            .try_update_current_sap(key_share_pk, &sap.prefix())
+            .try_update_current_sap(&key_share, &sap.prefix())
             .await
         {
             self.update_self_for_new_node_state(snapshot).await
@@ -280,8 +280,7 @@ impl Node {
                 .authority_provider()
                 .await
                 .elders_vec();
-            self.send_proposal_with(recipients, proposal, &key_share)
-                .await
+            self.send_proposal(recipients, proposal, &key_share).await
         }
     }
 

--- a/sn/src/node/core/messaging/handling/join.rs
+++ b/sn/src/node/core/messaging/handling/join.rs
@@ -14,6 +14,7 @@ use crate::messaging::system::{
 use crate::node::{
     api::cmds::Cmd,
     core::{relocation::RelocateDetailsUtils, Node},
+    network_knowledge::NodeState,
     Error, Result, SectionAuthUtils, FIRST_SECTION_MAX_AGE, MIN_ADULT_AGE,
 };
 use crate::types::{log_markers::LogMarker, Peer};
@@ -32,36 +33,11 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         debug!("Received {:?} from {}", join_request, peer);
 
-        // To avoid existing elders hanving different view of section members,
-        // JoinRequest for resource_proofing and aggregated NodeState
-        // shall be handled immediately without any semaphore or age check.
-
-        // If the joining node has aggregated shares from enough elders,
-        // verify the produced auth and accept it into the network.
-        if let Some(response) = join_request.aggregated {
-            if response.verify(&self.section_chain().await) {
-                info!("Handling Online agreement of {:?}", peer);
-                return Ok(vec![Cmd::HandleNewNodeOnline(response)]);
-            }
-        }
-
+        // JoinRequest for resource_proofing can be handled immediately
+        // without any semaphore or age check.
         // Require resource signed if joining as a new node.
         if let Some(response) = join_request.resource_proof_response {
-            if !self
-                .validate_resource_proof_response(&peer.name(), response)
-                .await
-            {
-                debug!(
-                    "Ignoring JoinRequest from {} - invalid resource signed response",
-                    peer
-                );
-                return Ok(vec![]);
-            } else {
-                return Ok(vec![Cmd::SendAcceptedOnlineShare {
-                    peer,
-                    previous_name: None,
-                }]);
-            }
+            return self.handle_resource_proof_response(peer, response).await;
         }
 
         let _permit = self
@@ -362,9 +338,8 @@ impl Node {
             ]);
         };
 
-        Ok(vec![Cmd::SendAcceptedOnlineShare {
-            peer,
-            previous_name: Some(relocate_details.previous_name),
-        }])
+        // Propose Join with BRB membership consensus protocol
+        let node_state = NodeState::joined(peer, Some(relocate_details.previous_name));
+        Ok(vec![Cmd::HandleNewNodeOnline(node_state)])
     }
 }

--- a/sn/src/node/core/messaging/handling/membership.rs
+++ b/sn/src/node/core/messaging/handling/membership.rs
@@ -1,0 +1,477 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use bls::Signature;
+use sn_membership::{consensus::VoteResponse, Ballot, Reconfig, SignedVote};
+use std::collections::{BTreeMap, BTreeSet};
+use tiny_keccak::{Hasher, Sha3};
+use xor_name::XorName;
+
+use crate::elder_count;
+use crate::messaging::system::{
+    KeyedSig, MembershipState, NodeState, RelocateDetails, SectionAuth,
+};
+use crate::node::{
+    api::cmds::Cmd,
+    core::{
+        relocation::{find_nodes_to_relocate, ChurnId, RelocateDetailsUtils},
+        Node,
+    },
+    ed25519::Digest256,
+    Event, Peer, MIN_ADULT_AGE,
+};
+use crate::types::log_markers::LogMarker;
+
+impl Node {
+    #[instrument(skip(self), level = "trace")]
+    pub(crate) async fn handle_membership_msg(
+        &self,
+        signed_vote: SignedVote<Reconfig<NodeState>>,
+    ) -> Vec<Cmd> {
+        debug!(">>> {}: {:?}", LogMarker::MembershipMsg, signed_vote);
+
+        // Before we handle the signed vote msg, let's verify we are ok with voting as well
+        if !self.do_we_agree_with_vote_msg(&signed_vote).await {
+            return vec![];
+        }
+
+        let state_write_guard = &mut *self.network_knowledge.membership_voting.write().await;
+        let state = if let Some(state) = state_write_guard {
+            state
+        } else {
+            warn!(
+                ">>> Dropping membership Vote msg since we don't hold a membership voting state: {:?}",
+                signed_vote
+            );
+            return vec![];
+        };
+
+        match state.handle_signed_vote(signed_vote.clone()) {
+            Err(err) => {
+                error!(">>> Failed to handle membership Vote msg: {:?}", err);
+                vec![]
+            }
+            Ok(VoteResponse::Broadcast(signed_vote)) => {
+                trace!(
+                    ">>> Membership Vote msg successfully handled, broadcasting our vote: {:?}",
+                    signed_vote
+                );
+                self.broadcast_membership_vote_msg(signed_vote).await
+            }
+            Ok(VoteResponse::WaitingForMoreVotes) => {
+                trace!(
+                    ">>> Membership Vote msg successfully handled, awaiting for more votes: {:?}",
+                    signed_vote
+                );
+                vec![]
+            }
+            Ok(VoteResponse::Decided { proposals, .. }) => {
+                trace!(
+                    ">>> Membership Vote msg successfully handled and consensus reached: {:?}",
+                    signed_vote
+                );
+                // We now update our knowledge of peers in our section as per consensus
+                let mut section_peers = self.network_knowledge.section_signed_members().await;
+                let public_key = self.network_knowledge.section_key().await;
+                proposals.iter().for_each(|(reconfig, signature)| {
+                    let sig = KeyedSig {
+                        public_key,
+                        signature: signature.clone(),
+                    };
+
+                    match reconfig {
+                        Reconfig::Join(node_state) => {
+                            let _ = section_peers.insert(
+                                SectionAuth {
+                                    value: node_state.clone(),
+                                    sig,
+                                }
+                                .into_authed_state(),
+                            );
+                        }
+                        Reconfig::Leave(node_state) => {
+                            let _ = section_peers.remove(
+                                &SectionAuth {
+                                    value: node_state.clone(),
+                                    sig,
+                                }
+                                .into_authed_state(),
+                            );
+                        }
+                    }
+                });
+
+                self.network_knowledge.set_members(section_peers).await;
+
+                self.handle_new_membership_consensus(proposals).await
+            }
+        }
+    }
+
+    // Private helper to check if we agree with reconfigs in an incoming signed_vote msg
+    async fn do_we_agree_with_vote_msg(
+        &self,
+        signed_vote: &SignedVote<Reconfig<NodeState>>,
+    ) -> bool {
+        let mut reconfigs = BTreeSet::default();
+        populate_set_of_reconfings(signed_vote, &mut reconfigs);
+        warn!(
+            ">>> Checking if we agree with {} reconfigs before voting: {:?}",
+            reconfigs.len(),
+            signed_vote
+        );
+
+        // Are we accepting joins now?
+        let joins_allowed = *self.joins_allowed.read().await;
+
+        for reconfig in reconfigs {
+            match reconfig {
+                Reconfig::Join(_) if !joins_allowed => {
+                    warn!(">>> Dropping membership Join vote msg since joins are currently not allowed: {:?}", signed_vote);
+                    return false;
+                }
+                Reconfig::Join(node_state_msg) => {
+                    let node_state = node_state_msg.into_state();
+                    // Check if node wasn't relocated or perhaps was a member in the past and left
+                    if self
+                        .network_knowledge
+                        .is_either_member_or_archived(&node_state.name())
+                        .await
+                        .is_some()
+                    {
+                        warn!(">>> Dropping membership Join vote msg since node is rejoining to our section: {:?}", signed_vote);
+                        return false;
+                    }
+
+                    // Check section key matches joining node's name
+                    if !self
+                        .network_knowledge
+                        .prefix()
+                        .await
+                        .matches(&node_state.name())
+                    {
+                        debug!(">>> Dropping membershp Join vote since node name ({}) doesn't match our prefix: {:?}",
+                            node_state.name(), signed_vote);
+                        return false;
+                    }
+
+                    // Joining node's age check
+                    let current_section_size = self.network_knowledge.section_size().await;
+                    let members = self.network_knowledge.section_members().await;
+                    let (is_age_invalid, expected_age) =
+                        self.verify_joining_node_age(node_state.peer()).await;
+
+                    if is_age_invalid {
+                        let adults = self.network_knowledge.adults().await.len();
+                        let elders = self
+                            .network_knowledge
+                            .authority_provider()
+                            .await
+                            .elder_count();
+                        debug!(">>> Dropping membershp Join vote for {:?} since node age ({}) is not the expected ({}), local section knowledge: {:?} Elders + {:?} Adults, section size {}, members: {:?}",
+                            node_state.name(), node_state.age(), expected_age, elders, adults,current_section_size,members);
+                        return false;
+                    }
+                }
+                Reconfig::Leave(node_state) => {
+                    unimplemented!();
+                    /*
+                    let churn_name = node_state.value.name;
+                    let churn_signature = node_state.sig;
+                    if let Some((node_state, relocate_details)) =
+                        find_nodes_to_relocate(&self.network_knowledge, churn_name, churn_signature)
+                            .await
+                    {
+                        // if the node_state that is being vote is the same as the one
+                        // we see that needs to be relocated then we vote for it
+                        // TODO!!
+                    } else {
+                        // We don't see any member needs to be relocated, so we don't vote
+                        return false;
+                    }
+                    */
+                }
+            }
+        }
+
+        true
+    }
+
+    async fn handle_new_membership_consensus(
+        &self,
+        changes: BTreeMap<Reconfig<NodeState>, Signature>,
+    ) -> Vec<Cmd> {
+        // All joining nodes will be excluded from relocation.
+        let mut excluded_from_relocation = BTreeSet::default();
+
+        // All the NodeState signatures will be hashed together to form the ChurnId,
+        // thus we accumulate them to have a deterministic order.
+        let mut signatures = BTreeSet::new();
+
+        let mut cmds = vec![];
+        for (reconfig, signature) in changes {
+            match reconfig {
+                Reconfig::Join(node_state) => {
+                    let node_name = node_state.name;
+                    info!(">>> JOIN RECONFIG AFTER HANDLING for: {:?}", node_name);
+
+                    let keyed_sig = KeyedSig {
+                        public_key: self.network_knowledge.section_key().await,
+                        signature: signature.clone(),
+                    };
+
+                    cmds.extend(self.handle_join_agreement(node_state, keyed_sig).await);
+
+                    let _inserted = excluded_from_relocation.insert(node_name);
+                    let _inserted = signatures.insert(signature.to_bytes());
+                }
+                Reconfig::Leave(node_state) => {
+                    info!(
+                        ">>> LEAVE RECONFIG AFTER HANDLING for: {:?}",
+                        node_state.name
+                    );
+
+                    let peer = Peer::new(node_state.name, node_state.addr);
+
+                    let sig = KeyedSig {
+                        public_key: self.network_knowledge.section_key().await,
+                        signature: signature.clone(),
+                    };
+                    let signed_node_state = SectionAuth {
+                        value: node_state,
+                        sig,
+                    };
+
+                    // If this is a Leave agreement where the new node state is Relocated,
+                    // we then need to send the Relocate msg to the peer, attaching the
+                    // signed NodeState with the relocation details.
+                    if matches!(signed_node_state.value.state, MembershipState::Relocated(_)) {
+                        match self.send_relocate(peer.clone(), signed_node_state).await {
+                            Ok(relocate_cmds) => cmds.push(relocate_cmds),
+                            Err(err) => {
+                                warn!(
+                                    ">>> Failed to generate Relocate msg for {:?}: {}",
+                                    peer, err
+                                )
+                            }
+                        }
+                    }
+
+                    if let Err(err) = self
+                        .liveness_retain_only(
+                            self.network_knowledge
+                                .adults()
+                                .await
+                                .iter()
+                                .map(|peer| peer.name())
+                                .collect(),
+                        )
+                        .await
+                    {
+                        warn!(
+                            ">>> Failed to update our Adults liveness check records: {}",
+                            err
+                        );
+                    }
+
+                    let _inserted = signatures.insert(signature.to_bytes());
+                }
+            };
+        }
+
+        // Generate cmds to relocate peers if necessary.
+        // All the NodeState signatures will be hashed together to form the ChurnId.
+        let mut signatures_hasher = Sha3::v256();
+        let mut hash = Digest256::default();
+        signatures
+            .iter()
+            .for_each(|sig| signatures_hasher.update(sig));
+        signatures_hasher.finalize(&mut hash);
+        let churn_id = ChurnId(hash.to_vec());
+        cmds.extend(
+            self.relocate_peers(churn_id, excluded_from_relocation)
+                .await,
+        );
+
+        self.log_section_stats().await;
+
+        // Using new membership information, make sure our flag to allow joins is up to date
+        self.update_joins_allowed_flag().await;
+
+        // Send AE-Update to Adults of our section
+        let our_adults = self.network_knowledge.adults().await;
+        let our_prefix = self.network_knowledge.prefix().await;
+        let our_section_pk = self.network_knowledge.section_key().await;
+        cmds.extend(
+            self.send_ae_update_to_nodes(our_adults, &our_prefix, our_section_pk)
+                .await,
+        );
+
+        // Check up to date members to generate cmds
+        // to promote and/or demote peers accordingly.
+        match self.promote_and_demote_elders().await {
+            Ok(new_cmds) => cmds.extend(new_cmds),
+            Err(err) => warn!(
+                ">>> An error occurred when trying to check for promotions/demotions: {:?}",
+                err
+            ),
+        }
+
+        info!(
+            ">>> Commands in queue for accepting joining node {:?}",
+            cmds
+        );
+        self.print_network_stats().await;
+
+        cmds
+    }
+
+    async fn handle_join_agreement(&self, new_node_state: NodeState, sig: KeyedSig) -> Vec<Cmd> {
+        debug!("{}", LogMarker::AgreementOfJoin);
+        /*
+        FIXME !!!!!!!: at this point we've already updated our section_peers set
+        if let Some(old_node_state) = self
+            .network_knowledge
+            .is_either_member_or_archived(&new_node_state.name)
+            .await
+        {
+            return self
+                .handle_rejoining_node(old_node_state.into_authed_msg(), new_node_state)
+                .await;
+        }
+        */
+
+        self.add_new_adult_to_trackers(new_node_state.name).await;
+
+        info!(
+            ">>> Joining node has been approved: {} at {}",
+            new_node_state.name, new_node_state.addr
+        );
+
+        // still used for testing
+        self.send_event(Event::MemberJoined {
+            name: new_node_state.name,
+            previous_name: new_node_state.previous_name,
+            age: new_node_state.age(),
+        })
+        .await;
+
+        // Generate the approval to be sent to the joining node
+        let signed_node_state = SectionAuth {
+            value: new_node_state,
+            sig,
+        };
+
+        self.send_node_approval(signed_node_state).await
+    }
+
+    // TODO !!!: make these validations before voting
+    async fn handle_rejoining_node(
+        &self,
+        old_node_state: SectionAuth<NodeState>,
+        new_node_state: NodeState,
+    ) -> Vec<Cmd> {
+        // This node is rejoining with same name. We allow it only if we are aware it
+        // previously left, and only if halving its previous age would still be over
+        // the MIN_ADULT_AGE, in which case we'll relocate it immediatelly with half its age.
+        if old_node_state.state != MembershipState::Left {
+            debug!(
+                ">>> Ignoring Joining node {} - previous state ('{:?}') is not 'Left'.",
+                new_node_state.name, old_node_state.state,
+            );
+
+            return vec![];
+        }
+
+        let new_age = old_node_state.age() / 2;
+        if new_age >= MIN_ADULT_AGE {
+            let mut cmds = vec![];
+            cmds.extend(self.send_node_approval(old_node_state.clone()).await);
+
+            let peer = Peer::new(new_node_state.name, new_node_state.addr);
+            let details =
+                RelocateDetails::with_age(&self.network_knowledge, &peer, peer.name(), new_age);
+            trace!(
+                ">>> Relocating {:?} to {} with age {} due to rejoin",
+                peer,
+                details.dst,
+                details.age
+            );
+
+            cmds.extend(
+                self.propose_remove_from_membership(
+                    old_node_state.value.into_state().relocate(details),
+                )
+                .await,
+            );
+
+            cmds
+        } else {
+            debug!(
+                ">>> Ignoring Joining node {} - halving its previous age ({}) goes below MIN_ADULT_AGE ({}).",
+                new_node_state.name,
+                old_node_state.age(),
+                MIN_ADULT_AGE
+            );
+            vec![]
+        }
+    }
+
+    async fn relocate_peers(&self, churn_id: ChurnId, excluded: BTreeSet<XorName>) -> Vec<Cmd> {
+        // Do not carry out relocations in the first section
+        if self.network_knowledge.prefix().await.is_empty() {
+            return vec![];
+        }
+
+        // Do not carry out relocation when there is not enough elder nodes.
+        if self
+            .network_knowledge
+            .authority_provider()
+            .await
+            .elder_count()
+            < elder_count()
+        {
+            return vec![];
+        }
+
+        let mut cmds = vec![];
+        for (node_state, relocate_details) in
+            find_nodes_to_relocate(&self.network_knowledge, &churn_id, excluded).await
+        {
+            debug!(
+                ">>> Relocating {:?} to {} (on churn of {})",
+                node_state.peer(),
+                relocate_details.dst,
+                churn_id
+            );
+
+            cmds.extend(
+                self.propose_remove_from_membership(node_state.relocate(relocate_details))
+                    .await,
+            )
+        }
+
+        cmds
+    }
+}
+
+fn populate_set_of_reconfings(
+    signed_vote: &SignedVote<Reconfig<NodeState>>,
+    reconfigs: &mut BTreeSet<Reconfig<NodeState>>,
+) {
+    match &signed_vote.vote.ballot {
+        Ballot::Propose(reconfig) => {
+            let _ = reconfigs.insert(reconfig.clone());
+        }
+        Ballot::Merge(votes) | Ballot::SuperMajority { votes, .. } => {
+            votes.iter().for_each(|signed_vote| {
+                populate_set_of_reconfings(signed_vote, reconfigs);
+            })
+        }
+    }
+}

--- a/sn/src/node/core/messaging/handling/proposals.rs
+++ b/sn/src/node/core/messaging/handling/proposals.rs
@@ -6,100 +6,112 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::signature_aggregator::SignatureAggregator;
 use crate::messaging::{signature_aggregator::Error as AggregatorError, MsgId};
-use crate::node::network_knowledge::NetworkKnowledge;
-use crate::node::{api::cmds::Cmd, core::Proposal, dkg::SigShare, Result};
+use crate::node::{
+    api::cmds::Cmd,
+    core::{Node, Proposal},
+    dkg::SigShare,
+    Result,
+};
 use crate::types::Peer;
 
-// Insert the proposal into the proposal aggregator and handle it if aggregated.
-pub(crate) async fn handle_proposal(
-    msg_id: MsgId,
-    proposal: Proposal,
-    sig_share: SigShare,
-    sender: Peer,
-    network_knowledge: &NetworkKnowledge,
-    proposal_aggregator: &SignatureAggregator,
-) -> Result<Vec<Cmd>> {
-    let sig_share_pk = &sig_share.public_key_set.public_key();
+impl Node {
+    // Insert the proposal into the proposal aggregator and handle it if aggregated.
+    pub(crate) async fn handle_proposal(
+        &self,
+        msg_id: MsgId,
+        proposal: Proposal,
+        sig_share: SigShare,
+        sender: Peer,
+    ) -> Result<Vec<Cmd>> {
+        let sig_share_pk = &sig_share.public_key_set.public_key();
 
-    // Any other proposal than SectionInfo needs to be signed by a known section key.
-    if let Proposal::SectionInfo(section_auth) = &proposal {
-        if section_auth.prefix() == network_knowledge.prefix().await
-            || section_auth
+        // Any other proposal than SectionInfo needs to be signed by a known section key.
+        if let Proposal::SectionInfo(section_auth) = &proposal {
+            if section_auth.prefix() == self.network_knowledge.prefix().await
+                || section_auth
+                    .prefix()
+                    .is_extension_of(&self.network_knowledge.prefix().await)
+            {
+                // This `SectionInfo` is proposed by the DKG participants and
+                // it's signed by the new key created by the DKG so we don't
+                // know it yet. We only require the src_name of the
+                // proposal to be one of the DKG participants.
+                if !section_auth.contains_elder(&sender.name()) {
+                    trace!(
+                        "Ignoring proposal from src not being a DKG participant: {:?}",
+                        proposal
+                    );
+                    return Ok(vec![]);
+                }
+            }
+        } else {
+            // Proposal from other section shall be ignored.
+            // TODO: check this is for our prefix , or a child prefix, otherwise just drop it
+            if !self
+                .network_knowledge
                 .prefix()
-                .is_extension_of(&network_knowledge.prefix().await)
-        {
-            // This `SectionInfo` is proposed by the DKG participants and
-            // it's signed by the new key created by the DKG so we don't
-            // know it yet. We only require the src_name of the
-            // proposal to be one of the DKG participants.
-            if !section_auth.contains_elder(&sender.name()) {
+                .await
+                .matches(&sender.name())
+            {
                 trace!(
-                    "Ignoring proposal from src not being a DKG participant: {:?}",
-                    proposal
+                    "Ignore proposal {:?} from other section, src {}: {:?}",
+                    proposal,
+                    sender,
+                    msg_id
+                );
+                return Ok(vec![]);
+            }
+
+            // Let's now verify the section key in the msg authority is trusted
+            // based on our current knowledge of the network and sections chains.
+            if !self.network_knowledge.has_chain_key(sig_share_pk).await {
+                warn!(
+                    "Dropped Propose msg ({:?}) with untrusted sig share from {}: {:?}",
+                    msg_id, sender, proposal
                 );
                 return Ok(vec![]);
             }
         }
-    } else {
-        // Proposal from other section shall be ignored.
-        // TODO: check this is for our prefix , or a child prefix, otherwise just drop it
-        if !network_knowledge.prefix().await.matches(&sender.name()) {
-            trace!(
-                "Ignore proposal {:?} from other section, src {}: {:?}",
-                proposal,
-                sender,
-                msg_id
-            );
-            return Ok(vec![]);
-        }
 
-        // Let's now verify the section key in the msg authority is trusted
-        // based on our current knowledge of the network and sections chains.
-        if !network_knowledge.has_chain_key(sig_share_pk).await {
-            warn!(
-                "Dropped Propose msg ({:?}) with untrusted sig share from {}: {:?}",
-                msg_id, sender, proposal
-            );
-            return Ok(vec![]);
-        }
-    }
+        let mut cmds = vec![];
 
-    let mut cmds = vec![];
-
-    match proposal.as_signable_bytes() {
-        Err(error) => error!(
-            "Failed to serialise proposal from {}, {:?}: {:?}",
-            sender, msg_id, error
-        ),
-        Ok(serialised_proposal) => {
-            match proposal_aggregator
-                .add(&serialised_proposal, sig_share)
-                .await
-            {
-                Ok(sig) => match proposal {
-                    Proposal::NewElders(_) => {
-                        cmds.push(Cmd::HandleNewEldersAgreement { proposal, sig })
-                    }
-                    _ => cmds.push(Cmd::HandleAgreement { proposal, sig }),
-                },
-                Err(AggregatorError::NotEnoughShares) => {
-                    trace!(
+        match proposal.as_signable_bytes() {
+            Err(error) => error!(
+                "Failed to serialise proposal from {}, {:?}: {:?}",
+                sender, msg_id, error
+            ),
+            Ok(serialised_proposal) => {
+                match self
+                    .proposal_aggregator
+                    .add(&serialised_proposal, sig_share)
+                    .await
+                {
+                    Ok(sig) => match proposal {
+                        Proposal::NewElders(signed_sap) => {
+                            cmds.push(Cmd::HandleNewEldersAgreement { signed_sap, sig })
+                        }
+                        Proposal::SectionInfo(section_auth) => {
+                            cmds.push(Cmd::HandleSectionInfoAgreement { section_auth, sig })
+                        }
+                    },
+                    Err(AggregatorError::NotEnoughShares) => {
+                        trace!(
                         "Proposal from {} inserted in aggregator, not enough sig shares yet: {:?}",
                         sender,
                         msg_id
                     );
-                }
-                Err(error) => {
-                    error!(
-                        "Failed to add proposal from {}, {:?}: {:?}",
-                        sender, msg_id, error
-                    );
+                    }
+                    Err(error) => {
+                        error!(
+                            "Failed to add proposal from {}, {:?}: {:?}",
+                            sender, msg_id, error
+                        );
+                    }
                 }
             }
         }
-    }
 
-    Ok(cmds)
+        Ok(cmds)
+    }
 }

--- a/sn/src/node/core/messaging/mod.rs
+++ b/sn/src/node/core/messaging/mod.rs
@@ -8,5 +8,3 @@
 
 mod handling;
 mod sending;
-
-pub(crate) use handling::handle_proposal;

--- a/sn/src/node/core/messaging/sending/membership.rs
+++ b/sn/src/node/core/messaging/sending/membership.rs
@@ -1,0 +1,68 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::messaging::system::{NodeState as NodeStateMsg, SystemMsg};
+use crate::node::{api::cmds::Cmd, core::Node, network_knowledge::NodeState};
+use sn_membership::{Reconfig, SignedVote};
+
+impl Node {
+    /// Broadcast proposal to Elders to accept a new peer to join the section membership
+    pub(crate) async fn propose_join_membership(&self, node_state: NodeState) -> Vec<Cmd> {
+        self.broadcast_membership_proposal(Reconfig::Join(node_state.to_msg()))
+            .await
+    }
+
+    /// Broadcast proposal to Elders to remove a node from section membership
+    pub(crate) async fn propose_remove_from_membership(&self, node_state: NodeState) -> Vec<Cmd> {
+        self.broadcast_membership_proposal(Reconfig::Leave(node_state.to_msg()))
+            .await
+    }
+
+    // Broadcast a section membership proposal to Elders
+    async fn broadcast_membership_proposal(&self, reconfig: Reconfig<NodeStateMsg>) -> Vec<Cmd> {
+        match *self.network_knowledge.membership_voting.write().await {
+            None => {
+                error!(">>> Failed to broadcast membership proposal since we don't hold a membership voting state");
+                return vec![];
+            }
+            Some(ref mut state) => match state.propose(reconfig.clone()) {
+                Ok(signed_vote) => {
+                    trace!(">>> Membership proposal {:?}", reconfig);
+                    self.broadcast_membership_vote_msg(signed_vote).await
+                }
+                Err(err) => {
+                    error!(
+                        ">>> Failed to generate membership proposal {:?}: {:?}",
+                        reconfig, err
+                    );
+                    vec![]
+                }
+            },
+        }
+    }
+
+    /// Broadcast BRB membership Vote message to Elders
+    pub(crate) async fn broadcast_membership_vote_msg(
+        &self,
+        signed_vote: SignedVote<Reconfig<NodeStateMsg>>,
+    ) -> Vec<Cmd> {
+        // Deliver each SignedVote to all current Elders
+        trace!(">>> Broadcasting Vote msg: {:?}", signed_vote);
+        let node_msg = SystemMsg::Membership(signed_vote);
+        match self.send_msg_to_our_elders(node_msg).await {
+            Ok(cmd) => vec![cmd],
+            Err(err) => {
+                error!(
+                    ">>> Failed to send SystemMsg::Membership message: {:?}",
+                    err
+                );
+                vec![]
+            }
+        }
+    }
+}

--- a/sn/src/node/core/messaging/sending/mod.rs
+++ b/sn/src/node/core/messaging/sending/mod.rs
@@ -9,6 +9,7 @@
 mod anti_entropy;
 mod approval;
 mod dkg_start;
+mod membership;
 mod proposal;
 mod services;
 mod system;

--- a/sn/src/node/core/messaging/sending/system.rs
+++ b/sn/src/node/core/messaging/sending/system.rs
@@ -7,12 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    system::{SectionAuth, SystemMsg},
+    system::{NodeState, SectionAuth, SystemMsg},
     DstLocation, MsgKind, WireMsg,
 };
-use crate::node::{
-    api::cmds::Cmd, core::Node, messages::WireMsgUtils, network_knowledge::NodeState, Error, Result,
-};
+use crate::node::{api::cmds::Cmd, core::Node, messages::WireMsgUtils, Error, Result};
 use crate::types::{log_markers::LogMarker, Peer, UnnamedPeer};
 
 use bls::PublicKey as BlsPublicKey;
@@ -65,7 +63,7 @@ impl Node {
         recipient: Peer,
         node_state: SectionAuth<NodeState>,
     ) -> Result<Cmd> {
-        let node_msg = SystemMsg::Relocate(node_state.into_authed_msg());
+        let node_msg = SystemMsg::Relocate(node_state);
         let section_pk = self.network_knowledge.section_key().await;
         self.send_direct_msg(recipient, node_msg, section_pk).await
     }

--- a/sn/src/node/core/proposal.rs
+++ b/sn/src/node/core/proposal.rs
@@ -7,19 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::system::{Proposal as ProposalMsg, SectionAuth};
-use crate::node::{
-    dkg::SigShare,
-    network_knowledge::{NodeState, SectionAuthorityProvider},
-    Result,
-};
+use crate::node::{dkg::SigShare, network_knowledge::SectionAuthorityProvider, Result};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum Proposal {
-    Offline(NodeState),
     SectionInfo(SectionAuthorityProvider),
     NewElders(SectionAuth<SectionAuthorityProvider>),
-    JoinsAllowed(bool),
 }
 
 impl Proposal {
@@ -40,10 +34,8 @@ impl Proposal {
 
     pub(crate) fn as_signable_bytes(&self) -> Result<Vec<u8>> {
         Ok(match self {
-            Self::Offline(node_state) => bincode::serialize(node_state),
             Self::SectionInfo(info) => bincode::serialize(info),
             Self::NewElders(info) => bincode::serialize(&info.sig.public_key),
-            Self::JoinsAllowed(joins_allowed) => bincode::serialize(&joins_allowed),
         }?)
     }
 }
@@ -54,10 +46,8 @@ impl Proposal {
 impl Proposal {
     pub(crate) fn into_msg(self) -> ProposalMsg {
         match self {
-            Self::Offline(node_state) => ProposalMsg::Offline(node_state.to_msg()),
             Self::SectionInfo(sap) => ProposalMsg::SectionInfo(sap.to_msg()),
             Self::NewElders(sap) => ProposalMsg::NewElders(sap.into_authed_msg()),
-            Self::JoinsAllowed(allowed) => ProposalMsg::JoinsAllowed(allowed),
         }
     }
 }
@@ -65,10 +55,8 @@ impl Proposal {
 impl ProposalMsg {
     pub(crate) fn into_state(self) -> Proposal {
         match self {
-            Self::Offline(node_state) => Proposal::Offline(node_state.into_state()),
             Self::SectionInfo(sap) => Proposal::SectionInfo(sap.into_state()),
             Self::NewElders(sap) => Proposal::NewElders(sap.into_authed_state()),
-            Self::JoinsAllowed(allowed) => Proposal::JoinsAllowed(allowed),
         }
     }
 }

--- a/sn/src/node/network_knowledge/node_state.rs
+++ b/sn/src/node/network_knowledge/node_state.rs
@@ -89,21 +89,12 @@ impl NodeState {
         self.peer.addr()
     }
 
-    pub(crate) fn state(&self) -> MembershipState {
-        self.state.clone()
-    }
-
     pub(crate) fn previous_name(&self) -> Option<XorName> {
         self.previous_name
     }
 
     pub(crate) fn age(&self) -> u8 {
         self.peer.age()
-    }
-
-    // Returns true if the state is a Relocated node
-    pub(crate) fn is_relocated(&self) -> bool {
-        matches!(self.state, MembershipState::Relocated(_))
     }
 
     pub(crate) fn leave(self) -> Result<Self, Error> {

--- a/sn/src/node/network_knowledge/section_keys.rs
+++ b/sn/src/node/network_knowledge/section_keys.rs
@@ -66,18 +66,6 @@ impl SectionKeysProvider {
         }
     }
 
-    /// Uses the secret key from cache, corresponding to
-    /// the provided public key.
-    pub(crate) async fn sign_with(
-        &self,
-        data: &[u8],
-        public_key: &bls::PublicKey,
-    ) -> Result<(usize, bls::SignatureShare)> {
-        let key_share = self.key_share(public_key).await?;
-
-        Ok((key_share.index, key_share.secret_key_share.sign(data)))
-    }
-
     /// Returns true if no key share exists.
     pub(crate) async fn is_empty(&self) -> bool {
         self.cache.read().await.is_empty()

--- a/sn/src/node/network_knowledge/section_peers.rs
+++ b/sn/src/node/network_knowledge/section_peers.rs
@@ -6,11 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::system::{MembershipState, SectionAuth};
+use crate::messaging::system::SectionAuth;
 use crate::node::network_knowledge::{NodeState, SectionAuthorityProvider};
 use crate::types::Peer;
 
-use dashmap::{mapref::entry::Entry, DashMap};
+use dashmap::DashMap;
 use itertools::Itertools;
 use secured_linked_list::SecuredLinkedList;
 use std::{
@@ -19,6 +19,7 @@ use std::{
     net::SocketAddr,
     sync::Arc,
 };
+use tokio::sync::RwLock;
 use xor_name::{Prefix, XorName};
 
 // Number of Elder churn events before a Left/Relocated member
@@ -28,43 +29,48 @@ const ELDER_CHURN_EVENTS_TO_PRUNE_ARCHIVE: usize = 5;
 /// Container for storing information about (current and archived) members of our section.
 #[derive(Clone, Default, Debug)]
 pub(super) struct SectionPeers {
-    members: Arc<DashMap<XorName, SectionAuth<NodeState>>>,
+    members: Arc<RwLock<BTreeMap<XorName, SectionAuth<NodeState>>>>,
     archive: Arc<DashMap<XorName, SectionAuth<NodeState>>>,
 }
 
 impl SectionPeers {
     /// Returns set of current members, i.e. those with state == `Joined`.
-    pub(super) fn members(&self) -> BTreeSet<SectionAuth<NodeState>> {
+    pub(super) async fn members(&self) -> BTreeSet<SectionAuth<NodeState>> {
         self.members
+            .read()
+            .await
             .iter()
-            .map(|entry| {
-                let (_, state) = entry.pair();
-                state.clone()
-            })
+            .map(|(_, state)| state.clone())
             .collect()
     }
 
     /// Returns the number of current members.
-    pub(super) fn num_of_members(&self) -> usize {
-        self.members.len()
+    pub(super) async fn num_of_members(&self) -> usize {
+        self.members.read().await.len()
     }
 
     /// Get the `NodeState` for the member with the given name.
-    pub(super) fn get(&self, name: &XorName) -> Option<NodeState> {
-        self.members.get(name).map(|state| state.value.clone())
+    pub(super) async fn get(&self, name: &XorName) -> Option<NodeState> {
+        self.members
+            .read()
+            .await
+            .get(name)
+            .map(|state| state.value.clone())
     }
 
     /// Returns whether the given peer is currently a member of our section.
-    pub(super) fn is_member(&self, name: &XorName) -> bool {
-        self.members.get(name).is_some()
+    pub(super) async fn is_member(&self, name: &XorName) -> bool {
+        self.members.read().await.get(name).is_some()
     }
 
     /// Returns whether the given peer is already relocated to our section.
-    pub(super) fn is_relocated_to_our_section(&self, name: &XorName) -> bool {
-        let is_previous_name_of_member = self.members.iter().any(|entry| {
-            let (_, state) = entry.pair();
-            state.previous_name() == Some(*name)
-        });
+    pub(super) async fn is_relocated_to_our_section(&self, name: &XorName) -> bool {
+        let is_previous_name_of_member = self
+            .members
+            .read()
+            .await
+            .iter()
+            .any(|(_, state)| state.previous_name() == Some(*name));
 
         is_previous_name_of_member
             || self.archive.iter().any(|entry| {
@@ -74,11 +80,11 @@ impl SectionPeers {
     }
 
     /// Get section signed `NodeState` for the member with the given name.
-    pub(super) fn is_either_member_or_archived(
+    pub(super) async fn is_either_member_or_archived(
         &self,
         name: &XorName,
     ) -> Option<SectionAuth<NodeState>> {
-        if let Some(member) = self.members.get(name).map(|state| state.value().clone()) {
+        if let Some(member) = self.members.read().await.get(name).cloned() {
             Some(member)
         } else {
             self.archive.get(name).map(|state| state.value().clone())
@@ -86,7 +92,7 @@ impl SectionPeers {
     }
 
     /// Returns the nodes that should be candidates to become the next elders, sorted by names.
-    pub(super) fn elder_candidates(
+    pub(super) async fn elder_candidates(
         &self,
         elder_size: usize,
         current_elders: &SectionAuthorityProvider,
@@ -94,86 +100,33 @@ impl SectionPeers {
         prefix: Option<&Prefix>,
     ) -> Vec<Peer> {
         self.members
+            .read()
+            .await
             .iter()
-            .filter(|entry| {
-                let (name, _) = entry.pair();
+            .filter(|(name, _)| {
                 prefix.map_or_else(|| true, |p| p.matches(name)) && !excluded_names.contains(name)
             })
-            .map(|entry| {
-                let (_, node_state) = entry.pair();
-                node_state.clone()
-            })
+            .map(|(_, node_state)| node_state.clone())
             .sorted_by(|lhs, rhs| cmp_elder_candidates(lhs, rhs, current_elders))
             .take(elder_size)
             .map(|node_state| node_state.peer().clone())
             .collect()
     }
 
-    /// Update a member of our section.
-    /// Returns whether anything actually changed.
-    /// To maintain commutativity, the only allowed transitions are:
-    /// - Joined -> Joined if the new age is greater than the old age
-    /// - Joined -> Left
-    /// - Joined -> Relocated
-    /// - Relocated <--> Left (should not happen, but needed for consistency)
-    pub(super) fn update(&self, new_state: SectionAuth<NodeState>) -> bool {
-        let node_name = new_state.name();
-        // do ops on the dashmap _after_ matching, so we can drop any refs to prevent deadlocking
-        let mut should_insert = false;
-        let mut should_remove = false;
-
-        let updating_something = match (self.members.entry(node_name), new_state.state()) {
-            (Entry::Vacant(_entry), MembershipState::Joined) => {
-                // unless it was already archived, insert it as current member
-                if self.archive.get(&node_name).is_none() {
-                    should_insert = true;
-                    true
-                } else {
-                    false
-                }
-            }
-            (Entry::Vacant(_), MembershipState::Left | MembershipState::Relocated(_)) => {
-                // insert it in our archive regardless it was there with another state
-                let _prev = self.archive.insert(node_name, new_state.clone());
-                true
-            }
-            (Entry::Occupied(entry), MembershipState::Joined)
-                if new_state.age() > entry.get().age() =>
-            {
-                should_insert = true;
-                true
-            }
-            (Entry::Occupied(_), MembershipState::Joined) => false,
-            (Entry::Occupied(_entry), MembershipState::Left | MembershipState::Relocated(_)) => {
-                //  remove it from our current members, and insert it into our archive
-                should_remove = true;
-                let _prev = self.archive.insert(node_name, new_state.clone());
-                true
-            }
-        };
-
-        // now we have dropped the entry ref
-        if should_insert {
-            let _prev = self.members.insert(node_name, new_state);
+    /// Set current list of members of our section.
+    pub(super) async fn set_members(&self, members: BTreeSet<SectionAuth<NodeState>>) {
+        let mut write_guard = self.members.write().await;
+        write_guard.clear();
+        for node_state in members.into_iter() {
+            let _prev = write_guard.insert(node_state.name(), node_state);
         }
-        if should_remove {
-            let _prev = self.members.remove(&node_name);
-        }
-
-        updating_something
-    }
-
-    /// Remove all members whose name does not match `prefix`.
-    pub(super) fn retain(&self, prefix: &Prefix) {
-        self.members.retain(|name, _| prefix.matches(name))
     }
 
     /// Merge connections into of our current members
     pub(super) async fn merge_connections(&self, sources: &BTreeMap<SocketAddr, &Peer>) {
-        for entry in self.members.iter() {
-            let (_, node) = entry.pair();
-            if let Some(source) = sources.get(&node.addr()) {
-                node.peer().merge_connection(source).await;
+        for (_, node_state) in self.members.read().await.iter() {
+            if let Some(source) = sources.get(&node_state.addr()) {
+                node_state.peer().merge_connection(source).await;
             }
         }
     }

--- a/sn/src/types/log_markers.rs
+++ b/sn/src/types/log_markers.rs
@@ -21,7 +21,9 @@ pub enum LogMarker {
     SplitAttempt,
     NewPrefix,
     AeSendUpdateToSiblings,
-    AgreementOfOnline,
+    // Membership
+    AgreementOfJoin,
+    MembershipMsg,
     // Messaging
     ServiceMsgToBeHandled,
     SystemMsgToBeHandled,


### PR DESCRIPTION
- Making section peers mutations atomic in local network knowledge
- Adapting node relocation logic to new approach with membership consensus
- Removing the JoinsAllowed proposal messaging logic
- Moving join/leave verifications to a common place

BREAKING CHANGE: removal of JoinsAllowed agreement message type