### PR TITLE
chore: simplify data replication cmds and flow

### DIFF
--- a/sn/src/client/client_api/file_apis.rs
+++ b/sn/src/client/client_api/file_apis.rs
@@ -606,7 +606,7 @@ mod tests {
 
         // 3 elders were chosen by the client (should only be 3 as even if client chooses adults, AE should kick in prior to them attempting any of this)
         the_logs
-            .assert_count(LogMarker::ChunkStoreReceivedAtElder, 3)
+            .assert_count(LogMarker::DataStoreReceivedAtElder, 3)
             .await?;
 
         // 4 adults * reqs from 3 elders storing the chunk

--- a/sn/src/messaging/data/data_exchange.rs
+++ b/sn/src/messaging/data/data_exchange.rs
@@ -17,7 +17,7 @@ use xor_name::XorName;
 
 /// Metadata (register and chunk holders) replication.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DataExchange {
+pub struct MetadataExchange {
     /// Adult storage levels.
     pub adult_levels: BTreeMap<XorName, StorageLevel>,
 }

--- a/sn/src/messaging/data/errors.rs
+++ b/sn/src/messaging/data/errors.rs
@@ -35,8 +35,15 @@ pub enum Error {
     #[error("Failed to write file")]
     FailedToWriteFile,
     /// Insufficient Adults found to store data
-    #[error("Failed to store chunk. Insufficient space found at section {0:?} adults")]
-    InsufficientAdults(Prefix),
+    #[error("Failed to store data. Insufficient replication count at section {prefix:?}. Expected {expected}, found {found}.")]
+    InsufficientAdults {
+        /// The prefix of the section.
+        prefix: Prefix,
+        /// Expected number of Adults for minimum replication.
+        expected: u8,
+        /// Actual number of Adults found to hold the data.
+        found: u8,
+    },
     /// Provided data already exists on the network
     #[error("Data provided already exists")]
     DataExists,

--- a/sn/src/messaging/data/mod.rs
+++ b/sn/src/messaging/data/mod.rs
@@ -16,7 +16,7 @@ mod register;
 
 pub use self::{
     cmd::DataCmd,
-    data_exchange::{DataExchange, RegisterStoreExport, ReplicatedRegisterLog, StorageLevel},
+    data_exchange::{MetadataExchange, RegisterStoreExport, ReplicatedRegisterLog, StorageLevel},
     errors::{Error, Result},
     query::DataQuery,
     register::{

--- a/sn/src/messaging/serialisation/mod.rs
+++ b/sn/src/messaging/serialisation/mod.rs
@@ -99,6 +99,7 @@ impl MessageType {
             MessageType::System {
                 msg:
                     SystemMsg::NodeCmd(_)
+                    | SystemMsg::NodeEvent(_)
                     | SystemMsg::NodeQuery(_)
                     | SystemMsg::NodeQueryResponse { .. }
                     | SystemMsg::NodeMsgError { .. },

--- a/sn/src/messaging/system/mod.rs
+++ b/sn/src/messaging/system/mod.rs
@@ -16,7 +16,7 @@ mod signed;
 pub use agreement::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, Proposal, SectionAuth};
 pub use join::{JoinRejectionReason, JoinRequest, JoinResponse, ResourceProofResponse};
 pub use join_as_relocated::{JoinAsRelocatedRequest, JoinAsRelocatedResponse};
-pub use node_msgs::{NodeCmd, NodeQuery, NodeQueryResponse};
+pub use node_msgs::{NodeCmd, NodeEvent, NodeQuery, NodeQueryResponse};
 pub use node_state::{MembershipState, NodeState, RelocateDetails};
 pub use signed::{KeyedSig, SigShare};
 
@@ -177,10 +177,12 @@ pub enum SystemMsg {
     /// Message that notifies a section to test
     /// the connectivity to a node
     StartConnectivityTest(XorName),
-    /// Cmds only sent internally in the network.
+    /// Cmds are orders to perform some operation, only sent internally in the network.
     NodeCmd(NodeCmd),
     /// Queries is a read-only operation.
     NodeQuery(NodeQuery),
+    /// Events are facts about something that happened on a node.
+    NodeEvent(NodeEvent),
     /// The response to a query, containing the query result.
     NodeQueryResponse {
         /// QueryResponse.

--- a/sn/src/messaging/system/node_msgs.rs
+++ b/sn/src/messaging/system/node_msgs.rs
@@ -7,7 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    data::{DataCmd, DataExchange, DataQuery, OperationId, QueryResponse, Result, StorageLevel},
+    data::{
+        DataCmd, DataQuery, MetadataExchange, OperationId, QueryResponse, Result, StorageLevel,
+    },
     EndUser, MessageId, ServiceAuth,
 };
 use crate::types::{
@@ -32,13 +34,6 @@ pub enum NodeCmd {
         /// Message source
         origin: EndUser,
     },
-    /// Data is stored by Adults
-    StoreData {
-        /// The data
-        data: ReplicatedData,
-        /// Message source
-        origin: EndUser,
-    },
     /// Notify Elders on nearing max capacity
     RecordStorageLevel {
         /// Node Id
@@ -48,15 +43,28 @@ pub enum NodeCmd {
         /// The storage level reported by the node.
         level: StorageLevel,
     },
-    /// Replicate a given chunk at an Adult (sent from elders on receipt of RepublishData)
+    /// Tells an Adult to store a replica of the data
     ReplicateData(ReplicatedData),
-    /// Tells the Elders to re-publish a chunk in the data section
-    RepublishData(ReplicatedData),
     /// Sent to all promoted nodes (also sibling if any) after
     /// a completed transition to a new constellation.
     ReceiveMetadata {
         /// Metadata
-        metadata: DataExchange,
+        metadata: MetadataExchange,
+    },
+}
+
+/// Event message sent among nodes
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub enum NodeEvent {
+    /// Sent by a full Adult, and tells the Elders to store a chunk at some other Adult in the section
+    CouldNotStoreData {
+        /// Node Id
+        node_id: PublicKey,
+        /// The data that the Adult couldn't store
+        data: ReplicatedData,
+        /// Whether store failed due to full
+        full: bool,
     },
 }
 

--- a/sn/src/node/core/data_records/mod.rs
+++ b/sn/src/node/core/data_records/mod.rs
@@ -11,7 +11,7 @@ use super::{Command, Core, Prefix};
 use crate::{
     data_copy_count,
     messaging::{
-        data::{CmdError, DataExchange, DataQuery, Error as ErrorMessage, StorageLevel},
+        data::{CmdError, DataQuery, MetadataExchange, StorageLevel},
         system::{NodeCmd, NodeQuery, SystemMsg},
         AuthorityProof, EndUser, MessageId, ServiceAuth,
     },
@@ -26,34 +26,23 @@ use tracing::info;
 use xor_name::XorName;
 
 impl Core {
-    pub(crate) async fn send_data_to_adults(
-        &self,
-        data: ReplicatedData,
-        msg_id: MessageId,
-        origin: Peer,
-    ) -> Result<Vec<Command>> {
-        trace!("{:?}: {:?}", LogMarker::DataStorageReceivedAtElder, data);
+    // Locate ideal holders for this data, line up wiremsgs for those to instruct them to store the data
+    pub(crate) async fn replicate_data(&self, data: ReplicatedData) -> Result<Vec<Command>> {
+        trace!("{:?}: {:?}", LogMarker::DataStoreReceivedAtElder, data);
+        if self.is_elder().await {
+            let targets = self.get_adults_who_should_store_data(data.name()).await;
 
-        let target = data.name();
+            info!(
+                "Replicating data {:?} to holders {:?}",
+                data.name(),
+                &targets,
+            );
 
-        let msg = SystemMsg::NodeCmd(NodeCmd::StoreData {
-            data,
-            origin: EndUser(origin.name()),
-        });
-
-        let targets = self.get_adults_who_should_store_data(target).await;
-
-        let aggregation = false;
-
-        if data_copy_count() > targets.len() {
-            let error = CmdError::Data(ErrorMessage::InsufficientAdults(
-                self.network_knowledge().prefix().await,
-            ));
-            return self.send_cmd_error_response(error, origin, msg_id).await;
+            let msg = SystemMsg::NodeCmd(NodeCmd::ReplicateData(data));
+            self.send_node_msg_to_targets(msg, targets, false).await
+        } else {
+            Err(Error::InvalidState)
         }
-
-        self.send_node_msg_to_targets(msg, targets, aggregation)
-            .await
     }
 
     pub(crate) async fn read_data_from_adults(
@@ -117,14 +106,14 @@ impl Core {
             .await
     }
 
-    pub(crate) async fn get_metadata_of(&self, prefix: &Prefix) -> DataExchange {
+    pub(crate) async fn get_metadata_of(&self, prefix: &Prefix) -> MetadataExchange {
         // Load tracked adult_levels
         let adult_levels = self.capacity.levels_matching(*prefix).await;
-        DataExchange { adult_levels }
+        MetadataExchange { adult_levels }
     }
 
-    pub(crate) async fn set_adult_levels(&self, adult_levels: DataExchange) {
-        let DataExchange { adult_levels } = adult_levels;
+    pub(crate) async fn set_adult_levels(&self, adult_levels: MetadataExchange) {
+        let MetadataExchange { adult_levels } = adult_levels;
         self.capacity.set_adult_levels(adult_levels).await
     }
 

--- a/sn/src/node/core/data_storage/mod.rs
+++ b/sn/src/node/core/data_storage/mod.rs
@@ -93,17 +93,6 @@ impl DataStorage {
 
     /// --- System calls ---
 
-    /// Stores data that Elders sent to it for replication.
-    /// Chunk should already have network authority
-    /// TODO: define what authority is needed here...
-    pub(crate) async fn store_for_replication(
-        &self,
-        data: &ReplicatedData,
-    ) -> Result<Option<StorageLevel>> {
-        debug!("Trying to store for replication: {:?}", data.name());
-        self.store(data).await
-    }
-
     // Read data from local store
     pub(crate) async fn get_for_replication(
         &self,
@@ -154,7 +143,7 @@ impl Core {
         let mut data_for_replication = BTreeMap::new();
         for addr in keys.iter() {
             if let Some((data, holders)) = self
-                .republish_and_cache(addr, &our_name, &new_adults, &lost_adults, &remaining)
+                .get_replica_targets(addr, &our_name, &new_adults, &lost_adults, &remaining)
                 .await
             {
                 let _prev = data_for_replication.insert(data.name(), (data, holders));
@@ -176,7 +165,7 @@ impl Core {
     }
 
     // on adults
-    async fn republish_and_cache(
+    async fn get_replica_targets(
         &self,
         address: &DataAddress,
         our_name: &XorName,
@@ -204,7 +193,6 @@ impl Core {
                     warn!("Error deleting data during republish: {:?}", err);
                 }
             }
-            // TODO: Push to LRU cache
             Some((data, new_holders))
         } else {
             None

--- a/sn/src/node/core/messaging.rs
+++ b/sn/src/node/core/messaging.rs
@@ -250,7 +250,6 @@ impl Core {
         old: &StateSnapshot,
     ) -> Result<Vec<Command>> {
         debug!("{}", LogMarker::AeSendUpdateToSiblings);
-        let mut commands = vec![];
         if let Some(sibling_sap) = self
             .network_knowledge
             .prefix_map()
@@ -271,24 +270,20 @@ impl Core {
             // sibling elders shall still in the state of pre-split.
             let previous_section_key = old.section_key;
 
-            commands.extend(
-                self.send_data_updates_to(
-                    sibling_sap.prefix(),
-                    promoted_sibling_elders,
-                    previous_section_key,
-                )
-                .await?,
-            );
-
-            Ok(commands)
+            self.send_metadata_updates_to(
+                sibling_sap.prefix(),
+                promoted_sibling_elders,
+                previous_section_key,
+            )
+            .await
         } else {
             error!("Failed to get sibling SAP during split.");
             Ok(vec![])
         }
     }
 
-    /// Send DataExchange packet to the target recipients
-    pub(crate) async fn send_data_updates_to(
+    /// Send MetadataExchange packet to the target recipients
+    pub(crate) async fn send_metadata_updates_to(
         &self,
         prefix: Prefix,
         recipients: Vec<Peer>,

--- a/sn/src/node/core/mod.rs
+++ b/sn/src/node/core/mod.rs
@@ -226,7 +226,7 @@ impl Core {
     }
 
     /// Generate commands and fire events based upon any node state changes.
-    pub(crate) async fn update_self_for_new_node_state_and_fire_events(
+    pub(crate) async fn update_self_for_new_node_state(
         &self,
         old: StateSnapshot,
     ) -> Result<Vec<Command>> {
@@ -313,7 +313,7 @@ impl Core {
                 }
             } else {
                 commands.extend(
-                    self.send_data_updates_to(
+                    self.send_metadata_updates_to(
                         self.network_knowledge.prefix().await,
                         self.network_knowledge
                             .authority_provider()
@@ -331,7 +331,7 @@ impl Core {
             };
 
             commands.extend(
-                self.send_data_updates_to(
+                self.send_metadata_updates_to(
                     self.network_knowledge.prefix().await,
                     self.network_knowledge
                         .authority_provider()

--- a/sn/src/node/core/msg_handling/agreement.rs
+++ b/sn/src/node/core/msg_handling/agreement.rs
@@ -322,7 +322,6 @@ impl Core {
             self.network_knowledge.prefix_map()
         );
 
-        self.update_self_for_new_node_state_and_fire_events(snapshot)
-            .await
+        self.update_self_for_new_node_state(snapshot).await
     }
 }

--- a/sn/src/node/core/msg_handling/anti_entropy.rs
+++ b/sn/src/node/core/msg_handling/anti_entropy.rs
@@ -64,10 +64,7 @@ impl Core {
         let mut commands = self.try_reorganize_data(old_adults).await?;
 
         // always run this, only changes will trigger events
-        commands.extend(
-            self.update_self_for_new_node_state_and_fire_events(snapshot)
-                .await?,
-        );
+        commands.extend(self.update_self_for_new_node_state(snapshot).await?);
 
         Ok(commands)
     }
@@ -108,10 +105,7 @@ impl Core {
                 self.create_or_wait_for_backoff(&sender).await;
 
                 let mut result = Vec::new();
-                if let Ok(cmds) = self
-                    .update_self_for_new_node_state_and_fire_events(snapshot)
-                    .await
-                {
+                if let Ok(cmds) = self.update_self_for_new_node_state(snapshot).await {
                     result.extend(cmds);
                 }
 

--- a/sn/src/node/core/msg_handling/dkg.rs
+++ b/sn/src/node/core/msg_handling/dkg.rs
@@ -269,8 +269,7 @@ impl Core {
             .try_update_current_sap(key_share_pk, &sap.prefix())
             .await
         {
-            self.update_self_for_new_node_state_and_fire_events(snapshot)
-                .await
+            self.update_self_for_new_node_state(snapshot).await
         } else {
             // This proposal is sent to the current set of elders to be aggregated
             // and section signed.

--- a/sn/src/node/core/msg_handling/service_msgs.rs
+++ b/sn/src/node/core/msg_handling/service_msgs.rs
@@ -8,7 +8,7 @@
 
 use crate::data_copy_count;
 use crate::messaging::{
-    data::{CmdError, DataCmd, DataQuery, ServiceMsg},
+    data::{CmdError, DataCmd, DataQuery, Error as ErrorMessage, ServiceMsg},
     system::{NodeQueryResponse, SystemMsg},
     DstLocation, EndUser, MessageId, MsgKind, NodeAuth, WireMsg,
 };
@@ -224,30 +224,40 @@ impl Core {
         msg_id: MessageId,
         msg: ServiceMsg,
         auth: AuthorityProof<ServiceAuth>,
-        user: Peer,
+        origin: Peer,
     ) -> Result<Vec<Command>> {
-        match msg {
+        if self.is_not_elder().await {
+            error!("Received unexpected message while Adult");
+            return Ok(vec![]);
+        }
+        // extract the data from the request
+        let data = match msg {
             // These reads/writes are for adult nodes...
-            ServiceMsg::Cmd(DataCmd::Register(cmd)) => {
-                let mut commands = self
-                    .send_data_to_adults(ReplicatedData::RegisterWrite(cmd), msg_id, user.clone())
-                    .await?;
-                commands.extend(self.send_cmd_ack(user, msg_id).await?);
-                Ok(commands)
+            ServiceMsg::Cmd(DataCmd::Register(cmd)) => ReplicatedData::RegisterWrite(cmd),
+            ServiceMsg::Cmd(DataCmd::StoreChunk(chunk)) => ReplicatedData::Chunk(chunk),
+            ServiceMsg::Query(query) => {
+                return self
+                    .read_data_from_adults(query, msg_id, auth, origin)
+                    .await
             }
-            ServiceMsg::Cmd(DataCmd::StoreChunk(chunk)) => {
-                let mut commands = self
-                    .send_data_to_adults(ReplicatedData::Chunk(chunk), msg_id, user.clone())
-                    .await?;
-                commands.extend(self.send_cmd_ack(user, msg_id).await?);
-                Ok(commands)
-            }
-            ServiceMsg::Query(query) => self.read_data_from_adults(query, msg_id, auth, user).await,
             _ => {
                 warn!("!!!! Unexpected ServiceMsg received in routing. Was not sent to node layer: {:?}", msg);
-                Ok(vec![])
+                return Ok(vec![]);
             }
+        };
+        // build the replication cmds
+        let mut commands = self.replicate_data(data).await?;
+        // make sure the expected replication factor is achieved
+        if data_copy_count() > commands.len() {
+            let error = CmdError::Data(ErrorMessage::InsufficientAdults {
+                prefix: self.network_knowledge().prefix().await,
+                expected: data_copy_count() as u8,
+                found: commands.len() as u8,
+            });
+            return self.send_cmd_error_response(error, origin, msg_id).await;
         }
+        commands.extend(self.send_cmd_ack(origin, msg_id).await?);
+        Ok(commands)
     }
 
     // Used to fetch the list of holders for given data name.

--- a/sn/src/types/log_markers.rs
+++ b/sn/src/types/log_markers.rs
@@ -26,11 +26,10 @@ pub enum LogMarker {
     ServiceMsgToBeHandled,
     SystemMsgToBeHandled,
     // Data
-    DataStorageReceivedAtElder,
+    DataStoreReceivedAtElder,
     DataQueryReceviedAtElder,
     // Chunks
     StoringChunk,
-    ChunkStoreReceivedAtElder,
     StoredNewChunk,
     ChunkQueryResponseReceviedFromAdult,
     ChunkQueryReceviedAtElder,


### PR DESCRIPTION
We had `StoreData`, `ReplicateData` and `RepublishData`, where it was a bit confusing what did what.
It is now simplified to `ReplicateData` cmd and `CouldNotStoreData` event, where one is
used to send data to Adults, and the other is sent by Adults to Elders
when they can't handle the data.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
