### PR TITLE
chore(docs): fix docs to match parameters

### DIFF
--- a/sn/src/client/client_api/blob_apis.rs
+++ b/sn/src/client/client_api/blob_apis.rs
@@ -194,9 +194,9 @@ impl Client {
         }
     }
 
-    /// Directly writes a [`Blob`] to the network in the
-    /// form of immutable self encrypted chunks, without any batching.
-    /// It also attempts to verify the Blob was uploaded to the network before returning.
+    /// Directly writes [`Bytes`] to the network in the
+    /// form of immutable chunks, without any batching.
+    /// It also attempts to verify that all the data was uploaded to the network before returning.
     #[instrument(skip_all, level = "trace")]
     pub async fn upload_and_verify(&self, bytes: Bytes, scope: Scope) -> Result<BytesAddress> {
         let address = self.upload(bytes, scope).await?;


### PR DESCRIPTION
Since the (to be renamed) blob_apis only deal with bytes.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
