### PR TITLE
ci: make more use of ubuntu self hosted

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -23,7 +23,6 @@ jobs:
     name: Build sn bins
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [self-hosted-ubuntu, windows-latest, macos-latest]
     steps:
@@ -54,7 +53,6 @@ jobs:
     name: Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [self-hosted-ubuntu, windows-latest, macos-latest]
     steps:
@@ -176,6 +174,14 @@ jobs:
       - name: Start the network
         run: ./target/release/testnet --interval 15000
         id: section-startup
+        if: matrix.os != 'self-hosted-ubuntu'
+
+      - name: Start the network (ubuntu self hosted)
+        run: ./target/release/testnet --interval 15000
+        id: section-startup
+        if: matrix.os == 'self-hosted-ubuntu'
+        env:
+            NODE_COUNT: 33
 
       - name: Print Network Log Stats at start
         shell: bash

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Start the network (ubuntu self hosted)
         run: ./target/release/testnet --interval 15000
-        id: section-startup
+        id: section-startup2
         if: matrix.os == 'self-hosted-ubuntu'
         env:
             NODE_COUNT: 33
@@ -186,7 +186,7 @@ jobs:
       - name: Print Network Log Stats at start
         shell: bash
         run: ./target/release/log_cmds_inspector $HOME/.safe/node/local-test-network
-        if: steps.section-startup.outcome == 'success' && matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-latest'
 
       - name: ubuntu install zsh
         if: matrix.os == 'self-hosted-ubuntu'
@@ -294,7 +294,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: ./target/release/log_cmds_inspector $HOME/.safe/node/local-test-network
-        if: steps.section-startup.outcome == 'success' &&  matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-latest'
 
       - name: Upload Node Logs to AWS for Windowns
           # Upload artifacts.


### PR DESCRIPTION
fail fast on build/unit tests there. They are much more solid.
Use a full network for ubuntu client tests

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
