### PR TITLE
Store Full Public Name in NRS Map and Remove API URL Sanitise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ run-local-baby-fleming:
 	pgrep sn_node | xargs kill -9
 	rm -rf ~/.safe
 	mkdir -p ~/.safe/node
-	(cd sn && cargo build --release)
+	cargo clean
+	cargo build --release --bin sn_node
 	cp target/release/sn_node ~/.safe/node
 	cargo run --release node run-baby-fleming

--- a/resources/scripts/api_tests.sh
+++ b/resources/scripts/api_tests.sh
@@ -2,6 +2,8 @@
 
 set -e -x
 
+# The default timeout value is 120 seconds, which causes NRS to run extremely slow.
+export SN_QUERY_TIMEOUT=10
 export RUST_BACKTRACE=1
 export TEST_BOOTSTRAPPING_PEERS=$(cat ~/.safe/node/node_connection_info.config)
 

--- a/resources/scripts/cli_tests.sh
+++ b/resources/scripts/cli_tests.sh
@@ -8,6 +8,8 @@ exit=0
 # The tests parse output from the CLI process and they are expecting it to be in a certain form, so
 # any additional logging needs to be disabled.
 unset RUST_LOG
+# The default timeout value is 120 seconds, which causes NRS to run extremely slow.
+export SN_QUERY_TIMEOUT=10
 export RUST_BACKTRACE=full
 
 cargo run --package sn_cli --release -- keys create --for-cli || ((exit++))

--- a/sn_api/src/app/files/mod.rs
+++ b/sn_api/src/app/files/mod.rs
@@ -253,7 +253,7 @@ impl Safe {
             ));
         }
 
-        let safe_url = Safe::parse_url(url)?;
+        let safe_url = SafeUrl::from_url(url)?;
 
         // If NRS name shall be updated then the URL has to be an NRS-URL
         if update_nrs && safe_url.content_type() != ContentType::NrsMapContainer {
@@ -448,7 +448,7 @@ impl Safe {
         recursive: bool,
         update_nrs: bool,
     ) -> Result<(VersionHash, ProcessedFiles, FilesMap)> {
-        let safe_url = Safe::parse_url(url)?;
+        let safe_url = SafeUrl::from_url(url)?;
         let dst_path = safe_url.path();
         if dst_path.is_empty() {
             return Err(Error::InvalidInput(
@@ -729,7 +729,7 @@ async fn validate_files_add_params(
     url: &str,
     update_nrs: bool,
 ) -> Result<(SafeUrl, Option<VersionHash>, FilesMap)> {
-    let safe_url = Safe::parse_url(url)?;
+    let safe_url = SafeUrl::from_url(url)?;
 
     // If NRS name shall be updated then the URL has to be an NRS-URL
     if update_nrs && safe_url.content_type() != ContentType::NrsMapContainer {
@@ -746,7 +746,7 @@ async fn validate_files_add_params(
 
     // Let's act according to if it's a local file path or a safe:// location
     if source_file.starts_with("safe://") {
-        let source_safe_url = Safe::parse_url(source_file)?;
+        let source_safe_url = SafeUrl::from_url(source_file)?;
         if source_safe_url.data_type() != DataType::File {
             return Err(Error::InvalidInput(format!(
                 "The source URL should target a file ('{}'), but the URL provided targets a '{}'",

--- a/sn_api/src/app/files/mod.rs
+++ b/sn_api/src/app/files/mod.rs
@@ -1914,10 +1914,8 @@ mod tests {
             Err(Error::UnversionedContentError(msg)) => {
                 assert_eq!(
                 msg,
-                format!(
-                    "The linked content (FilesContainer) is versionable, therefore NRS requires the link to specify a hash: {}",
-                    unversioned_link
-                )
+                "FilesContainer content is versionable. NRS requires the supplied link to specify \
+                a version hash.",
             );
                 Ok(())
             }

--- a/sn_api/src/app/multimap.rs
+++ b/sn_api/src/app/multimap.rs
@@ -88,7 +88,7 @@ impl Safe {
         })?;
 
         let data = serialised_entry.to_vec();
-        let safeurl = Safe::parse_url(multimap_url)?;
+        let safeurl = SafeUrl::from_url(multimap_url)?;
         let address = match safeurl.address() {
             DataAddress::Register(reg_address) => reg_address,
             other => {
@@ -123,7 +123,7 @@ impl Safe {
         to_remove: BTreeSet<EntryHash>,
     ) -> Result<EntryHash> {
         debug!("Removing from Multimap at {}: {:?}", url, to_remove);
-        let safeurl = Safe::parse_url(url)?;
+        let safeurl = SafeUrl::from_url(url)?;
         let address = match safeurl.address() {
             DataAddress::Register(reg_address) => reg_address,
             other => {

--- a/sn_api/src/app/nrs/mod.rs
+++ b/sn_api/src/app/nrs/mod.rs
@@ -50,7 +50,7 @@ pub fn validate_nrs_url(link: &SafeUrl) -> Result<()> {
 
 impl Safe {
     /// # Creates a nrs_map_container for a chosen top name
-    /// ```no_run
+    /// ```
     /// safe://<subName>.<topName>/path/to/whatever?var=value
     ///        |-----------------|
     ///            Public Name
@@ -221,7 +221,7 @@ impl Safe {
         public_name: &str,
         version: Option<VersionHash>,
     ) -> Result<NrsMap> {
-        let url = get_url_from_name(public_name)?;
+        let url = SafeUrl::from_url(&format!("safe://{}", public_name))?;
         let mut multimap = match self.fetch_multimap(&url).await {
             Ok(s) => Ok(s),
             Err(Error::EmptyContent(_)) => Ok(BTreeSet::new()),
@@ -308,7 +308,7 @@ fn set_nrs_url_props(url: &mut SafeUrl, entry_hash: EntryHash) -> Result<()> {
 }
 
 fn validate_nrs_top_name(top_name: &str) -> Result<SafeUrl> {
-    let url = get_url_from_name(top_name)?;
+    let url = SafeUrl::from_url(&format!("safe://{}", top_name))?;
     if url.top_name() != top_name {
         return Err(Error::InvalidInput(format!(
             "The NRS top name \"{}\" is invalid because it contains url parts. Please \
@@ -320,7 +320,7 @@ fn validate_nrs_top_name(top_name: &str) -> Result<SafeUrl> {
 }
 
 fn validate_nrs_public_name(public_name: &str) -> Result<SafeUrl> {
-    let url = get_url_from_name(public_name)?;
+    let url = SafeUrl::from_url(&format!("safe://{}", public_name))?;
     if url.public_name() != public_name {
         return Err(Error::InvalidInput(format!(
             "The NRS public name \"{}\" is invalid because it contains url parts. Please \
@@ -329,13 +329,6 @@ fn validate_nrs_public_name(public_name: &str) -> Result<SafeUrl> {
         )));
     }
     Ok(url)
-}
-
-fn get_url_from_name(name: &str) -> Result<SafeUrl> {
-    if !name.starts_with("safe://") {
-        return Ok(SafeUrl::from_url(&format!("safe://{}", name))?);
-    }
-    Ok(SafeUrl::from_url(name)?)
 }
 
 #[cfg(test)]

--- a/sn_api/src/app/nrs/mod.rs
+++ b/sn_api/src/app/nrs/mod.rs
@@ -202,10 +202,7 @@ impl Safe {
         let nrs_map = match self.nrs_get_subnames_map(public_name, version).await {
             Ok(result) => Ok(result),
             Err(Error::ConflictingNrsEntries(str, conflicting_entries, map)) => {
-                if conflicting_entries
-                    .iter()
-                    .any(|(sub, _)| sub == public_name)
-                {
+                if conflicting_entries.iter().any(|(p, _)| p == public_name) {
                     Err(Error::ConflictingNrsEntries(str, conflicting_entries, map))
                 } else {
                     Ok(map)
@@ -277,9 +274,9 @@ fn convert_multimap_to_nrs_set(multimap: &Multimap) -> Result<BTreeSet<(String, 
         .into_iter()
         .map(|x| {
             let kv = x.1;
-            let subname = str::from_utf8(&kv.0)?;
+            let public_name = str::from_utf8(&kv.0)?;
             let url = SafeUrl::from_url(str::from_utf8(&kv.1)?)?;
-            Ok((subname.to_owned(), url))
+            Ok((public_name.to_owned(), url))
         })
         .collect::<Result<BTreeSet<(String, SafeUrl)>>>()?;
     Ok(set)
@@ -287,18 +284,18 @@ fn convert_multimap_to_nrs_set(multimap: &Multimap) -> Result<BTreeSet<(String, 
 
 fn convert_multimap_to_nrs_map(multimap: &Multimap) -> Result<NrsMap> {
     let nrs_map_version = multimap.iter().map(|x| VersionHash::from(&x.0)).last();
-    let subnames_map: BTreeMap<String, SafeUrl> = multimap
+    let public_names_map: BTreeMap<String, SafeUrl> = multimap
         .clone()
         .into_iter()
         .map(|x| {
             let kv = x.1;
-            let subname = str::from_utf8(&kv.0)?;
+            let public_name = str::from_utf8(&kv.0)?;
             let url = SafeUrl::from_url(str::from_utf8(&kv.1)?)?;
-            Ok((subname.to_owned(), url))
+            Ok((public_name.to_owned(), url))
         })
         .collect::<Result<BTreeMap<String, SafeUrl>>>()?;
     let nrs_map = NrsMap {
-        map: subnames_map,
+        map: public_names_map,
         subname_version: nrs_map_version,
     };
     Ok(nrs_map)

--- a/sn_api/src/app/nrs/nrs_map.rs
+++ b/sn_api/src/app/nrs/nrs_map.rs
@@ -12,17 +12,17 @@ use log::debug;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-pub(crate) type Subname = String;
+pub(crate) type PublicName = String;
 
 /// An NRS map is a description of a registered topname and all subnames associated with that.
 ///
 /// Each subname will link to some content, e.g., a `FilesContainer`, and the topname can also
 /// optionally link to something.
 ///
-/// The struct is stored on the network using a Multimap. The entries are subname -> SafeUrl
+/// The struct is stored on the network using a Multimap. The entries are public name -> SafeUrl
 /// mappings.
 ///
-/// | Subname Key       | Full Name        | SafeUrl Value            |
+/// | PublicName Key    | Full Name        | SafeUrl Value            |
 /// |-------------------|------------------|--------------------------|
 /// | "example"         | "example"        | "safe://example"         |
 /// | "sub.example"     | "sub.example"    | "safe://sub.example"     |
@@ -33,7 +33,7 @@ pub(crate) type Subname = String;
 /// requested when the map is retrieved, it will be set to `None`.
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize, Clone)]
 pub struct NrsMap {
-    pub map: BTreeMap<Subname, SafeUrl>,
+    pub map: BTreeMap<PublicName, SafeUrl>,
     pub subname_version: Option<VersionHash>,
 }
 
@@ -42,13 +42,16 @@ impl NrsMap {
     pub fn get(&self, public_name: &str) -> Result<SafeUrl> {
         match self.map.get(public_name) {
             Some(link) => {
-                debug!("NRS: Subname resolution is: {} => {}", public_name, link);
+                debug!(
+                    "NRS: public name resolution is: {} => {}",
+                    public_name, link
+                );
                 Ok(link.to_owned())
             }
             None => {
                 debug!("NRS: No link found for subname(s): {}", public_name);
                 Err(Error::ContentError(format!(
-                    "Link not found in NRS Map Container for subname(s): \"{}\"",
+                    "Link not found in NRS Map Container for public name: \"{}\"",
                     public_name
                 )))
             }

--- a/sn_api/src/app/resolver/mod.rs
+++ b/sn_api/src/app/resolver/mod.rs
@@ -24,7 +24,7 @@ impl Safe {
     /// Parses a string URL "safe://url" and returns a safe URL
     /// Resolves until it reaches the final URL
     pub async fn parse_and_resolve_url(&self, url: &str) -> Result<SafeUrl> {
-        let safe_url = Safe::parse_url(url)?;
+        let safe_url = SafeUrl::from_url(url)?;
         let orig_path = safe_url.path_decoded()?;
 
         // Obtain the resolution chain without resolving the URL's path
@@ -78,7 +78,7 @@ impl Safe {
     /// # });
     /// ```
     pub async fn fetch(&self, url: &str, range: Range) -> Result<SafeData> {
-        let safe_url = Safe::parse_url(url)?;
+        let safe_url = SafeUrl::from_url(url)?;
         info!("URL parsed successfully, fetching: {}", url);
 
         let mut resolution_chain = self
@@ -133,7 +133,7 @@ impl Safe {
     /// # });
     /// ```
     pub async fn inspect(&self, url: &str) -> Result<Vec<SafeData>> {
-        let safe_url = Safe::parse_url(url)?;
+        let safe_url = SafeUrl::from_url(url)?;
         info!("URL parsed successfully, inspecting: {}", url);
         self.fully_resolve_url(safe_url, None, false, None, true)
             .await

--- a/sn_cli/src/subcommands/cat.rs
+++ b/sn_cli/src/subcommands/cat.rs
@@ -32,7 +32,7 @@ pub struct CatCommands {
 pub async fn cat_commander(cmd: CatCommands, output_fmt: OutputFmt, safe: &Safe) -> Result<()> {
     let link = get_from_arg_or_stdin(cmd.location, None)?;
     let url = get_target_url(&link)?;
-    debug!("Running cat for: {:?}", &url.to_string());
+    debug!("Running cat for: {}", &url.to_string());
 
     let mut attempts = 0;
 

--- a/sn_cli/src/subcommands/dog.rs
+++ b/sn_cli/src/subcommands/dog.rs
@@ -7,7 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    helpers::{get_from_arg_or_stdin, print_nrs_map, serialise_output, xorname_to_hex},
+    helpers::{
+        get_from_arg_or_stdin, get_target_url, print_nrs_map, serialise_output, xorname_to_hex,
+    },
     OutputFmt,
 };
 use color_eyre::Result;
@@ -25,12 +27,16 @@ pub struct DogCommands {
 }
 
 pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe) -> Result<()> {
-    let url = get_from_arg_or_stdin(cmd.location, None)?;
+    let link = get_from_arg_or_stdin(cmd.location, None)?;
+    let url = get_target_url(&link)?;
     debug!("Running dog for: {:?}", &url);
 
-    let resolved_content = safe.inspect(&url).await?;
+    let resolved_content = safe.inspect(&url.to_string()).await?;
     if OutputFmt::Pretty != output_fmt {
-        println!("{}", serialise_output(&(url, resolved_content), output_fmt));
+        println!(
+            "{}",
+            serialise_output(&(url.to_string(), resolved_content), output_fmt)
+        );
     } else {
         for (i, ref content) in resolved_content.iter().enumerate() {
             println!();

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -9,8 +9,8 @@
 use super::{
     files_get::{process_get_command, FileExistsAction, ProgressIndicator},
     helpers::{
-        gen_processed_files_table, get_from_arg_or_stdin, get_from_stdin, if_tty, notice_dry_run,
-        parse_stdin_arg, pluralize, serialise_output,
+        gen_processed_files_table, get_from_arg_or_stdin, get_from_stdin, get_target_url, if_tty,
+        notice_dry_run, parse_stdin_arg, pluralize, serialise_output,
     },
     OutputFmt,
 };
@@ -244,6 +244,7 @@ pub async fn files_commander(
             update_nrs,
         } => {
             let target = get_from_arg_or_stdin(target, None)?;
+            let mut target_url = get_target_url(&target)?;
             if safe.dry_run_mode && OutputFmt::Pretty == output_fmt {
                 notice_dry_run();
             }
@@ -251,7 +252,7 @@ pub async fn files_commander(
             let (content, processed_files) = safe
                 .files_container_sync(
                     &location,
-                    &target,
+                    &target_url.to_string(),
                     recursive,
                     follow_links,
                     delete,
@@ -265,28 +266,28 @@ pub async fn files_commander(
             if OutputFmt::Pretty == output_fmt {
                 let version_str = version.map_or("empty".to_string(), |v| format!("version {}", v));
                 if success_count > 0 {
-                    let url = match SafeUrl::from_url(&target) {
-                        Ok(mut safeurl) => {
-                            safeurl.set_content_version(version);
-                            safeurl.set_path("");
-                            safeurl.to_string()
-                        }
-                        Err(_) => target,
-                    };
-
-                    println!("FilesContainer synced up ({}): \"{}\"", version_str, url);
+                    target_url.set_content_version(version);
+                    target_url.set_path("");
+                    println!(
+                        "FilesContainer synced up ({}): \"{}\"",
+                        version_str, target_url
+                    );
                     table.printstd();
                 } else if !processed_files.is_empty() {
                     println!(
                         "No changes were made to FilesContainer ({}) at \"{}\"",
-                        version_str, target
+                        version_str, target_url
                     );
                     table.printstd();
                 } else {
-                    println!("No changes were required, source location is already in sync with FilesContainer ({}) at: \"{}\"", version_str, target);
+                    println!(
+                        "No changes were required, source location is already in sync with \
+                        FilesContainer ({}) at: \"{}\"",
+                        version_str, target
+                    );
                 }
             } else {
-                print_serialized_output(target, version, &processed_files, output_fmt);
+                print_serialized_output(target.to_string(), version, &processed_files, output_fmt);
             }
             Ok(())
         }
@@ -775,7 +776,7 @@ fn print_files_map(
 
 fn filter_files_map(files_map: &FilesMap, target_url: &str) -> Result<(u64, FilesMap)> {
     let mut filtered_filesmap = FilesMap::default();
-    let mut safeurl = Safe::parse_url(target_url)?;
+    let mut safeurl = SafeUrl::from_url(target_url)?;
     let mut total = 0;
 
     for (filepath, fileitem) in files_map.iter() {

--- a/sn_cli/src/subcommands/helpers.rs
+++ b/sn_cli/src/subcommands/helpers.rs
@@ -15,6 +15,7 @@ use serde::ser::Serialize;
 use sn_api::{
     files::{FilesMapChange, ProcessedFiles},
     nrs::NrsMap,
+    SafeUrl,
 };
 use std::io::{stdin, stdout, Read, Write};
 use tracing::debug;
@@ -227,4 +228,16 @@ pub fn div_or<X: Float>(num: X, den: X, default: X) -> X {
     } else {
         num / den
     }
+}
+
+/// Get the target URL from the link as a string.
+///
+/// If the user hasn't prefixed the link with `safe://`, we'll do that for them here.
+pub fn get_target_url(link: &str) -> Result<SafeUrl> {
+    if !link.starts_with("safe://") {
+        let url = SafeUrl::from_url(&format!("safe://{}", link))?;
+        return Ok(url);
+    }
+    let url = SafeUrl::from_url(link)?;
+    Ok(url)
 }

--- a/sn_cli/src/subcommands/helpers.rs
+++ b/sn_cli/src/subcommands/helpers.rs
@@ -235,9 +235,7 @@ pub fn div_or<X: Float>(num: X, den: X, default: X) -> X {
 /// If the user hasn't prefixed the link with `safe://`, we'll do that for them here.
 pub fn get_target_url(link: &str) -> Result<SafeUrl> {
     if !link.starts_with("safe://") {
-        let url = SafeUrl::from_url(&format!("safe://{}", link))?;
-        return Ok(url);
+        return Ok(SafeUrl::from_url(&format!("safe://{}", link))?);
     }
-    let url = SafeUrl::from_url(link)?;
-    Ok(url)
+    Ok(SafeUrl::from_url(link)?)
 }

--- a/sn_cli/src/subcommands/nrs.rs
+++ b/sn_cli/src/subcommands/nrs.rs
@@ -79,10 +79,6 @@ async fn run_register_subcommand(
     safe: &Safe,
     output_fmt: OutputFmt,
 ) -> Result<()> {
-    if let Some(ref link) = link {
-        get_target_url(link)?;
-    }
-
     match safe.nrs_create(&name).await {
         Ok(topname_url) => {
             let (nrs_url, summary) =

--- a/sn_cli/tests/cli_cat.rs
+++ b/sn_cli/tests/cli_cat.rs
@@ -232,6 +232,37 @@ fn calling_safe_cat_nrsurl_with_version() -> Result<()> {
 }
 
 #[test]
+fn calling_safe_cat_nrsurl_without_safe_prefix() -> Result<()> {
+    let with_trailing_slash = true;
+    let tmp_data_path = assert_fs::TempDir::new()?;
+    tmp_data_path.copy_from("../resources/testdata", &["**"])?;
+    let (files_container_xor, _processed_files, _) =
+        upload_path(&tmp_data_path, with_trailing_slash)?;
+    let mut url = SafeUrl::from_url(&files_container_xor)?;
+    url.set_path("test.md");
+
+    let public_name = format!("test.{}", get_random_nrs_string());
+    safe_cmd(
+        [
+            "nrs",
+            "add",
+            &public_name,
+            "--link",
+            &url.to_string(), // to_string has the version on the url
+            "--register-top-name",
+            "--json",
+        ],
+        Some(0),
+    )?;
+
+    safe_cmd(["cat", &public_name], Some(0))?
+        .assert()
+        .stdout(predicate::str::contains("hello tests!"));
+
+    Ok(())
+}
+
+#[test]
 fn calling_safe_cat_nrsurl_with_immutable_content() -> Result<()> {
     let with_trailing_slash = true;
     let tmp_data_path = assert_fs::TempDir::new()?;

--- a/sn_cli/tests/cli_nrs.rs
+++ b/sn_cli/tests/cli_nrs.rs
@@ -118,20 +118,6 @@ fn nrs_register_should_return_an_error_if_a_subname_is_specified() -> Result<()>
 }
 
 #[test]
-fn nrs_register_should_return_an_error_if_an_invalid_link_is_specified() -> Result<()> {
-    let topname = get_random_nrs_string();
-    safe_cmd(["nrs", "register", &topname, "--link", "invalid"], Some(1))?
-        .assert()
-        .stderr(predicate::str::contains(
-            "The supplied link was not a valid url.",
-        ))
-        .stderr(predicate::str::contains(
-            "Run the command again with a valid url for the --link argument.",
-        ));
-    Ok(())
-}
-
-#[test]
 fn nrs_register_should_return_an_error_if_link_to_versioned_content_has_no_version() -> Result<()> {
     let with_trailing_slash = true;
     let tmp_data_path = assert_fs::TempDir::new()?;
@@ -495,22 +481,6 @@ fn nrs_add_with_default_should_return_an_error_if_link_to_versioned_content_has_
         "Please run the command again with the version hash appended to the link. \
             The link should have the form safe://<url>?v=<versionhash>.",
     ));
-    Ok(())
-}
-
-#[test]
-fn nrs_add_should_return_an_error_if_an_invalid_link_is_specified() -> Result<()> {
-    let topname = get_random_nrs_string();
-    let public_name = format!("test.{}", &topname);
-    safe_cmd(["nrs", "register", &topname], Some(0))?;
-    safe_cmd(["nrs", "add", &public_name, "--link", "invalid"], Some(1))?
-        .assert()
-        .stderr(predicate::str::contains(
-            "The supplied link was not a valid url.",
-        ))
-        .stderr(predicate::str::contains(
-            "Run the command again with a valid url for the --link argument.",
-        ));
     Ok(())
 }
 


### PR DESCRIPTION
- 1115093a4 **feat: store full public name in nrs map**

  Entries will now use the full public name reference, rather than the just subname. Like so:
  * example -> link
  * a.example -> link
  * b.example -> link
  * a.b.example -> link

  This is to facilitate resolving NrsMapContainer content using its XorUrl, which effectively prints
  the NRS map. It was a feature we had that broke at some point. Right now, the XorUrl of the
  container will resolve the content the topname is linked to, or will result in an error if the
  there's no topname link.

- effc6fa5a **tests: rework nrs tests and provide more coverage**

  Added more coverage for code paths that weren't being tested:
  * `nrs_create` duplicate topname
  * `nrs_associate` with non-versioned files container link
  * `nrs_associate` with non-versioned NRS map container link
  * `nrs_associate` with register link
  * `nrs_associate` with invalid URL

  Some NRS tests were reworked as follows:
  * Make them single purpose. Some tests were testing a few things, which makes it a bit harder to
    identify what's failed.
  * Trim down. Some tests had assertions and setup that didn't seem quite relevant, like checking and
    assigning versions.
  * Test `nrs_associate` without calling `nrs_add`. This muddies the water a little bit because
    `nrs_add` calls associate.
  * Separate `nrs_associate` tests for topnames and subnames.

- 29fd62617 **refactor: remove url sanitisation from api**

  The `Safe::parse_url` function was removed from the API. This function 'sanitised' a URL by applying
  a `safe://` prefix to a URL string if the caller hadn't specified it.

  Initially, it was done to tidy up NRS code that was calling this function, but the same code was
  also calling a private function `parse_url` was making use of, so effectively the code was being
  called twice. More generally, we decided callers of the API should be responsible for passing a
  valid URL.

  The function was being called by various other parts of the API and also in the CLI, so these were
  changed to call `SafeUrl::from_url` directly.

  Some code was added to CLI commands to apply the `safe://` prefix if the user omitted it, so no
  functionality  was broken. A few test cases were added to cover it. A couple of NRS test cases for
  validating URLs were also removed as they no longer apply. This behaviour may actually have been
  incorrect in the first place.
  
  Also apply various clippy fixes.

- 58bf67879 **refactor: subname -> public name**

  Since we're now storing the full public name in the NRS map, the key should be referred to as the
  public name rather than the subname. Error messages were also updated.

- 9af70e778 **refactor: remove get_target_url function**

  This function contained an unnecessary check to see if the `safe://` prefix wasn't present in top
  name or public names, which we wouldn't expect it to be. I'm not sure what I was thinking with this.

  Also made some more readability changes based on PR feedback.