### PR TITLE
ci: nightly release run

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -1,44 +1,70 @@
-name: 'sn: Run Client Tests against DO Testnet'
+name: Nightly Release Run
 
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '30 2 * * *'
 
-
 env:
-  CARGO_INCREMENTAL: '0'
-  RUST_BACKTRACE: FULL
-  RUSTFLAGS: "-D warnings"
-  RUST_LOG: "safe_network=trace"
-  SAFE_AUTH_PASSPHRASE: "x"
-  SAFE_AUTH_PASSWORD: "y"
-  SN_QUERY_TIMEOUT: 20 # 20 secs
-  SN_AE_WAIT: 1 # 1 sec
-  NODE_COUNT: 11
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: 'eu-west-2'
 
 jobs:
-  launch-testnet:
-    name: Launch Digital Ocean testnet
+  build-node:
+    name: build node
     runs-on: ubuntu-latest
     steps:
-      - name: Launch testnet
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - shell: bash
+        name: build node
+        run: |
+          sudo apt update -y
+          sudo apt install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --release --target x86_64-unknown-linux-musl --bin sn_node
+      - uses: actions/upload-artifact@master
+        with:
+          name: sn_node-x86_64-unknown-linux-musl
+          path: |
+            target/x86_64-unknown-linux-musl/release
+
+  launch-testnet:
+    name: launch testnet
+    needs: build-node
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@master
+        with:
+          name: sn_node-x86_64-unknown-linux-musl
+          path: sn_node
+      - shell: bash
+        name: copy node to temp location
+        run: cp sn_node/sn_node /tmp
+      - name: launch testnet
         uses: maidsafe/sn_testnet_action@master
         with:
           do-token: ${{ secrets.DO_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ssh-secret-key: ${{ secrets.SSH_SECRET_KEY  }}
-          build-node: true
-          node-count: ${{ github.event.inputs.node-count || 50 }}
+          node-count: ${{ github.event.inputs.node-count || 11 }}
+          node-path: /tmp/sn_node
 
-  run-client-tests:
-    name: Run Client tests
-    runs-on: ubuntu-latest
-    needs: [launch-testnet]
+  client:
+    name: client tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    needs: launch-testnet
     steps:
       - uses: actions/checkout@v2
         with:
@@ -63,7 +89,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.safe/node
-          wget https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-node_connection_info.config -O ~/.safe/node/node_connection_info.config
+          curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-node_connection_info.config > ~/.safe/node/node_connection_info.config
 
       # a catchall to ensure any new client api tests are run (ideally any major new section should have its own test run)
       - name: Initital client tests...
@@ -83,10 +109,90 @@ jobs:
         shell: bash
         run: cargo run --release  --features=always-joinable,test-utils --example client_files
 
+  api:
+    name: api tests
+    if: ${{ always() }} # give the suite a chance to run, even if the client tests fail.
+    needs: client
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Set TESTNET_ID env
+        shell: bash
+        run: echo "TESTNET_ID=gha-testnet-$(echo ${{ github.event.pull_request.head.sha || github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
+      - name: Download network config
+        shell: bash
+        run: |
+          mkdir -p ~/.safe/node
+          curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-node_connection_info.config > ~/.safe/node/node_connection_info.config
+      - uses: Swatinem/rust-cache@v1
+        continue-on-error: true
+        with:
+          cache-on-failure: true
+          sharedKey: ${{github.run_id}}
+      - name: Build all sn_api tests
+        run: cargo test --no-run -p sn_api --release --lib
+      - name: run sn_api tests
+        shell: bash
+        run: ./resources/scripts/api_tests.sh
+        timeout-minutes: 45
+        env:
+          # these tests rely heavily on retry_loop
+          # TODO: Remove that dependency
+          SN_QUERY_TIMEOUT: 20
+
+  cli:
+    name: cli tests
+    if: ${{ always() }} # give the suite a chance to run, even if the api tests fail.
+    needs: api
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+        continue-on-error: true
+        with:
+          cache-on-failure: true
+          sharedKey: ${{github.run_id}}
+      - name: Set TESTNET_ID env
+        shell: bash
+        run: echo "TESTNET_ID=gha-testnet-$(echo ${{ github.event.pull_request.head.sha || github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
+      - name: Download network config
+        shell: bash
+        run: |
+          mkdir -p ~/.safe/node
+          curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-node_connection_info.config > ~/.safe/node/node_connection_info.config
+      - name: Build all CLI tests
+        run: cargo test --no-run -p sn_cli --release
+      - name: Run CLI tests
+        shell: bash
+        run: ./resources/scripts/cli_tests.sh
+        timeout-minutes: 90
+
   kill-testnet:
     name: Destroy Digital Ocean testnet
     runs-on: ubuntu-latest
-    needs: [launch-testnet, run-client-tests]
+    needs: [launch-testnet, client, api, cli]
     steps:
       - name: Kill testnet
         uses: maidsafe/sn_testnet_action@master
@@ -96,11 +202,45 @@ jobs:
           aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           action: 'destroy'
 
+  bump_version:
+    runs-on: ubuntu-20.04
+    needs: kill-testnet
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - shell: bash
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+      - shell: bash
+        run: cargo install cargo-smart-release
+      - shell: bash
+        run: ./resources/scripts/bump_version.sh
+      - name: push version bump commit and tags
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
+          branch: main
+          tags: true
+
   kill-if-fail:
     name: Destroy Digital Ocean testnet on fail
     runs-on: ubuntu-latest
-    if: ${{ always() && (needs.launch-testnet.result=='failure' || needs.run-client-tests.result=='failure') }}
-    needs: [launch-testnet, run-client-tests]
+    if: |
+      always() &&
+      (needs.launch-testnet.result=='failure' ||
+       needs.client.result=='failure' ||
+       needs.api.result=='failure' ||
+       needs.cli.result=='failure')
+    needs: [launch-testnet, client, api, cli]
     steps:
       - name: Kill testnet
         uses: maidsafe/sn_testnet_action@master

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ upload-sn_node-musl-to-s3:
 	rm -rf deploy
 	mkdir -p deploy
 	rustup target add x86_64-unknown-linux-musl
-	cargo build --release --target x86_64-unknown-linux-musl
+	cargo build --release --target x86_64-unknown-linux-musl --bin sn_node
 	(
 		cd deploy;
 		tar -C ../target/x86_64-unknown-linux-musl/release \

--- a/sn_cli/tests/cli_files.rs
+++ b/sn_cli/tests/cli_files.rs
@@ -970,19 +970,35 @@ fn calling_files_tree() -> Result<()> {
     assert_eq!(root["sub"][1]["name"], ".subhidden");
     assert_eq!(root["sub"][1]["details"]["type"], "inode/directory");
     assert_eq!(root["sub"][1]["sub"][0]["name"], "test.md");
+
+    // It seems to be possible for the sizes of files to vary based on the the OS they were
+    // uploaded from, so we won't hard code the values.
+    let another_file_len = get_file_len("../resources/testdata/another.md")?;
     assert_eq!(root["sub"][2]["name"], "another.md");
-    assert_eq!(root["sub"][2]["details"]["size"], "6");
+    assert_eq!(
+        root["sub"][2]["details"]["size"],
+        another_file_len.to_string()
+    );
     assert_eq!(root["sub"][2]["details"]["type"], "text/markdown");
+
     assert_eq!(root["sub"][3]["name"], "emptyfolder");
     assert_eq!(root["sub"][3]["details"]["size"], "0");
     assert_eq!(root["sub"][3]["details"]["type"], "inode/directory");
 
+    let markdown_file_len = get_file_len("../resources/testdata/large_markdown_file.md")?;
     assert_eq!(root["sub"][4]["name"], "large_markdown_file.md");
-    assert_eq!(root["sub"][4]["details"]["size"], "95864");
+    assert_eq!(
+        root["sub"][4]["details"]["size"],
+        markdown_file_len.to_string()
+    );
     assert_eq!(root["sub"][4]["details"]["type"], "text/markdown");
 
+    let noextension_file_len = get_file_len("../resources/testdata/noextension")?;
     assert_eq!(root["sub"][5]["name"], "noextension");
-    assert_eq!(root["sub"][5]["details"]["size"], "20");
+    assert_eq!(
+        root["sub"][5]["details"]["size"],
+        noextension_file_len.to_string()
+    );
     assert_eq!(root["sub"][5]["details"]["type"], "Raw");
     assert_eq!(root["sub"][6]["name"], "subfolder");
     assert_eq!(root["sub"][6]["sub"][0]["name"], "sub2.md");

--- a/sn_cli/tests/cli_node.rs
+++ b/sn_cli/tests/cli_node.rs
@@ -20,6 +20,7 @@ pub(crate) const SN_NODE_BIN_NAME: &str = "sn_node";
 pub(crate) const SN_NODE_BIN_NAME: &str = "sn_node.exe";
 
 #[test]
+#[ignore = "unfortunately this test is subject to rate limiting from the Github API"]
 fn node_install_should_install_the_latest_version() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let safe_dir = temp_dir.child(".safe");

--- a/sn_cmd_test_utilities/src/lib.rs
+++ b/sn_cmd_test_utilities/src/lib.rs
@@ -44,9 +44,12 @@ pub mod util {
             .header(reqwest::header::ACCEPT, "application/vnd.github.v3+json")
             .send()?;
         let response_json = response.json::<serde_json::Value>()?;
-        let tag_name = response_json["tag_name"]
-            .as_str()
-            .ok_or_else(|| eyre!("Failed to parse the tag_name field from the response"))?;
+        let tag_name = response_json["tag_name"].as_str().ok_or_else(|| {
+            eyre!(format!(
+                "Failed to parse the tag_name field from the response: {}",
+                response_json.to_string()
+            ))
+        })?;
         let version = get_version_from_release_version(tag_name)?;
         Ok(version)
     }


### PR DESCRIPTION
- 3b4069427 **ci: nightly release run**

  Sets up a release build to run nightly. It runs as follows:
  * Build the node binary using the latest code
  * Launch the testnet on Digital Ocean using our custom action
  * Run the client tests against the testnet
  * Run the API tests against the testnet
  * Run the CLI tests against the testnet
  * Kill the testnet
  * Bump any version numbers and push a new release commit to `main`

  The push to `main` should then trigger the release workflow, which will run as usual.

  A few noteworthy points:
  * In theory, the testnet custom action can build the node on a large Digital Ocean VM, but I found
    it unreliable.
  * The 3 test suites _could_ run in parallel, but for now they run sequentially.
  * All test suites get the opportunity to run, even if the previous one fails.
  * If any suite fails, the testnet is killed and no version bumping occurs.

  There were also a couple of changes related to CLI tests:
  * Change the `files tree` test to not use hard coded sizes for files. One of the test data files had
    been changed, and it also appeared to be the case that you could get a different file size if you
    uploaded files from Windows.
  * Set the ignore attribute on the `node install` latest version test. This test uses the Github API
    to get the latest version, and there appeared to be rate limiting issues, despite the fact that we
    would only make 3 calls for the entire test suite.