### PR TITLE
ci: fix crate change check in version bumping

### DIFF
--- a/resources/scripts/bump_version.sh
+++ b/resources/scripts/bump_version.sh
@@ -31,6 +31,7 @@ function perform_smart_release_dry_run() {
 }
 
 function crate_has_changes() {
+  local crate_name="$1"
   if [[ $dry_run_output == *"WOULD auto-bump provided package '$crate_name'"* ]]; then
     echo "true"
   else


### PR DESCRIPTION
The `crate_name` local variable is reintroduced to perform this check properly. This was accidentally removed in 2eaca44794e330420511e625a430005635f520ba.
