### PR TITLE
fix(cli): CLI shell was creating a new Safe API instance, and connecting to the net, for every command

### DIFF
--- a/sn_api/src/app/mod.rs
+++ b/sn_api/src/app/mod.rs
@@ -123,6 +123,11 @@ impl Safe {
         Ok(())
     }
 
+    /// Resturns true if we already have a connection with the network
+    pub fn is_connected(&self) -> bool {
+        self.client.is_some()
+    }
+
     /// Generate a new random Ed25519 keypair
     pub fn new_keypair(&self) -> Keypair {
         let mut rng = OsRng;

--- a/sn_cli/src/subcommands/xorurl.rs
+++ b/sn_cli/src/subcommands/xorurl.rs
@@ -94,10 +94,10 @@ pub async fn xorurl_of_files(
     recursive: bool,
     follow_symlinks: bool,
     output_fmt: OutputFmt,
-    xorurl_base: Option<XorUrlBase>,
+    xorurl_base: XorUrlBase,
 ) -> Result<()> {
     // Do a dry-run on the location
-    let safe = Safe::dry_runner(xorurl_base);
+    let safe = Safe::dry_runner(Some(xorurl_base));
 
     let location = get_from_arg_or_stdin(location, Some("...awaiting location path from stdin"))?;
     let (_, processed_files, _) = safe


### PR DESCRIPTION
When CLI is run in shell mode (i.e. no args passed), it now keeps a Safe API instance and connection in its internal state, so it doesn't need to connect to the network for every command.