### PR TITLE
ci: increase testnet initial client tests timeout for a bit more margin

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -200,7 +200,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         # always joinable not actually needed here, but should speed up compilation as we've just built with it
         run: cd sn && repeat 5 cargo test --release --features=always-joinable,test-utils -- client --skip client_api::reg --skip client_api::blob --test-threads=2 && sleep $POST_TEST_SLEEP
-        timeout-minutes: 5
+        timeout-minutes: 7
 
       # a catchall to ensure any new client api tests are run (ideally any major new section should have its own test run)
       - name: Initial client tests... (win)


### PR DESCRIPTION
Sometimes, we could get slight delays which might push the repeat tests over 5 minutes

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
