### PR TITLE
chore: simplify service msg flow

### DIFF
--- a/sn/src/node/api/cmds.rs
+++ b/sn/src/node/api/cmds.rs
@@ -8,7 +8,7 @@
 
 use crate::messaging::{
     system::{DkgFailureSigSet, KeyedSig, NodeState, SectionAuth, SystemMsg},
-    DstLocation, MsgId, NodeMsgAuthority, WireMsg,
+    DstLocation, WireMsg,
 };
 use crate::node::{
     core::Proposal,
@@ -17,7 +17,6 @@ use crate::node::{
 };
 use crate::peer::{Peer, UnnamedPeer};
 
-use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;
 use custom_debug::Debug;
 use std::{
@@ -38,19 +37,6 @@ pub(crate) enum Cmd {
         #[debug(skip)]
         // original bytes to avoid reserializing for entropy checks
         original_bytes: Option<Bytes>,
-    },
-    // TODO: rename this as/when this is all node for clarity
-    /// Handle Node, either directly or notify via event listener
-    HandleSystemMsg {
-        sender: Peer,
-        msg_id: MsgId,
-        msg: SystemMsg,
-        msg_authority: NodeMsgAuthority,
-        dst_location: DstLocation,
-        #[debug(skip)]
-        payload: Bytes,
-        #[debug(skip)]
-        known_keys: Vec<BlsPublicKey>,
     },
     /// Handle a timeout previously scheduled with `ScheduleTimeout`.
     HandleTimeout(u64),
@@ -107,9 +93,6 @@ impl fmt::Display for Cmd {
         match self {
             Cmd::HandleTimeout(_) => write!(f, "HandleTimeout"),
             Cmd::ScheduleTimeout { .. } => write!(f, "ScheduleTimeout"),
-            Cmd::HandleSystemMsg { msg_id, .. } => {
-                write!(f, "HandleSystemMsg {:?}", msg_id)
-            }
             Cmd::HandleMsg { wire_msg, .. } => {
                 write!(f, "HandleMsg {:?}", wire_msg.msg_id())
             }

--- a/sn/src/node/api/dispatcher.rs
+++ b/sn/src/node/api/dispatcher.rs
@@ -209,27 +209,6 @@ impl Dispatcher {
     /// Actually process the cmd
     async fn try_processing_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
         match cmd {
-            Cmd::HandleSystemMsg {
-                sender,
-                msg_id,
-                msg_authority,
-                dst_location,
-                msg,
-                payload,
-                known_keys,
-            } => {
-                self.core
-                    .handle_system_msg(
-                        sender,
-                        msg_id,
-                        msg_authority,
-                        dst_location,
-                        msg,
-                        payload,
-                        known_keys,
-                    )
-                    .await
-            }
             Cmd::SignOutgoingSystemMsg { msg, dst } => {
                 let src_section_pk = self.core.network_knowledge().section_key().await;
                 let wire_msg =


### PR DESCRIPTION
This PR verifies that removal of a cmd leads to unrelated tests being broken. They seem brittle and difficult to adjust for changes.
