### PR TITLE
chore: powershell install script for cli

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -15,7 +15,8 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: 'eu-west-2'
-  INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/master/resources/scripts/install.sh
+  INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.sh
+  POWERSHELL_INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.ps1
 
 jobs:
   cli-install-tests:
@@ -39,7 +40,7 @@ jobs:
              | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
           actual_version=$(safe --version | awk '{ print $2 }')
           echo "Expected version: $expected_version"
-          echo "Actual version: $expected_version"
+          echo "Actual version: $actual_version"
           if [[ $actual_version != $expected_version ]]; then exit 1; fi
       - shell: bash
         name: test install as non-root user
@@ -53,7 +54,7 @@ jobs:
              | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
           actual_version=$($HOME/.safe/cli/safe --version | awk '{ print $2 }')
           echo "Expected version: $expected_version"
-          echo "Actual version: $expected_version"
+          echo "Actual version: $actual_version"
           if [[ $actual_version != $expected_version ]]; then exit 1; fi
           # Since the installer attempts to update more than just the bashrc,
           # this isn't a comprehensive test, but I think it should do as a
@@ -62,6 +63,54 @@ jobs:
             echo "Installer has not updated the bashrc correctly"
             exit 1
           fi
+  windows-cli-install-test:
+    name: windows cli install test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - shell: powershell
+        name: run install
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force; `
+            iex ((New-Object System.Net.WebClient).DownloadString($env:POWERSHELL_INSTALL_SCRIPT_URL))
+      - shell: powershell
+        name: test install
+        run: |
+          # Use a new session to test the result of the install.
+          # This is because of things like the PATH modification, which requires a new session.
+          $installPath = Join-Path -Path $env:USERPROFILE -ChildPath ".safe\cli"
+          $safeBinPath = Join-Path -Path $installPath -ChildPath "safe.exe"
+          $failed = $false
+
+          $list = Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* `
+            | Where-Object { $_.DisplayName -like "Microsoft Visual C++*" } | Select-Object DisplayName
+          if ($list) {
+            echo "Visual C++ Redistributable was installed"
+          } else {
+            echo "Visual C++ Redistributable was not installed"
+            $failed = $true
+          }
+
+          $local:currentPaths = [Environment]::GetEnvironmentVariable(
+            'Path', [EnvironmentVariableTarget]::User) -split ';'
+          if ($currentPaths -contains $installPath) {
+            echo "CLI install path was added to user PATH variable"
+          } else {
+            echo "CLI install path was not added to user PATH variable"
+            $failed = $true
+          }
+
+          if (Test-Path $safeBinPath) {
+            echo "Detected safe binary at $safeBinPath"
+          } else {
+            echo "Expected safe binary at $safeBinPath"
+            $failed = $true
+          }
+
+          if ($failed) {
+            echo "Test run failed. Please see output to determine failure."
+            exit 1
+          }
 
   build-node:
     name: build node

--- a/resources/scripts/install.ps1
+++ b/resources/scripts/install.ps1
@@ -1,0 +1,80 @@
+$ErrorActionPreference = "Stop"
+$global:latestReleaseRequestUrl = "https://api.github.com/repos/maidsafe/safe_network/releases/latest"
+$global:vcRedistUrl = "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe"
+$global:installPath = Join-Path -Path $env:USERPROFILE -ChildPath ".safe\cli"
+$global:safeBinPath = Join-Path -Path $installPath -ChildPath "safe.exe"
+$global:pathModified = $false
+$global:vcRedistInstalled = $false
+
+function InstallVcppRedist {
+    $local:filename = $vcRedistUrl -split '/' | Select-Object -Last 1
+    $local:exePath = Join-Path -Path $env:TEMP -ChildPath $filename
+    $list = Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* `
+        | Where-Object { $_.DisplayName -like "Microsoft Visual C++*" } | Select-Object DisplayName
+    if ($list) {
+        echo "Visual C++ Redistributable is already installed"
+        return        
+    }
+    echo "Downloading Visual C++ Redistributable installer to $exePath"
+    wget $vcRedistUrl -outfile $exePath
+    echo "Running Visual C++ Redistributable installer as Administrator"
+    $p = Start-Process $exePath `
+        -ArgumentList "/install /quiet /norestart" -wait -PassThru -Verb RunAs
+    if ($p.ExitCode -ne 0) {
+        echo "Visual C++ Redistributable wasn't installed successfully"
+        exit 1
+    }
+    $global:vcRedistInstalled = $true
+    echo "Visual C++ Redistributable installed"
+    echo "Removing temporary $exePath file"
+    Remove-Item $exePath
+}
+
+function ConfigureInstallPath {
+    if (!(Test-Path $installPath)) {
+        New-Item -ItemType Directory -Path $installPath
+    }
+    $local:currentPaths = [Environment]::GetEnvironmentVariable(
+        'Path', [EnvironmentVariableTarget]::User) -split ';'
+    if ($currentPaths -notcontains $installPath) {
+        $global:pathModified = $true
+        echo "Adding CLI install path to user PATH variable"
+        $currentPaths = $currentPaths + $installPath | where { $_ }
+        [Environment]::SetEnvironmentVariable(
+            'Path', $currentPaths -join ';', [EnvironmentVariableTarget]::User)
+    }
+}
+
+function DownloadAndUnpackSafe {
+    if (Test-Path $safeBinPath) {
+        $proceed = Read-Host `
+            "A safe binary was already detected at $safeBinPath. Would you like to overwrite? [y/n]"
+        if (($proceed -ne "y") -or ($proceed -ne "Y")) {
+            return
+        }
+    }
+    echo "Obtaining latest version of safe"
+    $local:response = Invoke-RestMethod -Uri $latestReleaseRequestUrl
+    $version = $response.tag_name -split '-' | Select-Object -Last 1
+    echo "Latest version is $version"
+    $local:windowsAsset = $response.assets `
+        | Where-Object { $_.name -match "sn_cli-.*-x86_64-pc-windows-msvc.zip" }
+    $local:zipFileName = $windowsAsset.browser_download_url -split '/' | Select-Object -Last 1
+    $local:archivePath = Join-Path -Path $env:TEMP -ChildPath $zipFileName
+    echo "Downloading $zipFileName to $archivePath"
+    wget $windowsAsset.browser_download_url -outfile $archivePath
+    echo "Unpacking safe binary to $installPath"
+    Expand-Archive -Path $archivePath -DestinationPath $installPath -Force
+    echo "Removing temporary $archivePath file"
+    Remove-Item $archivePath
+}
+
+InstallVcppRedist
+ConfigureInstallPath
+DownloadAndUnpackSafe
+if ($pathModified -and !$vcRedistInstalled) {
+    echo "Restart your Powershell session to use safe"
+}
+if ($vcRedistInstalled) {
+    echo "Visual C++ Redistributable installation requires a restart"
+}

--- a/sn_cli/README.md
+++ b/sn_cli/README.md
@@ -56,19 +56,30 @@ The Safe CLI provides all the tools necessary to interact with the Safe Network,
 
 ## Quick Start
 
-If you're a Linux or macOS user and you have root access, you can run the following in your terminal:
+### Linux/macOS
+
+If you have root access, you can run the following in your terminal:
 ```
-$ curl -so- https://raw.githubusercontent.com/maidsafe/safe_network/master/resources/scripts/install.sh | sudo bash
+$ curl -so- https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.sh | sudo bash
 ```
 
-If you don't have root or prefer an install under your home directory:
+If you don't or prefer an install under your home directory:
 ```
-$ curl -so- https://raw.githubusercontent.com/maidsafe/safe_network/master/resources/scripts/install.sh | bash
+$ curl -so- https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.sh | bash
 ```
 
-In either case, if you can successfully run `safe --version`, you can now skip to [Using the CLI](#using-the-cli).
+The non-root option may require a new shell session; using root, `safe` should be available immediately.
 
-At the moment we don't have a quick start mechanism for Windows, but this will be coming soon.
+### Windows
+
+Start a Powershell session and run the following:
+```
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.ps1'))
+```
+
+If you don't have the Visual C++ Redistributable installed, the script will install it for you, but that requires admin access; otherwise, admin is not required. On the first install run, the location of `safe` will be added to your user `PATH` variable. Powershell requires a new session to pick this up. If VC++ was installed, this requires a machine restart. If later you use the install script to get a newer version of `safe`, neither will be necessary again.
+
+Now, if you can successfully run `safe --version`, you can skip to [Using the CLI](#using-the-cli).
 
 If you want more detail or alternative setup options, read the next section.
 
@@ -110,11 +121,7 @@ $ curl -so- https://raw.githubusercontent.com/maidsafe/sn_cli/master/resources/i
 
 #### Windows
 
-On Windows you can run the Bash install script using Bash emulation like [Git Bash](https://gitforwindows.org). You'll need to run it as an administrative user. The script can be run using the same commands as per the above section. The install script detects that it's running in emulation and will install a native Windows binary.
-
-You can also run the install script from [WSL](https://docs.microsoft.com/en-us/windows/wsl/about), though this will install a Linux-based binary inside the Linux emulation.
-
-We hope to make things much easier for Windows users by having a Powershell script that does something similar to the Bash script.
+The quickstart section has all the details for the Windows install script. No further elaboration is required.
 
 ### Binaries
 


### PR DESCRIPTION
Provide a Powershell install script for Windows users. This removes the requirement for using Git
Bash or other Linux emulation to setup the CLI.

The install process is:
* Download and install the Visual C++ Redistributable
* Create the `%USERPROFILE%\.safe\cli` directory
* Add `%USERPROFILE%\.safe\cli` to the user `PATH` variable
* Download and unpack the latest version of `safe` to `%USERPROFILE%\.safe\cli`

A few points worth noting. First, the script can run without admin access, but the VC++ install
requires that, so it will elevate to admin to run that. Second, the script is idempotent, so it will
run OK, if, e.g., VC++ is already installed. Third, the addition of the `PATH` variable
unfortunately requires users to start a new Powershell session. Finally, if VC++ was installed, that
requires a machine restart. The script informs users of either of those, and they are only required
the first time.

I tested it on a minimal Windows installation on a VM, before the VC++ prerequisite had been
installed. It worked as intended in this setup.

The README was updated to provide the user with instructions for running the script.
