### PR TITLE
feat: retrieve immutable content via nrs

### DIFF
--- a/resources/scripts/api_tests.sh
+++ b/resources/scripts/api_tests.sh
@@ -2,12 +2,8 @@
 
 set -e -x
 
-function run_api_tests() {
-    export TEST_BOOTSTRAPPING_PEERS=$(cat ~/.safe/node/node_connection_info.config)
+export RUST_BACKTRACE=1
+export TEST_BOOTSTRAPPING_PEERS=$(cat ~/.safe/node/node_connection_info.config)
 
-    # TODO: enable doc tests, for now they require work
-    cd sn_api && cargo test --lib --release -- --test-threads=2
-    cd -
-}
-
-run_api_tests
+# TODO: enable doc tests, for now they require work
+cd sn_api && cargo test --lib --release -- --test-threads=2

--- a/sn_api/src/app/nrs/nrs_map.rs
+++ b/sn_api/src/app/nrs/nrs_map.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::safeurl::VersionHash;
 use crate::{Error, Result, SafeUrl};
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -13,7 +14,7 @@ use std::collections::BTreeMap;
 
 pub(crate) type SubName = String;
 
-/// Mapping SubNames to SafeUrls
+/// Mapping Subnames to SafeUrls
 /// For a given Top Name : "example"
 ///
 /// | SubName Key   | Full Name        | SafeUrl Value|
@@ -22,9 +23,12 @@ pub(crate) type SubName = String;
 /// | "sub"         | "sub.example"    | "safe://eg2" |
 /// | "sub.sub"     | "sub.sub.example"| "safe://eg3" |
 ///
+/// The map also has a subname_version, which can be used if you want a subname at a particular
+/// version.
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize, Clone)]
 pub struct NrsMap {
     pub map: BTreeMap<SubName, SafeUrl>,
+    pub subname_version: Option<VersionHash>,
 }
 
 impl NrsMap {

--- a/sn_api/src/app/resolver/handlers.rs
+++ b/sn_api/src/app/resolver/handlers.rs
@@ -21,7 +21,6 @@ use std::collections::BTreeSet;
 
 impl Safe {
     pub(crate) async fn resolve_nrs_map_container(&self, input_url: SafeUrl) -> Result<SafeData> {
-        // get NRS resolution
         let (mut target_url, nrs_map) = self
             .nrs_get(input_url.public_name(), input_url.content_version())
             .await
@@ -31,19 +30,11 @@ impl Safe {
             })?;
         debug!("NRS Resolved {} => {}", input_url, target_url);
 
-        // concatenate paths
         let url_path = input_url.path_decoded()?;
         let target_path = target_url.path_decoded()?;
         target_url.set_path(&format!("{}{}", target_path, url_path));
 
-        // create safe_data ignoring the input path or subnames
         validate_nrs_url(&target_url)?;
-        let version = target_url.content_version().ok_or_else(|| {
-            Error::ContentError(format!(
-                "Missing content version in Url: {} while resolving: {}",
-                &target_url, &input_url
-            ))
-        })?;
         let mut nrs_url = input_url.clone();
         nrs_url.set_path("");
         nrs_url.set_sub_names("")?;
@@ -56,7 +47,6 @@ impl Safe {
             xorurl: nrs_url.to_xorurl_string(),
             xorname: nrs_url.xorname(),
             type_tag: nrs_url.type_tag(),
-            version,
             nrs_map,
             data_type: nrs_url.data_type(),
             resolves_into: Some(target_url),

--- a/sn_api/src/app/resolver/safe_data.rs
+++ b/sn_api/src/app/resolver/safe_data.rs
@@ -52,7 +52,6 @@ pub enum SafeData {
         xorurl: String,
         xorname: XorName,
         type_tag: u64,
-        version: VersionHash,
         nrs_map: NrsMap,
         data_type: DataType,
         resolves_into: Option<SafeUrl>,

--- a/sn_api/src/app/resolver/safe_data.rs
+++ b/sn_api/src/app/resolver/safe_data.rs
@@ -9,7 +9,7 @@
 pub use super::{ContentType, DataType, SafeUrl, VersionHash, XorUrlBase};
 use crate::app::{
     files::{FileInfo, FilesMap},
-    multimap::MultimapKeyValues,
+    multimap::Multimap,
     nrs::NrsMap,
     register::{Entry, EntryHash},
     XorName,
@@ -62,7 +62,7 @@ pub enum SafeData {
         xorurl: String,
         xorname: XorName,
         type_tag: u64,
-        data: MultimapKeyValues,
+        data: Multimap,
         resolved_from: String,
     },
     PublicRegister {

--- a/sn_cli/src/subcommands/cat.rs
+++ b/sn_cli/src/subcommands/cat.rs
@@ -90,12 +90,16 @@ pub async fn cat_commander(cmd: CatCommands, output_fmt: OutputFmt, safe: &mut S
         }
         SafeData::NrsMapContainer {
             public_name,
-            version,
             nrs_map,
             ..
         } => {
             if OutputFmt::Pretty == output_fmt {
-                println!("NRS Map Container (version {}) at \"{}\":", version, url);
+                let mut msg = String::from("NRS Map Container ");
+                if let Some(version) = nrs_map.subname_version {
+                    msg.push_str(&format!("(version {}) ", version));
+                }
+                msg.push_str(&format!("at \"{}\"", url));
+                println!("{}", msg);
                 print_nrs_map(nrs_map, public_name);
             } else {
                 println!("{}", serialise_output(&(url, nrs_map), output_fmt));

--- a/sn_cli/src/subcommands/dog.rs
+++ b/sn_cli/src/subcommands/dog.rs
@@ -41,7 +41,6 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &mut S
                     xorurl,
                     xorname,
                     type_tag,
-                    version,
                     nrs_map,
                     data_type,
                     resolved_from,
@@ -54,7 +53,12 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &mut S
                         None => {}
                     }
                     println!("XOR-URL: {}", xorurl);
-                    println!("Version: {}", version);
+                    println!(
+                        "Version: {}",
+                        nrs_map
+                            .subname_version
+                            .map_or("none".to_string(), |v| v.to_string())
+                    );
                     println!("Type tag: {}", type_tag);
                     println!("XOR name: 0x{}", xorname_to_hex(xorname));
                     println!("Native data type: {}", data_type);

--- a/sn_cli/tests/cli_nrs.rs
+++ b/sn_cli/tests/cli_nrs.rs
@@ -208,7 +208,6 @@ fn nrs_add_should_add_a_subname_to_versioned_content() -> Result<()> {
 }
 
 #[test]
-#[ignore = "adapt according to recent refactoring"]
 fn nrs_add_should_add_a_subname_to_immutable_content() -> Result<()> {
     let tmp_data_path = assert_fs::TempDir::new()?;
     tmp_data_path.copy_from("../resources/testdata", &["**"])?;
@@ -242,7 +241,6 @@ fn nrs_add_should_add_a_subname_to_immutable_content() -> Result<()> {
 }
 
 #[test]
-#[ignore = "adapt according to recent refactoring"]
 fn nrs_add_should_add_a_subname_and_set_it_as_the_default_for_the_topname() -> Result<()> {
     let tmp_data_path = assert_fs::TempDir::new()?;
     tmp_data_path.copy_from("../resources/testdata", &["**"])?;


### PR DESCRIPTION
- 2b06d802c **refactor: nrs map fetch and rename multimap**

  The `MultimapKeyValues` type alias was renamed to `Multimap` to make it easier to work with. Some
  functions were also renamed to the same effect, e.g., `fetch_multimap_values` -> `fetch_multimap`.
  
  The function for retrieving the NRS map was also refactored. Some aspects were broken down into
  smaller functions to reduce some complex if/else cases. Things were also setup for the version in
  the last entry in the Multimap to be collected. This is going to be used with the returned
  NrsMapContainer, to facilitate returning links to immutable content, which doesn't have a version.
  Currently the code isn't setup to support that scenario.

- e87774f48 **feat: retrieve immutable content via nrs**

  Changes the resolver to enable retrieval of NRS links to immutable content. Previously, the
  NRS `target_url` was incorrectly being checked to see if it contained a version. We now validate
  this URL using the same process used by NRS, which won't assert that a file link has a version. To
  reduce duplication, the `validate_nrs_url` function in the NRS module was changed to public.

  Tests were added to both the API and CLI to cover the scenario.

  The NrsMap struct was extended to include a subname_version field. This is going to be used to
  request the map with a particular version of a subname. If no version was specified when the
  container was retrieved, then the field won't be set. This is why it's an Option. Since we're
  storing this field on the NrsMap, the `version` field on the `NrsMapContainer` was removed.

  A couple of CLI NRS tests were also re-enabled, one of which happened to be related to immutable
  content.

