### PR TITLE
ci: run cli tests after api and client

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -192,6 +192,10 @@ jobs:
           mkdir -p ~/.safe/node
           curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-node_connection_info.config > ~/.safe/node/node_connection_info.config
 
+      - name: Build all test targets
+        run: cargo test --no-run --release --features=test-utils
+        working-directory: sn
+
       - name: Run client tests
         uses: jacderida/cargo-nextest@main
         with:
@@ -259,7 +263,7 @@ jobs:
     name: cli tests
     if: ${{ always() }} # give the suite a chance to run, even if the api tests fail.
     runs-on: ${{ matrix.os }}
-    needs: launch-testnet
+    needs: [api, client]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Running all three jobs at the same time didn't seem to be stable.

Going to try now with the client and API tests running at the same time, then let the CLI tests run
on their own, but still try with 10 threads.

Also added an explicit build step to the client tests, to avoid timeouts when performing the test
run.
