### PR TITLE
ci: manual trigger for nightly run

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '30 4 * * *'
+  workflow_dispatch:
+    inputs:
+      node-count:
+        description: number of nodes for the testnet
+        required: true
+        default: 11
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/resources/scripts/bump_version.sh
+++ b/resources/scripts/bump_version.sh
@@ -9,6 +9,21 @@ safe_network_has_changes=false
 sn_api_has_changes=false
 sn_cli_has_changes=false
 
+
+function perform_smart_release_dry_run() {
+  echo "Performing dry run for smart-release..."
+  dry_run_output=$(cargo smart-release \
+    --update-crates-index \
+    --no-push \
+    --no-publish \
+    --no-changelog-preview \
+    --allow-fully-generated-changelogs \
+    --no-changelog-github-release \
+    "safe_network" "sn_api" "sn_cli" 2>&1)
+  echo "Dry run output for smart-release:"
+  echo $dry_run_output
+}
+
 function crate_has_changes() {
   local crate_name="$1"
   if [[ $dry_run_output == *"WOULD auto-bump provided package '$crate_name'"* ]]; then
@@ -92,6 +107,7 @@ function amend_tags() {
   if [[ $sn_cli_has_changes == true ]]; then git tag "sn_cli-v${sn_cli_version}" -f; fi
 }
 
+perform_smart_release_dry_run
 determine_which_crates_have_changes
 generate_version_bump_commit
 generate_new_commit_message


### PR DESCRIPTION
- 30f62eeb3 **ci: manual trigger for nightly run**

  Uses the `workflow_dispatch` event to enable manual triggering of the nightly run, which can be
  useful if we want to release during the day.

  Also reintroduces the dry run for Smart Release. I mistakenly believed this was only being used to
  check for problems with publishing, forgetting it was also used to detect which crates have changes.
  That info is used in the release commit message to specify the crates with changes, which is
  subsequently used by the release workflow so that publishing only runs for crates with version bumps.