### PR TITLE
feat(testnet): add `flame` arg to use cargo flamegraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ build-tests/
 
 # Manual
 .cargo/
-*.log 
+*.log
 
 # Misc
 packages/
@@ -64,3 +64,8 @@ installer/docker/.env
 nodes
 fake_node_data.json
 *.orig
+
+#flamegraph
+cargo-flamegraph.stacks
+*flame.svg
+*flamegraph.svg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3749,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091de12d5e970370cfc3f8118ef70ec14279f5280e1f9dc219fc6cbc04bcd361"
+checksum = "162afd7d07769ed4d6d1727ad60c62c617361bf38ce124b74a6a84bbd49d9e78"
 dependencies = [
  "color-eyre",
  "dirs-next 1.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "sn_cli",
     "sn_cmd_test_utilities"
 ]
+
+[profile.release]
+debug = true

--- a/sn/Cargo.toml
+++ b/sn/Cargo.toml
@@ -10,9 +10,6 @@ readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
 version = "0.55.4"
 
-#[profile.release]
-#incremental = true
-
 [[bench]]
 name = "upload_bytes"
 harness = false
@@ -37,7 +34,6 @@ required-features = ["test-utils"]
 [features]
 default = []
 always-joinable = []
-unstable-command-prioritisation = []
 chaos = []
 unstable-wiremsg-debuginfo = []
 test-utils = []
@@ -80,7 +76,7 @@ serde_bytes = "0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
 sled = "0.34.6"
-sn_launch_tool = "0.9.4"
+sn_launch_tool = "~0.9.5"
 structopt = "~0.3.17"
 strum = "0.21"
 strum_macros = "0.21"

--- a/sn/src/bin/testnet.rs
+++ b/sn/src/bin/testnet.rs
@@ -64,6 +64,13 @@ struct Cmd {
     /// Format logs as JSON.
     #[structopt(long)]
     json_logs: bool,
+
+    /// Use flamegraph setup.
+    /// NB. This requires cargo flamegraph to be installed
+    /// NB. This runs nodes as `sudo`, so any files created will
+    /// have to be handled as such (ie, `sudo rm -rf ~/.safe/node/local-test-network`)
+    #[structopt(long)]
+    flame: bool,
 }
 
 #[tokio::main]
@@ -90,45 +97,48 @@ async fn main() -> Result<()> {
     // `cargo build --release --features=always-joinable,test-utils --bins`
     // before executing the testnet.exe.
     {
-        let mut args = vec!["build", "--release"];
+        let cmd_args = Cmd::from_args();
+        let mut build_args = vec!["build", "--release"];
 
         // Keep features consistent to avoid recompiling when possible
         if cfg!(feature = "unstable-command-prioritisation") {
-            args.push("--features");
-            args.push("unstable-command-prioritisation");
+            build_args.push("--features");
+            build_args.push("unstable-command-prioritisation");
         }
         if cfg!(feature = "always-joinable") {
-            args.push("--features");
-            args.push("always-joinable");
+            build_args.push("--features");
+            build_args.push("always-joinable");
         }
         if cfg!(feature = "test-utils") {
-            args.push("--features");
-            args.push("test-utils");
+            build_args.push("--features");
+            build_args.push("test-utils");
         }
         if cfg!(feature = "unstable-no-connection-pooling") {
-            args.push("--features");
-            args.push("unstable-no-connection-pooling");
+            build_args.push("--features");
+            build_args.push("unstable-no-connection-pooling");
         }
         if cfg!(feature = "unstable-wiremsg-debuginfo") {
-            args.push("--features");
-            args.push("unstable-wiremsg-debuginfo");
+            build_args.push("--features");
+            build_args.push("unstable-wiremsg-debuginfo");
         }
 
         info!("Building current sn_node");
-        debug!("Building current sn_node with args: {:?}", args);
-        Command::new("cargo")
-            .args(args.clone())
-            .current_dir("sn")
-            // .env("RUST_LOG", "debug")
-            // .env("RUST_BACKTRACE", "1")
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .output()
-            .map_err(Into::into)
-            .and_then(|result| result.status.success().then(|| ()).ok_or_else(|| eyre!("Command exited with error")))
-            .wrap_err_with(|| format!("Failed to run build command with args: {:?}", args))?;
+        debug!("Building current sn_node with args: {:?}", build_args);
 
-        info!("sn_node built successfully");
+        if !cmd_args.flame {
+            Command::new("cargo")
+                .args(build_args.clone())
+                .current_dir("sn")
+                // .env("RUST_LOG", "debug")
+                // .env("RUST_BACKTRACE", "1")
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .output()
+                .map_err(Into::into)
+                .and_then(|result| result.status.success().then(|| ()).ok_or_else(|| eyre!("Command exited with error")))
+                .wrap_err_with(|| format!("Failed to run build command with args: {:?}", build_args))?;
+            info!("sn_node built successfully");
+        }
     }
 
     run_network().await?;
@@ -192,6 +202,10 @@ pub async fn run_network() -> Result<()> {
 
     if args.json_logs {
         sn_launch_tool_args.push("--json-logs");
+    }
+
+    if args.flame {
+        sn_launch_tool_args.push("--flame");
     }
 
     // If RUST_LOG was set we pass it down to the launch tool

--- a/sn/src/lib.rs
+++ b/sn/src/lib.rs
@@ -159,7 +159,7 @@ where
     ) -> std::fmt::Result {
         // Write level and target
         let level = *event.metadata().level();
-        let target = event.metadata().file().expect("will never be `None`");
+        let target = event.metadata().file().unwrap_or("No target file known.");
         let span_separation_string = "\t ➤ ";
         let time = SystemTime::default();
         write!(writer, " {} ", level)?;
@@ -170,7 +170,7 @@ where
             writer,
             " [{}:L{}]:",
             target,
-            event.metadata().line().expect("will never be `None`"),
+            event.metadata().line().unwrap_or(0),
         )?;
 
         write!(writer, "{}", span_separation_string)?;

--- a/sn/src/node/core/comm.rs
+++ b/sn/src/node/core/comm.rs
@@ -798,6 +798,7 @@ mod tests {
         // Keep the socket alive to keep the address bound, but don't read/write to it so any
         // attempt to connect to it will fail.
         let _handle = tokio::spawn(async move {
+            debug!("get invalid peer");
             future::pending::<()>().await;
             let _ = socket;
         });


### PR DESCRIPTION
uses the launcher option to enable flamegraph generation per node

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
