### PR TITLE
refactor(elder targets): rename + use glob const

### DIFF
--- a/sn/src/client/client_api/commands.rs
+++ b/sn/src/client/client_api/commands.rs
@@ -8,12 +8,12 @@
 
 use super::Client;
 use crate::client::Error;
-use crate::elder_count;
 use crate::messaging::{
     data::{DataCmd, ServiceMsg},
     ServiceAuth, WireMsg,
 };
 use crate::types::{PublicKey, Signature};
+use crate::{at_least_one_correct_elder, elder_count};
 use bytes::Bytes;
 use xor_name::XorName;
 
@@ -46,17 +46,8 @@ impl Client {
         let client_pk = self.public_key();
         let dst_name = cmd.dst_name();
 
-        let chunk_count = (elder_count() / 3) + 1;
-
-        // (should be a global constant in the codebase,
-        // derived from also global const Elder count,
-        // and the max num faulty assumption - also as a const).
-        // Explanation:
-        // max num faulty = < 1/3
-        // So it's no more than 2 with 7 Elders.
-        // With 3 we are "guaranteed" 1 correctly functioning Elder.
         let targets = match &cmd {
-            DataCmd::StoreChunk(_) => chunk_count, // stored at Adults, so only 1 correctly functioning Elder need to relay
+            DataCmd::StoreChunk(_) => at_least_one_correct_elder(), // stored at Adults, so only 1 correctly functioning Elder need to relay
             DataCmd::Register(_) => elder_count(), // only stored at Elders, all need a copy
         };
 

--- a/sn/src/client/connections/listeners.rs
+++ b/sn/src/client/connections/listeners.rs
@@ -7,11 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Session;
+
 use crate::client::{
     connections::messaging::{send_message, NUM_OF_ELDERS_SUBSET_FOR_QUERIES},
     Error, Result,
 };
-use crate::elder_count;
 use crate::messaging::{
     data::{CmdError, DataCmd, ServiceMsg},
     system::{KeyedSig, SectionAuth, SystemMsg},
@@ -20,6 +20,7 @@ use crate::messaging::{
 use crate::node::routing::SectionAuthorityProvider;
 use crate::peer::Peer;
 use crate::types::{log_markers::LogMarker, utils::write_data_to_disk};
+use crate::{at_least_one_correct_elder, elder_count};
 
 use bytes::Bytes;
 use itertools::Itertools;
@@ -419,10 +420,8 @@ impl Session {
 
         let (target_count, dst_address_of_bounced_msg) = match service_msg.clone() {
             ServiceMsg::Cmd(cmd) => {
-                let chunk_count = (elder_count() / 3) + 1;
-
                 match &cmd {
-                    DataCmd::StoreChunk(_) => (chunk_count, cmd.dst_name()), // stored at Adults, so only 1 correctly functioning Elder need to relay
+                    DataCmd::StoreChunk(_) => (at_least_one_correct_elder(), cmd.dst_name()), // stored at Adults, so only 1 correctly functioning Elder need to relay
                     DataCmd::Register(_) => (elder_count(), cmd.dst_name()), // only stored at Elders, all need a copy
                 }
             }

--- a/sn/src/lib.rs
+++ b/sn/src/lib.rs
@@ -68,9 +68,26 @@ use tracing_subscriber::{
 
 /// Number of elders per section.
 pub(crate) const DEFAULT_ELDER_COUNT: usize = 7;
-const SN_ELDER_COUNT: &str = "SN_ELDER_COUNT";
+/// Number of copies of a chunk
+pub(crate) const DEFAULT_CHUNK_COPY_COUNT: usize = 3;
 
-/// Get the expected elder count for our network, defaults to DEFAULT_ELDER_COUNT, but can be overridden by the env var SN_ELDER_COUNT
+const SN_ELDER_COUNT: &str = "SN_ELDER_COUNT";
+const SN_CHUNK_COPY_COUNT: &str = "SN_CHUNK_COPY_COUNT";
+
+/// Max number of faulty Elders is assumed to be less than 1/3.
+/// So it's no more than 2 with 7 Elders.
+pub(crate) fn max_num_faulty_elders() -> usize {
+    elder_count() / 3
+}
+
+/// The least number of Elders to select, to be "guaranteed" one correctly functioning Elder.
+/// This number will be 3 with 7 Elders.
+pub(crate) fn at_least_one_correct_elder() -> usize {
+    max_num_faulty_elders() + 1
+}
+
+/// Get the expected elder count for our network.
+/// Defaults to DEFAULT_ELDER_COUNT, but can be overridden by the env var SN_ELDER_COUNT.
 pub(crate) fn elder_count() -> usize {
     // if we have an env var for this, lets override
     match std::env::var(SN_ELDER_COUNT) {
@@ -83,11 +100,33 @@ pub(crate) fn elder_count() -> usize {
                 count
             }
             Err(error) => {
-                warn!("There was an error parsing {:?} env var. Defaultelder_count() will be used: {:?}", SN_ELDER_COUNT, error);
+                warn!("There was an error parsing {:?} env var. DEFAULT_ELDER_COUNT will be used: {:?}", SN_ELDER_COUNT, error);
                 DEFAULT_ELDER_COUNT
             }
         },
         Err(_) => DEFAULT_ELDER_COUNT,
+    }
+}
+
+/// Get the expected chunk copy count for our network.
+/// Defaults to DEFAULT_CHUNK_COPY_COUNT, but can be overridden by the env var SN_CHUNK_COPY_COUNT.
+pub(crate) fn chunk_copy_count() -> usize {
+    // if we have an env var for this, lets override
+    match std::env::var(SN_CHUNK_COPY_COUNT) {
+        Ok(count) => match count.parse() {
+            Ok(count) => {
+                warn!(
+                    "CHUNK_COPY_COUNT countout set from env var SN_CHUNK_COPY_COUNT: {:?}",
+                    SN_CHUNK_COPY_COUNT
+                );
+                count
+            }
+            Err(error) => {
+                warn!("There was an error parsing {:?} env var. DEFAULT_CHUNK_COPY_COUNT will be used: {:?}", SN_CHUNK_COPY_COUNT, error);
+                DEFAULT_CHUNK_COPY_COUNT
+            }
+        },
+        Err(_) => DEFAULT_CHUNK_COPY_COUNT,
     }
 }
 

--- a/sn/src/node/routing/core/capacity/mod.rs
+++ b/sn/src/node/routing/core/capacity/mod.rs
@@ -18,7 +18,6 @@ use std::{
 use tokio::sync::RwLock;
 
 // The number of separate copies of a chunk which should be maintained.
-pub(crate) const CHUNK_COPY_COUNT: usize = 4;
 pub(crate) const MIN_LEVEL_WHEN_FULL: u8 = 9; // considered full when >= 90 %.
 
 /// A util for sharing the

--- a/sn/src/node/routing/core/msg_handling/service_msgs.rs
+++ b/sn/src/node/routing/core/msg_handling/service_msgs.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::chunk_copy_count;
 use crate::dbs::convert_to_error_message as convert_db_error_to_error_message;
 use crate::messaging::{
     data::{CmdError, DataCmd, DataQuery, QueryResponse, RegisterRead, RegisterWrite, ServiceMsg},
@@ -14,10 +15,7 @@ use crate::messaging::{
 };
 use crate::node::{
     error::Result,
-    routing::{
-        api::command::Command,
-        core::{capacity::CHUNK_COPY_COUNT, Core},
-    },
+    routing::{api::command::Command, core::Core},
 };
 use crate::peer::Peer;
 use crate::types::{log_markers::LogMarker, ChunkAddress, PublicKey};
@@ -340,7 +338,7 @@ impl Core {
             .into_iter()
             .sorted_by(|lhs, rhs| target.cmp_distance(lhs, rhs))
             .filter(|peer| !full_adults.contains(peer))
-            .take(CHUNK_COPY_COUNT)
+            .take(chunk_copy_count())
             .collect::<BTreeSet<_>>();
 
         trace!(
@@ -387,7 +385,7 @@ impl Core {
             .into_iter()
             .sorted_by(|lhs, rhs| target.cmp_distance(lhs, rhs))
             .filter(|peer| !full_adults.contains(peer))
-            .take(CHUNK_COPY_COUNT)
+            .take(chunk_copy_count())
             .collect::<BTreeSet<_>>();
 
         trace!(


### PR DESCRIPTION
- Adds max_num_faulty_elders based on const assumption for
max number of faulty Elders as 1/3.
- Adds at_least_one_correct_elder based on max_num_faulty_elders.

These numbers were made dependent on global consts, as was asked for in
the todo comment prior to this change.

Also, the number of Elders to whom a client sends a chunk is not based
on the chunk copy count, but on our assumptions on max number of faulty
Elders, hence renaming the variable.
