### PR TITLE
Feat no permits any more

### DIFF
--- a/sn/src/messaging/serialisation/mod.rs
+++ b/sn/src/messaging/serialisation/mod.rs
@@ -13,10 +13,10 @@ use xor_name::XorName;
 
 // highest prio as we can't do anything until we've joined
 pub(crate) const DKG_MSG_PRIORITY: i32 = 3;
-pub(crate) const AE_MSG_PRIORITY: i32 = 2;
 pub(crate) const INFRASTRUCTURE_MSG_PRIORITY: i32 = 1;
 pub(crate) const NODE_DATA_MSG_PRIORITY: i32 = 0;
-pub(crate) const SERVICE_MSG_PRIORITY: i32 = -2;
+pub(crate) const SERVICE_CMD_PRIORITY: i32 = -1;
+pub(crate) const SERVICE_QUERY_PRIORITY: i32 = -2;
 pub(crate) const JOIN_RESPONSE_PRIORITY: i32 = -5;
 
 use crate::types::PublicKey;
@@ -107,7 +107,11 @@ impl MsgType {
             } => NODE_DATA_MSG_PRIORITY,
 
             // Client<->node service comms
-            MsgType::Service { .. } => SERVICE_MSG_PRIORITY,
+            MsgType::Service {
+                msg: ServiceMsg::Cmd(_),
+                ..
+            } => SERVICE_CMD_PRIORITY,
+            MsgType::Service { .. } => SERVICE_QUERY_PRIORITY,
         }
     }
 }

--- a/sn/src/node/api/cmds.rs
+++ b/sn/src/node/api/cmds.rs
@@ -7,14 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    serialisation::{DKG_MSG_PRIORITY, INFRASTRUCTURE_MSG_PRIORITY},
     system::{DkgFailureSigSet, KeyedSig, NodeState, SectionAuth, SystemMsg},
     DstLocation, MsgId, NodeMsgAuthority, WireMsg,
 };
 use crate::node::{
     core::Proposal,
     network_knowledge::{SectionAuthorityProvider, SectionKeyShare},
-    Result, XorName,
+    XorName,
 };
 use crate::peer::{Peer, UnnamedPeer};
 
@@ -104,26 +103,6 @@ pub(crate) enum Cmd {
     StartConnectivityTest(XorName),
     /// Test Connectivity
     TestConnectivity(XorName),
-}
-
-impl Cmd {
-    /// Return the cmds priority, higher being higher prio
-    pub(crate) fn priority(&self) -> Result<i32> {
-        // we should not have to worry about child cmds here
-        // we use the cmd_id to check for a "root cmd" and go off that cmd's priority
-        // so this prio may not have an impact if the root was higher/lower
-        let prio = match self {
-            Self::HandleMsg { wire_msg, .. } => wire_msg.into_msg()?.priority(),
-            Self::HandleDkgOutcome { .. } | Self::HandleDkgFailure(_) => DKG_MSG_PRIORITY,
-            Self::HandleNewEldersAgreement { .. } => DKG_MSG_PRIORITY, // its end of DKG
-            Self::HandleAgreement { .. } | Self::HandleSystemMsg { .. } => {
-                INFRASTRUCTURE_MSG_PRIORITY
-            }
-            _ => -2,
-        };
-
-        Ok(prio)
-    }
 }
 
 impl fmt::Display for Cmd {

--- a/sn/src/node/api/dispatcher.rs
+++ b/sn/src/node/api/dispatcher.rs
@@ -7,47 +7,22 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Cmd;
-use crate::messaging::{
-    serialisation::{
-        AE_MSG_PRIORITY, DKG_MSG_PRIORITY, INFRASTRUCTURE_MSG_PRIORITY, JOIN_RESPONSE_PRIORITY,
-        NODE_DATA_MSG_PRIORITY,
-    },
-    system::SystemMsg,
-    DstLocation, EndUser, MsgKind, WireMsg,
-};
+use crate::messaging::{system::SystemMsg, DstLocation, EndUser, MsgKind, WireMsg};
 use crate::node::{
     core::{Core, Proposal, SendStatus},
     Error, Result,
 };
 use crate::peer::Peer;
 use crate::types::log_markers::LogMarker;
-use std::collections::BTreeMap;
 use std::{sync::Arc, time::Duration};
 use tokio::time::MissedTickBehavior;
-use tokio::{
-    sync::{watch, OwnedSemaphorePermit, RwLock, Semaphore},
-    time,
-};
+use tokio::{sync::watch, time};
 use tracing::Instrument;
 
 const PROBE_INTERVAL: Duration = Duration::from_secs(30);
 
-// this doesn't realistically limit concurrency
-// the prioritisation will do that, preventing lower prio messages being kicked off when
-// high prio messages exist
-const SEMAPHORE_COUNT: usize = 100;
-
-// A cmd/subcmd id e.g. "963111461", "963111461.0"
+// A command/subcommand id e.g. "963111461", "963111461.0"
 type CmdId = String;
-type PermitInfo = (OwnedSemaphorePermit, SubCmdsCount, Priority);
-type SubCmdsCount = usize;
-type Priority = i32;
-
-fn get_root_cmd_id(cmd_id: &str) -> CmdId {
-    let mut root_cmd_id = cmd_id.to_string();
-    root_cmd_id.truncate(cmd_id.find('.').unwrap_or_else(|| cmd_id.len()));
-    root_cmd_id
-}
 
 // Cmd Dispatcher.
 pub(crate) struct Dispatcher {
@@ -55,13 +30,6 @@ pub(crate) struct Dispatcher {
 
     cancel_timer_tx: watch::Sender<bool>,
     cancel_timer_rx: watch::Receiver<bool>,
-    ae_permits: Arc<Semaphore>,
-    infra_permits: Arc<Semaphore>,
-    node_data_permits: Arc<Semaphore>,
-    dkg_permits: Arc<Semaphore>,
-    service_msg_permits: Arc<Semaphore>,
-    // root cmd id to semaphore and a count of processes using it, and the root priority
-    cmd_permit_map: Arc<RwLock<BTreeMap<CmdId, PermitInfo>>>,
 }
 
 impl Drop for Dispatcher {
@@ -78,210 +46,6 @@ impl Dispatcher {
             core,
             cancel_timer_tx,
             cancel_timer_rx,
-            ae_permits: Arc::new(Semaphore::new(SEMAPHORE_COUNT)),
-            infra_permits: Arc::new(Semaphore::new(SEMAPHORE_COUNT)),
-            dkg_permits: Arc::new(Semaphore::new(SEMAPHORE_COUNT)),
-            service_msg_permits: Arc::new(Semaphore::new(SEMAPHORE_COUNT)),
-            node_data_permits: Arc::new(Semaphore::new(SEMAPHORE_COUNT)),
-            cmd_permit_map: Arc::new(RwLock::new(BTreeMap::default())),
-        }
-    }
-
-    /// block progress until there are no tasks pending in this semaphore
-    /// intended to allow us to wait for super high priority tasks before doing others...
-    /// It should only be used after checking that no permits are held by a root cmd eg
-    async fn wait_for_priority_cmds_to_finish(
-        &self,
-        semaphore: Arc<Semaphore>,
-        count: usize,
-    ) -> Result<()> {
-        // there's probably a neater way to do this
-        debug!("available, permits {:?}", semaphore.available_permits());
-
-        let mut loop_count = 0;
-        while semaphore.available_permits() != count {
-            loop_count += 1;
-
-            if loop_count > 500 {
-                return Err(Error::CouldNotGetPermitInTime);
-            }
-
-            time::sleep(Duration::from_millis(50)).await;
-            trace!(
-                "looping while we wait for available permits to be {:?}: {:?}",
-                count,
-                semaphore.available_permits()
-            );
-        }
-
-        Ok(())
-    }
-
-    /// returns the root cmd priority if a permit already exists for that cmd
-    async fn a_root_cmd_permit_exists(&self, root_cmd_id: String) -> Option<Priority> {
-        let permit_map = self.cmd_permit_map.clone();
-        let mut write_guard = permit_map.write().await;
-        let prior_permit = write_guard.remove(&root_cmd_id);
-        if let Some((current_root_permit, mut count, root_prio)) = prior_permit {
-            count += 1;
-            let _nonexistant_entry =
-                write_guard.insert(root_cmd_id.clone(), (current_root_permit, count, root_prio));
-            return Some(root_prio);
-        }
-
-        None
-    }
-
-    /// Waits until higher priority msgs have all been handled
-    async fn wait_until_nothing_higher_priority_to_handle(
-        &self,
-        priority: i32,
-        cmd_id: CmdId,
-    ) -> Result<()> {
-        match priority {
-            DKG_MSG_PRIORITY => {}
-            AE_MSG_PRIORITY => {
-                trace!(
-                    "{:?} Awaiting DKG Completion before continuing with AE Msg",
-                    cmd_id
-                );
-
-                self.wait_for_priority_cmds_to_finish(self.dkg_permits.clone(), SEMAPHORE_COUNT)
-                    .await?;
-            }
-            INFRASTRUCTURE_MSG_PRIORITY => {
-                trace!(
-                    "{:?} Awaiting AE/DKG Completion before continuing msg",
-                    cmd_id
-                );
-                self.wait_for_priority_cmds_to_finish(self.dkg_permits.clone(), SEMAPHORE_COUNT)
-                    .await?;
-                self.wait_for_priority_cmds_to_finish(self.ae_permits.clone(), SEMAPHORE_COUNT)
-                    .await?;
-            }
-            NODE_DATA_MSG_PRIORITY => {
-                trace!(
-                    "{:?} Awaiting Infra/AE/DKG Completion before continuing msg",
-                    cmd_id
-                );
-                self.wait_for_priority_cmds_to_finish(self.dkg_permits.clone(), SEMAPHORE_COUNT)
-                    .await?;
-                self.wait_for_priority_cmds_to_finish(self.ae_permits.clone(), SEMAPHORE_COUNT)
-                    .await?;
-                self.wait_for_priority_cmds_to_finish(self.infra_permits.clone(), SEMAPHORE_COUNT)
-                    .await?;
-            }
-            // service msgs...
-            _ => {
-                trace!(
-                    "{:?} Awaiting Data/Infra/AE/DKG Completion before continuing msg handling",
-                    cmd_id
-                );
-                self.wait_for_priority_cmds_to_finish(self.dkg_permits.clone(), SEMAPHORE_COUNT)
-                    .await?;
-                self.wait_for_priority_cmds_to_finish(self.ae_permits.clone(), SEMAPHORE_COUNT)
-                    .await?;
-                self.wait_for_priority_cmds_to_finish(self.infra_permits.clone(), SEMAPHORE_COUNT)
-                    .await?;
-                self.wait_for_priority_cmds_to_finish(
-                    self.node_data_permits.clone(),
-                    SEMAPHORE_COUNT,
-                )
-                .await?;
-            }
-        };
-
-        Ok(())
-    }
-
-    /// Based upon message priority will wait for any higher priority cmds to be completed before continuing
-    async fn acquire_permit_or_wait(&self, prio: i32, cmd_id: CmdId) -> Result<()> {
-        debug!("{:?} start of acquire permit", cmd_id);
-        let mut the_prio = prio;
-        // if we already have a permit, increase our count and continue
-        let root_cmd_id = get_root_cmd_id(&cmd_id);
-        let permit_map = self.cmd_permit_map.clone();
-        let cmds_len = permit_map.read().await.len();
-        debug!("Cmds in flight (root permit len): {:?}", cmds_len);
-
-        let root_prio = self.a_root_cmd_permit_exists(root_cmd_id.clone()).await;
-
-        if let Some(prio) = root_prio {
-            // use the root priority for all subsequent cmds
-            the_prio = prio;
-        }
-
-        // If we have our feat enabled, wait until anything higher prio has completed.
-        if cfg!(feature = "unstable-cmd-prioritisation") {
-            self.wait_until_nothing_higher_priority_to_handle(the_prio, cmd_id.clone())
-                .await?;
-        }
-
-        if root_prio.is_some() {
-            return Ok(());
-        }
-
-        let permit = match the_prio {
-            JOIN_RESPONSE_PRIORITY => {
-                // as we're already a node accepted to the network, we can discard this
-                return Err(Error::AlreadyJoinedTheNetwork);
-            }
-            DKG_MSG_PRIORITY => self
-                .dkg_permits
-                .clone()
-                .acquire_owned()
-                .await
-                .map_err(|_| Error::SemaphoreClosed),
-
-            AE_MSG_PRIORITY => self
-                .ae_permits
-                .clone()
-                .acquire_owned()
-                .await
-                .map_err(|_| Error::SemaphoreClosed),
-
-            INFRASTRUCTURE_MSG_PRIORITY => self
-                .infra_permits
-                .clone()
-                .acquire_owned()
-                .await
-                .map_err(|_| Error::SemaphoreClosed),
-
-            NODE_DATA_MSG_PRIORITY => self
-                .node_data_permits
-                .clone()
-                .acquire_owned()
-                .await
-                .map_err(|_| Error::SemaphoreClosed),
-
-            // service msgs...
-            _ => match self.service_msg_permits.clone().try_acquire_owned() {
-                Ok(permit) => Ok(permit),
-                Err(error) => {
-                    error!(
-                        "Could not acquire service msg permit, dropping the cmd {:?} {:?}",
-                        cmd_id, error
-                    );
-                    Err(Error::AtMaxServiceCmdThroughput)
-                }
-            },
-        };
-
-        trace!("CmdId {:?} continuing...", cmd_id);
-        match permit {
-            // there was no error w/ semaphore
-            Ok(permit) => {
-                debug!("inserting permit for cmd {:?}", cmd_id);
-                let mut permit_map_write_guard = permit_map.write().await;
-                let _old_permit = permit_map_write_guard.insert(root_cmd_id, (permit, 1, prio));
-                debug!("inserted permit");
-                Ok(())
-            }
-            Err(error) => {
-                // log error, it can only be permit acquisition here, so that's okay and we ignore it / drop cmd as we've bigger issues
-                error!("{:?}", error);
-                Err(error)
-            }
         }
     }
 
@@ -293,8 +57,6 @@ impl Dispatcher {
     ) -> Result<()> {
         let _ = tokio::spawn(async {
             let cmd_id: CmdId = cmd_id.unwrap_or_else(|| rand::random::<u32>().to_string());
-            self.acquire_permit_or_wait(cmd.priority()?, cmd_id.clone())
-                .await?;
 
             self.handle_cmd_and_offshoots(cmd, Some(cmd_id)).await
         });
@@ -437,19 +199,6 @@ impl Dispatcher {
                     Err(error)
                 }
             };
-            // and now we're done, reduce permit count or drop if none left using it.
-            let root_cmd_id = get_root_cmd_id(cmd_id);
-            let permit_map = self.cmd_permit_map.clone();
-            let mut permit_map_write_guard = permit_map.write().await;
-            if let Some((permit, mut count, prio)) = permit_map_write_guard.remove(&root_cmd_id) {
-                // if we're not the last spawned cmd here
-                if count > 1 {
-                    count -= 1;
-                    // put the permit back as other cmds are still being handled under it.
-                    let _nonexistant_entry =
-                        permit_map_write_guard.insert(root_cmd_id.clone(), (permit, count, prio));
-                }
-            }
             res
         }
         .instrument(span)

--- a/sn/src/node/core/mod.rs
+++ b/sn/src/node/core/mod.rs
@@ -84,6 +84,11 @@ pub(crate) const CONCURRENT_JOINS: usize = 7;
 // the section).
 const DATA_QUERY_TIMEOUT: Duration = Duration::from_secs(60 * 5 /* 5 mins */);
 
+// This prevents pending query limit unbound growth
+pub(crate) const DATA_QUERY_LIMIT: usize = 100;
+// per query we can have this many peers, so the total peers waiting can be QUERY_LIMIT * MAX_WAITING_PEERS_PER_QUERY
+pub(crate) const MAX_WAITING_PEERS_PER_QUERY: usize = 25;
+
 // Store up to 100 in use backoffs
 pub(crate) type AeBackoffCache =
     Arc<RwLock<LRUCache<(Peer, ExponentialBackoff), BACKOFF_CACHE_LIMIT>>>;
@@ -114,7 +119,7 @@ pub(crate) struct Core {
     pub(super) data_storage: DataStorage,
     capacity: Capacity,
     liveness: Liveness,
-    pending_data_queries: Arc<Cache<OperationId, Peer>>,
+    pending_data_queries: Arc<Cache<OperationId, Vec<Peer>>>,
     ae_backoff_cache: AeBackoffCache,
 }
 

--- a/sn/src/node/core/mod.rs
+++ b/sn/src/node/core/mod.rs
@@ -74,7 +74,7 @@ pub(super) const RESOURCE_PROOF_DIFFICULTY: u8 = 10;
 const BACKOFF_CACHE_LIMIT: usize = 100;
 pub(crate) const CONCURRENT_JOINS: usize = 7;
 
-// How long to hold on to correlated `Peer`s for chunk queries. Since chunk queries are forwarded
+// How long to hold on to correlated `Peer`s for data queries. Since data queries are forwarded
 // from elders (with whom the client is connected) to adults (who hold the data), the elder handling
 // the query cannot reply immediately. For now, they stash a reference to the client `Peer` in
 // `Core::pending_data_queries`, which is a cache with duration-based expiry.
@@ -82,7 +82,7 @@ pub(crate) const CONCURRENT_JOINS: usize = 7;
 // `crate::client::SN_CLIENT_QUERY_TIMEOUT`), but the timeout is configurable. Ideally this would be
 // based on liveness properties (e.g. the timeout should be dynamic based on the responsiveness of
 // the section).
-const CHUNK_QUERY_TIMEOUT: Duration = Duration::from_secs(60 * 5 /* 5 mins */);
+const DATA_QUERY_TIMEOUT: Duration = Duration::from_secs(60 * 5 /* 5 mins */);
 
 // Store up to 100 in use backoffs
 pub(crate) type AeBackoffCache =
@@ -167,7 +167,7 @@ impl Core {
             data_storage,
             capacity,
             liveness: adult_liveness,
-            pending_data_queries: Arc::new(Cache::with_expiry_duration(CHUNK_QUERY_TIMEOUT)),
+            pending_data_queries: Arc::new(Cache::with_expiry_duration(DATA_QUERY_TIMEOUT)),
             ae_backoff_cache: AeBackoffCache::default(),
         })
     }

--- a/sn/src/node/core/msg_handling/mod.rs
+++ b/sn/src/node/core/msg_handling/mod.rs
@@ -43,6 +43,11 @@ use ed25519_dalek::Signer;
 use std::collections::BTreeSet;
 use xor_name::XorName;
 
+// this doesn't realistically limit concurrency
+// the prioritisation will do that, preventing lower prio messages being kicked off when
+// high prio messages exist
+const QUERY_LIMIT: usize = 1000;
+
 // Message handling
 impl Core {
     #[instrument(skip(self, original_bytes))]
@@ -53,7 +58,6 @@ impl Core {
         original_bytes: Option<Bytes>,
     ) -> Result<Vec<Cmd>> {
         let mut cmds = vec![];
-        trace!("handling msg");
 
         // Apply backpressure if needed.
         if let Some(load_report) = self.comm.check_strain(sender.addr()).await {
@@ -67,8 +71,9 @@ impl Core {
         }
 
         // Deserialize the payload of the incoming message
-        let payload = wire_msg.payload.clone();
         let msg_id = wire_msg.msg_id();
+        // payload needed for aggregation
+        let payload = wire_msg.payload.clone();
 
         let message_type = match wire_msg.into_msg() {
             Ok(message_type) => message_type,
@@ -204,6 +209,18 @@ impl Core {
                             .await?,
                     );
                     return Ok(cmds);
+                }
+
+                // First we check if it's query and we have too many on the go at the moment...
+                if let ServiceMsg::Query(_) = msg {
+                    // we have a query, check if we have too many on the go....
+                    let pending_query_length = self.pending_data_queries.len().await;
+
+                    if pending_query_length > QUERY_LIMIT {
+                        // TODO: check if query is pending for this already.. add to that if that makes sense.
+                        warn!("Pending queries length exceeded, dropping query {msg:?}");
+                        return Ok(vec![]);
+                    }
                 }
 
                 // First we perform AE checks


### PR DESCRIPTION

    chore(node): Batch pending requests together per name 9bb839e7ad35bd06472807601ca1500e7c5b4502

    Previously we were only allowing one operation id, which could be overwritten by new clients.
    This allows client requests to await one response together

    chore(sn/node): only prioritise service cmd/query with permits. 75efdb52cbc403f916e1780a27fa00b91a722da8

    Previously we were holding permits in a RwLock struct for any command.

    Now we remove both the conecpt of permits here, removing one potential
    locking loction, and the unused message prioritisation is removed to
    clean that up.

    Now we simply check if we have max allowed pending queries at any one
    time, and if so, we drop inbound queries.
