### PR TITLE
chore: sudo based installation for cli

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -15,8 +15,54 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: 'eu-west-2'
+  INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/master/resources/scripts/install.sh
 
 jobs:
+  cli-install-tests:
+    name: cli install tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - shell: bash
+        name: test install as root user
+        run: |
+          curl -so- $INSTALL_SCRIPT_URL | sudo bash
+          if [[ ! -f /usr/local/bin/safe ]]; then
+            echo "Failed to unpack safe to /usr/local/bin"
+            exit 1
+          fi
+          expected_version=$(grep "^version" < sn_cli/Cargo.toml \
+             | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+          actual_version=$(safe --version | awk '{ print $2 }')
+          echo "Expected version: $expected_version"
+          echo "Actual version: $expected_version"
+          if [[ $actual_version != $expected_version ]]; then exit 1; fi
+      - shell: bash
+        name: test install as non-root user
+        run: |
+          curl -so- $INSTALL_SCRIPT_URL | bash
+          if [[ ! -f "$HOME/.safe/cli/safe" ]]; then
+            echo "Failed to unpack safe to $HOME/.safe/cli/safe"
+            exit 1
+          fi
+          expected_version=$(grep "^version" < sn_cli/Cargo.toml \
+             | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+          actual_version=$($HOME/.safe/cli/safe --version | awk '{ print $2 }')
+          echo "Expected version: $expected_version"
+          echo "Actual version: $expected_version"
+          if [[ $actual_version != $expected_version ]]; then exit 1; fi
+          # Since the installer attempts to update more than just the bashrc,
+          # this isn't a comprehensive test, but I think it should do as a
+          # starting point. Or until the other conditions could be reproduced.
+          if ! $(cat "$HOME/.bashrc" | grep "^export PATH=\$PATH:$HOME/.safe/cli"); then
+            echo "Installer has not updated the bashrc correctly"
+            exit 1
+          fi
+
   build-node:
     name: build node
     runs-on: ubuntu-latest

--- a/sn_cli/README.md
+++ b/sn_cli/README.md
@@ -56,18 +56,23 @@ The Safe CLI provides all the tools necessary to interact with the Safe Network,
 
 ## Quick Start
 
-If you're a Linux or macOS user, you can simply run the following in your terminal:
+If you're a Linux or macOS user and you have root access, you can run the following in your terminal:
 ```
-$ curl -so- https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh | bash
+$ curl -so- https://raw.githubusercontent.com/maidsafe/safe_network/master/resources/scripts/install.sh | sudo bash
 ```
 
-This will make the latest version of `safe` available. If you can successfully run `safe --version`, you can now skip to [Using the CLI](#using-the-cli).
+If you don't have root or prefer an install under your home directory:
+```
+$ curl -so- https://raw.githubusercontent.com/maidsafe/safe_network/master/resources/scripts/install.sh | bash
+```
+
+In either case, if you can successfully run `safe --version`, you can now skip to [Using the CLI](#using-the-cli).
 
 At the moment we don't have a quick start mechanism for Windows, but this will be coming soon.
 
-## Installation and Setup
+If you want more detail or alternative setup options, read the next section.
 
-If you want more detail or alternative setup options, continue reading this section.
+## Installation and Setup
 
 ### Prerequisites
 
@@ -84,15 +89,19 @@ If you use Visual Studio, you may already have these libraries installed.
 
 #### Linux and macOS
 
-The [install script](https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh) will download the latest Safe CLI binary, unpack it to `~/.safe/cli/`, and extend your `PATH` variable with that location. When using a terminal, you can then refer to the `safe` binary from any location.
+The [install script](https://raw.githubusercontent.com/maidsafe/safe_network/master/resources/scripts/install.sh) can get you running quickly. If you have root access to your machine, in your terminal, you can run:
+```
+$ curl -so- https://raw.githubusercontent.com/maidsafe/safe_network/master/resources/scripts/install.sh | sudo bash
+```
 
-Run either of the following commands from a terminal:
+This downloads and unpacks the latest `safe` binary to `/usr/local/bin`; this location is almost always on the `PATH` variable, so `safe` will be immediately available.
+
+If you don't have root access or prefer an install under your home directory:
 ```
-$ curl -so- https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh | bash
+$ curl -so- https://raw.githubusercontent.com/maidsafe/safe_network/master/resources/scripts/install.sh | bash
 ```
-```
-$ wget -qO- https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/install.sh | bash
-```
+
+In this case, `safe` is unpacked to `~/.safe/cli/`, and your `PATH` variable is extended with that location. To do so, the install script modifies your shell configuration, such as your `~/.bashrc` file. If you'd prefer the install not modify your configuration, use the sudo option above.
 
 The install script also has a `--version` argument to enable retrieval of a specific version:
 ```


### PR DESCRIPTION
Give users the option to run the CLI installer as sudo.

In this case, the CLI will be installed to /usr/local/bin, which is very common for installations on
Linux. That location is almost always already on PATH, even in minimal setups. This removes the need
for modifying any of the user's shell configurations, which some users don't like. I've also
personally dealt with users who had a problem when the installer wasn't modifying their shell
configuration correctly.

Some simple installer tests were added to the nightly configuration and the README was also updated
with new instructions, which included fixing an invalid link to the install script.

I tested the install tests on my fork:
https://github.com/jacderida/safe_network/actions/runs/1829688162
