### PR TITLE
feat(sn/client): Add jitter into client query request timing

### DIFF
--- a/sn/src/client/config_handler.rs
+++ b/sn/src/client/config_handler.rs
@@ -240,7 +240,7 @@ mod tests {
             root_dir: root_dir.clone(),
             genesis_key,
             qp2p: QuicP2pConfig {
-                idle_timeout: Some(Duration::from_secs(120)),
+                idle_timeout: Some(DEFAULT_QUERY_TIMEOUT),
                 keep_alive_interval: Some(Duration::from_secs(30)),
                 ..Default::default()
             },

--- a/sn/src/client/config_handler.rs
+++ b/sn/src/client/config_handler.rs
@@ -23,7 +23,7 @@ use tracing::{debug, warn};
 const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 
 /// Default amount of time to wait for responses to queries before giving up and returning an error.
-pub const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(120);
+pub const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(500);
 /// Default amount of time to wait (to keep the client alive) after sending a command. This allows AE messages to be parsed/resent.
 /// Larger PUT operations may need larger ae wait time
 pub const DEFAULT_AE_WAIT: Duration = Duration::from_secs(0);

--- a/sn/src/client/config_handler.rs
+++ b/sn/src/client/config_handler.rs
@@ -23,7 +23,11 @@ use tracing::{debug, warn};
 const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 
 /// Default amount of time to wait for responses to queries before giving up and returning an error.
-pub const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(500);
+pub const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(120);
+/// Default idle timeout on the elder connection
+const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+/// Default keep alive for elder comms
+const DEFAULT_KEEP_ALIVE: Duration = Duration::from_secs(30);
 /// Default amount of time to wait (to keep the client alive) after sending a command. This allows AE messages to be parsed/resent.
 /// Larger PUT operations may need larger ae wait time
 pub const DEFAULT_AE_WAIT: Duration = Duration::from_secs(0);
@@ -78,8 +82,8 @@ impl ClientConfig {
             Some(path) => read_config_file(path).await.unwrap_or_default(),
         };
 
-        qp2p.idle_timeout = Some(DEFAULT_QUERY_TIMEOUT);
-        qp2p.keep_alive_interval = Some(Duration::from_secs(30));
+        qp2p.idle_timeout = Some(DEFAULT_IDLE_TIMEOUT);
+        qp2p.keep_alive_interval = Some(DEFAULT_KEEP_ALIVE);
 
         let query_timeout = query_timeout.unwrap_or(DEFAULT_QUERY_TIMEOUT);
         let standard_wait = standard_wait.unwrap_or(DEFAULT_AE_WAIT);
@@ -240,8 +244,8 @@ mod tests {
             root_dir: root_dir.clone(),
             genesis_key,
             qp2p: QuicP2pConfig {
-                idle_timeout: Some(DEFAULT_QUERY_TIMEOUT),
-                keep_alive_interval: Some(Duration::from_secs(30)),
+                idle_timeout: Some(DEFAULT_IDLE_TIMEOUT),
+                keep_alive_interval: Some(DEFAULT_KEEP_ALIVE),
                 ..Default::default()
             },
             query_timeout: expected_query_timeout,

--- a/sn/src/node/routing/api/dispatcher.rs
+++ b/sn/src/node/routing/api/dispatcher.rs
@@ -616,7 +616,7 @@ impl Dispatcher {
                 if let Err(err) = self
                     .core
                     .comm
-                    .send_on_existing_connection(recipients, wire_msg.clone())
+                    .send_on_existing_connection_to_client(recipients, wire_msg.clone())
                     .await
                 {
                     error!("Failed sending message {:?} to recipients {:?} on existing connection with error {:?}",

--- a/sn/src/node/routing/core/comm.rs
+++ b/sn/src/node/routing/core/comm.rs
@@ -117,12 +117,13 @@ impl Comm {
     }
 
     /// Sends a message on an existing connection. If no such connection exists, returns an error.
-    pub(crate) async fn send_on_existing_connection(
+    /// Drops the connection after the message has been sent.
+    pub(crate) async fn send_on_existing_connection_to_client(
         &self,
         recipients: &[Peer],
         mut wire_msg: WireMsg,
     ) -> Result<(), Error> {
-        trace!("Sending msg on existing connection to {:?}", recipients);
+        trace!("Sending msg on existing connection to client {:?}", recipients);
         for recipient in recipients {
             let name = recipient.name();
             let addr = recipient.addr();

--- a/sn/src/node/routing/core/comm.rs
+++ b/sn/src/node/routing/core/comm.rs
@@ -123,7 +123,10 @@ impl Comm {
         recipients: &[Peer],
         mut wire_msg: WireMsg,
     ) -> Result<(), Error> {
-        trace!("Sending msg on existing connection to client {:?}", recipients);
+        trace!(
+            "Sending msg on existing connection to client {:?}",
+            recipients
+        );
         for recipient in recipients {
             let name = recipient.name();
             let addr = recipient.addr();


### PR DESCRIPTION
The last comnet showed that for larger files we want a larger query timeout. This seems like it should probably be the default. So that's addressed here, alongside some query timeout jitter to help smooth out request barrages

This should help prevent nodes being hammered over the same period.
This PR also increases the default client query time to 500s.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
