### PR TITLE
feat(chunks): batch store

### DIFF
--- a/sn/src/dbs/chunk_store.rs
+++ b/sn/src/dbs/chunk_store.rs
@@ -6,25 +6,24 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{Error, Result};
+use super::kv_store::KvStore;
+use super::Result;
 
 use crate::types::{Chunk, ChunkAddress};
 use crate::UsedSpace;
 
-use bytes::Bytes;
-use std::path::{Path, PathBuf};
-use tokio::io::AsyncWriteExt;
-use walkdir::WalkDir;
-use xor_name::{Prefix, XorName};
-
-const BIT_TREE_DEPTH: usize = 20;
-const CHUNK_DB_DIR: &str = "chunkdb";
+use self_encryption::MAX_CHUNK_SIZE;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 /// A disk store for chunks
 #[derive(Clone)]
 pub(crate) struct ChunkStore {
-    bit_tree_depth: usize,
-    chunk_store_path: PathBuf,
+    db: KvStore<Chunk>,
+    mem_pool: Arc<RwLock<BTreeMap<ChunkAddress, Chunk>>>,
+    old_mem_pool: Arc<RwLock<Vec<Chunk>>>,
     used_space: UsedSpace,
 }
 
@@ -35,145 +34,81 @@ impl ChunkStore {
     ///
     /// Used space of the dir is tracked
     pub(crate) fn new<P: AsRef<Path>>(root: P, used_space: UsedSpace) -> Result<Self> {
-        let chunk_store_path = root.as_ref().join(CHUNK_DB_DIR);
-
         Ok(ChunkStore {
-            bit_tree_depth: BIT_TREE_DEPTH,
-            chunk_store_path,
+            db: KvStore::new(root, used_space.clone())?,
+            mem_pool: Arc::new(RwLock::new(BTreeMap::new())),
+            old_mem_pool: Arc::new(RwLock::new(vec![])),
             used_space,
         })
     }
 
-    // ---------------------- helper methods ----------------------
-
-    // Helper that returns the prefix tree path of depth `bit_count` for a given xorname
-    // Example:
-    // - with a xorname with starting bits `010001110110....`
-    // - and a bit_count of `6`
-    // returns the path `CHUNK_STORE_PATH/0/1/0/0/0/1`
-    // If the provided bit count is larger than `self.bit_tree_depth`, uses `self.bit_tree_depth`
-    // to stay within the prefix tree path
-    fn prefix_tree_path(&self, xorname: XorName, bit_count: usize) -> PathBuf {
-        let bin = format!("{:b}", xorname);
-        let prefix_dir_path: PathBuf = bin
-            .chars()
-            .take(std::cmp::min(bit_count, self.bit_tree_depth))
-            .map(|c| format!("{}", c))
-            .collect();
-
-        let mut path = self.chunk_store_path.clone();
-        path.push(prefix_dir_path);
-        path
-    }
-
-    fn address_to_filepath(&self, addr: &ChunkAddress) -> Result<PathBuf> {
-        let xorname = *addr.name();
-        let filename = addr.encode_to_zbase32()?;
-        let mut path = self.prefix_tree_path(xorname, self.bit_tree_depth);
-        path.push(filename);
-        Ok(path)
-    }
-
-    fn filepath_to_address(&self, path: &str) -> Result<ChunkAddress> {
-        let filename = Path::new(path)
-            .file_name()
-            .ok_or(Error::NoFilename)?
-            .to_str()
-            .ok_or(Error::InvalidFilename)?;
-        Ok(ChunkAddress::decode_from_zbase32(filename)?)
-    }
-
     // ---------------------- api methods ----------------------
+
+    pub(crate) fn keys(&self) -> Result<Vec<ChunkAddress>> {
+        self.db.keys()
+    }
 
     pub(crate) fn can_add(&self, size: usize) -> bool {
         self.used_space.can_add(size)
     }
 
-    pub(crate) async fn write_chunk(&self, data: &Chunk) -> Result<ChunkAddress> {
-        let addr = data.address();
-        let filepath = self.address_to_filepath(addr)?;
-        if let Some(dirs) = filepath.parent() {
-            tokio::fs::create_dir_all(dirs).await?;
+    pub(crate) async fn write_chunk(&self, chunk: Chunk) -> Result<ChunkAddress> {
+        let addr = *chunk.address();
+        let chunk_size = chunk.value().len();
+
+        let store_batch = {
+            let mut pool = self.mem_pool.write().await;
+            let _ = pool.insert(addr, chunk);
+            let pool_len = pool.len();
+            let pool_size: usize = pool.values().map(|c| c.value().len()).sum();
+
+            // TODO: randomize the flush
+            if pool_len > 1000 || pool_size > 100 * MAX_CHUNK_SIZE {
+                self.old_mem_pool
+                    .write()
+                    .await
+                    .extend(pool.values().cloned());
+                pool.clear();
+                true
+            } else {
+                false
+            }
+        };
+
+        self.used_space.increase(chunk_size);
+
+        if store_batch {
+            let batch: Vec<_> = { self.old_mem_pool.read().await.to_vec() };
+            self.db.store_batch(&batch).await?;
+            self.old_mem_pool
+                .write()
+                .await
+                .retain(|c| !batch.contains(c));
         }
 
-        let mut file = tokio::fs::File::create(filepath).await?;
-        file.write_all(data.value()).await?;
-
-        self.used_space.increase(data.value().len());
-
-        Ok(*addr)
+        Ok(addr)
     }
 
     #[allow(dead_code)]
-    pub(crate) async fn delete_chunk(&self, addr: &ChunkAddress) -> Result<()> {
-        let filepath = self.address_to_filepath(addr)?;
-        let meta = tokio::fs::metadata(filepath.clone()).await?;
-        tokio::fs::remove_file(filepath).await?;
-        self.used_space.decrease(meta.len() as usize);
+    pub(crate) fn delete_chunk(&self, addr: &ChunkAddress) -> Result<()> {
+        if let Some(size) = self.db.delete(addr)? {
+            self.used_space.decrease(size);
+        }
         Ok(())
     }
 
     pub(crate) async fn read_chunk(&self, addr: &ChunkAddress) -> Result<Chunk> {
-        let file_path = self.address_to_filepath(addr)?;
-        let bytes = Bytes::from(tokio::fs::read(file_path).await?);
-        let chunk = Chunk::new(bytes);
-        Ok(chunk)
-    }
-
-    pub(crate) fn chunk_file_exists(&self, addr: &ChunkAddress) -> Result<bool> {
-        let filepath = self.address_to_filepath(addr)?;
-        Ok(filepath.exists())
-    }
-
-    pub(crate) fn list_all_files(&self) -> Result<Vec<String>> {
-        list_files_in(&self.chunk_store_path)
-    }
-
-    pub(crate) fn list_all_chunk_addresses(&self) -> Result<Vec<ChunkAddress>> {
-        let all_files = self.list_all_files()?;
-        let all_addrs = all_files
-            .iter()
-            .map(|filepath| self.filepath_to_address(filepath))
-            .collect();
-        all_addrs
+        let pool = self.mem_pool.read().await;
+        match pool.get(addr) {
+            Some(chunk) => Ok(chunk.clone()),
+            None => self.db.get(addr),
+        }
     }
 
     #[allow(unused)]
-    /// quickly find chunks related or not to a section, might be useful when adults change sections
-    /// not used yet
-    pub(crate) fn list_files_without_prefix(&self, prefix: Prefix) -> Result<Vec<String>> {
-        let all_files = self.list_all_files()?;
-        let prefix_path = self.prefix_tree_path(prefix.name(), prefix.bit_count());
-        let outside_prefix = all_files
-            .into_iter()
-            .filter(|p| !Path::new(&p).starts_with(&prefix_path.as_path()))
-            .collect();
-        Ok(outside_prefix)
+    pub(crate) fn exists(&self, addr: &ChunkAddress) -> Result<bool> {
+        self.db.has(addr)
     }
-
-    #[allow(unused)]
-    /// quickly find chunks related or not to a section, might be useful when adults change sections
-    /// not used yet
-    pub(crate) fn list_files_with_prefix(&self, prefix: Prefix) -> Result<Vec<String>> {
-        let prefix_path = self.prefix_tree_path(prefix.name(), prefix.bit_count());
-        list_files_in(prefix_path.as_path())
-    }
-}
-
-fn list_files_in(path: &Path) -> Result<Vec<String>> {
-    let files = WalkDir::new(path)
-        .into_iter()
-        .filter_map(|e| match e {
-            Ok(direntry) => Some(direntry),
-            Err(err) => {
-                warn!("ChunkStore: failed to process file entry: {}", err);
-                None
-            }
-        })
-        .filter(|e| e.file_type().is_file())
-        .map(|e| e.path().display().to_string())
-        .collect();
-    Ok(files)
 }
 
 #[cfg(test)]
@@ -181,6 +116,7 @@ mod tests {
     use crate::types::utils::random_bytes;
 
     use super::*;
+    use bytes::Bytes;
     use futures::future::join_all;
     use rayon::prelude::*;
     use tempfile::tempdir;
@@ -192,15 +128,17 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_write_read_chunk() {
         let store = init_chunk_disk_store();
         // test that a range of different chunks return the written chunk
-        for _ in 0..10 {
+        let mut keys = vec![];
+
+        // flushing occurs after 1k entries
+        for _ in 0..1100 {
             let chunk = Chunk::new(random_bytes(100));
 
             let addr = store
-                .write_chunk(&chunk)
+                .write_chunk(chunk.clone())
                 .await
                 .expect("Failed to write chunk.");
 
@@ -210,6 +148,16 @@ mod tests {
                 .expect("Failed to read chunk.");
 
             assert_eq!(chunk.value(), read_chunk.value());
+
+            keys.push(addr);
+        }
+
+        // check all is available also after flushing
+        for addr in keys {
+            let _chunk = store
+                .read_chunk(&addr)
+                .await
+                .expect("Failed to read chunk.");
         }
     }
 
@@ -234,7 +182,7 @@ mod tests {
 
     async fn write_and_read_chunks(chunks: &[Chunk], store: ChunkStore) {
         // write all chunks
-        let tasks = chunks.iter().map(|c| store.write_chunk(c));
+        let tasks = chunks.iter().map(|c| store.write_chunk(c.clone()));
         let results = join_all(tasks).await;
 
         // read all chunks

--- a/sn/src/dbs/kv_store/kv.rs
+++ b/sn/src/dbs/kv_store/kv.rs
@@ -6,24 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-mod chunk_store;
-mod encoding;
-mod errors;
-mod event_store;
-mod kv_store;
-mod lru_cache;
-mod used_space;
+use super::ToDbKey;
+use serde::{de::DeserializeOwned, Serialize};
 
-pub(crate) use chunk_store::ChunkStore;
-pub(crate) use encoding::{deserialise, serialise};
-pub(crate) use errors::{convert_to_error_msg, Error, Result};
-pub(crate) use event_store::EventStore;
-pub(crate) use lru_cache::LruCache;
-use std::path::Path;
-pub use used_space::UsedSpace;
+pub(crate) trait Key: ToDbKey + PartialEq + Eq + DeserializeOwned {}
 
-pub(crate) const SLED_FLUSH_TIME_MS: Option<u64> = Some(10000);
-
-pub(crate) trait Subdir {
-    fn subdir() -> &'static Path;
+/// A value in a key-value store.
+///
+/// The KV-store is paramaterised by the value type, from which a key can be derived.
+pub(crate) trait Value: Serialize + DeserializeOwned {
+    type Key: Key;
+    fn key(&self) -> &Self::Key;
 }

--- a/sn/src/dbs/kv_store/mod.rs
+++ b/sn/src/dbs/kv_store/mod.rs
@@ -1,0 +1,233 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! A simple, persistent, disk-based key-value store.
+
+mod kv;
+#[cfg(test)]
+mod tests;
+
+pub(super) mod to_db_key;
+
+pub(crate) use kv::{Key, Value};
+
+use super::{
+    deserialise,
+    used_space::UsedSpace,
+    {encoding::serialise, Error, Result},
+};
+use serde::de::DeserializeOwned;
+use sled::Db;
+use std::{marker::PhantomData, path::Path};
+use to_db_key::ToDbKey;
+
+const CHUNK_DB_DIR: &str = "chunks";
+
+/// `KvStore` is a store of keys and values into a Sled db, while maintaining a maximum disk
+/// usage to restrict storage.
+#[derive(Clone, Debug)]
+pub(crate) struct KvStore<V> {
+    // tracks space used.
+    used_space: UsedSpace,
+    db: Db,
+    _v: PhantomData<V>,
+}
+
+impl<V: Value> KvStore<V> {
+    /// Creates a new `KvStore` at location `root/STORE_DIR/<type>`.
+    ///
+    /// If the location specified already exists, the previous KvStore there is opened, otherwise
+    /// the required folder structure is created.
+    ///
+    /// Used space of the dir is tracked.
+    pub(crate) fn new<P: AsRef<Path>>(root: P, used_space: UsedSpace) -> Result<Self> {
+        let dir = root.as_ref().join("db").join(CHUNK_DB_DIR);
+
+        let db = sled::Config::default()
+            .path(&dir)
+            .flush_every_ms(Some(10000))
+            .open()
+            .map_err(Error::from)?;
+
+        Ok(KvStore {
+            used_space,
+            db,
+            _v: PhantomData,
+        })
+    }
+}
+
+impl<V: Value + Send + Sync> KvStore<V> {
+    ///
+    #[cfg(test)]
+    pub(crate) async fn total_used_space(&self) -> usize {
+        self.used_space.total().await
+    }
+
+    /// Tests if a value has been previously stored under `key`.
+    pub(crate) fn has(&self, key: &V::Key) -> Result<bool> {
+        let key = key.to_db_key()?;
+        self.db.contains_key(key).map_err(Error::from)
+    }
+
+    /// Deletes the value stored under `key`.
+    ///
+    /// If the data doesn't exist, it does nothing and returns `Ok`.  In the case of an IO error, it
+    /// returns `Error::Io`.
+    pub(crate) fn delete(&self, key: &V::Key) -> Result<Option<usize>> {
+        let key = key.to_db_key()?;
+        self.db
+            .remove(key)
+            .map_err(Error::from)
+            .map(|option| option.map(|data| data.len()))
+    }
+
+    /// Stores a new value.
+    ///
+    /// If there is not enough storage space available, returns `Error::NotEnoughSpace`.  In case of
+    /// an IO error, it returns `Error::Io`.
+    ///
+    /// If a value with the same id already exists, it will not be overwritten.
+    #[cfg(test)]
+    pub(crate) async fn store(&self, value: &V) -> Result<()> {
+        debug!("Writing value to KV store");
+
+        let key = value.key().to_db_key()?;
+        let serialised_value = serialise(value)?.to_vec();
+
+        let exists = self.db.contains_key(key.clone()).map_err(Error::from)?;
+        if !exists && !self.used_space.can_add(serialised_value.len()) {
+            return Err(Error::NotEnoughSpace);
+        }
+
+        // Atomically write the value if it's new - this prevents multiple concurrent writes from
+        // consuming extra space (since sled is backed by a log).
+        match self
+            .db
+            .compare_and_swap::<_, &[u8], _>(key, None, Some(serialised_value))?
+        {
+            Ok(()) => debug!("Successfully wrote new value"),
+            Err(sled::CompareAndSwapError { .. }) => {
+                // We throw away the value if the compare_and_swap failed since current use-cases do
+                // not require updates. In future we may want to return the preexisting value, or
+                // have a separate API for overwriting stores.
+                debug!("Value already existed, so we didn't have to write")
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Stores a batch of values.
+    ///
+    /// If there is not enough storage space available, returns `Error::NotEnoughSpace`.  In case of
+    /// an IO error, it returns `Error::Io`.
+    ///
+    /// If a value with the same id already exists, it will be overwritten.
+    pub(crate) async fn store_batch(&self, values: &[V]) -> Result<()> {
+        info!("Writing batch");
+        use rayon::prelude::*;
+        type KvPair = (String, Vec<u8>);
+        type KvPairResults = Vec<Result<KvPair>>;
+
+        let mut batch = sled::Batch::default();
+        let (ok, err_results): (KvPairResults, KvPairResults) = values
+            .par_iter()
+            .map(|value| {
+                let serialised_value = serialise(value)?.to_vec();
+                let key = value.key().to_db_key()?;
+                Ok((key, serialised_value))
+            })
+            .partition(|r| r.is_ok());
+
+        if !err_results.is_empty() {
+            for e in err_results {
+                error!("{:?}", e);
+            }
+
+            return Err(Error::SledBatching);
+        }
+
+        let consumed_space = ok
+            .into_iter()
+            .flatten()
+            .map(|(key, value)| {
+                let consumed_space = value.len();
+                // FIXME: this will write value redundantly if it is already set, upsetting used
+                // space calculation and wasting resources. This is quite likely to occur in
+                // practice since many operations are applied redundantly from multiple nodes.
+                batch.insert(key.as_bytes(), value);
+                consumed_space
+            })
+            .sum();
+
+        if !self.used_space.can_add(consumed_space) {
+            return Err(Error::NotEnoughSpace);
+        }
+
+        let res = self.db.apply_batch(batch);
+
+        match res {
+            Ok(_) => {
+                info!("Writing batch succeeded!");
+                self.used_space.increase(consumed_space);
+                Ok(())
+            }
+            Err(e) => {
+                warn!("Writing batch failed!");
+                Err(Error::Sled(e))
+            }
+        }
+    }
+
+    /// Returns a value previously stored under `key`.
+    ///
+    /// If the value can't be accessed, it returns `Error::NoSuchData`.
+    pub(crate) fn get(&self, key: &V::Key) -> Result<V> {
+        let db_key = key.to_db_key()?;
+        let res = self
+            .db
+            .get(db_key.clone())
+            .map_err(|_| Error::KeyNotFound(db_key.clone()))?;
+
+        if let Some(data) = res {
+            let value: V = deserialise(&data)?;
+            // Check it's the requested value.
+            if value.key() == key {
+                return Ok(value);
+            }
+        }
+
+        Err(Error::KeyNotFound(db_key))
+    }
+
+    /// Lists all keys of currently stored data.
+    pub(crate) fn keys(&self) -> Result<Vec<V::Key>> {
+        let keys = self
+            .db
+            .iter()
+            .flatten()
+            .map(|(key, _)| key)
+            .flat_map(convert)
+            .collect();
+        Ok(keys)
+    }
+
+    // We should avoid manually flushing in real code, since it can take a lot of time - tuning
+    // `flush_every_ms` would be preferrable. This is useful in tests, however.
+    #[cfg(test)]
+    pub(crate) async fn flush(&self) -> Result<()> {
+        let _bytes_flushed = self.db.flush_async().await?;
+        Ok(())
+    }
+}
+
+pub(crate) fn convert<T: DeserializeOwned>(key: sled::IVec) -> Result<T> {
+    let db_key = &String::from_utf8(key.to_vec()).map_err(|_| Error::CouldNotConvertDbKey)?;
+    to_db_key::from_db_key(db_key)
+}

--- a/sn/src/dbs/kv_store/mod.rs
+++ b/sn/src/dbs/kv_store/mod.rs
@@ -187,7 +187,7 @@ impl<V: Value + Send + Sync> KvStore<V> {
 
     /// Returns a value previously stored under `key`.
     ///
-    /// If the value can't be accessed, it returns `Error::NoSuchData`.
+    /// If the value can't be accessed, it returns `Error::KeyNotFound`.
     pub(crate) fn get(&self, key: &V::Key) -> Result<V> {
         let db_key = key.to_db_key()?;
         let res = self

--- a/sn/src/dbs/kv_store/tests.rs
+++ b/sn/src/dbs/kv_store/tests.rs
@@ -1,0 +1,342 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{
+    super::Subdir, Error, Key, KvStore, Result as KvStoreResult, ToDbKey, UsedSpace, Value,
+};
+use eyre::{eyre, Result};
+use rand::{distributions::Standard, rngs::ThreadRng, Rng};
+use serde::{Deserialize, Serialize};
+use std::{path::Path, u64};
+use tempfile::{tempdir, TempDir};
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct TestData {
+    id: Id,
+    value: Vec<u8>,
+}
+
+impl Value for TestData {
+    type Key = Id;
+    fn key(&self) -> &Self::Key {
+        &self.id
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+struct Id(u64);
+
+impl ToDbKey for Id {}
+impl Key for Id {}
+
+impl Subdir for KvStore<TestData> {
+    fn subdir() -> &'static Path {
+        Path::new("test")
+    }
+}
+
+// TODO: use seedable rng
+fn new_rng() -> ThreadRng {
+    rand::thread_rng()
+}
+
+fn temp_dir() -> KvStoreResult<TempDir> {
+    tempdir().map_err(|e| Error::TempDirCreationFailed(e.to_string()))
+}
+
+struct Chunks {
+    data_and_sizes: Vec<(Vec<u8>, usize)>,
+    total_size: usize,
+}
+
+impl Chunks {
+    // Construct random amount of randomly-sized chunks, keeping track of the total size of all
+    // chunks when serialised.
+    fn gen<R: Rng>(rng: &mut R) -> Result<Self> {
+        let mut chunks = Self {
+            data_and_sizes: vec![],
+            total_size: 0,
+        };
+        let chunk_count: u8 = rng.gen();
+        for _ in 0..chunk_count {
+            let size: u8 = rng.gen();
+            let data = TestData {
+                id: Id(0),
+                value: rng.sample_iter(&Standard).take(size as usize).collect(),
+            };
+            let serialised_size = bincode::serialized_size(&data).map_err(Error::Bincode)? as usize;
+
+            chunks.total_size += serialised_size;
+            chunks.data_and_sizes.push((data.value, serialised_size));
+        }
+        Ok(chunks)
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs refactor"]
+async fn used_space_increases() -> Result<()> {
+    let mut rng = new_rng();
+    let chunks = Chunks::gen(&mut rng)?;
+
+    let root = temp_dir()?;
+    let used_space = UsedSpace::new(u64::MAX as usize);
+    let db = KvStore::<TestData>::new(root.path(), used_space)?;
+
+    let used_space_before = db.total_used_space().await;
+
+    for (index, (data, _size)) in chunks.data_and_sizes.iter().enumerate().rev() {
+        let the_data = &TestData {
+            id: Id(index as u64),
+            value: data.clone(),
+        };
+
+        assert!(!db.has(&the_data.id)?);
+        db.store(the_data).await?;
+        assert!(db.has(&the_data.id)?);
+    }
+
+    db.flush().await?;
+    let used_space_after = db.total_used_space().await;
+    assert!(used_space_after > used_space_before);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "it doesn't decrease.."]
+async fn used_space_decreases() -> Result<()> {
+    let mut rng = new_rng();
+    let chunks = Chunks::gen(&mut rng)?;
+
+    let root = temp_dir()?;
+    let used_space = UsedSpace::new(u64::MAX as usize);
+    let db = KvStore::<TestData>::new(root.path(), used_space)?;
+
+    for (index, (data, _size)) in chunks.data_and_sizes.iter().enumerate().rev() {
+        let the_data = &TestData {
+            id: Id(index as u64),
+            value: data.clone(),
+        };
+
+        assert!(!db.has(&the_data.id)?);
+        db.store(the_data).await?;
+        assert!(db.has(&the_data.id)?);
+    }
+
+    let used_space_before = db.total_used_space().await;
+
+    for key in db.keys()? {
+        let _ = db.delete(&key)?;
+    }
+
+    db.flush().await?;
+    let used_space_after = db.total_used_space().await;
+    assert!(used_space_after < used_space_before);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn successful_put() -> Result<()> {
+    let mut rng = new_rng();
+    let chunks = Chunks::gen(&mut rng)?;
+
+    let root = temp_dir()?;
+    let used_space = UsedSpace::new(u64::MAX as usize);
+    let db = KvStore::<TestData>::new(root.path(), used_space)?;
+
+    for (index, (data, _size)) in chunks.data_and_sizes.iter().enumerate().rev() {
+        let the_data = &TestData {
+            id: Id(index as u64),
+            value: data.clone(),
+        };
+        assert!(!db.has(&the_data.id)?);
+        db.store(the_data).await?;
+        assert!(db.has(&the_data.id)?);
+    }
+
+    let mut keys = db.keys()?;
+    keys.sort();
+    assert_eq!(
+        (0..chunks.data_and_sizes.len())
+            .map(|i| Id(i as u64))
+            .collect::<Vec<_>>(),
+        keys
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn failed_put_when_not_enough_space() -> Result<()> {
+    let mut rng = new_rng();
+    let root = temp_dir()?;
+    let capacity = 32;
+    let used_space = UsedSpace::new(capacity);
+    let db = KvStore::new(root.path(), used_space)?;
+
+    let data = TestData {
+        id: Id(rng.gen()),
+        value: rng.sample_iter(&Standard).take(capacity + 1).collect(),
+    };
+
+    match db.store(&data).await {
+        Err(Error::NotEnoughSpace) => (),
+        x => return Err(eyre!(format!("Unexpected: {:?}", x))),
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete() -> Result<()> {
+    let mut rng = new_rng();
+    let chunks = Chunks::gen(&mut rng)?;
+
+    let root = temp_dir()?;
+    let used_space = UsedSpace::new(u64::MAX as usize);
+    let db = KvStore::new(root.path(), used_space)?;
+
+    for (index, (data, _size)) in chunks.data_and_sizes.iter().enumerate() {
+        let the_data = &TestData {
+            id: Id(index as u64),
+            value: data.clone(),
+        };
+        db.store(the_data).await?;
+
+        while !db.has(&the_data.id)? {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+
+        let _ = db.delete(&the_data.id)?;
+
+        while db.has(&the_data.id)? {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_and_get_value_should_be_same() -> Result<()> {
+    let mut rng = new_rng();
+    let chunks = Chunks::gen(&mut rng)?;
+
+    let root = temp_dir()?;
+    let used_space = UsedSpace::new(u64::MAX as usize);
+    let db = KvStore::new(root.path(), used_space)?;
+
+    for (index, (data, _)) in chunks.data_and_sizes.iter().enumerate() {
+        db.store(&TestData {
+            id: Id(index as u64),
+            value: data.clone(),
+        })
+        .await?
+    }
+
+    for (index, (data, _)) in chunks.data_and_sizes.iter().enumerate() {
+        let retrieved_value = db.get(&Id(index as u64))?;
+        assert_eq!(*data, retrieved_value.value);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs refactor"]
+async fn no_overwrite_value() -> Result<()> {
+    let mut rng = new_rng();
+    let chunks = Chunks::gen(&mut rng)?;
+    let (first_chunk, remaining_chunks) = chunks
+        .data_and_sizes
+        .split_first()
+        .expect("generated empty chunks");
+
+    let root = temp_dir()?;
+    let used_space = UsedSpace::new(u64::MAX as usize);
+    let db = KvStore::new(root.path(), used_space)?;
+
+    let initial_used_space = db.total_used_space().await;
+
+    let key = &Id(0);
+    db.store(&TestData {
+        id: *key,
+        value: first_chunk.0.clone(),
+    })
+    .await?;
+    db.flush().await?;
+
+    let total_used_space = db.total_used_space().await;
+    assert!(total_used_space >= initial_used_space + first_chunk.1);
+
+    for (data, _) in remaining_chunks {
+        db.store(&TestData {
+            id: *key,
+            value: data.clone(),
+        })
+        .await?;
+
+        assert_eq!(db.total_used_space().await, total_used_space);
+        assert_eq!(db.get(key)?.value, first_chunk.0);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_fails_when_key_does_not_exist() -> Result<()> {
+    let root = temp_dir()?;
+    let used_space = UsedSpace::new(u64::MAX as usize);
+    let db: KvStore<TestData> = KvStore::new(root.path(), used_space)?;
+
+    let id = Id(new_rng().gen());
+    match db.get(&id) {
+        Err(Error::KeyNotFound(_)) => (),
+        x => return Err(eyre!(format!("Unexpected {:?}", x))),
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn keys() -> Result<()> {
+    let mut rng = new_rng();
+    let chunks = Chunks::gen(&mut rng)?;
+
+    let root = temp_dir()?;
+    let used_space = UsedSpace::new(u64::MAX as usize);
+    let db = KvStore::new(root.path(), used_space)?;
+
+    for (index, (data, _)) in chunks.data_and_sizes.iter().enumerate() {
+        let id = Id(index as u64);
+        assert!(!db.keys()?.contains(&id));
+        db.store(&TestData {
+            id,
+            value: data.clone(),
+        })
+        .await?;
+
+        let keys = db.keys()?;
+        assert!(keys.contains(&id));
+        assert_eq!(keys.len(), index + 1);
+    }
+
+    for (index, _) in chunks.data_and_sizes.iter().enumerate() {
+        let id = Id(index as u64);
+
+        assert!(db.keys()?.contains(&id));
+        let _ = db.delete(&id)?;
+
+        let keys = db.keys()?;
+        assert!(!keys.contains(&id));
+        assert_eq!(keys.len(), chunks.data_and_sizes.len() - index - 1);
+    }
+
+    Ok(())
+}

--- a/sn/src/dbs/kv_store/to_db_key.rs
+++ b/sn/src/dbs/kv_store/to_db_key.rs
@@ -1,0 +1,66 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{
+    super::encoding::{deserialise, serialise},
+    Error, Key, Result, Value,
+};
+use crate::types::{Chunk, ChunkAddress, Keypair, PublicKey, RegisterAddress};
+use serde::{de::DeserializeOwned, Serialize};
+use xor_name::XorName;
+
+pub(crate) trait ToDbKey: Serialize {
+    /// The encoded string representation of an identifier, used as a key in the context of a
+    /// Db <key,value> store.
+    fn to_db_key(&self) -> Result<String> {
+        let serialised = serialise(&self)?;
+        Ok(hex::encode(&serialised))
+    }
+}
+
+pub(crate) fn from_db_key<T: DeserializeOwned>(key: &str) -> Result<T> {
+    let decoded = hex::decode(key).map_err(|_| Error::CouldNotDecodeDbKey(key.to_string()))?;
+    deserialise(&decoded)
+}
+
+impl ToDbKey for RegisterAddress {}
+impl ToDbKey for Keypair {}
+impl ToDbKey for ChunkAddress {}
+impl ToDbKey for PublicKey {}
+impl ToDbKey for XorName {}
+
+impl Key for ChunkAddress {}
+
+impl Value for Chunk {
+    type Key = ChunkAddress;
+
+    fn key(&self) -> &Self::Key {
+        self.address()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::node::Result;
+    use crate::types::PublicKey;
+    use bls::SecretKey;
+
+    #[test]
+    fn to_from_db_key() -> Result<()> {
+        let key = get_random_pk();
+        let serialised = key.to_db_key()?;
+        let deserialised: PublicKey = from_db_key(&serialised)?;
+        assert_eq!(key, deserialised);
+        Ok(())
+    }
+
+    fn get_random_pk() -> PublicKey {
+        PublicKey::from(SecretKey::random().public_key())
+    }
+}

--- a/sn/src/dbs/used_space.rs
+++ b/sn/src/dbs/used_space.rs
@@ -29,6 +29,12 @@ impl UsedSpace {
         }
     }
 
+    // Total used
+    #[cfg(test)]
+    pub(crate) async fn total(&self) -> usize {
+        self.used_space.load(Ordering::Relaxed)
+    }
+
     pub(crate) fn increase(&self, size: usize) {
         let _ = self.used_space.fetch_add(size, Ordering::Relaxed);
     }

--- a/sn/src/node/core/data/storage/chunks.rs
+++ b/sn/src/node/core/data/storage/chunks.rs
@@ -32,13 +32,13 @@ impl ChunkStorage {
     }
 
     pub(crate) fn keys(&self) -> Result<Vec<ChunkAddress>> {
-        self.db.list_all_chunk_addresses()
+        self.db.keys()
     }
 
     #[allow(dead_code)]
-    pub(crate) async fn remove_chunk(&self, address: &ChunkAddress) -> Result<()> {
+    pub(crate) fn remove_chunk(&self, address: &ChunkAddress) -> Result<()> {
         trace!("Removing chunk, {:?}", address);
-        self.db.delete_chunk(address).await
+        self.db.delete_chunk(address)
     }
 
     pub(crate) async fn get_chunk(&self, address: &ChunkAddress) -> Result<Chunk> {
@@ -65,7 +65,7 @@ impl ChunkStorage {
     /// If that chunk was already in the local store, just overwrites it
     #[instrument(skip_all)]
     pub(super) async fn store(&self, data: &Chunk) -> Result<()> {
-        if self.db.chunk_file_exists(data.address())? {
+        if self.db.exists(data.address())? {
             info!(
                 "{}: Chunk already exists, not storing: {:?}",
                 self,
@@ -84,7 +84,7 @@ impl ChunkStorage {
 
         // store the data
         trace!("{:?}", LogMarker::StoringChunk);
-        let _addr = self.db.write_chunk(data).await?;
+        let _addr = self.db.write_chunk(data.clone()).await?;
         trace!("{:?}", LogMarker::StoredNewChunk);
 
         Ok(())

--- a/sn/src/node/core/data/storage/chunks.rs
+++ b/sn/src/node/core/data/storage/chunks.rs
@@ -36,9 +36,9 @@ impl ChunkStorage {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn remove_chunk(&self, address: &ChunkAddress) -> Result<()> {
+    pub(crate) async fn remove_chunk(&self, address: &ChunkAddress) -> Result<()> {
         trace!("Removing chunk, {:?}", address);
-        self.db.delete_chunk(address)
+        self.db.delete_chunk(address).await
     }
 
     pub(crate) async fn get_chunk(&self, address: &ChunkAddress) -> Result<Chunk> {
@@ -46,6 +46,7 @@ impl ChunkStorage {
 
         match self.db.read_chunk(address).await {
             Ok(res) => Ok(res),
+            Err(Error::KeyNotFound(_key)) => Err(Error::ChunkNotFound(*address.name())),
             Err(error) => match error {
                 Error::Io(io_error) if io_error.kind() == ErrorKind::NotFound => {
                     Err(Error::ChunkNotFound(*address.name()))

--- a/sn/src/node/core/data/storage/mod.rs
+++ b/sn/src/node/core/data/storage/mod.rs
@@ -115,7 +115,7 @@ impl DataStorage {
     #[allow(dead_code)]
     pub(crate) async fn remove(&self, address: &DataAddress) -> Result<()> {
         match address {
-            DataAddress::Chunk(addr) => self.chunks.remove_chunk(addr).await,
+            DataAddress::Chunk(addr) => self.chunks.remove_chunk(addr),
             DataAddress::Register(addr) => self.registers.remove_register(addr).await,
         }
     }

--- a/sn/src/node/core/data/storage/mod.rs
+++ b/sn/src/node/core/data/storage/mod.rs
@@ -115,7 +115,7 @@ impl DataStorage {
     #[allow(dead_code)]
     pub(crate) async fn remove(&self, address: &DataAddress) -> Result<()> {
         match address {
-            DataAddress::Chunk(addr) => self.chunks.remove_chunk(addr),
+            DataAddress::Chunk(addr) => self.chunks.remove_chunk(addr).await,
             DataAddress::Register(addr) => self.registers.remove_register(addr).await,
         }
     }
@@ -291,7 +291,7 @@ mod tests {
             .get_from_local_store(&replicated_data.address())
             .await
         {
-            Err(Error::ChunkNotFound(address)) => assert_eq!(address, replicated_data.name()),
+            Err(Error::ChunkNotFound(name)) => assert_eq!(name, replicated_data.name()),
             _ => panic!("Unexpected data found"),
         }
 


### PR DESCRIPTION
Sled batching write speed far outperforms both sled singles and the
hierarchical dir store.
Additionally, read access times are improved for recently stored chunks.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
