### PR TITLE
ci: remove smart release dry run

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -3,7 +3,7 @@ name: Nightly Release Run
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '30 2 * * *'
+    - cron:  '30 4 * * *'
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -200,11 +200,11 @@ jobs:
         timeout-minutes: 90
 
   kill-testnet:
-    name: Destroy Digital Ocean testnet
+    name: kill testnet
     runs-on: ubuntu-latest
     needs: [launch-testnet, client, api, cli]
     steps:
-      - name: Kill testnet
+      - name: kill testnet
         uses: maidsafe/sn_testnet_action@master
         with:
           do-token: ${{ secrets.DO_TOKEN }}
@@ -242,7 +242,7 @@ jobs:
           tags: true
 
   kill-if-fail:
-    name: Destroy Digital Ocean testnet on fail
+    name: kill testnet on fail
     runs-on: ubuntu-latest
     if: |
       always() &&

--- a/resources/scripts/bump_version.sh
+++ b/resources/scripts/bump_version.sh
@@ -9,27 +9,6 @@ safe_network_has_changes=false
 sn_api_has_changes=false
 sn_cli_has_changes=false
 
-function perform_smart_release_dry_run() {
-  echo "Performing dry run for smart-release..."
-  dry_run_output=$(cargo smart-release \
-    --update-crates-index \
-    --no-push \
-    --no-publish \
-    --no-changelog-preview \
-    --allow-fully-generated-changelogs \
-    --no-changelog-github-release \
-    "safe_network" "sn_api" "sn_cli" 2>&1)
-  echo "Dry run output for smart-release:"
-  echo $dry_run_output
-
-  if [[ $dry_run_output == *"Manifest version of provided package"* ]]; then
-    echo "Dry run output contains 'Manifest version of provided package'."
-    echo "This indicates that some crate version failed to publish."
-    echo "Make sure there is a crate publish for every tag that exists."
-    exit 1
-  fi
-}
-
 function crate_has_changes() {
   local crate_name="$1"
   if [[ $dry_run_output == *"WOULD auto-bump provided package '$crate_name'"* ]]; then
@@ -113,7 +92,6 @@ function amend_tags() {
   if [[ $sn_cli_has_changes == true ]]; then git tag "sn_cli-v${sn_cli_version}" -f; fi
 }
 
-perform_smart_release_dry_run
 determine_which_crates_have_changes
 generate_version_bump_commit
 generate_new_commit_message


### PR DESCRIPTION
- 4dbda7363 **ci: remove smart release dry run**

  Previously, the dry run was being used to detect a string of text I had seen appear when version
  bumping succeeded but publishing of one or more crates failed.

  Two days ago, Smart Release had a new release (v0.8.0) and it seems this assumption no longer holds.
  The text is appearing now, but the version it's referring to has had its crate published. This was
  the only thing the dry run was checking, so it doesn't serve any purpose now.

  The scheduled time for the nightly run was also pushed back a couple of hours, as we'd seen Bors
  still running and pushing to main after 0230.
