### PR TITLE
ci: run nightly tests in same fashion as pr tests

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -94,8 +94,13 @@ jobs:
       # a catchall to ensure any new client api tests are run (ideally any major new section should have its own test run)
       - name: Initital client tests...
         shell: bash
-        # always joinable not actually needed here, but should speed up compilation as we've just built with it
-        run: cargo test --release --features=always-joinable,test-utils -- client_api --skip client_api::reg --skip client_api::file --skip client_api::transfer && sleep 5
+        run: |
+          # always joinable isn't needed, but can speed up compilation.
+          cargo test \
+            --release \
+            --features=always-joinable,test-utils \
+            -- client --skip client_api::reg --skip client_api::file --test-threads=2
+          sleep 5
 
       - name: Client reg tests
         shell: bash
@@ -103,7 +108,12 @@ jobs:
 
       - name: Client file tests
         shell: bash
-        run: cargo test --release --features=always-joinable,test-utils -- client_api::file --test-threads=1 && sleep 5
+        run: |
+          cargo test \
+            --release \
+            --features=always-joinable,test-utils \
+            -- client_api::file --skip ae --skip from_many_clients --test-threads=1
+          sleep 5
 
       - name: Run example app for file API
         shell: bash

--- a/resources/scripts/cli_tests.sh
+++ b/resources/scripts/cli_tests.sh
@@ -5,6 +5,9 @@
 # they're all independent of one another.
 exit=0
 
+# The tests parse output from the CLI process and they are expecting it to be in a certain form, so
+# any additional logging needs to be disabled.
+unset RUST_LOG
 export RUST_BACKTRACE=full
 
 cargo run --package sn_cli --release -- keys create --for-cli || ((exit++))


### PR DESCRIPTION
- 199100a4b **ci: run nightly tests in same fashion as pr tests**

  The nightly client tests were running slightly differently from the same tests in the PR run. This
  brings them into parity.

- 1ea810af6 **ci: switch off verbose logging for cli tests**

  The CLI tests parse output from the CLI and they expect it to be in a certain form, so any
  additional logging needs to be switched off.

  The other tests in the PR workflow switch verbose logging on because it's useful for those tests and
  there are also some scripts that parse the output to try and determine if the network is ready.