### PR TITLE
ci: re-enable cli tests for pr tests

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -292,6 +292,8 @@ jobs:
           curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-node_connection_info.config > ~/.safe/node/node_connection_info.config
       - name: Build all CLI tests
         run: cargo test --no-run -p sn_cli --release
+      - name: Generate keys for test run
+        run: cargo run --package sn_cli --release -- keys create --for-cli
       - name: Run CLI tests
         uses: jacderida/cargo-nextest@main
         with:

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -469,13 +469,136 @@ jobs:
           rm -rf ~/.safe
           killall -9 sn_node
 
+  cli:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
+    name: Run CLI tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+        continue-on-error: true
+        with:
+          cache-on-failure: true
+          sharedKey: ${{github.run_id}}
+
+      - name: Mac install ripgrep
+        if: matrix.os == 'macos-latest'
+        run: brew install ripgrep
+
+      - name: ubuntu install ripgrep
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get -y install ripgrep
+
+      - name: windows install ripgrep
+        if: matrix.os == 'windows-latest'
+        run: choco install ripgrep
+
+      - name: Build sn bins
+        run: cd sn && cargo build --release --features=test-utils --bins
+        timeout-minutes: 60
+
+      - name: Build testnet
+        run: cargo build  --release --bin testnet
+        timeout-minutes: 60
+
+      - name: Build log_cmds_inspector
+        run: cargo build  --release --bin log_cmds_inspector
+        timeout-minutes: 60
+
+      - name: Start the network
+        run: ./target/release/testnet
+        id: section-startup
+        env:
+          RUST_LOG: "safe_network,sn_api,sn_node=trace"
+
+      - name: Print Network Log Stats at start
+        shell: bash
+        run: ./target/release/log_cmds_inspector $HOME/.safe/node/local-test-network
+        if: steps.section-startup.outcome == 'success' && matrix.os != 'windows-latest'
+
+      - name: Wait for all nodes to join
+        shell: bash
+        run: ./resources/scripts/wait_for_nodes_to_join.sh
+        timeout-minutes: 10
+
+      - name: Build all CLI tests
+        run: cargo test --no-run -p sn_cli --release
+
+      - name: Generate keys for test run
+        run: cargo run --package sn_cli --release -- keys create --for-cli
+
+      - name: Run CLI tests
+        uses: jacderida/cargo-nextest@main
+        with:
+          test-run-name: cli-${{ matrix.os }}
+          profile: ci
+          junit-path: junit.xml
+          package: sn_cli
+          release: true
+          test-threads: 10
+        timeout-minutes: 60
+        env:
+          SN_QUERY_TIMEOUT: 10
+
+      - name: Are nodes still running...?
+        shell: bash
+        timeout-minutes: 1
+        if: failure() && matrix.os
+        run: |
+          echo "$(pgrep sn_node | wc -l) nodes still running"
+          ls $HOME/.safe/node/local-test-network
+
+      - name: Print Network Log Stats
+        shell: bash
+        continue-on-error: true
+        run: ./target/release/log_cmds_inspector $HOME/.safe/node/local-test-network
+        if: steps.section-startup.outcome == 'success'
+
+      - name: Upload Node Logs to AWS for Windowns
+        run: aws s3 sync C:\Users\runneradmin\.safe\node\local-test-network\ s3://safe-network-ci-logs/${{github.sha}}/${{ github.run_id }}-${{ github.run_number }}/${{matrix.os}}
+        if: failure() &&  matrix.os == 'windows-latest'
+        continue-on-error: true
+
+      - name: Upload Node Logs to AWS for Non-Windows
+        run: aws s3 sync ~/.safe/node/local-test-network/ s3://safe-network-ci-logs/${{github.sha}}/${{ github.run_id }}-${{ github.run_number }}/${{matrix.os}}
+        if: failure() &&  matrix.os != 'windows-latest'
+        continue-on-error: true
+
+      - name: Upload Node Logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: sn_node_logs_api_${{matrix.os}}
+          path: ~/.safe/node/local-test-network/**/*.log*
+        if: failure()
+        continue-on-error: true
+
+      # if we don't clean up, the .safe folder might persist between runs
+      - name: Cleanup self-hosted runner
+        if: matrix.os == 'ubuntu-latest' && always()
+        run: |
+          rm -rf ~/.safe
+          killall -9 sn_node
+
   # This is required for publishing test results that come from forks. The actual publishing of the
   # results occurs in another workflow that will be triggered when this one finishes. Uploading this
   # 'event file' is necessary for the triggering to occur.
   upload_event_file:
     if: always()
     name: Upload event file
-    needs: [unit, e2e, e2e-split, api]
+    needs: [unit, e2e, e2e-split, api, cli]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Foolishly, I had forgotten to include key generation before the test run, which hopefully explains
the failures I was seeing in the previous runs.

This has also been included for the nightly run too.

With this done, the CLI tests should be able to run for PRs, as it was before.
