### PR TITLE
ci: use zsh to repeat e2e tests

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -223,7 +223,7 @@ jobs:
         run: cd sn && cargo test --release --features=always-joinable,test-utils -- client_api::reg --test-threads=1 --skip ae --skip batching && sleep $POST_TEST_SLEEP
         timeout-minutes: 10
 
-      # register api batching check, only run this once as it's slow, and we verify the
+      # register api batching check, only run this once as it's slow, and we verify the basic tests above
       - name: Client register batching
         shell: bash
         run: cd sn && cargo test --release --features=always-joinable,test-utils -- register_batching --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -14,6 +14,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: 'eu-west-2'
+  POST_TEST_SLEEP: 5
 
 jobs:
   build:
@@ -180,42 +181,81 @@ jobs:
         run: ./target/release/log_cmds_inspector $HOME/.safe/node/local-test-network
         if: steps.section-startup.outcome == 'success' && matrix.os != 'windows-latest'
 
+      - name: ubuntu install zsh
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get -y install zsh
+
       - name: Run network asserts one by one
         shell: bash
         # here test-threads=1 is important so we dont pollute log counts by running tests in parallel
-        run: cd sn && cargo test --release --features=always-joinable,test-utils -- --ignored network_assert --test-threads=1 --skip health && sleep 30
+        run: cd sn && cargo test --release --features=always-joinable,test-utils -- --ignored network_assert --test-threads=1 --skip health && sleep $POST_TEST_SLEEP
         timeout-minutes: 5
         continue-on-error: true
 
       # a catchall to ensure any new client api tests are run (ideally any major new section should have its own test run)
-      - name: Initial client tests...
+      - name: Initial client tests... (unix)
+        shell: zsh {0}
+        if: matrix.os != 'windows-latest'
+        # always joinable not actually needed here, but should speed up compilation as we've just built with it
+        run: cd sn && repeat 5 cargo test --release --features=always-joinable,test-utils -- client --skip client_api::reg --skip client_api::blob --test-threads=2 && sleep $POST_TEST_SLEEP
+        timeout-minutes: 5
+
+      # a catchall to ensure any new client api tests are run (ideally any major new section should have its own test run)
+      - name: Initial client tests... (win)
+        if: matrix.os == 'windows-latest'
         shell: bash
         # always joinable not actually needed here, but should speed up compilation as we've just built with it
-        run: cd sn && cargo test --release --features=always-joinable,test-utils -- client --skip client_api::reg --skip client_api::blob --test-threads=2 && sleep 5
+        run: cd sn && cargo test --release --features=always-joinable,test-utils -- client --skip client_api::reg --skip client_api::blob --test-threads=2 && sleep $POST_TEST_SLEEP
         timeout-minutes: 5
 
       # register api
-      - name: Client reg tests against local network
-        shell: bash
-        run: cd sn && cargo test --release --features=always-joinable,test-utils -- client_api::reg --test-threads=1 --skip ae --skip batching && sleep 30
+      - name: Client reg tests against local network (unix)
+        shell: zsh {0}
+        if: matrix.os != 'windows-latest'
+        run: cd sn && repeat 5 cargo test --release --features=always-joinable,test-utils -- client_api::reg --test-threads=1 --skip ae --skip batching && sleep $POST_TEST_SLEEP
         timeout-minutes: 10
 
-      # register api batching check
+      # register api
+      - name: Client reg tests against local network (unix)
+        shell: bash
+        if: matrix.os == 'windows-latest'
+        run: cd sn && cargo test --release --features=always-joinable,test-utils -- client_api::reg --test-threads=1 --skip ae --skip batching && sleep $POST_TEST_SLEEP
+        timeout-minutes: 10
+
+      # register api batching check, only run this once as it's slow, and we verify the
       - name: Client register batching
         shell: bash
-        run: cd sn && cargo test --release --features=always-joinable,test-utils -- register_batching --test-threads=1 --skip ae && sleep 30
+        run: cd sn && cargo test --release --features=always-joinable,test-utils -- register_batching --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP
         timeout-minutes: 10
 
       # blob api
-      - name: client blob tests against local network
-        shell: bash
-        run: cd sn && cargo test --release --features=always-joinable,test-utils -- client_api::blob --test-threads=1 --skip ae --skip from_many_clients  && sleep 30
+      - name: client blob tests against local network (unix)
+        shell: zsh {0}
+        if: matrix.os != 'windows-latest'
+        run: cd sn && repeat 5 cargo test --release --features=always-joinable,test-utils -- client_api::blob --test-threads=1 --skip ae --skip from_many_clients  && sleep $POST_TEST_SLEEP
         timeout-minutes: 20
 
-      # ae tests api
-      - name: client ae tests against local network
+      # blob api
+      - name: client blob tests against local network (win)
         shell: bash
-        run: cd sn && cargo test --release --features=always-joinable,test-utils -- ae_checks --test-threads=2 && sleep 30
+        if: matrix.os == 'windows-latest'
+        run: cd sn && cargo test --release --features=always-joinable,test-utils -- client_api::blob --test-threads=1 --skip ae --skip from_many_clients  && sleep $POST_TEST_SLEEP
+        timeout-minutes: 15
+
+      # ae tests api
+      - name: client ae tests against local network (unix)
+        shell: zsh {0}
+        if: matrix.os != 'windows-latest'
+        run: cd sn && repeat 5 cargo test --release --features=always-joinable,test-utils -- ae_checks --test-threads=2 && sleep $POST_TEST_SLEEP
+        timeout-minutes: 10
+        env:
+          SN_AE_WAIT: 10
+
+      - name: client ae tests against local network (win)
+        shell: bash
+        if: matrix.os == 'windows-latest'
+        run: cd sn && cargo test --release --features=always-joinable,test-utils -- ae_checks --test-threads=2 && sleep $POST_TEST_SLEEP
         timeout-minutes: 10
         env:
           SN_AE_WAIT: 10
@@ -228,7 +268,7 @@ jobs:
       # # many client connections
       # - name: many client test against local network
       #   shell: bash
-      #   run: cd sn && cargo test --release --features=always-joinable,test-utils -- from_many_clients  && sleep 30
+      #   run: cd sn && cargo test --release --features=always-joinable,test-utils -- from_many_clients  && sleep $POST_TEST_SLEEP
       #   timeout-minutes: 20
       #   env:
       #     SN_QUERY_TIMEOUT: 240 # 240 secs


### PR DESCRIPTION
We've seen occasionally flakey e2e tests. This sets the basic e2e tests to run 5 times back to back, which should increase confidence in each PR being merged and reduce fluke ci-passes

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
