### PR TITLE
refactor(node): keep section Left/Relocated members in a separate archive container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,12 +930,13 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+checksum = "b799062aaf67eb976af3bdca031ee6f846d2f0a5710ddbb0d2efee33f3cc4760"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
+ "parking_lot",
  "serde",
 ]
 

--- a/sn/Cargo.toml
+++ b/sn/Cargo.toml
@@ -54,7 +54,7 @@ color-eyre = "0.5.11"
 console-subscriber = { version = "0.1.0", optional = true }
 crdts = "~7.0"
 custom_debug = "0.5.0"
-dashmap = {version = "~4.0.2", features = [ "serde" ]}
+dashmap = {version = "5.0.0", features = [ "serde" ]}
 dirs-next = "2.0.0"
 ed25519 = { version = "1.2.0", features = ["serde_bytes"] }
 ed25519-dalek = { version = "1.0.0", features = ["serde"] }

--- a/sn/src/client/client_api/mod.rs
+++ b/sn/src/client/client_api/mod.rs
@@ -229,8 +229,8 @@ impl Client {
         // Send the dummy message to probe the network for it's infrastructure details.
         while attempts < NETWORK_PROBE_RETRY_COUNT && initial_probe.is_err() {
             error!(
-                "Initial probe msg to network failed. Trying again, attempt: {}",
-                attempts
+                "Initial probe msg to network failed. Trying again (attempt {}): {:?}",
+                attempts, initial_probe
             );
 
             if attempts == NETWORK_PROBE_RETRY_COUNT {

--- a/sn/src/node/api/dispatcher.rs
+++ b/sn/src/node/api/dispatcher.rs
@@ -586,7 +586,12 @@ impl Dispatcher {
             ]),
             Command::TestConnectivity(name) => {
                 let mut commands = vec![];
-                if let Some(member_info) = self.core.network_knowledge().get_section_member(&name) {
+                if let Some(member_info) = self
+                    .core
+                    .network_knowledge()
+                    .get_section_member(&name)
+                    .await
+                {
                     if self
                         .core
                         .comm

--- a/sn/src/node/api/tests/mod.rs
+++ b/sn/src/node/api/tests/mod.rs
@@ -640,6 +640,7 @@ async fn handle_agreement_on_offline_of_non_elder() -> Result<()> {
         .core
         .network_knowledge()
         .section_members()
+        .await
         .contains(&node_state));
 
     Ok(())
@@ -662,6 +663,7 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
 
     let remove_node_state = section
         .get_section_member(&remove_peer.name())
+        .await
         .expect("member not found")
         .leave()?;
 
@@ -735,6 +737,7 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
         .core
         .network_knowledge()
         .section_members()
+        .await
         .contains(&remove_node_state));
 
     // The removed peer is still our elder because we haven't yet processed the section update.

--- a/sn/src/node/core/api.rs
+++ b/sn/src/node/core/api.rs
@@ -255,6 +255,7 @@ impl Core {
         let members = self
             .network_knowledge
             .section_signed_members()
+            .await
             .into_iter()
             .map(|itr| itr.into_authed_msg())
             .collect();

--- a/sn/src/node/core/connectivity.rs
+++ b/sn/src/node/core/connectivity.rs
@@ -16,7 +16,7 @@ use xor_name::XorName;
 
 impl Core {
     pub(crate) async fn handle_peer_lost(&self, addr: &SocketAddr) -> Result<Vec<Command>> {
-        let name = if let Some(peer) = self.network_knowledge.find_member_by_addr(addr) {
+        let name = if let Some(peer) = self.network_knowledge.find_member_by_addr(addr).await {
             debug!("Lost known peer {}", peer);
             peer.name()
         } else {
@@ -55,7 +55,7 @@ impl Core {
             .collect();
         let mut result: Vec<Command> = Vec::new();
         for name in names.iter() {
-            if let Some(info) = self.network_knowledge.get_section_member(name) {
+            if let Some(info) = self.network_knowledge.get_section_member(name).await {
                 let info = info.leave()?;
                 if let Ok(commands) = self
                     .send_proposal(elders.clone(), Proposal::Offline(info))

--- a/sn/src/node/core/delivery_group.rs
+++ b/sn/src/node/core/delivery_group.rs
@@ -48,7 +48,7 @@ pub(crate) async fn delivery_targets(
             if name == our_name {
                 return Ok((Vec::new(), 0));
             }
-            if let Some(node) = get_peer(name, network_knowledge) {
+            if let Some(node) = get_peer(name, network_knowledge).await {
                 return Ok((vec![node], 1));
             }
 
@@ -155,8 +155,8 @@ async fn candidates(
 }
 
 // Returns a `Peer` for a known node.
-fn get_peer(name: &XorName, network_knowledge: &NetworkKnowledge) -> Option<Peer> {
-    match network_knowledge.get_section_member(name) {
+async fn get_peer(name: &XorName, network_knowledge: &NetworkKnowledge) -> Option<Peer> {
+    match network_knowledge.get_section_member(name).await {
         Some(info) => Some(info.peer().clone()),
         None => network_knowledge
             .section_by_name(name)

--- a/sn/src/node/core/messaging.rs
+++ b/sn/src/node/core/messaging.rs
@@ -151,6 +151,7 @@ impl Core {
         let members = self
             .network_knowledge
             .section_signed_members()
+            .await
             .iter()
             .map(|state| state.clone().into_authed_msg())
             .collect();
@@ -202,6 +203,7 @@ impl Core {
         let nodes: Vec<_> = self
             .network_knowledge
             .section_members()
+            .await
             .into_iter()
             .filter(|info| info.name() != our_name)
             .map(|info| info.peer().clone())

--- a/sn/src/node/core/mod.rs
+++ b/sn/src/node/core/mod.rs
@@ -382,7 +382,7 @@ impl Core {
         self.comm.print_stats();
     }
 
-    pub(super) async fn log_network_stats(&self) {
+    pub(super) async fn log_section_stats(&self) {
         let adults = self.network_knowledge.adults().await.len();
         let elders = self
             .network_knowledge

--- a/sn/src/node/core/msg_handling/agreement.rs
+++ b/sn/src/node/core/msg_handling/agreement.rs
@@ -52,10 +52,10 @@ impl Core {
         let mut commands = vec![];
         if let Some(old_info) = self
             .network_knowledge
-            .get_section_signed_member(&new_info.name())
+            .is_either_member_or_archived(&new_info.name())
+            .await
         {
             // This node is rejoin with same name.
-
             if old_info.state() != MembershipState::Left {
                 debug!(
                     "Ignoring Online node {} - {:?} not Left.",
@@ -104,7 +104,7 @@ impl Core {
         })
         .await;
 
-        self.log_network_stats().await;
+        self.log_section_stats().await;
 
         // Do not disable node joins in first section.
         if !self.network_knowledge.prefix().await.is_empty() {

--- a/sn/src/node/core/msg_handling/join.rs
+++ b/sn/src/node/core/msg_handling/join.rs
@@ -87,7 +87,7 @@ impl Core {
         }
 
         // Check if we already have this peer in our section
-        if self.network_knowledge.is_section_member(&peer.name()) {
+        if self.network_knowledge.is_section_member(&peer.name()).await {
             debug!(
                 "Ignoring JoinRequest from {} - already member of our section.",
                 peer
@@ -204,7 +204,7 @@ impl Core {
         // During the first section, nodes shall use ranged age to avoid too many nodes getting
         // relocated at the same time. After the first section splits, nodes shall only
         // start with an age of MIN_ADULT_AGE
-        let current_section_size = self.network_knowledge.section_size();
+        let current_section_size = self.network_knowledge.section_size().await;
         let our_prefix = self.network_knowledge.prefix().await;
 
         // Prefix will be empty for first section
@@ -279,7 +279,7 @@ impl Core {
             ]);
         }
 
-        if self.network_knowledge.is_section_member(&peer.name()) {
+        if self.network_knowledge.is_section_member(&peer.name()).await {
             debug!(
                 "Ignoring JoinAsRelocatedRequest from {} - already member of our section.",
                 peer
@@ -344,6 +344,7 @@ impl Core {
         if self
             .network_knowledge
             .is_relocated_to_our_section(&relocate_details.previous_name)
+            .await
         {
             debug!(
                 "Ignoring JoinAsRelocatedRequest from {} - original node {:?} already relocated to us.",

--- a/sn/src/node/core/msg_handling/relocation.rs
+++ b/sn/src/node/core/msg_handling/relocation.rs
@@ -51,7 +51,7 @@ impl Core {
 
         let mut commands = vec![];
         for (node_state, relocate_details) in
-            find_nodes_to_relocate(&self.network_knowledge, &churn_id, excluded)
+            find_nodes_to_relocate(&self.network_knowledge, &churn_id, excluded).await
         {
             debug!(
                 "Relocating {:?} to {} (on churn of {})",

--- a/sn/src/node/network_knowledge/section_authority_provider.rs
+++ b/sn/src/node/network_knowledge/section_authority_provider.rs
@@ -23,7 +23,6 @@ use std::{
 /// A new `SectionAuthorityProvider` is created whenever the elders change, due to an elder being
 /// added or removed, or the section splitting or merging.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-// TODO: make pub(crate) - but it's used by routing stress_example atm
 pub struct SectionAuthorityProvider {
     prefix: Prefix,
     public_key_set: PublicKeySet,
@@ -135,16 +134,11 @@ impl SectionAuthorityProvider {
     }
 
     /// Key of the section.
-    // TODO: make pub(crate) - but it's used by routing stress_example atm
     pub fn section_key(&self) -> PublicKey {
         self.public_key_set.public_key()
     }
-}
 
-// Add conversion methods to/from `messaging::...::NodeState`
-// We prefer this over `From<...>` to make it easier to read the conversion.
-
-impl SectionAuthorityProvider {
+    // We prefer this over `From<...>` to make it easier to read the conversion.
     pub(crate) fn to_msg(&self) -> SectionAuthorityProviderMsg {
         SectionAuthorityProviderMsg {
             prefix: self.prefix,

--- a/sn/src/node/node_info.rs
+++ b/sn/src/node/node_info.rs
@@ -21,7 +21,6 @@ use xor_name::{XorName, XOR_NAME_LEN};
 pub(crate) struct Node {
     // Keep the secret key in Arc to allow Clone while also preventing multiple copies to exist in
     // memory which might be insecure.
-    // TODO: find a way to not require `Clone`.
     #[debug(skip)]
     pub(crate) keypair: Arc<Keypair>,
     pub(crate) addr: SocketAddr,


### PR DESCRIPTION
Also, removing an archived section member when its state is previous to last five Elder churn events.