### PR TITLE
Resolve NRS Map Container Content

### DIFF
--- a/resources/scripts/api_tests.sh
+++ b/resources/scripts/api_tests.sh
@@ -8,4 +8,5 @@ export RUST_BACKTRACE=1
 export TEST_BOOTSTRAPPING_PEERS=$(cat ~/.safe/node/node_connection_info.config)
 
 # TODO: enable doc tests, for now they require work
-cd sn_api && cargo test --lib --release -- --test-threads=2
+#cd sn_api && cargo test --lib --release -- --test-threads=2
+cd sn_api && cargo test --lib --release -- app::nrs::tests --test-threads=2

--- a/resources/scripts/api_tests.sh
+++ b/resources/scripts/api_tests.sh
@@ -8,5 +8,4 @@ export RUST_BACKTRACE=1
 export TEST_BOOTSTRAPPING_PEERS=$(cat ~/.safe/node/node_connection_info.config)
 
 # TODO: enable doc tests, for now they require work
-#cd sn_api && cargo test --lib --release -- --test-threads=2
-cd sn_api && cargo test --lib --release -- app::nrs::tests --test-threads=2
+cd sn_api && cargo test --lib --release -- --test-threads=2

--- a/sn/src/client/client_api/register_apis.rs
+++ b/sn/src/client/client_api/register_apis.rs
@@ -129,6 +129,7 @@ impl Client {
     ) -> Result<(EntryHash, RegisterWriteAheadLog), Error> {
         // First we fetch it so we can get the causality info,
         // either from local CRDT replica or from the network if not found
+        debug!("Writing to register at {:?}", address);
         let mut register = self.get_register(address).await?;
 
         // We can now write the entry to the Register

--- a/sn_api/src/app/multimap.rs
+++ b/sn_api/src/app/multimap.rs
@@ -156,7 +156,7 @@ impl Safe {
     pub(crate) async fn fetch_multimap(&self, safeurl: &SafeUrl) -> Result<Multimap> {
         let entries = match self.register_fetch_entries(safeurl).await {
             Ok(data) => {
-                debug!("Multimap retrieved...");
+                debug!("Multimap retrieved with {} entries...", data.len());
                 Ok(data)
             }
             Err(Error::EmptyContent(_)) => Err(Error::EmptyContent(format!(

--- a/sn_api/src/app/nrs/mod.rs
+++ b/sn_api/src/app/nrs/mod.rs
@@ -21,33 +21,6 @@ use std::str;
 // Type tag to use for the NrsMapContainer stored on Register
 pub(crate) const NRS_MAP_TYPE_TAG: u64 = 1_500;
 
-/// Helper to check if an NRS SafeUrl:
-/// - is valid
-/// - has a version (if its data is versionable)
-///
-/// It's public because we perform the same check in the resolver.
-pub fn validate_nrs_url(link: &SafeUrl) -> Result<()> {
-    if link.content_version().is_none() {
-        let content_type = link.content_type();
-        let data_type = link.data_type();
-        if content_type == ContentType::FilesContainer
-            || content_type == ContentType::NrsMapContainer
-        {
-            return Err(Error::UnversionedContentError(format!(
-                "{} content is versionable. NRS requires the supplied link to specify a version hash.",
-                content_type
-            )));
-        } else if data_type == DataType::Register {
-            return Err(Error::UnversionedContentError(format!(
-                "{} content is versionable. NRS requires the supplied link to specify a version hash.",
-                data_type
-            )));
-        }
-    }
-
-    Ok(())
-}
-
 impl Safe {
     /// # Creates a nrs_map_container for a chosen top name
     /// ```
@@ -360,6 +333,31 @@ fn validate_nrs_public_name(public_name: &str) -> Result<SafeUrl> {
         )));
     }
     Ok(url)
+}
+
+/// Helper to check if an NRS SafeUrl:
+/// - is valid
+/// - has a version (if its data is versionable)
+fn validate_nrs_url(link: &SafeUrl) -> Result<()> {
+    if link.content_version().is_none() {
+        let content_type = link.content_type();
+        let data_type = link.data_type();
+        if content_type == ContentType::FilesContainer
+            || content_type == ContentType::NrsMapContainer
+        {
+            return Err(Error::UnversionedContentError(format!(
+                "{} content is versionable. NRS requires the supplied link to specify a version hash.",
+                content_type
+            )));
+        } else if data_type == DataType::Register {
+            return Err(Error::UnversionedContentError(format!(
+                "{} content is versionable. NRS requires the supplied link to specify a version hash.",
+                data_type
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/sn_api/src/app/nrs/nrs_map.rs
+++ b/sn_api/src/app/nrs/nrs_map.rs
@@ -88,7 +88,7 @@ impl NrsMap {
         let mut v = self
             .map
             .iter()
-            .map(|x| (x.0.clone(), x.1.to_string().clone()))
+            .map(|x| (x.0.clone(), x.1.to_string()))
             .collect::<Vec<(String, String)>>();
         v.sort_by(|a, b| a.0.len().cmp(&b.0.len()));
         v

--- a/sn_api/src/app/resolver/handlers.rs
+++ b/sn_api/src/app/resolver/handlers.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Range, SafeData};
-use crate::app::nrs::validate_nrs_url;
 use crate::app::{
     files::{self, FileInfo, FilesMap},
     multimap::Multimap,
@@ -33,8 +32,6 @@ impl Safe {
             let url_path = input_url.path_decoded()?;
             let target_path = target_url.path_decoded()?;
             target_url.set_path(&format!("{}{}", target_path, url_path));
-            validate_nrs_url(&target_url)?;
-
             let version = input_url.content_version().map(|v| v.entry_hash());
             let safe_data = SafeData::NrsEntry {
                 xorurl: target_url.to_xorurl_string(),

--- a/sn_api/src/app/resolver/handlers.rs
+++ b/sn_api/src/app/resolver/handlers.rs
@@ -21,38 +21,40 @@ use std::collections::BTreeSet;
 
 impl Safe {
     pub(crate) async fn resolve_nrs_map_container(&self, input_url: SafeUrl) -> Result<SafeData> {
-        let (mut target_url, nrs_map) = self
+        let (target_url, nrs_map) = self
             .nrs_get(input_url.public_name(), input_url.content_version())
             .await
             .map_err(|e| {
                 warn!("NRS failed to resolve {}: {}", input_url, e);
                 Error::ContentNotFound(format!("Content not found at {}", input_url))
             })?;
-        debug!("NRS Resolved {} => {}", input_url, target_url);
+        if let Some(mut target_url) = target_url {
+            debug!("NRS Resolved {} => {}", input_url, target_url);
+            let url_path = input_url.path_decoded()?;
+            let target_path = target_url.path_decoded()?;
+            target_url.set_path(&format!("{}{}", target_path, url_path));
+            validate_nrs_url(&target_url)?;
 
-        let url_path = input_url.path_decoded()?;
-        let target_path = target_url.path_decoded()?;
-        target_url.set_path(&format!("{}{}", target_path, url_path));
-
-        validate_nrs_url(&target_url)?;
-        let mut nrs_url = input_url.clone();
-        nrs_url.set_path("");
-        nrs_url.set_sub_names("")?;
+            let version = input_url.content_version().map(|v| v.entry_hash());
+            let safe_data = SafeData::NrsEntry {
+                xorurl: target_url.to_xorurl_string(),
+                public_name: input_url.public_name().to_string(),
+                data_type: target_url.data_type(),
+                resolves_into: target_url,
+                resolved_from: input_url.to_string(),
+                version,
+            };
+            return Ok(safe_data);
+        }
+        debug!("No target associated with input {}", input_url);
+        debug!("Returning NrsMapContainer with NRS Map.");
         let safe_data = SafeData::NrsMapContainer {
-            public_name: if nrs_url.is_xorurl() {
-                None
-            } else {
-                Some(nrs_url.top_name().to_string())
-            },
-            xorurl: nrs_url.to_xorurl_string(),
-            xorname: nrs_url.xorname(),
-            type_tag: nrs_url.type_tag(),
+            xorurl: input_url.to_xorurl_string(),
+            xorname: input_url.xorname(),
+            type_tag: input_url.type_tag(),
             nrs_map,
-            data_type: nrs_url.data_type(),
-            resolves_into: Some(target_url),
-            resolved_from: nrs_url.to_string(),
+            data_type: input_url.data_type(),
         };
-
         Ok(safe_data)
     }
 

--- a/sn_cli/src/subcommands/cat.rs
+++ b/sn_cli/src/subcommands/cat.rs
@@ -92,19 +92,10 @@ pub async fn cat_commander(cmd: CatCommands, output_fmt: OutputFmt, safe: &Safe)
                     .context("Failed to print out the content of the file")?;
             }
         }
-        SafeData::NrsMapContainer {
-            public_name,
-            nrs_map,
-            ..
-        } => {
+        SafeData::NrsMapContainer { nrs_map, .. } => {
             if OutputFmt::Pretty == output_fmt {
-                let mut msg = String::from("NRS Map Container ");
-                if let Some(version) = nrs_map.subname_version {
-                    msg.push_str(&format!("(version {}) ", version));
-                }
-                msg.push_str(&format!("at \"{}\"", url));
-                println!("{}", msg);
-                print_nrs_map(nrs_map, public_name);
+                println!("NRS Map Container at {}", url);
+                print_nrs_map(nrs_map);
             } else {
                 println!(
                     "{}",
@@ -116,6 +107,7 @@ pub async fn cat_commander(cmd: CatCommands, output_fmt: OutputFmt, safe: &Safe)
             println!("No content to show since the URL targets a SafeKey. Use the 'dog' command to obtain additional information about the targeted SafeKey.");
         }
         SafeData::Multimap { .. }
+        | SafeData::NrsEntry { .. }
         | SafeData::PrivateRegister { .. }
         | SafeData::PublicRegister { .. } => unimplemented!(),
     }

--- a/sn_cli/src/subcommands/dog.rs
+++ b/sn_cli/src/subcommands/dog.rs
@@ -43,35 +43,41 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
             println!("== URL resolution step {} ==", i + 1);
             match content {
                 SafeData::NrsMapContainer {
-                    public_name,
                     xorurl,
                     xorname,
                     type_tag,
                     nrs_map,
                     data_type,
-                    resolved_from,
                     ..
                 } => {
-                    println!("Resolved from: {}", resolved_from);
                     println!("= NRS Map Container =");
-                    match public_name {
-                        Some(name) => println!("PublicName: \"{}\"", name),
-                        None => {}
-                    }
                     println!("XOR-URL: {}", xorurl);
-                    println!(
-                        "Version: {}",
-                        nrs_map
-                            .subname_version
-                            .map_or("none".to_string(), |v| v.to_string())
-                    );
                     println!("Type tag: {}", type_tag);
                     println!("XOR name: 0x{}", xorname_to_hex(xorname));
                     println!("Native data type: {}", data_type);
                     let mut safeurl = SafeUrl::from_url(xorurl)?;
                     safeurl.set_content_type(ContentType::Raw)?;
                     println!("Native data XOR-URL: {}", safeurl);
-                    print_nrs_map(nrs_map, public_name);
+                    print_nrs_map(nrs_map);
+                }
+                SafeData::NrsEntry {
+                    xorurl,
+                    public_name,
+                    data_type,
+                    resolves_into,
+                    resolved_from,
+                    version,
+                } => {
+                    println!("Resolved from: {}", resolved_from);
+                    println!("= NrsEntry =");
+                    println!("Public name: {}", public_name);
+                    println!("Target XOR-URL: {}", xorurl);
+                    println!("Target native data type: {}", data_type);
+                    println!("Resolves into: {}", resolves_into);
+                    println!(
+                        "Version: {}",
+                        version.map_or("none".to_string(), |v| v.to_string())
+                    );
                 }
                 SafeData::FilesContainer {
                     xorurl,

--- a/sn_cli/src/subcommands/helpers.rs
+++ b/sn_cli/src/subcommands/helpers.rs
@@ -21,8 +21,6 @@ use std::io::{stdin, stdout, Read, Write};
 use tracing::debug;
 use xor_name::XorName;
 
-const UNKNOWN_PUBLIC_NAME: &str = "<unknown>";
-
 // Warn the user about a dry-run being performed
 pub fn notice_dry_run() {
     println!("NOTE the operation is being performed in dry-run mode, therefore no changes are committed to the network.");
@@ -182,25 +180,12 @@ where
     }
 }
 
-// Pretty print an NRS Map
-pub fn print_nrs_map(nrs_map: &NrsMap, public_name: &Option<String>) {
-    let mut table = Table::new();
-    table.add_row(row![bFg->"NRS name/subname", bFg->"Created", bFg->"Modified", bFg->"Link"]);
-
+pub fn print_nrs_map(nrs_map: &NrsMap) {
+    println!("Listing NRS map contents:");
     let summary = nrs_map.get_map_summary();
-    let pub_name: &str = match public_name {
-        Some(name) => name,
-        None => UNKNOWN_PUBLIC_NAME,
-    };
-    summary.iter().for_each(|(name, rdf_info)| {
-        table.add_row(row![
-            format!("{}{}", name, pub_name),
-            rdf_info["created"],
-            rdf_info["modified"],
-            rdf_info["link"],
-        ]);
+    summary.iter().for_each(|(pub_name, link)| {
+        println!("{}: {}", pub_name, link);
     });
-    table.printstd();
 }
 
 // returns singular or plural version of string, based on count.

--- a/sn_cli/src/subcommands/nrs.rs
+++ b/sn_cli/src/subcommands/nrs.rs
@@ -81,8 +81,14 @@ async fn run_register_subcommand(
 ) -> Result<()> {
     match safe.nrs_create(&name).await {
         Ok(topname_url) => {
-            let (nrs_url, summary) =
-                get_new_nrs_url_for_topname(&name, safe, topname_url, link).await?;
+            let mut summary = String::new();
+            summary.push_str("The container for the map is located at ");
+            summary.push_str(&topname_url.to_xorurl_string());
+            if let Some(ref link) = link {
+                let url = get_target_url(&link)?;
+                let _ = associate_url_with_public_name(&name, safe, &url).await?;
+                summary.push_str(&format!("\nThe entry points to {link}"));
+            }
             print_summary(
                 output_fmt,
                 &format!(
@@ -90,8 +96,9 @@ async fn run_register_subcommand(
                     name.replace("safe://", "")
                 ),
                 summary,
-                &nrs_url,
-                ("+", &name, &nrs_url.to_string()),
+                &topname_url.to_xorurl_string(),
+                &topname_url,
+                ("+", &name, &topname_url.to_string()),
             );
             Ok(())
         }
@@ -140,7 +147,11 @@ async fn run_add_subcommand(
 
     let mut summary_header = String::new();
     if topname_was_registered {
-        summary_header.push_str("New NRS Map created. ");
+        summary_header.push_str("New NRS Map created.\n");
+        summary_header.push_str("The container for the map is located at ");
+        summary_header.push_str(
+            &SafeUrl::from_url(&format!("safe://{}", url.top_name()))?.to_xorurl_string(),
+        );
     } else {
         summary_header.push_str("Existing NRS Map updated. ");
     }
@@ -148,7 +159,7 @@ async fn run_add_subcommand(
         .content_version()
         .ok_or_else(|| eyre!("Content version not set for returned NRS SafeUrl"))?
         .to_string();
-    summary_header.push_str(&format!("Now at version {}. ", version));
+    summary_header.push_str(&format!("\nNow at version {}. ", version));
 
     if default {
         let topname = get_topname_from_public_name(&name)?;
@@ -162,6 +173,7 @@ async fn run_add_subcommand(
         output_fmt,
         &summary_header,
         "".to_string(),
+        &SafeUrl::from_url(&format!("safe://{}", url.top_name()))?.to_xorurl_string(),
         &url,
         ("+", &name, &link),
     );
@@ -179,6 +191,7 @@ async fn run_remove_subcommand(name: String, safe: &Safe, output_fmt: OutputFmt)
                 output_fmt,
                 &format!("NRS Map updated (version {})", version),
                 "".to_string(),
+                &SafeUrl::from_url(&format!("safe://{}", url.top_name()))?.to_xorurl_string(),
                 &url,
                 ("-", &name, ""),
             );
@@ -203,25 +216,6 @@ async fn run_remove_subcommand(name: String, safe: &Safe, output_fmt: OutputFmt)
             _ => Err(eyre!(error)),
         },
     }
-}
-
-/// Get the new NRS URL that's going to be displayed to the user.
-///
-/// If no target link has been supplied, the URL is just going to be the one returned from the
-/// topname creation; otherwise, associate the link with the newly registered topname, and return the
-/// URL generated from the association.
-async fn get_new_nrs_url_for_topname(
-    name: &str,
-    safe: &Safe,
-    topname_url: SafeUrl,
-    link: Option<String>,
-) -> Result<(SafeUrl, String)> {
-    if let Some(link) = link {
-        let url = get_target_url(&link)?;
-        let new_url = associate_url_with_public_name(name, safe, &url).await?;
-        return Ok((new_url, format!("The entry points to {}", link)));
-    }
-    Ok((topname_url, "".to_string()))
 }
 
 async fn associate_url_with_public_name(
@@ -274,6 +268,7 @@ fn print_summary(
     output_fmt: OutputFmt,
     header: &str,
     summary: String,
+    container_xorurl: &str,
     nrs_url: &SafeUrl,
     processed_entry: (&str, &str, &str),
 ) {
@@ -295,7 +290,7 @@ fn print_summary(
     } else {
         println!(
             "{}",
-            serialise_output(&(nrs_url, processed_entry), output_fmt)
+            serialise_output(&(container_xorurl, nrs_url, processed_entry), output_fmt)
         );
     }
 }

--- a/sn_cli/src/subcommands/nrs.rs
+++ b/sn_cli/src/subcommands/nrs.rs
@@ -85,7 +85,7 @@ async fn run_register_subcommand(
             summary.push_str("The container for the map is located at ");
             summary.push_str(&topname_url.to_xorurl_string());
             if let Some(ref link) = link {
-                let url = get_target_url(&link)?;
+                let url = get_target_url(link)?;
                 let _ = associate_url_with_public_name(&name, safe, &url).await?;
                 summary.push_str(&format!("\nThe entry points to {link}"));
             }

--- a/sn_cli/tests/cli_cat.rs
+++ b/sn_cli/tests/cli_cat.rs
@@ -459,7 +459,7 @@ fn calling_safe_cat_nrs_map_container() -> Result<()> {
             "add",
             &format!("test.{site_name}"),
             "--link",
-            &test_file_link,
+            test_file_link,
         ],
         Some(0),
     )?;
@@ -469,7 +469,7 @@ fn calling_safe_cat_nrs_map_container() -> Result<()> {
             "add",
             &format!("another.{site_name}"),
             "--link",
-            &another_file_link,
+            another_file_link,
         ],
         Some(0),
     )?;

--- a/sn_cli/tests/cli_cat.rs
+++ b/sn_cli/tests/cli_cat.rs
@@ -17,7 +17,7 @@ use sn_cmd_test_utilities::util::{
     safe_cmd_stdout, safeurl_from, test_symlinks_are_valid, upload_path,
     upload_test_symlinks_folder, CLI,
 };
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const TEST_DATA: &str = "../resources/testdata/";
@@ -219,7 +219,7 @@ fn calling_safe_cat_nrsurl_with_version() -> Result<()> {
         Some(0),
     )?;
 
-    let (nrs_url, _) = parse_nrs_register_output(&output)?;
+    let (_, nrs_url, _) = parse_nrs_register_output(&output)?;
     let version = nrs_url.content_version();
 
     let mut nrs_url = SafeUrl::from_url(&format!("safe://{}", public_name))?;
@@ -419,5 +419,74 @@ fn calling_cat_symlinks_resolve_dir_outside() -> Result<()> {
     let output = safe_cmd_stderr(["cat", &safeurl.to_string()], Some(1))?;
     assert!(output.contains("ContentNotFound: Cannot ascend beyond root directory"));
 
+    Ok(())
+}
+
+#[test]
+fn calling_safe_cat_nrs_map_container() -> Result<()> {
+    let with_trailing_slash = true;
+    let tmp_data_path = assert_fs::TempDir::new()?;
+    tmp_data_path.copy_from("../resources/testdata", &["**"])?;
+    let (files_container_xor, processed_files, _) =
+        upload_path(&tmp_data_path, with_trailing_slash)?;
+
+    let test_file_link = processed_files
+        .get(&PathBuf::from(tmp_data_path.path()).join("test.md"))
+        .ok_or_else(|| eyre!("test.md should be in files container"))?
+        .link()
+        .ok_or_else(|| eyre!("should have link"))?;
+    let another_file_link = processed_files
+        .get(&PathBuf::from(tmp_data_path.path()).join("another.md"))
+        .ok_or_else(|| eyre!("another.md should be in files container"))?
+        .link()
+        .ok_or_else(|| eyre!("should have link"))?;
+
+    let site_name = get_random_nrs_string();
+    let container_xorurl = SafeUrl::from_url(&format!("safe://{}", site_name))?.to_xorurl_string();
+    safe_cmd(
+        [
+            "nrs",
+            "register",
+            &site_name,
+            "--link",
+            &files_container_xor,
+        ],
+        Some(0),
+    )?;
+    safe_cmd(
+        [
+            "nrs",
+            "add",
+            &format!("test.{site_name}"),
+            "--link",
+            &test_file_link,
+        ],
+        Some(0),
+    )?;
+    safe_cmd(
+        [
+            "nrs",
+            "add",
+            &format!("another.{site_name}"),
+            "--link",
+            &another_file_link,
+        ],
+        Some(0),
+    )?;
+
+    safe_cmd(["cat", &container_xorurl], Some(0))?
+        .assert()
+        .stdout(predicate::str::contains(&format!(
+            "{site_name}: {}",
+            files_container_xor
+        )))
+        .stdout(predicate::str::contains(&format!(
+            "test.{site_name}: {}",
+            test_file_link
+        )))
+        .stdout(predicate::str::contains(&format!(
+            "another.{site_name}: {}",
+            another_file_link
+        )));
     Ok(())
 }

--- a/sn_cli/tests/cli_dog.rs
+++ b/sn_cli/tests/cli_dog.rs
@@ -171,7 +171,7 @@ fn calling_safe_dog_with_nrs_map_container_link() -> Result<()> {
             "add",
             &format!("test.{site_name}"),
             "--link",
-            &test_file_link,
+            test_file_link,
         ],
         Some(0),
     )?;
@@ -181,7 +181,7 @@ fn calling_safe_dog_with_nrs_map_container_link() -> Result<()> {
             "add",
             &format!("another.{site_name}"),
             "--link",
-            &another_file_link,
+            another_file_link,
         ],
         Some(0),
     )?;

--- a/sn_cli/tests/cli_dog.rs
+++ b/sn_cli/tests/cli_dog.rs
@@ -6,12 +6,16 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
 use color_eyre::{eyre::eyre, Result};
-use sn_api::resolver::SafeData;
+use predicates::prelude::*;
+use sn_api::resolver::{SafeData, SafeUrl};
 use sn_cmd_test_utilities::util::{
-    create_and_get_keys, get_random_nrs_string, parse_dog_output, parse_files_put_or_sync_output,
-    safe_cmd, safe_cmd_stdout, safeurl_from,
+    create_and_get_keys, get_random_nrs_string, parse_files_put_or_sync_output, safe_cmd,
+    safe_cmd_stdout, upload_path,
 };
+use std::path::PathBuf;
 
 const TEST_FILE: &str = "../resources/testdata/test.md";
 
@@ -131,53 +135,70 @@ fn calling_safe_dog_safekey_nrsurl() -> Result<()> {
 }
 
 #[test]
-#[ignore = "still broken"]
-fn calling_safe_dog_nrs_url_with_subnames() -> Result<()> {
-    let (safekey_xorurl, _sk) = create_and_get_keys()?;
+fn calling_safe_dog_with_nrs_map_container_link() -> Result<()> {
+    let with_trailing_slash = true;
+    let tmp_data_path = assert_fs::TempDir::new()?;
+    tmp_data_path.copy_from("../resources/testdata", &["**"])?;
+    let (files_container_xor, processed_files, _) =
+        upload_path(&tmp_data_path, with_trailing_slash)?;
 
-    let pub_name = get_random_nrs_string();
-    let nrsurl = format!("subname.{}", pub_name);
-    safe_cmd(["nrs", "register", &nrsurl, "-l", &safekey_xorurl], Some(0))?;
+    let test_file_link = processed_files
+        .get(&PathBuf::from(tmp_data_path.path()).join("test.md"))
+        .ok_or_else(|| eyre!("test.md should be in files container"))?
+        .link()
+        .ok_or_else(|| eyre!("should have link"))?;
+    let another_file_link = processed_files
+        .get(&PathBuf::from(tmp_data_path.path()).join("another.md"))
+        .ok_or_else(|| eyre!("another.md should be in files container"))?
+        .link()
+        .ok_or_else(|| eyre!("should have link"))?;
 
-    // let's check the output with NRS-URL first
-    let dog_output = safe_cmd_stdout(["dog", &nrsurl, "--json"], Some(0))?;
-    let (url, safe_data_vec) = parse_dog_output(&dog_output)?;
-    assert_eq!(url, format!("safe://{}", nrsurl));
-    let mut safeurl = safeurl_from(&nrsurl)?;
-    safeurl.set_sub_names("").map_err(|e| eyre!(e))?;
-    let nrs_map_xorurl = safeurl.to_xorurl_string();
+    let site_name = get_random_nrs_string();
+    let container_xorurl = SafeUrl::from_url(&format!("safe://{}", site_name))?.to_xorurl_string();
+    safe_cmd(
+        [
+            "nrs",
+            "register",
+            &site_name,
+            "--link",
+            &files_container_xor,
+        ],
+        Some(0),
+    )?;
+    safe_cmd(
+        [
+            "nrs",
+            "add",
+            &format!("test.{site_name}"),
+            "--link",
+            &test_file_link,
+        ],
+        Some(0),
+    )?;
+    safe_cmd(
+        [
+            "nrs",
+            "add",
+            &format!("another.{site_name}"),
+            "--link",
+            &another_file_link,
+        ],
+        Some(0),
+    )?;
 
-    if let sn_api::resolver::SafeData::NrsMapContainer {
-        resolved_from,
-        xorurl,
-        public_name,
-        ..
-    } = &safe_data_vec[0]
-    {
-        assert_eq!(*resolved_from, nrsurl);
-        assert_eq!(*xorurl, nrs_map_xorurl);
-        assert_eq!(*public_name, Some(pub_name));
-    } else {
-        panic!("Content retrieved was unexpected: {:?}", safe_data_vec);
-    }
-
-    // let's now check the output with its XOR-URL
-    let dog_output = safe_cmd_stdout(["dog", &nrs_map_xorurl, "--json"], Some(0))?;
-    let (url, safe_data_vec) = parse_dog_output(&dog_output)?;
-    assert_eq!(url, *nrs_map_xorurl);
-    if let sn_api::resolver::SafeData::NrsMapContainer {
-        resolved_from,
-        xorurl,
-        public_name,
-        ..
-    } = &safe_data_vec[0]
-    {
-        assert_eq!(*resolved_from, nrs_map_xorurl);
-        assert_eq!(*xorurl, nrs_map_xorurl);
-        // it doesn't know the public name as it was resolved from a XOR-URL
-        assert_eq!(*public_name, None);
-        Ok(())
-    } else {
-        panic!("Content retrieved was unexpected: {:?}", safe_data_vec);
-    }
+    safe_cmd(["dog", &container_xorurl], Some(0))?
+        .assert()
+        .stdout(predicate::str::contains(&format!(
+            "{site_name}: {}",
+            files_container_xor
+        )))
+        .stdout(predicate::str::contains(&format!(
+            "test.{site_name}: {}",
+            test_file_link
+        )))
+        .stdout(predicate::str::contains(&format!(
+            "another.{site_name}: {}",
+            another_file_link
+        )));
+    Ok(())
 }

--- a/sn_cli/tests/cli_files.rs
+++ b/sn_cli/tests/cli_files.rs
@@ -484,7 +484,7 @@ fn calling_files_sync_and_fetch_with_nrsurl_and_nrs_update() -> Result<()> {
         ],
         Some(0),
     )?;
-    let (nrs_xorurl, _) = parse_nrs_register_output(&output)?;
+    let (_, nrs_xorurl, _) = parse_nrs_register_output(&output)?;
     let nrs_version = nrs_xorurl
         .content_version()
         .ok_or_else(|| eyre!("failed to get content version from xorurl"))?;

--- a/sn_cmd_test_utilities/src/lib.rs
+++ b/sn_cmd_test_utilities/src/lib.rs
@@ -110,7 +110,7 @@ pub mod util {
 
     pub fn create_nrs_link(name: &str, link: &str) -> Result<SafeUrl> {
         let nrs_creation = safe_cmd_stdout(["nrs", "create", name, "-l", link, "--json"], Some(0))?;
-        let (nrs_map_xorurl, _change_map) = parse_nrs_register_output(&nrs_creation)?;
+        let (_, nrs_map_xorurl, _change_map) = parse_nrs_register_output(&nrs_creation)?;
         Ok(nrs_map_xorurl)
     }
 
@@ -313,7 +313,9 @@ pub mod util {
         })
     }
 
-    pub fn parse_nrs_register_output(output: &str) -> Result<(SafeUrl, (String, String, String))> {
+    pub fn parse_nrs_register_output(
+        output: &str,
+    ) -> Result<(String, SafeUrl, (String, String, String))> {
         serde_json::from_str(output)
             .map_err(|_| eyre!("Failed to parse output of `safe nrs register`: {}", output))
     }


### PR DESCRIPTION
- ced0f6631 **feat: retrieve subname version**

  The `nrs_get` function is changed to make use of the version argument to retrieve a subname at a
  specific version.

  A helper struct was created to reduce test verbosity. It uploads a file container and stores file
  path/URL pairs in a hash table.

- b9ceb2290 **tests: update nrs tests to use helper**

  The helper was moved into the test_helpers module and renamed to TestDataFilesContainer, since this
  seems more accurate.

  A test was added for retrieving a topname link. This is arguably covered by the `nrs_associate`
  tests, but I think it's good to have this test to call it out as functionality we don't want to
  break.

- 0bc50ae33 **feat: resolve nrs map container content**

  The resolver can now return `NrsMapContainer` content, which can then be displayed by the CLI with
  the `cat` and `dog` commands. This functionality was unintentionally broken at some point.

  The first change introduced an `NrsEntry` field in `SafeData`, and modified the `NrsMapContainer` to
  remove its `resolve_into` and `public_name` fields. The intention is for the resolver to return
  `NrsMapContainer` data when a container XOR-URL is used, but when using an NRS URL, an `NrsEntry`
  will be returned. The `NrsMapContainer` data will have the NRS map, whereas the `NrsEntry` will only
  contain the target link and subname version. It's worth noting, the `NrsEntry` doesn't have an
  XOR-URL because the entries are still stored in the map. An NRS URL still has an `NrsMapContainer`
  content type and that content is retrieved during the resolution process.

  This brings us to the next change. The `nrs_get` API was modified to return an `Option<SafeUrl>`,
  where `None` will now be returned if the container XOR-URL is used. In this case, the resolver will
  know to return `NrsMapContainer` data, otherwise, it will return the `NrsEntry` with the target URL.
  One exception is worth mentioning: if the NRS URL uses the registered topname and that topname
  *doesn't* link to anything, `NrsMapContainer` data will also be returned. To make these extensions,
  small unit tests were added to the `NrsMap` and several tests were added to the resolver to cover
  these scenarios.

  With these changes in place, the CLI could then be updated. The `cat` and `dog` commands were
  modified to print the NRS map when `NrsMapContainer` data was returned. Previously, the map was
  printed as a table, but this isn't really suitable for presentation because the table crate doesn't
  have the ability to use multi-line cells and the target links are too large, so I changed it to
  print a list. Test cases were added for both commands, which should hopefully prevent us breaking
  the feature again.

  Finally, some usability changes were also made to `nrs` commands to give the user the XOR-URL of the
  container. This can be useful to them if they want to list all the entries in a map.

- f558b5c60 **refactor: make nrs url validation private**

  We made URL validation public to share code during NRS resolution, but there's no need for
  validation during resolution because the URLs have already been validated at the point of
  association.

  Also fix some clippy warnings.