### PR TITLE
chore: improve acronym consistency

### DIFF
--- a/sn/examples/routing_stress.rs
+++ b/sn/examples/routing_stress.rs
@@ -39,7 +39,7 @@ use xor_name::{Prefix, XorName};
 use yansi::{Color, Style};
 
 use safe_network::messaging::{
-    data::Error::FailedToWriteFile, system::SystemMsg, DstLocation, MessageId,
+    data::Error::FailedToWriteFile, system::SystemMsg, DstLocation, MsgId,
 };
 use safe_network::node::{
     create_test_max_capacity_and_root_storage, Config, Event as RoutingEvent, NodeApi,
@@ -464,7 +464,7 @@ impl Network {
         // just some valid message
         let node_msg = SystemMsg::NodeMsgError {
             error: FailedToWriteFile,
-            correlation_id: MessageId::new(),
+            correlation_id: MsgId::new(),
         };
 
         let dst_location = DstLocation::Section {
@@ -474,7 +474,7 @@ impl Network {
 
         let wire_msg = node.sign_single_src_msg(node_msg, dst_location).await?;
 
-        match node.parse_and_send_message_to_nodes(wire_msg).await {
+        match node.send_msg_to_nodes(wire_msg).await {
             Ok(()) => Ok(true),
             Err(error) => {
                 Err(error).context(format!("failed to send probe by {}", node.name().await))

--- a/sn/src/client/client_api/cmds.rs
+++ b/sn/src/client/client_api/cmds.rs
@@ -21,14 +21,14 @@ use xor_name::XorName;
 
 impl Client {
     /// Send a Cmd to the network and await a response.
-    /// Commands are not retried if the timeout is hit.
+    /// Cmds are not retried if the timeout is hit.
     #[instrument(skip(self), level = "debug")]
     pub async fn send_cmd_without_retry(&self, cmd: DataCmd) -> Result<(), Error> {
         self.send_cmd_with_retry_count(cmd, 1.0).await
     }
 
     // Send a Cmd to the network and await a response.
-    // Commands are automatically retried if an error is returned
+    // Cmds are automatically retried if an error is returned
     // This function is a private helper.
     #[instrument(skip(self), level = "debug")]
     async fn send_cmd_with_retry_count(&self, cmd: DataCmd, retry_count: f32) -> Result<(), Error> {
@@ -62,7 +62,7 @@ impl Client {
             debug!("Attempting {:?} (attempt #{})", debug_cmd, attempt);
 
             let res = self
-                .send_signed_command(
+                .send_signed_cmd(
                     dst_name,
                     client_pk,
                     serialised_cmd.clone(),
@@ -91,8 +91,8 @@ impl Client {
 
     /// Send a signed DataCmd to the network.
     /// This is to be part of a public API, for the user to
-    /// provide the serialised and already signed command.
-    pub async fn send_signed_command(
+    /// provide the serialised and already signed cmd.
+    pub async fn send_signed_cmd(
         &self,
         dst_address: XorName,
         client_pk: PublicKey,

--- a/sn/src/client/client_api/mod.rs
+++ b/sn/src/client/client_api/mod.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-mod commands;
+mod cmds;
 mod data;
 mod file_apis;
 mod queries;

--- a/sn/src/client/client_api/register_apis.rs
+++ b/sn/src/client/client_api/register_apis.rs
@@ -163,7 +163,7 @@ impl Client {
         let query_result = self.send_query(query).await?;
         match query_result.response {
             QueryResponse::GetRegister((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMessage { source: err, op_id })
+                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
             }
             _ => Err(Error::ReceivedUnexpectedEvent),
         }
@@ -179,7 +179,7 @@ impl Client {
         let query_result = self.send_query(query).await?;
         match query_result.response {
             QueryResponse::ReadRegister((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMessage { source: err, op_id })
+                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
             }
             _ => Err(Error::ReceivedUnexpectedEvent),
         }
@@ -196,7 +196,7 @@ impl Client {
         let query_result = self.send_query(query).await?;
         match query_result.response {
             QueryResponse::GetRegisterEntry((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMessage { source: err, op_id })
+                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
             }
             _ => Err(Error::ReceivedUnexpectedEvent),
         }
@@ -213,7 +213,7 @@ impl Client {
         let query_result = self.send_query(query).await?;
         match query_result.response {
             QueryResponse::GetRegisterOwner((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMessage { source: err, op_id })
+                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
             }
             _ => Err(Error::ReceivedUnexpectedEvent),
         }
@@ -234,7 +234,7 @@ impl Client {
         let query_result = self.send_query(query).await?;
         match query_result.response {
             QueryResponse::GetRegisterUserPermissions((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMessage { source: err, op_id })
+                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
             }
             _ => Err(Error::ReceivedUnexpectedEvent),
         }
@@ -247,7 +247,7 @@ impl Client {
         let query_result = self.send_query(query).await?;
         match query_result.response {
             QueryResponse::GetRegisterPolicy((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMessage { source: err, op_id })
+                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
             }
             _ => Err(Error::ReceivedUnexpectedEvent),
         }
@@ -281,7 +281,7 @@ mod tests {
         },
         Error,
     };
-    use crate::messaging::data::Error as ErrorMessage;
+    use crate::messaging::data::Error as ErrorMsg;
     use crate::retry_loop_for_pattern;
     use crate::types::{
         log_markers::LogMarker,
@@ -534,8 +534,8 @@ mod tests {
             .await
         {
             Ok(_) => bail!("Should not be able to retrieve an entry for a random user"),
-            Err(Error::ErrorMessage {
-                source: ErrorMessage::NoSuchEntry,
+            Err(Error::ErrorMsg {
+                source: ErrorMsg::NoSuchEntry,
                 ..
             }) => Ok(()),
             Err(err) => Err(eyre!(
@@ -589,8 +589,8 @@ mod tests {
             .await
         {
             Ok(_) => bail!("Should not be able to retrieve an entry for a random user"),
-            Err(Error::ErrorMessage {
-                source: ErrorMessage::NoSuchEntry,
+            Err(Error::ErrorMsg {
+                source: ErrorMsg::NoSuchEntry,
                 ..
             }) => Ok(()),
             Err(err) => Err(eyre!(
@@ -686,8 +686,8 @@ mod tests {
             .instrument(tracing::info_span!("final get"))
             .await
         {
-            Err(Error::ErrorMessage {
-                source: ErrorMessage::NoSuchEntry,
+            Err(Error::ErrorMsg {
+                source: ErrorMsg::NoSuchEntry,
                 ..
             }) => Ok(()),
             Err(err) => Err(eyre!(
@@ -796,7 +796,7 @@ mod tests {
         let batch2 = client.delete_register(address).await?;
         match client.publish_register_ops(batch2).await {
             Err(Error::ErrorCmd {
-                source: ErrorMessage::InvalidOperation(_),
+                source: ErrorMsg::InvalidOperation(_),
                 ..
             }) => {}
             Err(err) => bail!(

--- a/sn/src/client/config_handler.rs
+++ b/sn/src/client/config_handler.rs
@@ -24,7 +24,7 @@ const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 
 /// Default amount of time to wait for operations to succeed (query/cmd) before giving up and returning an error.
 pub const DEFAULT_OPERATION_TIMEOUT: Duration = Duration::from_secs(120);
-/// Default amount of time to wait (to keep the client alive) after sending a command. This allows AE messages to be parsed/resent.
+/// Default amount of time to wait (to keep the client alive) after sending a cmd. This allows AE messages to be parsed/resent.
 /// Larger PUT operations may need larger ae wait time
 pub const DEFAULT_AE_WAIT: Duration = Duration::from_secs(0);
 
@@ -48,7 +48,7 @@ pub struct ClientConfig {
     pub query_timeout: Duration,
     /// The amount of time to wait for cmds to not error before giving up and returning an error.
     pub cmd_timeout: Duration,
-    /// The amount of time to wait after a command is sent for AE flows to complete.
+    /// The amount of time to wait after a cmd is sent for AE flows to complete.
     pub standard_wait: Duration,
 }
 

--- a/sn/src/client/connections/mod.rs
+++ b/sn/src/client/connections/mod.rs
@@ -10,7 +10,7 @@ mod listeners;
 mod messaging;
 use crate::messaging::{
     data::{CmdError, OperationId, QueryResponse},
-    MessageId,
+    MsgId,
 };
 use crate::peer::Peer;
 use crate::prefix_map::NetworkPrefixMap;
@@ -24,12 +24,12 @@ use tokio::time::Duration;
 use xor_name::XorName;
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
-type PendingQueryResponses = Arc<DashMap<OperationId, Vec<(MessageId, QueryResponseSender)>>>;
+type PendingQueryResponses = Arc<DashMap<OperationId, Vec<(MsgId, QueryResponseSender)>>>;
 use uluru::LRUCache;
 type QueryResponseSender = Sender<QueryResponse>;
 
 type CmdResponse = (std::net::SocketAddr, Option<CmdError>);
-type PendingCmdAcks = Arc<DashMap<MessageId, Sender<CmdResponse>>>;
+type PendingCmdAcks = Arc<DashMap<MsgId, Sender<CmdResponse>>>;
 
 #[derive(Debug)]
 pub struct QueryResult {
@@ -58,8 +58,8 @@ pub(super) struct Session {
     ae_retry_cache: Arc<RwLock<AeCache>>,
     /// Network's genesis key
     genesis_key: bls::PublicKey,
-    /// Initial network comms messageId
-    initial_connection_check_msg_id: Arc<RwLock<Option<MessageId>>>,
+    /// Initial network comms MsgId
+    initial_connection_check_msg_id: Arc<RwLock<Option<MsgId>>>,
     /// Standard time to await potential AE messages:
     standard_wait: Duration,
     /// Closed connection tracking, used to validate if a new connection is needed or not. Xorname to ConnectionId

--- a/sn/src/client/errors.rs
+++ b/sn/src/client/errors.rs
@@ -6,10 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-pub use crate::messaging::data::Error as ErrorMessage;
+pub use crate::messaging::data::Error as ErrorMsg;
 use crate::messaging::{
     data::{CmdError, OperationId, QueryResponse},
-    Error as MessagingError, MessageId,
+    Error as MessagingError, MsgId,
 };
 use crate::types::Error as DtError;
 use bls::PublicKey;
@@ -109,21 +109,21 @@ pub enum Error {
         source,
         op_id
     )]
-    ErrorMessage {
-        /// The source of an error message
-        source: ErrorMessage,
+    ErrorMsg {
+        /// The source of an error msg
+        source: ErrorMsg,
         /// operation ID that was used to send the query
         op_id: OperationId,
     },
     /// Error response received for a client cmd sent to the network
     #[error("Error received from the network: {:?} for cmd: {:?}", source, msg_id)]
     ErrorCmd {
-        /// The source of an error message
-        source: ErrorMessage,
-        /// message ID that was used to send the cmd
-        msg_id: MessageId,
+        /// The source of an error msg
+        source: ErrorMsg,
+        /// MsgId of the cmd
+        msg_id: MsgId,
     },
-    /// Errors occurred when serialising or deserialising messages
+    /// Errors occurred when serialising or deserialising msgs
     #[error(transparent)]
     MessagingProtocol(#[from] MessagingError),
     /// self_enryption errors
@@ -168,16 +168,16 @@ pub enum Error {
     },
 }
 
-impl From<(CmdError, MessageId)> for Error {
-    fn from((error, msg_id): (CmdError, MessageId)) -> Self {
+impl From<(CmdError, MsgId)> for Error {
+    fn from((error, msg_id): (CmdError, MsgId)) -> Self {
         let CmdError::Data(source) = error;
         Error::ErrorCmd { source, msg_id }
     }
 }
 
-impl From<(ErrorMessage, OperationId)> for Error {
-    fn from((source, op_id): (ErrorMessage, OperationId)) -> Self {
-        Self::ErrorMessage { source, op_id }
+impl From<(ErrorMsg, OperationId)> for Error {
+    fn from((source, op_id): (ErrorMsg, OperationId)) -> Self {
+        Self::ErrorMsg { source, op_id }
     }
 }
 

--- a/sn/src/client/mod.rs
+++ b/sn/src/client/mod.rs
@@ -33,7 +33,7 @@ mod errors;
 
 pub use client_api::{Client, RegisterWriteAheadLog};
 pub use config_handler::{ClientConfig, DEFAULT_AE_WAIT, DEFAULT_OPERATION_TIMEOUT};
-pub use errors::ErrorMessage;
+pub use errors::ErrorMsg;
 pub use errors::{Error, Result};
 pub use qp2p::Config as QuicP2pConfig;
 

--- a/sn/src/client/utils/test_utils/test_client.rs
+++ b/sn/src/client/utils/test_utils/test_client.rs
@@ -117,7 +117,7 @@ pub async fn create_test_client_with(
     let (genesis_key, bootstrap_nodes) = read_network_conn_info()?;
 
     let standard_wait = if read_prefix_map {
-        // there should be No AE needed and commands should work first time
+        // there should be No AE needed and cmds should work first time
         Some(Duration::from_secs(0))
     } else {
         // AE may be needed, so lets go with defaults

--- a/sn/src/dbs/errors.rs
+++ b/sn/src/dbs/errors.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::data::Error as ErrorMessage;
-use crate::types::{convert_dt_error_to_error_message, DataAddress, PublicKey};
+use crate::messaging::data::Error as ErrorMsg;
+use crate::types::{convert_dt_error_to_error_msg, DataAddress, PublicKey};
 use std::io;
 use thiserror::Error;
 use xor_name::XorName;
@@ -98,17 +98,15 @@ pub enum Error {
 }
 
 /// Convert db error to messaging error message for sending over the network.
-pub(crate) fn convert_to_error_message(error: Error) -> ErrorMessage {
+pub(crate) fn convert_to_error_msg(error: Error) -> ErrorMsg {
     match error {
-        Error::NotEnoughSpace => ErrorMessage::FailedToWriteFile,
-        Error::DataIdNotFound(address) => ErrorMessage::DataNotFound(address),
-        Error::NoSuchData(address) => ErrorMessage::DataNotFound(address),
-        Error::ChunkNotFound(xorname) => ErrorMessage::ChunkNotFound(xorname),
-        Error::TempDirCreationFailed(_) => ErrorMessage::FailedToWriteFile,
-        Error::DataExists => ErrorMessage::DataExists,
-        Error::NetworkData(error) => convert_dt_error_to_error_message(error),
-        other => {
-            ErrorMessage::InvalidOperation(format!("Failed to perform operation: {:?}", other))
-        }
+        Error::NotEnoughSpace => ErrorMsg::FailedToWriteFile,
+        Error::DataIdNotFound(address) => ErrorMsg::DataNotFound(address),
+        Error::NoSuchData(address) => ErrorMsg::DataNotFound(address),
+        Error::ChunkNotFound(xorname) => ErrorMsg::ChunkNotFound(xorname),
+        Error::TempDirCreationFailed(_) => ErrorMsg::FailedToWriteFile,
+        Error::DataExists => ErrorMsg::DataExists,
+        Error::NetworkData(error) => convert_dt_error_to_error_msg(error),
+        other => ErrorMsg::InvalidOperation(format!("Failed to perform operation: {:?}", other)),
     }
 }

--- a/sn/src/dbs/mod.rs
+++ b/sn/src/dbs/mod.rs
@@ -13,7 +13,7 @@ mod lru_cache;
 mod used_space;
 
 pub(crate) use encoding::{deserialise, serialise};
-pub(crate) use errors::{convert_to_error_message, Error, Result};
+pub(crate) use errors::{convert_to_error_msg, Error, Result};
 pub(crate) use event_store::EventStore;
 pub(crate) use lru_cache::LruCache;
 use std::path::Path;

--- a/sn/src/messaging/data/cmd.rs
+++ b/sn/src/messaging/data/cmd.rs
@@ -11,7 +11,7 @@ use crate::types::Chunk;
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
-/// Data commands - creating, updating, or removing data.
+/// Data cmds - creating, updating, or removing data.
 ///
 /// See the [`types`] module documentation for more details of the types supported by the Safe
 /// Network, and their semantics.
@@ -32,7 +32,7 @@ pub enum DataCmd {
 
 impl DataCmd {
     /// Creates a Response containing an error, with the Response variant corresponding to the
-    /// command variant.
+    /// cmd variant.
     pub fn error(&self, error: Error) -> CmdError {
         use DataCmd::*;
         match self {
@@ -41,7 +41,7 @@ impl DataCmd {
         }
     }
 
-    /// Returns the xorname of the data for this command.
+    /// Returns the xorname of the data for this cmd.
     pub fn dst_name(&self) -> XorName {
         use DataCmd::*;
         match self {

--- a/sn/src/messaging/data/mod.rs
+++ b/sn/src/messaging/data/mod.rs
@@ -30,7 +30,7 @@ use crate::types::{
     Chunk, ChunkAddress, DataAddress,
 };
 use crate::{
-    messaging::{data::Error as ErrorMessage, MessageId},
+    messaging::{data::Error as ErrorMsg, MsgId},
     types::utils,
 };
 use bytes::Bytes;
@@ -90,7 +90,7 @@ pub enum ServiceMsg {
         /// The result of the query.
         response: QueryResponse,
         /// ID of the query message.
-        correlation_id: MessageId,
+        correlation_id: MsgId,
     },
     /// An error response to a [`Cmd`].
     ///
@@ -101,7 +101,7 @@ pub enum ServiceMsg {
         /// ID of causing [`Cmd`] message.
         ///
         /// [`Cmd`]: Self::Cmd
-        correlation_id: MessageId,
+        correlation_id: MsgId,
     },
     /// A message indicating that an error occurred as a node was handling a client's message.
     ServiceError(ServiceError),
@@ -111,12 +111,12 @@ pub enum ServiceMsg {
         /// ID of causing [`Cmd`] message.
         ///
         /// [`Cmd`]: Self::Cmd
-        correlation_id: MessageId,
+        correlation_id: MsgId,
     },
 }
 
 impl ServiceMsg {
-    /// Returns the destination address for Commands and Queries only.
+    /// Returns the destination address for cmds and Queries only.
     pub fn dst_address(&self) -> Option<XorName> {
         match self {
             Self::Cmd(cmd) => Some(cmd.dst_name()),
@@ -191,31 +191,31 @@ impl QueryResponse {
         match self {
             GetChunk(result) => match result {
                 Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMessage::ChunkNotFound(_)),
+                Err(error) => matches!(*error, ErrorMsg::ChunkNotFound(_)),
             },
             GetRegister((result, _op_id)) => match result {
                 Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMessage::DataNotFound(_)),
+                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
             },
             GetRegisterEntry((result, _op_id)) => match result {
                 Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMessage::DataNotFound(_)),
+                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
             },
             GetRegisterOwner((result, _op_id)) => match result {
                 Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMessage::DataNotFound(_)),
+                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
             },
             ReadRegister((result, _op_id)) => match result {
                 Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMessage::DataNotFound(_)),
+                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
             },
             GetRegisterPolicy((result, _op_id)) => match result {
                 Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMessage::DataNotFound(_)),
+                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
             },
             GetRegisterUserPermissions((result, _op_id)) => match result {
                 Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMessage::DataNotFound(_)),
+                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
             },
             FailedToCreateOperationId => false,
         }
@@ -230,11 +230,11 @@ impl QueryResponse {
         match self {
             GetChunk(result) => match result {
                 Ok(chunk) => chunk_operation_id(chunk.address()),
-                Err(ErrorMessage::ChunkNotFound(name)) => chunk_operation_id(&ChunkAddress(*name)),
-                Err(ErrorMessage::DataNotFound(DataAddress::Bytes(address))) => {
+                Err(ErrorMsg::ChunkNotFound(name)) => chunk_operation_id(&ChunkAddress(*name)),
+                Err(ErrorMsg::DataNotFound(DataAddress::Bytes(address))) => {
                     chunk_operation_id(&ChunkAddress(*address.name()))
                 }
-                Err(ErrorMessage::DataNotFound(another_address)) => {
+                Err(ErrorMsg::DataNotFound(another_address)) => {
                     error!(
                         "{:?} address returned when we were expecting a ChunkAddress",
                         another_address

--- a/sn/src/messaging/mod.rs
+++ b/sn/src/messaging/mod.rs
@@ -46,8 +46,8 @@ pub use self::{
     },
     errors::{Error, Result},
     location::{DstLocation, EndUser, SrcLocation},
-    msg_id::{MessageId, MESSAGE_ID_LEN},
+    msg_id::{MsgId, MESSAGE_ID_LEN},
     msg_kind::MsgKind,
     sap::SectionAuthorityProvider,
-    serialisation::{MessageType, NodeMsgAuthority, WireMsg},
+    serialisation::{MsgType, NodeMsgAuthority, WireMsg},
 };

--- a/sn/src/messaging/msg_id.rs
+++ b/sn/src/messaging/msg_id.rs
@@ -11,23 +11,23 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use xor_name::XorName;
 
-/// Constant byte length of `MessageId`.
+/// Constant byte length of `MsgId`.
 pub const MESSAGE_ID_LEN: usize = 32;
 
 /// Unique ID for messages.
 #[derive(
     Ord, PartialOrd, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, custom_debug::Debug,
 )]
-pub struct MessageId(#[debug(with = "Self::fmt_bytes")] [u8; MESSAGE_ID_LEN]);
+pub struct MsgId(#[debug(with = "Self::fmt_bytes")] [u8; MESSAGE_ID_LEN]);
 
-impl MessageId {
-    /// Generates a new `MessageId` with random content.
+impl MsgId {
+    /// Generates a new `MsgId` with random content.
     pub fn new() -> Self {
         // Here we use XorName just as helper to generate a random id
         Self(XorName::random().0)
     }
 
-    /// Convert an XorName into a MessageId
+    /// Convert an XorName into a MsgId
     pub fn from_xor_name(xor_name: XorName) -> Self {
         Self(xor_name.0)
     }
@@ -37,13 +37,13 @@ impl MessageId {
     }
 }
 
-impl Default for MessageId {
+impl Default for MsgId {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl AsRef<[u8; MESSAGE_ID_LEN]> for MessageId {
+impl AsRef<[u8; MESSAGE_ID_LEN]> for MsgId {
     fn as_ref(&self) -> &[u8; MESSAGE_ID_LEN] {
         &self.0
     }

--- a/sn/src/messaging/serialisation/mod.rs
+++ b/sn/src/messaging/serialisation/mod.rs
@@ -23,7 +23,7 @@ use crate::types::PublicKey;
 
 pub use self::wire_msg::WireMsg;
 use super::{
-    data::ServiceMsg, system::SystemMsg, AuthorityProof, BlsShareAuth, DstLocation, MessageId,
+    data::ServiceMsg, system::SystemMsg, AuthorityProof, BlsShareAuth, DstLocation, MsgId,
     NodeAuth, SectionAuth, ServiceAuth,
 };
 
@@ -32,11 +32,11 @@ use super::{
 /// never serialised or even part of the message that is sent over the wire.
 #[derive(PartialEq, Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
-pub enum MessageType {
+pub enum MsgType {
     /// Service message
     Service {
         /// Message ID
-        msg_id: MessageId,
+        msg_id: MsgId,
         /// Requester's authority over this message
         auth: AuthorityProof<ServiceAuth>,
         /// Message destination location
@@ -47,7 +47,7 @@ pub enum MessageType {
     /// System message
     System {
         /// Message ID
-        msg_id: MessageId,
+        msg_id: MsgId,
         /// Node authority over this message
         msg_authority: NodeMsgAuthority,
         /// Message destination location
@@ -57,16 +57,16 @@ pub enum MessageType {
     },
 }
 
-impl MessageType {
+impl MsgType {
     /// The priority of the message, when handled by lower level comms.
     pub fn priority(&self) -> i32 {
         match self {
-            MessageType::System {
+            MsgType::System {
                 msg: SystemMsg::JoinResponse(_) | SystemMsg::JoinAsRelocatedResponse(_),
                 ..
             } => JOIN_RESPONSE_PRIORITY,
             // DKG messages
-            MessageType::System {
+            MsgType::System {
                 msg:
                     SystemMsg::DkgStart { .. }
                     | SystemMsg::DkgSessionUnknown { .. }
@@ -80,7 +80,7 @@ impl MessageType {
             } => DKG_MSG_PRIORITY,
 
             // Node messages for AE updates
-            MessageType::System {
+            MsgType::System {
                 msg:
                     SystemMsg::AntiEntropyRetry { .. }
                     | SystemMsg::AntiEntropyRedirect { .. }
@@ -96,7 +96,7 @@ impl MessageType {
             } => INFRASTRUCTURE_MSG_PRIORITY,
 
             // Inter-node comms related to processing client requests
-            MessageType::System {
+            MsgType::System {
                 msg:
                     SystemMsg::NodeCmd(_)
                     | SystemMsg::NodeEvent(_)
@@ -107,7 +107,7 @@ impl MessageType {
             } => NODE_DATA_MSG_PRIORITY,
 
             // Client<->node service comms
-            MessageType::Service { .. } => SERVICE_MSG_PRIORITY,
+            MsgType::Service { .. } => SERVICE_MSG_PRIORITY,
         }
     }
 }

--- a/sn/src/messaging/serialisation/wire_msg_header.rs
+++ b/sn/src/messaging/serialisation/wire_msg_header.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::{DstLocation, Error, MessageId, MsgKind, Result};
+use crate::messaging::{DstLocation, Error, MsgId, MsgKind, Result};
 use bincode::{
     config::{BigEndian, FixintEncoding, WithOtherEndian, WithOtherIntEncoding},
     Options,
@@ -37,7 +37,7 @@ pub struct WireMsgHeader {
 // all this information before deciding to deserialise the actual message payload.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MsgEnvelope {
-    pub msg_id: MessageId,
+    pub msg_id: MsgId,
     pub msg_kind: MsgKind,
     pub dst_location: DstLocation,
 }
@@ -73,7 +73,7 @@ lazy_static! {
 
 impl WireMsgHeader {
     // Instantiate a WireMsgHeader as per current supported version.
-    pub fn new(msg_id: MessageId, msg_kind: MsgKind, dst_location: DstLocation) -> Self {
+    pub fn new(msg_id: MsgId, msg_kind: MsgKind, dst_location: DstLocation) -> Self {
         Self {
             //header_size: Self::max_size(),
             version: MESSAGING_PROTO_VERSION,

--- a/sn/src/messaging/system/mod.rs
+++ b/sn/src/messaging/system/mod.rs
@@ -23,7 +23,7 @@ pub use signed::{KeyedSig, SigShare};
 /// List of peers of a section
 pub type SectionPeers = BTreeSet<SectionAuth<NodeState>>;
 
-use crate::messaging::{EndUser, MessageId, SectionAuthorityProvider};
+use crate::messaging::{EndUser, MsgId, SectionAuthorityProvider};
 use bls_dkg::key_gen::message::Message as DkgMessage;
 use bytes::Bytes;
 use secured_linked_list::SecuredLinkedList;
@@ -188,7 +188,7 @@ pub enum SystemMsg {
         /// QueryResponse.
         response: NodeQueryResponse,
         /// ID of causing query.
-        correlation_id: MessageId,
+        correlation_id: MsgId,
         /// TEMP: Add user here as part of return flow. Remove this as we have chunk routing etc
         user: EndUser,
     },
@@ -198,7 +198,7 @@ pub enum SystemMsg {
         // TODO: return node::Error instead
         error: crate::messaging::data::Error,
         /// ID of causing cmd.
-        correlation_id: MessageId,
+        correlation_id: MsgId,
     },
 }
 

--- a/sn/src/messaging/system/node_msgs.rs
+++ b/sn/src/messaging/system/node_msgs.rs
@@ -10,7 +10,7 @@ use crate::messaging::{
     data::{
         DataCmd, DataQuery, MetadataExchange, OperationId, QueryResponse, Result, StorageLevel,
     },
-    EndUser, MessageId, ServiceAuth,
+    EndUser, MsgId, ServiceAuth,
 };
 use crate::types::{
     register::{Entry, EntryHash, Permissions, Policy, Register, User},
@@ -21,13 +21,13 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use xor_name::XorName;
 
-/// Command message sent among nodes
+/// cmd message sent among nodes
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum NodeCmd {
     /// Metadata is handled by Elders
     Metadata {
-        /// The contained command
+        /// The contained cmd
         cmd: DataCmd,
         /// Requester pk and signature
         auth: ServiceAuth,
@@ -90,7 +90,7 @@ pub enum NodeQuery {
         /// The user that has initiated this query
         origin: EndUser,
         /// The correlation id that recorded in Elders for this query
-        correlation_id: MessageId,
+        correlation_id: MsgId,
     },
 }
 

--- a/sn/src/node/api/event.rs
+++ b/sn/src/node/api/event.rs
@@ -9,7 +9,7 @@
 use crate::messaging::{
     data::ServiceMsg,
     system::{NodeCmd, NodeQuery, NodeQueryResponse},
-    AuthorityProof, DstLocation, EndUser, MessageId, ServiceAuth, SrcLocation,
+    AuthorityProof, DstLocation, EndUser, MsgId, ServiceAuth, SrcLocation,
 };
 
 use bls::PublicKey as BlsPublicKey;
@@ -57,7 +57,7 @@ pub enum Event {
     /// Received a message from another Node.
     MessageReceived {
         /// The message ID
-        msg_id: MessageId,
+        msg_id: MsgId,
         /// Source location
         src: SrcLocation,
         /// Destination location
@@ -112,7 +112,7 @@ pub enum Event {
     /// Received a message from a peer.
     ServiceMsgReceived {
         /// The message ID
-        msg_id: MessageId,
+        msg_id: MsgId,
         /// The content of the message.
         msg: Box<ServiceMsg>,
         /// Data authority
@@ -148,6 +148,6 @@ pub enum MessageReceived {
         /// QueryResponse.
         response: NodeQueryResponse,
         /// ID of causing query.
-        correlation_id: MessageId,
+        correlation_id: MsgId,
     },
 }

--- a/sn/src/node/cfg/config_handler.rs
+++ b/sn/src/node/cfg/config_handler.rs
@@ -146,7 +146,7 @@ pub struct Config {
 
 impl Config {
     /// Returns a new `Config` instance.  Tries to read from the default node config file location,
-    /// and overrides values with any equivalent command line args.
+    /// and overrides values with any equivalent cmd line args.
     pub async fn new() -> Result<Self, Error> {
         // FIXME: Re-enable when we have rejoins working
         // let mut config = match Self::read_from_file() {
@@ -156,24 +156,24 @@ impl Config {
 
         let mut config = Config::default();
 
-        let mut command_line_args = Config::from_args();
-        command_line_args.validate().map_err(Error::Configuration)?;
+        let mut cmd_line_args = Config::from_args();
+        cmd_line_args.validate().map_err(Error::Configuration)?;
 
-        if command_line_args.hard_coded_contacts.is_empty() {
+        if cmd_line_args.hard_coded_contacts.is_empty() {
             debug!("Using node connection config file as no hard coded contacts were passed in");
             if let Ok((_, info)) = read_conn_info_from_file().await {
-                command_line_args.hard_coded_contacts = info;
+                cmd_line_args.hard_coded_contacts = info;
             }
         }
 
-        if command_line_args.genesis_key.is_none() {
+        if cmd_line_args.genesis_key.is_none() {
             debug!("Using node connection config file as no genesis key was passed in");
             if let Ok((genesis_key, _)) = read_conn_info_from_file().await {
-                command_line_args.genesis_key = Some(genesis_key);
+                cmd_line_args.genesis_key = Some(genesis_key);
             }
         }
 
-        config.merge(command_line_args);
+        config.merge(cmd_line_args);
 
         config.clear_data_from_disk().await.unwrap_or_else(|_| {
             tracing::error!("Error deleting data file from disk");
@@ -183,7 +183,7 @@ impl Config {
         Ok(config)
     }
 
-    /// Validate configuration that came from the command line.
+    /// Validate configuration that came from the cmd line.
     ///
     /// `StructOpt` doesn't support validation that crosses multiple field values.
     fn validate(&self) -> Result<(), String> {

--- a/sn/src/node/core/bootstrap/relocate.rs
+++ b/sn/src/node/core/bootstrap/relocate.rs
@@ -12,8 +12,8 @@ use crate::messaging::{
     DstLocation, WireMsg,
 };
 use crate::node::{
-    api::command::Command, ed25519, messages::WireMsgUtils,
-    network_knowledge::SectionAuthorityProvider, node_info::Node, Error, Result,
+    api::cmds::Cmd, ed25519, messages::WireMsgUtils, network_knowledge::SectionAuthorityProvider,
+    node_info::Node, Error, Result,
 };
 use crate::peer::Peer;
 use crate::types::PublicKey;
@@ -37,7 +37,7 @@ pub(crate) struct JoiningAsRelocated {
 }
 
 impl JoiningAsRelocated {
-    // Generates the first command to send a `JoinAsRelocatedRequest`, responses
+    // Generates the first cmd to send a `JoinAsRelocatedRequest`, responses
     // shall be fed back with `handle_join_response` function.
     pub(crate) fn start(
         node: Node,
@@ -47,7 +47,7 @@ impl JoiningAsRelocated {
         dst_xorname: XorName,
         dst_section_key: BlsPublicKey,
         new_age: u8,
-    ) -> Result<(Self, Command)> {
+    ) -> Result<(Self, Cmd)> {
         let recipients: Vec<_> = bootstrap_addrs
             .iter()
             .map(|addr| Peer::new(dst_xorname, *addr))
@@ -89,7 +89,7 @@ impl JoiningAsRelocated {
         &mut self,
         join_response: JoinAsRelocatedResponse,
         sender: SocketAddr,
-    ) -> Result<Option<Command>> {
+    ) -> Result<Option<Cmd>> {
         trace!("Hanlde JoinResponse {:?}", join_response);
         match join_response {
             JoinAsRelocatedResponse::Retry(section_auth) => {
@@ -215,7 +215,7 @@ impl JoiningAsRelocated {
         recipients: &[Peer],
         dst_name: XorName,
         new_name_sig: Signature,
-    ) -> Result<Command> {
+    ) -> Result<Cmd> {
         let join_request = JoinAsRelocatedRequest {
             section_key: self.dst_section_key,
             relocate_proof: self.relocate_proof.clone(),
@@ -235,7 +235,7 @@ impl JoiningAsRelocated {
             self.genesis_key,
         )?;
 
-        let cmd = Command::SendMessage {
+        let cmd = Cmd::SendMsg {
             recipients: recipients.to_vec(),
             wire_msg,
         };

--- a/sn/src/node/core/data_storage/chunk_storage/mod.rs
+++ b/sn/src/node/core/data_storage/chunk_storage/mod.rs
@@ -8,7 +8,7 @@
 
 mod chunk_disk_store;
 
-use crate::dbs::{convert_to_error_message, Error, Result};
+use crate::dbs::{convert_to_error_msg, Error, Result};
 use crate::messaging::system::NodeQueryResponse;
 use crate::types::{log_markers::LogMarker, Chunk, ChunkAddress};
 use crate::UsedSpace;
@@ -60,11 +60,7 @@ impl ChunkStorage {
     // Read chunk from local store and return NodeQueryResponse
     pub(crate) async fn get(&self, address: &ChunkAddress) -> NodeQueryResponse {
         trace!("{:?}", LogMarker::ChunkQueryReceviedAtAdult);
-        NodeQueryResponse::GetChunk(
-            self.get_chunk(address)
-                .await
-                .map_err(convert_to_error_message),
-        )
+        NodeQueryResponse::GetChunk(self.get_chunk(address).await.map_err(convert_to_error_msg))
     }
 
     /// Store a chunk in the local disk store

--- a/sn/src/node/core/data_storage/errors.rs
+++ b/sn/src/node/core/data_storage/errors.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::data::Error as ErrorMessage;
-use crate::types::convert_dt_error_to_error_message;
+use crate::messaging::data::Error as ErrorMsg;
+use crate::types::convert_dt_error_to_error_msg;
 use std::io;
 use thiserror::Error;
 use xor_name::XorName;

--- a/sn/src/node/core/data_storage/mod.rs
+++ b/sn/src/node/core/data_storage/mod.rs
@@ -9,7 +9,7 @@
 mod chunk_storage;
 mod register_storage;
 
-use super::{Command, Core};
+use super::{Cmd, Core};
 
 use crate::{
     dbs::Result,
@@ -137,7 +137,7 @@ impl Core {
         new_adults: BTreeSet<XorName>,
         lost_adults: BTreeSet<XorName>,
         remaining: BTreeSet<XorName>,
-    ) -> Result<Vec<Command>> {
+    ) -> Result<Vec<Cmd>> {
         let data = self.data_storage.clone();
         let keys = data.keys().await?;
         let mut data_for_replication = BTreeMap::new();
@@ -150,18 +150,18 @@ impl Core {
             }
         }
 
-        let mut commands = vec![];
+        let mut cmds = vec![];
         let section_pk = self.network_knowledge.section_key().await;
         for (_, (data, targets)) in data_for_replication {
             for name in targets {
-                commands.push(Command::PrepareNodeMsgToSendToNodes {
+                cmds.push(Cmd::SignOutgoingSystemMsg {
                     msg: SystemMsg::NodeCmd(NodeCmd::ReplicateData(data.clone())),
                     dst: crate::messaging::DstLocation::Node { name, section_pk },
                 })
             }
         }
 
-        Ok(commands)
+        Ok(cmds)
     }
 
     // on adults

--- a/sn/src/node/core/data_storage/register_storage.rs
+++ b/sn/src/node/core/data_storage/register_storage.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::dbs::{
-    convert_to_error_message, Error, EventStore, LruCache, Result, UsedSpace, SLED_FLUSH_TIME_MS,
+    convert_to_error_msg, Error, EventStore, LruCache, Result, UsedSpace, SLED_FLUSH_TIME_MS,
 };
 use crate::messaging::{
     data::{
@@ -502,7 +502,7 @@ impl RegisterStorage {
     ) -> NodeQueryResponse {
         let result = match self.get_register(&address, Action::Read, requester).await {
             Ok(register) => Ok(register),
-            Err(error) => Err(convert_to_error_message(error)),
+            Err(error) => Err(convert_to_error_msg(error)),
         };
 
         NodeQueryResponse::GetRegister((result, operation_id))
@@ -519,7 +519,7 @@ impl RegisterStorage {
             Err(error) => Err(error),
         };
 
-        NodeQueryResponse::ReadRegister((result.map_err(convert_to_error_message), operation_id))
+        NodeQueryResponse::ReadRegister((result.map_err(convert_to_error_msg), operation_id))
     }
 
     async fn get_owner(
@@ -530,7 +530,7 @@ impl RegisterStorage {
     ) -> NodeQueryResponse {
         let result = match self.get_register(&address, Action::Read, requester).await {
             Ok(res) => Ok(res.owner()),
-            Err(error) => Err(convert_to_error_message(error)),
+            Err(error) => Err(convert_to_error_msg(error)),
         };
 
         NodeQueryResponse::GetRegisterOwner((result, operation_id))
@@ -549,7 +549,7 @@ impl RegisterStorage {
             .and_then(|register| register.get(hash).map(|c| c.clone()).map_err(Error::from))
         {
             Ok(res) => Ok(res),
-            Err(error) => Err(convert_to_error_message(error)),
+            Err(error) => Err(convert_to_error_msg(error)),
         };
 
         NodeQueryResponse::GetRegisterEntry((result, operation_id))
@@ -568,7 +568,7 @@ impl RegisterStorage {
             .and_then(|register| register.permissions(user).map_err(Error::from))
         {
             Ok(res) => Ok(res),
-            Err(error) => Err(convert_to_error_message(error)),
+            Err(error) => Err(convert_to_error_msg(error)),
         };
 
         NodeQueryResponse::GetRegisterUserPermissions((result, operation_id))
@@ -586,7 +586,7 @@ impl RegisterStorage {
             .map(|register| register.policy().clone())
         {
             Ok(res) => Ok(res),
-            Err(error) => Err(convert_to_error_message(error)),
+            Err(error) => Err(convert_to_error_msg(error)),
         };
 
         NodeQueryResponse::GetRegisterPolicy((result, operation_id))

--- a/sn/src/node/core/msg_handling/proposals.rs
+++ b/sn/src/node/core/msg_handling/proposals.rs
@@ -6,9 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::{signature_aggregator::Error as AggregatorError, MessageId};
+use crate::messaging::{signature_aggregator::Error as AggregatorError, MsgId};
 use crate::node::{
-    api::command::Command,
+    api::cmds::Cmd,
     core::{Core, Proposal},
     dkg::SigShare,
     Result,
@@ -20,11 +20,11 @@ impl Core {
     // Insert the proposal into the proposal aggregator and handle it if aggregated.
     pub(crate) async fn handle_proposal(
         &self,
-        msg_id: MessageId,
+        msg_id: MsgId,
         proposal: Proposal,
         sig_share: SigShare,
         sender: Peer,
-    ) -> Result<Vec<Command>> {
+    ) -> Result<Vec<Cmd>> {
         let sig_share_pk = &sig_share.public_key_set.public_key();
 
         // Any other proposal than SectionInfo needs to be signed by a known section key.
@@ -75,7 +75,7 @@ impl Core {
             }
         }
 
-        let mut commands = vec![];
+        let mut cmds = vec![];
 
         match proposal.as_signable_bytes() {
             Err(error) => error!(
@@ -90,9 +90,9 @@ impl Core {
                 {
                     Ok(sig) => match proposal {
                         Proposal::NewElders(_) => {
-                            commands.push(Command::HandleNewEldersAgreement { proposal, sig })
+                            cmds.push(Cmd::HandleNewEldersAgreement { proposal, sig })
                         }
-                        _ => commands.push(Command::HandleAgreement { proposal, sig }),
+                        _ => cmds.push(Cmd::HandleAgreement { proposal, sig }),
                     },
                     Err(AggregatorError::NotEnoughShares) => {
                         trace!(
@@ -111,6 +111,6 @@ impl Core {
             }
         }
 
-        Ok(commands)
+        Ok(cmds)
     }
 }

--- a/sn/src/node/core/msg_handling/resource_proof.rs
+++ b/sn/src/node/core/msg_handling/resource_proof.rs
@@ -8,7 +8,7 @@
 
 use crate::messaging::system::{JoinResponse, ResourceProofResponse, SystemMsg};
 use crate::node::{
-    api::command::Command,
+    api::cmds::Cmd,
     core::{Core, RESOURCE_PROOF_DATA_SIZE, RESOURCE_PROOF_DIFFICULTY},
     ed25519, Error, Result,
 };
@@ -47,7 +47,7 @@ impl Core {
             .validate_all(&response.nonce, &response.data, response.solution)
     }
 
-    pub(crate) async fn send_resource_proof_challenge(&self, peer: Peer) -> Result<Command> {
+    pub(crate) async fn send_resource_proof_challenge(&self, peer: Peer) -> Result<Cmd> {
         let nonce: [u8; 32] = rand::random();
         let serialized =
             bincode::serialize(&(peer.name(), &nonce)).map_err(|_| Error::InvalidMessage)?;
@@ -59,7 +59,7 @@ impl Core {
         }));
 
         trace!("{}", LogMarker::SendResourceProofChallenge);
-        self.send_direct_message(peer, response, self.network_knowledge.section_key().await)
+        self.send_direct_msg(peer, response, self.network_knowledge.section_key().await)
             .await
     }
 }

--- a/sn/src/node/core/msg_handling/update_section.rs
+++ b/sn/src/node/core/msg_handling/update_section.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::{api::command::Command, core::Core, Result};
+use crate::node::{api::cmds::Cmd, core::Core, Result};
 use crate::types::log_markers::LogMarker;
 use std::collections::BTreeSet;
 use xor_name::XorName;
@@ -17,7 +17,7 @@ impl Core {
     pub(crate) async fn try_reorganize_data(
         &self,
         old_adults: BTreeSet<XorName>,
-    ) -> Result<Vec<Command>> {
+    ) -> Result<Vec<Cmd>> {
         if self.is_elder().await {
             // only adults carry out the ops in this method
             return Ok(vec![]);

--- a/sn/src/node/error.rs
+++ b/sn/src/node/error.rs
@@ -8,8 +8,8 @@
 
 use super::Prefix;
 
-use crate::messaging::data::Error as ErrorMessage;
-use crate::types::{convert_dt_error_to_error_message, DataAddress, PublicKey};
+use crate::messaging::data::Error as ErrorMsg;
+use crate::types::{convert_dt_error_to_error_msg, DataAddress, PublicKey};
 
 use secured_linked_list::error::Error as SecuredLinkedListError;
 use std::io;
@@ -24,8 +24,8 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
-    #[error("Max amount of service commands being handled, dropping command.")]
-    AtMaxServiceCommandThroughput,
+    #[error("Max amount of service cmds being handled, dropping cmd.")]
+    AtMaxServiceCmdThroughput,
     #[error("Permit was not retrieved in 500 loops")]
     CouldNotGetPermitInTime,
     #[error("Node prioritisation semaphore was closed early.")]
@@ -153,14 +153,12 @@ impl From<qp2p::SendError> for Error {
     }
 }
 
-pub(crate) fn convert_to_error_message(error: Error) -> ErrorMessage {
+pub(crate) fn convert_to_error_msg(error: Error) -> ErrorMsg {
     match error {
-        Error::InvalidOwner(key) => ErrorMessage::InvalidOwner(key),
-        Error::NoSuchData(address) => ErrorMessage::DataNotFound(address),
-        Error::DataExists => ErrorMessage::DataExists,
-        Error::NetworkData(error) => convert_dt_error_to_error_message(error),
-        other => {
-            ErrorMessage::InvalidOperation(format!("Failed to perform operation: {:?}", other))
-        }
+        Error::InvalidOwner(key) => ErrorMsg::InvalidOwner(key),
+        Error::NoSuchData(address) => ErrorMsg::DataNotFound(address),
+        Error::DataExists => ErrorMsg::DataExists,
+        Error::NetworkData(error) => convert_dt_error_to_error_msg(error),
+        other => ErrorMsg::InvalidOperation(format!("Failed to perform operation: {:?}", other)),
     }
 }

--- a/sn/src/node/messages/mod.rs
+++ b/sn/src/node/messages/mod.rs
@@ -12,7 +12,7 @@ pub(super) use self::msg_authority::NodeMsgAuthorityUtils;
 
 use crate::messaging::{
     system::{SigShare, SystemMsg},
-    AuthorityProof, BlsShareAuth, DstLocation, MessageId, MsgKind, NodeAuth, WireMsg,
+    AuthorityProof, BlsShareAuth, DstLocation, MsgId, MsgKind, NodeAuth, WireMsg,
 };
 use crate::node::{network_knowledge::SectionKeyShare, node_info::Node, Error, Result};
 
@@ -55,7 +55,7 @@ impl WireMsgUtils for WireMsg {
             bls_share_authorize(src_section_pk, src_name, key_share, &msg_payload).into_inner(),
         );
 
-        let wire_msg = WireMsg::new_msg(MessageId::new(), msg_payload, msg_kind, dst)?;
+        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, msg_kind, dst)?;
 
         #[cfg(feature = "unstable-wiremsg-debuginfo")]
         let wire_msg = wire_msg.set_payload_debug(node_msg);
@@ -77,7 +77,7 @@ impl WireMsgUtils for WireMsg {
             NodeAuth::authorize(src_section_pk, &node.keypair, &msg_payload).into_inner(),
         );
 
-        let wire_msg = WireMsg::new_msg(MessageId::new(), msg_payload, msg_kind, dst)?;
+        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, msg_kind, dst)?;
 
         #[cfg(feature = "unstable-wiremsg-debuginfo")]
         let wire_msg = wire_msg.set_payload_debug(node_msg);

--- a/sn/src/node/network_knowledge/mod.rs
+++ b/sn/src/node/network_knowledge/mod.rs
@@ -359,10 +359,10 @@ impl NetworkKnowledge {
                 .collect();
 
             if self.merge_members(peers).await? {
+                let prefix = self.prefix().await;
                 info!(
                     "Updated our section's members ({:?}): {:?}",
-                    self.prefix().await,
-                    self.section_peers
+                    prefix, self.section_peers
                 );
             }
         }

--- a/sn/src/node/tests/drop.rs
+++ b/sn/src/node/tests/drop.rs
@@ -59,7 +59,7 @@ async fn test_node_drop() -> Result<()> {
             dst: DstLocation::Node(dropped_name),
             aggregation: Aggregation::None,
         };
-        node.send_message(itinerary, Bytes::from(b"hello".to_vec()), None)
+        node.send_msg(itinerary, Bytes::from(b"hello".to_vec()), None)
             .await?
     }
 

--- a/sn/src/node/tests/messages.rs
+++ b/sn/src/node/tests/messages.rs
@@ -16,7 +16,7 @@ use crate::messaging::client::ServiceMsg;
 use crate::messaging::{
     client::{ServiceMsg, ClientSig, Query, TransferQuery},
     location::{Aggregation, Itinerary},
-    DstLocation, MessageId, SrcLocation,
+    DstLocation, MsgId, SrcLocation,
 };
 use crate::node::routing_api::{Config, Error, Event, NodeElderChange};
 use std::net::{IpAddr, Ipv4Addr};
@@ -40,7 +40,7 @@ async fn test_messages_client_node() -> Result<()> {
         public_key: pk,
         signature: keypair.sign(b"the msg"),
     };
-    let id = MessageId::new();
+    let id = MsgId::new();
 
     // create a client which sends a message to the node
     let mut config = routing::TransportConfig {
@@ -70,7 +70,7 @@ async fn test_messages_client_node() -> Result<()> {
             match event {
                 Event::ServiceMsgReceived { msg, user } => {
                     assert_eq!(*msg, query_clone.clone());
-                    node.send_message(
+                    node.send_msg(
                         Itinerary {
                             src: SrcLocation::Node(node.name().await),
                             dst: DstLocation::EndUser(user),
@@ -92,7 +92,7 @@ async fn test_messages_client_node() -> Result<()> {
 
     let query_bytes = query.serialize(XorName::from(pk), section_key)?;
     client_endpoint
-        .send_message(query_bytes.clone(), &node_addr)
+        .send_msg(query_bytes.clone(), &node_addr)
         .await?;
 
     // just await for node to respond to client
@@ -171,7 +171,7 @@ async fn test_messages_between_nodes() -> Result<()> {
     };
 
     node2
-        .send_message(itinerary, Bytes::from_static(msg), None)
+        .send_msg(itinerary, Bytes::from_static(msg), None)
         .await?;
 
     println!("msg sent");
@@ -189,7 +189,7 @@ async fn test_messages_between_nodes() -> Result<()> {
 
     // send response from node1 to node2
     node1
-        .send_message(itinerary, Bytes::from_static(response), None)
+        .send_msg(itinerary, Bytes::from_static(response), None)
         .await?;
 
     println!("checking response received..");

--- a/sn/src/peer/mod.rs
+++ b/sn/src/peer/mod.rs
@@ -259,7 +259,7 @@ impl Peer {
 /// in this case there is no physical connection, and we technically would know our own identity.
 /// It's possible that we're self-sending at the wrong level of the API (e.g. we currently serialise
 /// and self-deliver a `WireMsg`, when we could instead directly generate the appropriate
-/// `Command`). One benefit of this is it also works with tests, where we also often don't have an
+/// `Cmd`). One benefit of this is it also works with tests, where we also often don't have an
 /// actual connection.
 #[derive(Clone, Debug)]
 pub(crate) struct UnnamedPeer {

--- a/sn/src/types/errors.rs
+++ b/sn/src/types/errors.rs
@@ -8,7 +8,7 @@
 
 use super::{register::User, RegisterAddress};
 
-use crate::messaging::data::Error as ErrorMessage;
+use crate::messaging::data::Error as ErrorMsg;
 
 use std::{
     collections::BTreeMap,
@@ -125,13 +125,13 @@ pub(crate) fn convert_bincode_error(err: bincode::Error) -> Error {
 }
 
 /// Convert type errors to messaging::Errors for sending scross the network
-pub fn convert_dt_error_to_error_message(error: Error) -> ErrorMessage {
+pub fn convert_dt_error_to_error_msg(error: Error) -> ErrorMsg {
     match error {
         Error::InvalidOperation => {
-            ErrorMessage::InvalidOperation("DtError::InvalidOperation".to_string())
+            ErrorMsg::InvalidOperation("DtError::InvalidOperation".to_string())
         }
-        Error::NoSuchEntry => ErrorMessage::NoSuchEntry,
-        Error::AccessDenied(pk) => ErrorMessage::AccessDenied(pk),
-        other => ErrorMessage::InvalidOperation(format!("DtError: {:?}", other)),
+        Error::NoSuchEntry => ErrorMsg::NoSuchEntry,
+        Error::AccessDenied(pk) => ErrorMsg::AccessDenied(pk),
+        other => ErrorMsg::InvalidOperation(format!("DtError: {:?}", other)),
     }
 }

--- a/sn/src/types/log_markers.rs
+++ b/sn/src/types/log_markers.rs
@@ -40,13 +40,13 @@ pub enum LogMarker {
     RegisterWrite,
     RegisterQueryReceivedAtElder,
     RegisterQueryReceivedAtAdult,
-    // Routing commands
+    // Routing cmds
     DispatchHandleMsgCmd,
     DispatchSendMsgCmd,
-    CommandHandleSpawned,
-    CommandHandleStart,
-    CommandHandleEnd,
-    CommandHandleError,
+    CmdHandlingSpawned,
+    CmdProcessStart,
+    CmdProcessEnd,
+    CmdProcessingError,
     // DKG + Promotion
     PromotedToElder,
     DemotedFromElder,

--- a/sn/src/types/mod.rs
+++ b/sn/src/types/mod.rs
@@ -28,7 +28,7 @@ pub use address::{
 };
 pub use cache::Cache;
 pub use chunk::{Chunk, MAX_CHUNK_SIZE_IN_BYTES};
-pub use errors::{convert_dt_error_to_error_message, Error, Result};
+pub use errors::{convert_dt_error_to_error_msg, Error, Result};
 pub use keys::{
     keypair::{BlsKeypairShare, Encryption, Keypair, OwnerType, Signing},
     node_keypairs::NodeKeypairs,

--- a/sn_api/src/app/register.rs
+++ b/sn_api/src/app/register.rs
@@ -166,7 +166,7 @@ impl Safe {
             .get_register_entry(address, hash)
             .await
             .map_err(|err| {
-                if let ClientError::ErrorMessage {
+                if let ClientError::ErrorMsg {
                     source: safe_network::messaging::data::Error::NoSuchEntry,
                     ..
                 } = err

--- a/sn_api/src/authenticator/mod.rs
+++ b/sn_api/src/authenticator/mod.rs
@@ -415,7 +415,7 @@ impl SafeAuthenticator {
 
         //             keypair
         //         }
-        //         Err(ClientError::ErrorMessage {
+        //         Err(ClientError::ErrorMsg {
         //             source: NoSuchEntry,
         //             ..
         //         }) => {

--- a/sn_cmd_test_utilities/src/lib.rs
+++ b/sn_cmd_test_utilities/src/lib.rs
@@ -100,10 +100,10 @@ pub mod util {
     }
 
     pub fn create_and_get_keys() -> Result<(String, String)> {
-        let pk_command_result = safe_cmd_stdout(["keys", "create", "--json"], Some(0))?;
+        let pk_cmd_result = safe_cmd_stdout(["keys", "create", "--json"], Some(0))?;
 
         let (xorurl, (_pk, sk)): (String, (String, String)) =
-            parse_keys_create_output(&pk_command_result)?;
+            parse_keys_create_output(&pk_cmd_result)?;
 
         Ok((xorurl, sk))
     }
@@ -342,7 +342,7 @@ pub mod util {
     ///
     /// This was changed to use the assert_cmd crate because the newer version of this crate
     /// provides *both* the stdout and stderr if the process doesn't exit as expected. This is
-    /// extremely useful in this test suite because there are lots of commands used to setup the
+    /// extremely useful in this test suite because there are lots of cmds used to setup the
     /// context for the tests, and you need to be able to see why those fail too.
     pub fn safe_cmd<'a>(
         args: impl IntoIterator<Item = &'a str>,
@@ -369,7 +369,7 @@ pub mod util {
             .to_owned())
     }
 
-    // Executes arbitrary `safe ` commands and returns
+    // Executes arbitrary `safe` cmds and returns
     // stdout output
     //
     // If expect_exit_code is Some, then an Err is returned
@@ -384,7 +384,7 @@ pub mod util {
         Ok(stdout.trim().to_string())
     }
 
-    // Executes arbitrary `safe ` commands and returns
+    // Executes arbitrary `safe` cmds and returns
     // stderr output
     //
     // If expect_exit_code is Some, then an Err is returned


### PR DESCRIPTION
Where we have very frequently used terminology, with wide
spread acronyms, we have been consistently replacing the
 longer variants with the acronyms (such as `src` for `source`
 and `dst` for `destination`, `msg` for `message`).
 Therefore we now also do it with `cmd` for `command`.
  This also removes some lingering inconsistent usage of
 `message` here and there.
 NB: sn_cli has been mostly left out in this round.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
