### PR TITLE
Sorry! Fix Makefile shell for real this time?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := $(shell command -v bash)
+SHELL := bash
 SN_NODE_VERSION := $(shell grep "^version" < sn/Cargo.toml | head -n 1 | awk '{ print $$3 }' | sed 's/\"//g')
 SN_CLI_VERSION := $(shell grep "^version" < sn_cli/Cargo.toml | head -n 1 | awk '{ print $$3 }' | sed 's/\"//g')
 UNAME_S := $(shell uname -s)


### PR DESCRIPTION
I just read on the forum that some version were not release and my PR was the culprit. I indeed think it was me! Sorry!

It seems there are generally [two better solutions](https://sourcegraph.com/search?q=context:global+SHELL%5C+%3D.*%5B%5E/%5Dbash+file:%5EMakefile&patternType=regexp), one is `SHELL = bash`, the other is `SHELL = /usr/bin/env bash`.

I have opted for `SHELL = bash` as it seems more portable. I assume this takes the `bash` from the `PATH` environment variable, so should be good to go on Linux, Windows and MacOS.

@jacderida @joshuef Let me know what you guys think. (What is `bash` needed for, actually?)