### PR TITLE
chore: remove pointless and long checks in reg batch

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -326,20 +326,14 @@ jobs:
       - name: Client reg tests against local network (unix)
         shell: zsh {0}
         if: matrix.os != 'windows-latest'
-        run: cd sn && repeat 5 cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae --skip batching && sleep $POST_TEST_SLEEP
+        run: cd sn && repeat 5 cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae  && sleep $POST_TEST_SLEEP
         timeout-minutes: 10
 
       # register api
       - name: Client reg tests against local network (win)
         shell: bash
         if: matrix.os == 'windows-latest'
-        run: cd sn && cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae --skip batching && sleep $POST_TEST_SLEEP
-        timeout-minutes: 10
-
-      # register api batching check, only run this once as it's slow, and we verify the basic tests above
-      - name: Client register batching
-        shell: bash
-        run: cd sn && cargo test --release --features=test-utils -- register_batching --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP
+        run: cd sn && cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP
         timeout-minutes: 10
 
 
@@ -504,15 +498,9 @@ jobs:
       # register api
       - name: Client reg tests against local network (unix)
         shell: zsh {0}
-        run: cd sn && repeat 5 cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae --skip batching && sleep $POST_TEST_SLEEP
+        run: cd sn && repeat 5 cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP
         timeout-minutes: 10
 
-
-      # register api batching check, only run this once as it's slow, and we verify the basic tests above
-      - name: Client register batching
-        shell: bash
-        run: cd sn && cargo test --release --features=test-utils -- register_batching --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP
-        timeout-minutes: 10
 
       # file api
       - name: client file tests against local network (unix)

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -237,21 +237,16 @@ jobs:
       - name: Client reg tests against local network (unix)
         shell: zsh {0}
         if: matrix.os != 'windows-latest'
-        run: cd sn && repeat 5 cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae --skip batching && sleep $POST_TEST_SLEEP
+        run: cd sn && repeat 5 cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP
         timeout-minutes: 10
 
       # register api
       - name: Client reg tests against local network (win)
         shell: bash
         if: matrix.os == 'windows-latest'
-        run: cd sn && cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae --skip batching && sleep $POST_TEST_SLEEP
+        run: cd sn && cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP
         timeout-minutes: 10
 
-      # register api batching check, only run this once as it's slow, and we verify the basic tests above
-      - name: Client register batching
-        shell: bash
-        run: cd sn && cargo test --release --features=test-utils -- register_batching --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP
-        timeout-minutes: 10
 
       # file api
       - name: client file tests against local network (unix)
@@ -431,15 +426,9 @@ jobs:
       # register api
       - name: Client reg tests against local network (unix)
         shell: zsh {0}
-        run: cd sn && repeat 5 cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae --skip batching && sleep $POST_TEST_SLEEP
+        run: cd sn && repeat 5 cargo test --release --features=test-utils -- client_api::reg --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP
         timeout-minutes: 10
 
-
-      # register api batching check, only run this once as it's slow, and we verify the basic tests above
-      - name: Client register batching
-        shell: bash
-        run: cd sn && cargo test --release --features=test-utils -- register_batching --test-threads=1 --skip ae && sleep $POST_TEST_SLEEP
-        timeout-minutes: 10
 
       # file api
       - name: client file tests against local network (unix)

--- a/sn/src/client/client_api/register_apis.rs
+++ b/sn/src/client/client_api/register_apis.rs
@@ -45,7 +45,7 @@ impl Client {
         Ok(())
     }
 
-    /// Creates a Register on the network which can then be written to.
+    /// Creates a Register which can then be written to.
     ///
     /// Returns a write ahead log (WAL) of register operations, note that the changes are not uploaded to the
     /// network until the WAL is published with `publish_register_ops`
@@ -317,20 +317,10 @@ mod tests {
             .create_register(name, tag, private_policy(owner))
             .await?;
 
-        // make sure private register was not uploaded
-        tokio::time::sleep(one_sec).await;
-        let register = client.get_register(address).await;
-        assert!(register.is_err());
-
         // create a Public Register
         let (address2, mut batch2) = client
             .create_register(name, tag, public_policy(owner))
             .await?;
-
-        // make sure public register was not uploaded
-        tokio::time::sleep(one_sec).await;
-        let register = client.get_register(address2).await;
-        assert!(register.is_err());
 
         // batch them up
         batch.append(&mut batch2);


### PR DESCRIPTION
Previously we needlessly attempt to check for a reg which
didnt exist, to confirm that it didnt.

This took a QUERY_TIMEOUT length of time, and was obviously slow.

This speeds up the test from ~4 mins to 7secs

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
