### PR TITLE
Active Data Republishing

### DIFF
--- a/sn/src/messaging/system/node_msgs.rs
+++ b/sn/src/messaging/system/node_msgs.rs
@@ -66,6 +66,8 @@ pub enum NodeEvent {
         /// Whether store failed due to full
         full: bool,
     },
+    /// Inform Adults of a possible deviant node
+    DeviantsDetected(BTreeSet<XorName>),
 }
 
 /// Query originating at a node

--- a/sn/src/node/core/data/records/liveness_tracking.rs
+++ b/sn/src/node/core/data/records/liveness_tracking.rs
@@ -16,8 +16,8 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-const NEIGHBOUR_COUNT: usize = 2;
-const MIN_PENDING_OPS: usize = 10;
+const NEIGHBOUR_COUNT: usize = 3;
+const MIN_PENDING_OPS: usize = 400;
 const ACTIVE_REPLICATION_THRESHOLD: usize = MIN_PENDING_OPS / 2;
 const PENDING_OP_TOLERANCE_RATIO: f64 = 0.1;
 const ACTIVE_REPLICATION_TOLERANCE_RATIO: f64 = 0.05;
@@ -266,9 +266,9 @@ mod tests {
         let adults = (0..10).map(|_| XorName::random()).collect::<Vec<XorName>>();
         let liveness_tracker = Liveness::new(adults.clone());
 
-        // Write data 5 times to the 10 adults
+        // Write data MIN_PENDING_OPS times to the 10 adults
         for adult in &adults {
-            for _ in 0..5 {
+            for _ in 0..MIN_PENDING_OPS {
                 let random_addr = ChunkAddress(XorName::random());
                 let op_id = chunk_operation_id(&random_addr)?;
                 liveness_tracker
@@ -289,8 +289,7 @@ mod tests {
 
         // Write data MIN_PENDING_OPS + 1 times on total to first 10 adults
         for adult in &adults {
-            // We already wrote 5 times
-            for _ in 0..MIN_PENDING_OPS - 4 {
+            for _ in 0..MIN_PENDING_OPS + 1 {
                 let random_addr = ChunkAddress(XorName::random());
                 let op_id = chunk_operation_id(&random_addr)?;
                 liveness_tracker
@@ -317,8 +316,8 @@ mod tests {
         // Assert total adult count
         assert_eq!(liveness_tracker.closest_nodes_to.len(), 11);
 
-        // Write data 100+ times to the new adult which is not cleared
-        for _ in 0..150 {
+        // Write data 30 x MIN_PENDING_OPS times to the new adult which is not cleared
+        for _ in 0..MIN_PENDING_OPS * 30 {
             let random_addr = ChunkAddress(XorName::random());
             let op_id = chunk_operation_id(&random_addr)?;
             liveness_tracker

--- a/sn/src/node/core/data/storage/mod.rs
+++ b/sn/src/node/core/data/storage/mod.rs
@@ -137,7 +137,7 @@ impl Node {
         new_adults: BTreeSet<XorName>,
         lost_adults: BTreeSet<XorName>,
         remaining: BTreeSet<XorName>,
-        active_replication: bool,
+        preemptive_replication: bool,
     ) -> Result<Vec<Cmd>, crate::node::Error> {
         let data = self.data_storage.clone();
         let keys = data.keys().await?;
@@ -150,7 +150,7 @@ impl Node {
                     &new_adults,
                     &lost_adults,
                     &remaining,
-                    active_replication,
+                    preemptive_replication,
                 )
                 .await
             {
@@ -180,7 +180,7 @@ impl Node {
         new_adults: &BTreeSet<XorName>,
         lost_adults: &BTreeSet<XorName>,
         remaining: &BTreeSet<XorName>,
-        active_replication: bool,
+        preemptive_replication: bool,
     ) -> Option<(ReplicatedData, BTreeSet<XorName>)> {
         let storage = self.data_storage.clone();
 
@@ -198,8 +198,8 @@ impl Node {
             trace!("We are not a holder anymore? {}, New Adult is Holder? {}, Lost Adult was holder? {}", we_are_not_holder_anymore, new_adult_is_holder, lost_old_holder);
             let data = storage.get_for_replication(address).await.ok()?;
 
-            // Do not delete data if this is just for active replication
-            if we_are_not_holder_anymore && !active_replication {
+            // Do not delete data if this is just for preemptive replication
+            if we_are_not_holder_anymore && !preemptive_replication {
                 if let Err(err) = storage.remove(address).await {
                     warn!("Error deleting data during republish: {:?}", err);
                 }

--- a/sn/src/node/core/data/storage/mod.rs
+++ b/sn/src/node/core/data/storage/mod.rs
@@ -24,6 +24,7 @@ use crate::{
 pub(crate) use chunks::ChunkStorage;
 pub(crate) use registers::RegisterStorage;
 
+use crate::messaging::DstLocation;
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::Path,
@@ -137,7 +138,8 @@ impl Node {
         new_adults: BTreeSet<XorName>,
         lost_adults: BTreeSet<XorName>,
         remaining: BTreeSet<XorName>,
-    ) -> Result<Vec<Cmd>> {
+        republish: bool,
+    ) -> Result<Vec<Cmd>, crate::node::Error> {
         let data = self.data_storage.clone();
         let keys = data.keys().await?;
         let mut data_for_replication = BTreeMap::new();

--- a/sn/src/node/core/messaging/handling/mod.rs
+++ b/sn/src/node/core/messaging/handling/mod.rs
@@ -699,7 +699,7 @@ impl Node {
             }
             SystemMsg::NodeEvent(NodeEvent::DeviantsDetected(deviants)) => {
                 info!(
-                    "Received probable deviants nodes {deviants:?} Starting active data replication"
+                    "Received probable deviants nodes {deviants:?} Starting preemptive data replication"
                 );
                 debug!("{}", LogMarker::DeviantsDetected);
 

--- a/sn/src/node/core/messaging/handling/mod.rs
+++ b/sn/src/node/core/messaging/handling/mod.rs
@@ -933,7 +933,7 @@ impl Node {
     async fn republish_data_for_deviant_nodes(
         &self,
         deviants: BTreeSet<XorName>,
-    ) -> Result<Vec<Command>> {
+    ) -> Result<Vec<Cmd>> {
         let our_adults = self
             .network_knowledge
             .adults()

--- a/sn/src/node/core/messaging/handling/mod.rs
+++ b/sn/src/node/core/messaging/handling/mod.rs
@@ -35,7 +35,9 @@ use crate::node::{
     network_knowledge::NetworkKnowledge,
     Error, Event, MessageReceived, Result, MIN_LEVEL_WHEN_FULL,
 };
-use crate::types::{log_markers::LogMarker, Peer, PublicKey, UnnamedPeer};
+use crate::types::{log_markers::LogMarker, PublicKey};
+use crate::types::{Peer, UnnamedPeer};
+use std::collections::BTreeSet;
 
 use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;
@@ -943,7 +945,7 @@ impl Node {
             .collect::<BTreeSet<XorName>>();
 
         self.reorganize_data(
-            self.node.read().await.name(),
+            self.info.read().await.name(),
             BTreeSet::new(),
             deviants,
             our_adults,

--- a/sn/src/node/core/messaging/handling/mod.rs
+++ b/sn/src/node/core/messaging/handling/mod.rs
@@ -697,6 +697,14 @@ impl Node {
                     Ok(vec![])
                 };
             }
+            SystemMsg::NodeEvent(NodeEvent::DeviantsDetected(deviants)) => {
+                info!(
+                    "Received probable deviants nodes {deviants:?} Starting active data replication"
+                );
+                debug!("{}", LogMarker::DeviantsDetected);
+
+                return self.republish_data_for_deviant_nodes(deviants).await;
+            }
             SystemMsg::NodeCmd(NodeCmd::ReplicateData(data)) => {
                 info!("ReplicateData MsgId: {:?}", msg_id);
                 return if self.is_elder().await {
@@ -736,13 +744,6 @@ impl Node {
                         }
                     }
                 };
-            }
-            SystemMsg::NodeCmd(NodeEvent::DeviantsDetected(deviants)) => {
-                info!(
-                    "Received probable deviants nodes {deviants:?} Starting active data replication"
-                );
-
-                return self.republish_data_for_deviant_nodes(deviants).await;
             }
             SystemMsg::NodeCmd(node_cmd) => {
                 self.send_event(Event::MessageReceived {

--- a/sn/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn/src/node/core/messaging/handling/service_msgs.rs
@@ -127,7 +127,7 @@ impl Node {
                 .collect::<Vec<Peer>>();
 
             for adult in valid_adults {
-                commands.push(Command::PrepareNodeMsgToSendToNodes {
+                cmds.push(Cmd::SignOutgoingSystemMsg {
                     msg: SystemMsg::NodeEvent(NodeEvent::DeviantsDetected(deviants.clone())),
                     dst: DstLocation::Node {
                         name: adult.name(),

--- a/sn/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn/src/node/core/messaging/handling/service_msgs.rs
@@ -132,6 +132,7 @@ impl Node {
                     section_pk: *self.section_chain().await.last_key(),
                 },
             });
+            debug!("{:?}", LogMarker::SendDeviantsDetected);
         }
 
         if !pending_removed {

--- a/sn/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn/src/node/core/messaging/handling/service_msgs.rs
@@ -16,7 +16,6 @@ use crate::node::{api::cmds::Cmd, core::Node, Result};
 use crate::types::{log_markers::LogMarker, register::User, Peer, PublicKey, ReplicatedData};
 
 use crate::messaging::system::NodeEvent;
-use itertools::Itertools;
 use xor_name::XorName;
 
 impl Node {

--- a/sn/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn/src/node/core/messaging/handling/service_msgs.rs
@@ -117,7 +117,7 @@ impl Node {
         }
 
         if !deviants.is_empty() {
-            warn!("{deviants:?} have crossed active replication threshold. Triggering active data replication");
+            warn!("{deviants:?} have crossed preemptive replication threshold. Triggering preemptive data replication");
 
             let our_adults = self.network_knowledge.adults().await;
             let valid_adults = our_adults

--- a/sn/src/node/core/messaging/handling/update_section.rs
+++ b/sn/src/node/core/messaging/handling/update_section.rs
@@ -43,7 +43,7 @@ impl Node {
         // so we reorganise the data stored in this section..:
         let our_name = self.info.read().await.name();
         let remaining = old_adults.intersection(&current_adults).copied().collect();
-        self.reorganize_data(our_name, added, removed, remaining)
+        self.reorganize_data(our_name, added, removed, remaining, false)
             .await
             .map_err(super::Error::from)
     }

--- a/sn/src/types/log_markers.rs
+++ b/sn/src/types/log_markers.rs
@@ -81,6 +81,7 @@ pub enum LogMarker {
     SendJoinsDisallowed,
     SendDKGUnderway,
     SendNodeApproval,
+    SendDeviantsDetected,
     // Approved to join
     ReceivedJoinApproval,
     // Connections

--- a/sn/src/types/log_markers.rs
+++ b/sn/src/types/log_markers.rs
@@ -22,6 +22,8 @@ pub enum LogMarker {
     NewPrefix,
     AeSendUpdateToSiblings,
     AgreementOfOnline,
+    // Malice
+    DeviantsDetected,
     // Messaging
     ServiceMsgToBeHandled,
     SystemMsgToBeHandled,


### PR DESCRIPTION
Tweaks the liveness tracker to detect nodes that begin to accumulate pending operations. These deviant nodes' data are pre-emptively replicated to avoid data loss and improve fault tolerance in the network.