### PR TITLE
refactor(node): removing unnecessary Error type definitions

### DIFF
--- a/sn/src/bin/sn_node.rs
+++ b/sn/src/bin/sn_node.rs
@@ -169,9 +169,7 @@ async fn run_node() -> Result<()> {
     let (node, mut event_stream) = loop {
         match Node::new(&config, bootstrap_retry_duration).await {
             Ok(result) => break result,
-            Err(Error::CannotConnectEndpoint {
-                err: qp2p::EndpointError::Upnp(error),
-            }) => {
+            Err(Error::CannotConnectEndpoint(qp2p::EndpointError::Upnp(error))) => {
                 return Err(error).suggestion(
                     "You can disable port forwarding by supplying --skip-auto-port-forwarding. Without port\n\
                     forwarding, your machine must be publicly reachable by the given\n\
@@ -185,7 +183,7 @@ async fn run_node() -> Result<()> {
                 );
             }
             #[cfg(feature = "always-joinable")]
-            Err(Error::CannotConnectEndpoint { err, .. }) => {
+            Err(Error::CannotConnectEndpoint(err)) => {
                 warn!(
                     "In 'always-joinable' mode. Continuing to try and join after error: {:?}",
                     err

--- a/sn/src/node/cfg/keypair_storage.rs
+++ b/sn/src/node/cfg/keypair_storage.rs
@@ -36,16 +36,23 @@ pub async fn get_network_keypair(root_dir: &Path) -> Result<Option<Keypair>> {
     if !path.is_file() {
         return Ok(None);
     }
-    let keypair_hex_bytes = fs::read(path).await?;
+
+    let keypair_hex_bytes = fs::read(&path).await?;
     let keypair_bytes = decode(keypair_hex_bytes).map_err(|err| {
-        Error::Logic(format!(
-            "Couldn't hex-decode network keypair bytes: {}",
+        Error::Configuration(format!(
+            "couldn't hex-decode network keypair bytes read from {}: {}",
+            path.display(),
             err
         ))
     })?;
 
-    let keypair = Keypair::from_bytes(&keypair_bytes)
-        .map_err(|_| Error::Logic("Config error: Invalid network keypair bytes".to_string()))?;
+    let keypair = Keypair::from_bytes(&keypair_bytes).map_err(|err| {
+        Error::Configuration(format!(
+            "invalid network keypair bytes read from {}: {}",
+            path.display(),
+            err
+        ))
+    })?;
 
     Ok(Some(keypair))
 }
@@ -66,16 +73,23 @@ pub async fn get_reward_pk(root_dir: &Path) -> Result<Option<PublicKey>> {
     if !path.is_file() {
         return Ok(None);
     }
-    let pk_hex_bytes = fs::read(path).await?;
+
+    let pk_hex_bytes = fs::read(&path).await?;
     let pk_bytes = decode(pk_hex_bytes).map_err(|err| {
-        Error::Logic(format!(
-            "Couldn't hex-decode Ed25519 public key bytes: {}",
+        Error::Configuration(format!(
+            "couldn't hex-decode rewards Ed25519 public key bytes from {}: {}",
+            path.display(),
             err
         ))
     })?;
 
-    let pk = PublicKey::from_bytes(&pk_bytes)
-        .map_err(|_| Error::Logic("Config error: Invalid Ed25519 public key bytes".to_string()))?;
+    let pk = PublicKey::from_bytes(&pk_bytes).map_err(|err| {
+        Error::Configuration(format!(
+            "invalid rewards Ed25519 public key bytes read from {}: {}",
+            path.display(),
+            err
+        ))
+    })?;
 
     Ok(Some(pk))
 }


### PR DESCRIPTION
BREAKING CHANGE: some public API error types were removed, and others were changed.
