### PR TITLE
chore: bump bls_dkg, self_encryption, xor_name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -451,18 +451,18 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "block-padding"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5808df4b2412175c4db3afb115c83d8d0cd26ca4f30a042026cddef8580e526a"
+checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "blocking"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046e47d4b2d391b1f6f8b407b1deb8dee56c1852ccd868becf2710f601b5f427"
+checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
 dependencies = [
  "async-channel",
  "async-task",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "bls_dkg"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0fe69538c9605742021daa40276f6be6651a00f8ce13b81e257bacd99f22a0"
+checksum = "424051475736994fd19dac9ee8c0e81fd543ad54cd02332e6029fccdecea292e"
 dependencies = [
  "aes 0.7.5",
  "bincode",
@@ -489,7 +489,7 @@ dependencies = [
  "serde_derive",
  "thiserror",
  "tiny-keccak",
- "xor_name 3.1.0",
+ "xor_name",
 ]
 
 [[package]]
@@ -808,9 +808,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -898,10 +898,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
@@ -911,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -921,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b75a27dc8d220f1f8521ea69cd55a34d720a200ebb3a624d9aa19193d3b432"
+checksum = "f1fd7173631a4e9e2ca8b32ae2fad58aab9843ea5aaf56642661937d87e28a3e"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -994,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
  "syn",
@@ -1037,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
+checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
@@ -1126,7 +1127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.0",
+ "redox_users 0.4.2",
  "winapi",
 ]
 
@@ -1150,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed12bbf7b5312f8da1c2722bc06d8c6b12c2d86a7fb35a194c7f3e6fc2bbe39"
+checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -1684,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1951,7 +1952,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1f03d4ab4d5dc9ec2d219f86c15d2a15fc08239d1cd3b2d6a19717c0a2f443"
 dependencies = [
- "block-padding 0.3.1",
+ "block-padding 0.3.2",
  "generic-array",
 ]
 
@@ -2050,9 +2051,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "linked-hash-map"
@@ -2188,14 +2189,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -2240,13 +2242,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check",
 ]
 
 [[package]]
@@ -2366,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
 dependencies = [
  "libc",
 ]
@@ -2935,7 +2936,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustls 0.20.4",
- "rustls-pemfile",
+ "rustls-pemfile 0.2.1",
  "slab",
  "thiserror",
  "tinyvec",
@@ -2960,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
 dependencies = [
  "proc-macro2",
 ]
@@ -3180,12 +3181,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "7776223e2696f1aa4c6b0170e83212f47296a00424305117d013dfe86fb0fe55"
 dependencies = [
  "getrandom 0.2.5",
  "redox_syscall 0.2.11",
+ "thiserror",
 ]
 
 [[package]]
@@ -3231,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -3253,7 +3255,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.4",
- "rustls-pemfile",
+ "rustls-pemfile 0.3.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3377,6 +3379,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,7 +3477,7 @@ dependencies = [
  "uluru",
  "url",
  "walkdir",
- "xor_name 3.1.0",
+ "xor_name",
  "yansi",
 ]
 
@@ -3520,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "self_encryption"
-version = "0.27.3"
+version = "0.27.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c065dc840e9a653d112c8276843619af178da52cf268234c580f35c89623d7cf"
+checksum = "636472c0b4e0354c08736d6a3f86ddf2746c739cd6605d2d9dc4472ba28351cf"
 dependencies = [
  "aes 0.8.1",
  "bincode",
@@ -3538,7 +3549,7 @@ dependencies = [
  "serde",
  "tiny-keccak",
  "tokio",
- "xor_name 3.1.0",
+ "xor_name",
 ]
 
 [[package]]
@@ -3818,7 +3829,7 @@ dependencies = [
  "url",
  "urlencoding",
  "walkdir",
- "xor_name 3.1.0",
+ "xor_name",
 ]
 
 [[package]]
@@ -3865,8 +3876,7 @@ dependencies = [
  "tracing-subscriber 0.2.25",
  "url",
  "walkdir",
- "xor_name 2.0.0",
- "xor_name 3.1.0",
+ "xor_name",
 ]
 
 [[package]]
@@ -3986,9 +3996,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4222,7 +4232,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.0",
+ "mio 0.8.2",
  "num_cpus",
  "pin-project-lite",
  "socket2 0.4.4",
@@ -4389,9 +4399,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4402,9 +4412,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab026b18a46ac429e5c98bec10ca06424a97b3ad7b3949d9b4a102fff6623c4"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
  "time 0.3.7",
@@ -4707,6 +4717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4913,9 +4929,9 @@ checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"
-version = "0.7.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
@@ -4946,24 +4962,12 @@ dependencies = [
 
 [[package]]
 name = "xor_name"
-version = "2.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b96e12687409134d5e3a785002b40b2ea4c566a86ee0847a3170ec96cb27979"
+checksum = "f6b076044ecafc4d0bad1455f9f0b8ef13e1992b3db789e1440f17bed7633f82"
 dependencies = [
- "rand 0.7.3",
- "rand_core 0.5.1",
- "serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "xor_name"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac010ec8541cbd12e6394b5ea6ded89aaf08e4077cb26cd0e376cd8e9dd1861"
-dependencies = [
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.5",
+ "rand_core 0.6.3",
  "serde",
  "tiny-keccak",
 ]

--- a/sn/Cargo.toml
+++ b/sn/Cargo.toml
@@ -43,7 +43,7 @@ tokio-console = ["console-subscriber"]
 base64 = "0.13.0"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "3.1.0" }
-bls_dkg = "0.9.0"
+bls_dkg = "0.9.2"
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "0.6.0"
 console-subscriber = { version = "0.1.0", optional = true }
@@ -68,7 +68,7 @@ rayon = "1.5.1"
 resource_proof = "1.0.38"
 rmp-serde = "1.0.0"
 secured_linked_list = "~0.5.0"
-self_encryption = "0.27.1"
+self_encryption = "0.27.4"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "~1.0.53"
@@ -88,7 +88,7 @@ tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 uluru="~3.0.0"
 url = "~2.2.0"
 walkdir = "~2"
-xor_name = "~3.1.0"
+xor_name = "~4.0.1"
 file-rotate = "~0.6.0"
 
 [dependencies.backoff]

--- a/sn/examples/routing_stress.rs
+++ b/sn/examples/routing_stress.rs
@@ -426,7 +426,7 @@ impl Network {
         for (node, prefix) in nodes {
             let dst = *cache
                 .entry(prefix)
-                .or_insert_with(|| prefix.substituted_in(rand::random()));
+                .or_insert_with(|| prefix.substituted_in(xor_name::rand::random()));
 
             let nodes_section = node
                 .matching_section(&node.name().await)

--- a/sn/src/client/client_api/mod.rs
+++ b/sn/src/client/client_api/mod.rs
@@ -178,7 +178,7 @@ impl Client {
             pk: PublicKey,
         ) -> Result<(XorName, ServiceAuth, Bytes), Error> {
             // Generate a random query to send a dummy message
-            let random_dst_addr = XorName::random();
+            let random_dst_addr = xor_name::rand::random();
             let serialised_cmd = {
                 let msg = ServiceMsg::Query(DataQuery::Register(RegisterQuery::Get(
                     RegisterAddress::Public {
@@ -201,7 +201,7 @@ impl Client {
 
         // either use our known prefixmap elders, or fallback to plain node config file
         let bootstrap_nodes = {
-            if let Some(sap) = prefix_map.closest_or_opposite(&XorName::random(), None) {
+            if let Some(sap) = prefix_map.closest_or_opposite(&xor_name::rand::random(), None) {
                 sap.elders_vec()
             } else {
                 // these peers will be nonsense peers, and dropped after we connect. Replaced by whatever SectionAuthorityProvider peers we have received
@@ -209,7 +209,7 @@ impl Client {
                 bootstrap_nodes
                     .iter()
                     .copied()
-                    .map(|socket| Peer::new(XorName::random(), socket))
+                    .map(|socket| Peer::new(xor_name::rand::random(), socket))
                     .collect_vec()
             }
         };

--- a/sn/src/client/client_api/register_apis.rs
+++ b/sn/src/client/client_api/register_apis.rs
@@ -299,7 +299,6 @@ mod tests {
     };
     use tokio::time::Duration;
     use tracing::Instrument;
-    use xor_name::XorName;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_register_batching() -> Result<()> {
@@ -308,7 +307,7 @@ mod tests {
 
         let client = create_test_client().await?;
         let one_sec = tokio::time::Duration::from_secs(1);
-        let name = XorName(rand::random());
+        let name = xor_name::rand::random();
         let tag = 15000;
         let owner = User::Key(client.public_key());
 
@@ -364,7 +363,7 @@ mod tests {
         let delay = tokio::time::Duration::from_secs(network_assert_delay);
         debug!("Running network asserts with delay of {:?}", delay);
 
-        let name = XorName(rand::random());
+        let name = xor_name::rand::random();
         let tag = 15000;
         let owner = User::Key(client.public_key());
 
@@ -391,7 +390,7 @@ mod tests {
 
         let client = create_test_client().await?;
 
-        let name = XorName(rand::random());
+        let name = xor_name::rand::random();
         let tag = 10;
         let owner = User::Key(client.public_key());
 
@@ -438,7 +437,7 @@ mod tests {
         let _outer_span = tracing::info_span!("test__register_basics").entered();
 
         let client = create_test_client().await?;
-        let name = XorName(rand::random());
+        let name = xor_name::rand::random();
         let tag = 15000;
         let owner = User::Key(client.public_key());
 
@@ -484,7 +483,7 @@ mod tests {
 
         let client = create_test_client().await?;
 
-        let name = XorName(rand::random());
+        let name = xor_name::rand::random();
         let tag = 15000;
         let owner = User::Key(client.public_key());
 
@@ -542,7 +541,7 @@ mod tests {
 
         let client = create_test_client().await?;
 
-        let name = XorName(rand::random());
+        let name = xor_name::rand::random();
         let tag = 15000;
         let owner = User::Key(client.public_key());
 
@@ -597,7 +596,7 @@ mod tests {
 
         let client = create_test_client().await?;
 
-        let name = XorName(rand::random());
+        let name = xor_name::rand::random();
         let tag = 10;
         let owner = User::Key(client.public_key());
 
@@ -698,7 +697,7 @@ mod tests {
 
         let client = create_test_client().await?;
 
-        let name = XorName(rand::random());
+        let name = xor_name::rand::random();
         let tag = 10;
         let owner = User::Key(client.public_key());
 
@@ -722,7 +721,7 @@ mod tests {
 
         let mut client = create_test_client().await?;
 
-        let name = XorName(rand::random());
+        let name = xor_name::rand::random();
         let tag = 15000;
         let owner = User::Key(client.public_key());
 
@@ -768,7 +767,7 @@ mod tests {
 
         let client = create_test_client().await?;
 
-        let name = XorName(rand::random());
+        let name = xor_name::rand::random();
         let tag = 15000;
         let owner = User::Key(client.public_key());
 
@@ -810,7 +809,7 @@ mod tests {
         let _outer_span = tracing::info_span!("ae_checks_register_test").entered();
         let client = create_test_client_with(None, None, false).await?;
 
-        let name = XorName::random();
+        let name = xor_name::rand::random();
         let tag = 15000;
         let owner = User::Key(client.public_key());
 

--- a/sn/src/dbs/event_store.rs
+++ b/sn/src/dbs/event_store.rs
@@ -73,10 +73,11 @@ mod test {
     use crate::types::Token;
     use std::path::Path;
     use tempfile::tempdir;
+    use xor_name::XorName;
 
     #[tokio::test]
     async fn history() -> Result<()> {
-        let id = xor_name::XorName::random();
+        let id: XorName = xor_name::rand::random();
         let tmp_dir = tempdir()?;
         let db_dir = tmp_dir.path().join(Path::new(&"Token"));
         let db = sled::open(db_dir).map_err(|error| {

--- a/sn/src/dbs/lru_cache.rs
+++ b/sn/src/dbs/lru_cache.rs
@@ -101,15 +101,14 @@ mod test {
     use super::LruCache;
 
     use std::sync::Arc;
-    use xor_name::XorName;
 
     #[tokio::test]
     async fn test_basic() {
         let cache = LruCache::new(3);
 
-        let key_1 = &XorName::random();
-        let key_2 = &XorName::random();
-        let key_3 = &XorName::random();
+        let key_1 = &xor_name::rand::random();
+        let key_2 = &xor_name::rand::random();
+        let key_3 = &xor_name::rand::random();
         cache.insert(key_1, Arc::new("Strawberries")).await;
         cache.insert(key_2, Arc::new("Bananas")).await;
         cache.insert(key_3, Arc::new("Peaches")).await;
@@ -124,10 +123,10 @@ mod test {
     async fn test_lru() {
         let cache = LruCache::new(3);
 
-        let key_1 = &XorName::random();
-        let key_2 = &XorName::random();
-        let key_3 = &XorName::random();
-        let key_4 = &XorName::random();
+        let key_1 = &xor_name::rand::random();
+        let key_2 = &xor_name::rand::random();
+        let key_3 = &xor_name::rand::random();
+        let key_4 = &xor_name::rand::random();
         cache.insert(key_1, Arc::new("Strawberries")).await;
         cache.insert(key_2, Arc::new("Bananas")).await;
         cache.insert(key_3, Arc::new("Peaches")).await;
@@ -143,9 +142,9 @@ mod test {
     async fn test_remove() {
         let cache = LruCache::new(3);
 
-        let key_1 = &XorName::random();
-        let key_2 = &XorName::random();
-        let key_3 = &XorName::random();
+        let key_1 = &xor_name::rand::random();
+        let key_2 = &xor_name::rand::random();
+        let key_3 = &xor_name::rand::random();
         cache.insert(key_1, Arc::new("Strawberries")).await;
         cache.insert(key_2, Arc::new("Bananas")).await;
         cache.insert(key_3, Arc::new("Peaches")).await;

--- a/sn/src/messaging/msg_id.rs
+++ b/sn/src/messaging/msg_id.rs
@@ -23,8 +23,7 @@ pub struct MsgId(#[debug(with = "Self::fmt_bytes")] [u8; MESSAGE_ID_LEN]);
 impl MsgId {
     /// Generates a new `MsgId` with random content.
     pub fn new() -> Self {
-        // Here we use XorName just as helper to generate a random id
-        Self(XorName::random().0)
+        Self(rand::random())
     }
 
     /// Convert an XorName into a MsgId

--- a/sn/src/messaging/serialisation/wire_msg.rs
+++ b/sn/src/messaging/serialisation/wire_msg.rs
@@ -258,7 +258,6 @@ mod tests {
     use bls::SecretKey;
     use eyre::Result;
     use rand::rngs::OsRng;
-    use xor_name::XorName;
 
     #[test]
     fn serialisation_node_msg() -> Result<()> {
@@ -266,7 +265,7 @@ mod tests {
         let mut rng = OsRng;
         let src_node_keypair = ed25519_dalek::Keypair::generate(&mut rng);
 
-        let dst_name = XorName::random();
+        let dst_name = xor_name::rand::random();
         let dst_section_pk = SecretKey::random().public_key();
         let dst_location = DstLocation::Node {
             name: dst_name,
@@ -317,7 +316,7 @@ mod tests {
         let mut rng = OsRng;
         let src_client_keypair = Keypair::new_ed25519(&mut rng);
 
-        let dst_name = XorName::random();
+        let dst_name = xor_name::rand::random();
         let dst_section_pk = SecretKey::random().public_key();
         let dst_location = DstLocation::Node {
             name: dst_name,
@@ -326,7 +325,8 @@ mod tests {
 
         let msg_id = MsgId::new();
 
-        let client_msg = ServiceMsg::Query(DataQuery::GetChunk(ChunkAddress(XorName::random())));
+        let client_msg =
+            ServiceMsg::Query(DataQuery::GetChunk(ChunkAddress(xor_name::rand::random())));
 
         let payload = WireMsg::serialize_msg_payload(&client_msg)?;
         let auth = ServiceAuth {

--- a/sn/src/node/api/tests/mod.rs
+++ b/sn/src/node/api/tests/mod.rs
@@ -409,7 +409,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
     // Handle agreement on Online of a peer that is older than the youngest
     // current elder - that means this peer is going to be promoted.
     let new_peer = create_peer(MIN_ADULT_AGE + 1);
-    let node_state = NodeState::joined(new_peer.clone(), Some(XorName::random()));
+    let node_state = NodeState::joined(new_peer.clone(), Some(xor_name::rand::random()));
 
     let auth = section_signed(sk_set.secret_key(), node_state.to_msg())?;
 
@@ -1449,7 +1449,8 @@ async fn create_section(
 // (or greater that) `age`.
 fn create_relocation_trigger(sk: &bls::SecretKey, age: u8) -> Result<SectionAuth<NodeStateMsg>> {
     loop {
-        let node_state = NodeState::joined(create_peer(MIN_ADULT_AGE), Some(rand::random()));
+        let node_state =
+            NodeState::joined(create_peer(MIN_ADULT_AGE), Some(xor_name::rand::random()));
         let auth = section_signed(sk, node_state.to_msg())?;
 
         let churn_id = ChurnId(auth.sig.signature.to_bytes().to_vec());

--- a/sn/src/node/core/bootstrap/join.rs
+++ b/sn/src/node/core/bootstrap/join.rs
@@ -786,7 +786,7 @@ mod tests {
 
             // Send JoinResponse::Redirect
             let new_bootstrap_addrs: BTreeMap<_, _> = (0..elder_count())
-                .map(|_| (XorName::random(), gen_addr()))
+                .map(|_| (xor_name::rand::random(), gen_addr()))
                 .collect();
 
             let (new_section_auth, _, new_sk_set) =
@@ -897,7 +897,7 @@ mod tests {
             task::yield_now().await;
 
             let addrs = (0..elder_count())
-                .map(|_| (XorName::random(), gen_addr()))
+                .map(|_| (xor_name::rand::random(), gen_addr()))
                 .collect();
 
             send_response(
@@ -1028,7 +1028,12 @@ mod tests {
         );
 
         let elders = (0..elder_count())
-            .map(|_| Peer::new(good_prefix.substituted_in(rand::random()), gen_addr()))
+            .map(|_| {
+                Peer::new(
+                    good_prefix.substituted_in(xor_name::rand::random()),
+                    gen_addr(),
+                )
+            })
             .collect();
         let join_task = state.join(section_key, section_key, elders);
 

--- a/sn/src/node/core/comm/mod.rs
+++ b/sn/src/node/core/comm/mod.rs
@@ -516,7 +516,6 @@ mod tests {
     use rand::rngs::OsRng;
     use std::{net::Ipv4Addr, time::Duration};
     use tokio::{net::UdpSocket, sync::mpsc, time};
-    use xor_name::XorName;
 
     const TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -668,7 +667,7 @@ mod tests {
         let (recv_endpoint, mut incoming_connections, _) =
             Endpoint::new_peer(local_addr(), &[], Config::default()).await?;
         let recv_addr = recv_endpoint.public_addr();
-        let name = XorName::random();
+        let name = xor_name::rand::random();
 
         let msg0 = new_test_msg()?;
         let status = send_comm
@@ -722,7 +721,11 @@ mod tests {
 
         // Send a message to establish the connection
         let status = comm1
-            .send(&[Peer::new(XorName::random(), addr0)], 1, new_test_msg()?)
+            .send(
+                &[Peer::new(xor_name::rand::random(), addr0)],
+                1,
+                new_test_msg()?,
+            )
             .await?;
         assert_matches!(status, SendStatus::AllRecipients);
 
@@ -737,7 +740,7 @@ mod tests {
 
     fn new_test_msg() -> Result<WireMsg> {
         let dst_location = DstLocation::Node {
-            name: XorName::random(),
+            name: xor_name::rand::random(),
             section_pk: bls::SecretKey::random().public_key(),
         };
 
@@ -745,7 +748,7 @@ mod tests {
         let src_keypair = Keypair::new_ed25519(&mut rng);
 
         let payload = WireMsg::serialize_msg_payload(&ServiceMsg::Query(DataQuery::GetChunk(
-            ChunkAddress(XorName::random()),
+            ChunkAddress(xor_name::rand::random()),
         )))?;
         let auth = ServiceAuth {
             public_key: src_keypair.public_key(),
@@ -777,7 +780,7 @@ mod tests {
             }
         });
 
-        Ok((Peer::new(XorName::random(), addr), rx))
+        Ok((Peer::new(xor_name::rand::random(), addr), rx))
     }
 
     async fn get_invalid_peer() -> Result<Peer> {
@@ -792,7 +795,7 @@ mod tests {
             let _ = socket;
         });
 
-        Ok(Peer::new(XorName::random(), addr))
+        Ok(Peer::new(xor_name::rand::random(), addr))
     }
 
     fn local_addr() -> SocketAddr {

--- a/sn/src/node/core/data/records/liveness_tracking.rs
+++ b/sn/src/node/core/data/records/liveness_tracking.rs
@@ -131,7 +131,7 @@ impl Liveness {
     /// Inserts a random OperationId to decrease the credibility of the given Adult node.
     #[allow(unused)]
     pub(crate) async fn penalise_member(&self, member: XorName) {
-        if let Ok(random_op_id) = chunk_operation_id(&ChunkAddress(XorName::random())) {
+        if let Ok(random_op_id) = chunk_operation_id(&ChunkAddress(xor_name::rand::random())) {
             self.add_a_pending_request_operation(member, random_op_id)
                 .await
         } else {
@@ -275,13 +275,15 @@ mod tests {
 
     #[tokio::test]
     async fn liveness_basics() -> Result<(), Error> {
-        let adults = (0..10).map(|_| XorName::random()).collect::<Vec<XorName>>();
+        let adults = (0..10)
+            .map(|_| xor_name::rand::random())
+            .collect::<Vec<XorName>>();
         let liveness_tracker = Liveness::new(adults.clone());
 
         // Write data MIN_PENDING_OPS times to the 10 adults
         for adult in &adults {
             for _ in 0..MIN_PENDING_OPS {
-                let random_addr = ChunkAddress(XorName::random());
+                let random_addr = ChunkAddress(xor_name::rand::random());
                 let op_id = chunk_operation_id(&random_addr)?;
                 liveness_tracker
                     .add_a_pending_request_operation(*adult, op_id)
@@ -301,7 +303,7 @@ mod tests {
         );
 
         // Add a new adults
-        let new_adult = XorName::random();
+        let new_adult = xor_name::rand::random();
         liveness_tracker.add_new_adult(new_adult);
 
         // Assert total adult count
@@ -309,7 +311,7 @@ mod tests {
 
         // Write data (EXCESSIVE_OPS_TOLERANCE/2) + 1 x MIN_PENDING_OPS times to the new adult to check for preemptive replication
         for _ in 0..MIN_PENDING_OPS * ((EXCESSIVE_OPS_TOLERANCE as usize / 2) + 1) {
-            let random_addr = ChunkAddress(XorName::random());
+            let random_addr = ChunkAddress(xor_name::rand::random());
             let op_id = chunk_operation_id(&random_addr)?;
             liveness_tracker
                 .add_a_pending_request_operation(new_adult, op_id)
@@ -326,7 +328,7 @@ mod tests {
 
         // Write data another EXCESSIVE_OPS_TOLERANCE x 50 times to the new adult to check for unresponsiveness.
         for _ in 0..MIN_PENDING_OPS * EXCESSIVE_OPS_TOLERANCE as usize {
-            let random_addr = ChunkAddress(XorName::random());
+            let random_addr = ChunkAddress(xor_name::rand::random());
             let op_id = chunk_operation_id(&random_addr)?;
             liveness_tracker
                 .add_a_pending_request_operation(new_adult, op_id)
@@ -347,7 +349,9 @@ mod tests {
 
     #[tokio::test]
     async fn liveness_retain_members() -> Result<(), Error> {
-        let adults = (0..10).map(|_| XorName::random()).collect::<Vec<XorName>>();
+        let adults = (0..10)
+            .map(|_| xor_name::rand::random())
+            .collect::<Vec<XorName>>();
         let liveness_tracker = Liveness::new(adults.clone());
 
         let live_adults = adults[5..10].iter().cloned().collect::<BTreeSet<XorName>>();
@@ -367,12 +371,12 @@ mod tests {
     async fn liveness_compute_closest() -> Result<(), Error> {
         // Adults with prefix 0
         let mut adults0 = (0..10)
-            .map(|_| XorName::random().with_bit(0, false))
+            .map(|_| xor_name::rand::random::<XorName>().with_bit(0, false))
             .collect::<Vec<XorName>>();
 
         // Adults with prefix 1
         let mut adults1 = (0..10)
-            .map(|_| XorName::random().with_bit(0, true))
+            .map(|_| xor_name::rand::random::<XorName>().with_bit(0, true))
             .collect::<Vec<XorName>>();
 
         // Whole set of Adults
@@ -399,11 +403,11 @@ mod tests {
 
         // Add 5 new adults for each 0 and 1 prefix
         let new_adults0 = (0..5)
-            .map(|_| XorName::random().with_bit(0, false))
+            .map(|_| xor_name::rand::random::<XorName>().with_bit(0, false))
             .collect::<Vec<XorName>>();
 
         let new_adults1 = (0..5)
-            .map(|_| XorName::random().with_bit(0, true))
+            .map(|_| xor_name::rand::random::<XorName>().with_bit(0, true))
             .collect::<Vec<XorName>>();
 
         let mut new_adults = vec![];

--- a/sn/src/node/core/data/storage/registers.rs
+++ b/sn/src/node/core/data/storage/registers.rs
@@ -726,7 +726,7 @@ mod test {
     use rand::rngs::OsRng;
     use rand::Rng;
     use tempfile::tempdir;
-    use xor_name::{Prefix, XorName};
+    use xor_name::Prefix;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_register_write() -> Result<()> {
@@ -986,7 +986,7 @@ mod test {
 
     fn create_reg_w_policy(policy: Policy, keypair: Keypair) -> Result<RegisterCmd> {
         let op = CreateRegister::Empty {
-            name: XorName::random(),
+            name: xor_name::rand::random(),
             tag: 1,
             size: u16::MAX,
             policy,

--- a/sn/src/node/core/delivery_group.rs
+++ b/sn/src/node/core/delivery_group.rs
@@ -242,7 +242,7 @@ mod tests {
         let dst_name = network_knowledge
             .prefix()
             .await
-            .substituted_in(rand::random());
+            .substituted_in(xor_name::rand::random());
         let section_pk = network_knowledge.authority_provider().await.section_key();
         let dst = DstLocation::Section {
             name: dst_name,
@@ -298,7 +298,9 @@ mod tests {
             .get(&Prefix::default().pushed(true))
             .context("unknown section")?;
 
-        let dst_name = section_auth1.prefix().substituted_in(rand::random());
+        let dst_name = section_auth1
+            .prefix()
+            .substituted_in(xor_name::rand::random());
         let section_pk = network_knowledge.authority_provider().await.section_key();
         let dst = DstLocation::Node {
             name: dst_name,
@@ -329,7 +331,7 @@ mod tests {
         let dst_name = elders_info1
             .prefix()
             .pushed(false)
-            .substituted_in(rand::random());
+            .substituted_in(xor_name::rand::random());
         let section_pk = network_knowledge.authority_provider().await.section_key();
         let dst = DstLocation::Node {
             name: dst_name,
@@ -358,7 +360,9 @@ mod tests {
             .get(&Prefix::default().pushed(true))
             .context("unknown section")?;
 
-        let dst_name = section_auth1.prefix().substituted_in(rand::random());
+        let dst_name = section_auth1
+            .prefix()
+            .substituted_in(xor_name::rand::random());
         let section_pk = network_knowledge.authority_provider().await.section_key();
         let dst = DstLocation::Section {
             name: dst_name,
@@ -389,7 +393,7 @@ mod tests {
         let dst_name = elders_info1
             .prefix()
             .pushed(false)
-            .substituted_in(rand::random());
+            .substituted_in(xor_name::rand::random());
         let section_pk = network_knowledge.authority_provider().await.section_key();
         let dst = DstLocation::Section {
             name: dst_name,
@@ -443,7 +447,7 @@ mod tests {
         let dst_name = network_knowledge
             .prefix()
             .await
-            .substituted_in(rand::random());
+            .substituted_in(xor_name::rand::random());
         let section_pk = network_knowledge.authority_provider().await.section_key();
         let dst = DstLocation::Node {
             name: dst_name,
@@ -471,7 +475,7 @@ mod tests {
         let dst_name = network_knowledge
             .prefix()
             .await
-            .substituted_in(rand::random());
+            .substituted_in(xor_name::rand::random());
         let section_pk = network_knowledge.authority_provider().await.section_key();
         let dst = DstLocation::Section {
             name: dst_name,
@@ -498,7 +502,7 @@ mod tests {
 
         let dst_name = Prefix::default()
             .pushed(true)
-            .substituted_in(rand::random());
+            .substituted_in(xor_name::rand::random());
         let section_pk = network_knowledge.authority_provider().await.section_key();
         let dst = DstLocation::Node {
             name: dst_name,
@@ -525,7 +529,7 @@ mod tests {
 
         let dst_name = Prefix::default()
             .pushed(true)
-            .substituted_in(rand::random());
+            .substituted_in(xor_name::rand::random());
         let section_pk = network_knowledge.authority_provider().await.section_key();
         let dst = DstLocation::Section {
             name: dst_name,
@@ -614,7 +618,7 @@ mod tests {
         let our_name = network_knowledge
             .prefix()
             .await
-            .substituted_in(rand::random());
+            .substituted_in(xor_name::rand::random());
 
         Ok((our_name, network_knowledge))
     }

--- a/sn/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn/src/node/core/messaging/handling/anti_entropy.rs
@@ -467,21 +467,19 @@ mod tests {
             test_utils::{gen_addr, gen_section_authority_provider},
             SectionKeyShare, SectionKeysProvider,
         },
-        NodeInfo, XorName, MIN_ADULT_AGE,
+        NodeInfo, MIN_ADULT_AGE,
     };
     use crate::UsedSpace;
 
     use assert_matches::assert_matches;
     use bls::SecretKey;
     use eyre::{Context, Result};
-    use rand::Rng;
     use secured_linked_list::SecuredLinkedList;
     use tokio::sync::mpsc;
     use xor_name::Prefix;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ae_everything_up_to_date() -> Result<()> {
-        let mut rng = rand::thread_rng();
         let env = Env::new().await?;
         let our_prefix = env.node.network_knowledge().prefix().await;
         let (msg, src_location) = env.create_msg(
@@ -489,7 +487,7 @@ mod tests {
             env.node.network_knowledge().section_key().await,
         )?;
         let sender = env.node.info.read().await.peer();
-        let dst_name = our_prefix.substituted_in(rng.gen());
+        let dst_name = our_prefix.substituted_in(xor_name::rand::random());
         let dst_section_key = env.node.network_knowledge().section_key().await;
 
         let cmd = env
@@ -588,7 +586,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ae_outdated_dst_key_of_our_section() -> Result<()> {
-        let mut rng = rand::thread_rng();
         let env = Env::new().await?;
         let our_prefix = env.node.network_knowledge().prefix().await;
 
@@ -597,7 +594,7 @@ mod tests {
             env.node.network_knowledge().section_key().await,
         )?;
         let sender = env.node.info.read().await.peer();
-        let dst_name = our_prefix.substituted_in(rng.gen());
+        let dst_name = our_prefix.substituted_in(xor_name::rand::random());
         let dst_section_key = env.node.network_knowledge().genesis_key();
 
         let cmd = env
@@ -629,7 +626,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ae_wrong_dst_key_of_our_section_returns_retry() -> Result<()> {
-        let mut rng = rand::thread_rng();
         let env = Env::new().await?;
         let our_prefix = env.node.network_knowledge().prefix().await;
 
@@ -638,7 +634,7 @@ mod tests {
             env.node.network_knowledge().section_key().await,
         )?;
         let sender = env.node.info.read().await.peer();
-        let dst_name = our_prefix.substituted_in(rng.gen());
+        let dst_name = our_prefix.substituted_in(xor_name::rand::random());
 
         let bogus_env = Env::new().await?;
         let dst_section_key = bogus_env.node.network_knowledge().genesis_key();
@@ -755,10 +751,10 @@ mod tests {
             let sender_name = sender.name();
             let src_node_keypair = sender.keypair;
 
-            let payload_msg = SystemMsg::StartConnectivityTest(XorName::random());
+            let payload_msg = SystemMsg::StartConnectivityTest(xor_name::rand::random());
             let payload = WireMsg::serialize_msg_payload(&payload_msg)?;
 
-            let dst_name = XorName::random();
+            let dst_name = xor_name::rand::random();
             let dst_section_key = SecretKey::random().public_key();
             let dst_location = DstLocation::Node {
                 name: dst_name,

--- a/sn/src/node/core/mod.rs
+++ b/sn/src/node/core/mod.rs
@@ -183,11 +183,11 @@ impl Node {
 
     pub(crate) async fn generate_probe_msg(&self) -> Result<Cmd> {
         // Generate a random address not belonging to our Prefix
-        let mut dst = XorName::random();
+        let mut dst = xor_name::rand::random();
 
         // We don't probe ourselves
         while self.network_knowledge.prefix().await.matches(&dst) {
-            dst = XorName::random();
+            dst = xor_name::rand::random();
         }
 
         let matching_section = self.network_knowledge.section_by_name(&dst)?;

--- a/sn/src/node/ed25519.rs
+++ b/sn/src/node/ed25519.rs
@@ -34,7 +34,7 @@ pub(super) fn name(public_key: &PublicKey) -> XorName {
 /// Construct a random `XorName` whose last byte represents the targeted age.
 pub(super) fn gen_name_with_age(age: u8) -> XorName {
     loop {
-        let name = XorName::random();
+        let name: XorName = xor_name::rand::random();
         if age == name[XOR_NAME_LEN - 1] {
             return name;
         }

--- a/sn/src/types/address/mod.rs
+++ b/sn/src/types/address/mod.rs
@@ -151,11 +151,10 @@ impl ChunkAddress {
 #[cfg(test)]
 mod tests {
     use crate::types::{BytesAddress, DataAddress, Result};
-    use xor_name::XorName;
 
     #[test]
     fn zbase32_encode_decode_chunk_address() -> Result<()> {
-        let name = XorName::random();
+        let name = xor_name::rand::random();
         let address = DataAddress::Bytes(BytesAddress::Public(name));
         let encoded = address.encode_to_zbase32()?;
         let decoded = DataAddress::decode_from_zbase32(&encoded)?;

--- a/sn/src/types/keys/public_key.rs
+++ b/sn/src/types/keys/public_key.rs
@@ -187,7 +187,7 @@ impl From<PublicKey> for XorName {
             PublicKey::Bls(pub_key) => pub_key.to_bytes(),
             PublicKey::BlsShare(pub_key) => pub_key.to_bytes(),
         };
-        let mut xor_name = XorName::random();
+        let mut xor_name: XorName = xor_name::rand::random();
         xor_name.0.clone_from_slice(&bytes[..XOR_NAME_LEN]);
         xor_name
     }

--- a/sn/src/types/prefix_map/mod.rs
+++ b/sn/src/types/prefix_map/mod.rs
@@ -415,7 +415,6 @@ mod tests {
     use super::*;
     use crate::node::{gen_section_authority_provider, section_signed};
     use eyre::{eyre, Context, Result};
-    use rand::Rng;
 
     #[test]
     fn insert_existing_prefix() -> Result<()> {
@@ -463,8 +462,6 @@ mod tests {
 
     #[test]
     fn return_opposite_prefix_if_none_matching() -> Result<()> {
-        let mut rng = rand::thread_rng();
-
         let (map, _, _) = new_network_prefix_map();
         let p0 = prefix("0")?;
         let p1 = prefix("1")?;
@@ -474,20 +471,20 @@ mod tests {
         let _changed = map.insert(sap0.clone());
 
         assert_eq!(
-            map.section_by_name(&p1.substituted_in(rng.gen()))?,
+            map.section_by_name(&p1.substituted_in(xor_name::rand::random()))?,
             sap0.value
         );
 
         // There are no matching prefixes, so return an opposite prefix.
         assert_eq!(
-            map.closest_or_opposite(&p1.substituted_in(rng.gen()), None)
+            map.closest_or_opposite(&p1.substituted_in(xor_name::rand::random()), None)
                 .ok_or(Error::NoMatchingSection)?,
             sap0
         );
 
         let _changed = map.insert(sap0.clone());
         assert_eq!(
-            map.closest_or_opposite(&p1.substituted_in(rng.gen()), None)
+            map.closest_or_opposite(&p1.substituted_in(xor_name::rand::random()), None)
                 .ok_or(Error::NoMatchingSection)?,
             sap0
         );
@@ -554,8 +551,6 @@ mod tests {
 
     #[test]
     fn get_matching() -> Result<()> {
-        let mut rng = rand::thread_rng();
-
         let (map, _, _) = new_network_prefix_map();
         let p = prefix("")?;
         let p0 = prefix("0")?;
@@ -570,14 +565,14 @@ mod tests {
         let _changed = map.insert(sap.clone());
 
         assert_eq!(
-            map.section_by_name(&p0.substituted_in(rng.gen()))?,
+            map.section_by_name(&p0.substituted_in(xor_name::rand::random()))?,
             sap.value
         );
 
         let _changed = map.insert(sap0.clone());
 
         assert_eq!(
-            map.section_by_name(&p1.substituted_in(rng.gen()))?,
+            map.section_by_name(&p1.substituted_in(xor_name::rand::random()))?,
             sap0.value
         );
 
@@ -585,18 +580,18 @@ mod tests {
         let _changed = map.insert(sap10.clone());
 
         assert_eq!(
-            map.section_by_name(&p0.substituted_in(rng.gen()))?,
+            map.section_by_name(&p0.substituted_in(xor_name::rand::random()))?,
             sap0.value
         );
 
         // sap1 get pruned once sap10 inserted.
         assert_eq!(
-            map.section_by_name(&prefix("11")?.substituted_in(rng.gen()))?,
+            map.section_by_name(&prefix("11")?.substituted_in(xor_name::rand::random()))?,
             sap10.value
         );
 
         assert_eq!(
-            map.section_by_name(&p10.substituted_in(rng.gen()))?,
+            map.section_by_name(&p10.substituted_in(xor_name::rand::random()))?,
             sap10.value
         );
 
@@ -653,10 +648,9 @@ mod tests {
         chain10.insert(&genesis_pk, pk10, sig10)?;
         let _updated = map.verify_with_chain_and_update(section_auth_10, &chain10, &chain);
 
-        let mut rng = rand::thread_rng();
-        let n01 = p01.substituted_in(rng.gen());
-        let n10 = p10.substituted_in(rng.gen());
-        let n11 = p11.substituted_in(rng.gen());
+        let n01 = p01.substituted_in(xor_name::rand::random());
+        let n10 = p10.substituted_in(xor_name::rand::random());
+        let n11 = p11.substituted_in(xor_name::rand::random());
 
         assert_eq!(map.closest(&n01, None).map(|sap| sap.prefix()), Some(p01));
         assert_eq!(map.closest(&n10, None).map(|sap| sap.prefix()), Some(p10));

--- a/sn/src/types/register/mod.rs
+++ b/sn/src/types/register/mod.rs
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn register_create_public() {
-        let name = XorName::random();
+        let name = xor_name::rand::random();
         let tag = 43_000;
         let (authority_keypair, register) = &gen_pub_reg_replicas(None, name, tag, None, 1)[0];
 
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn register_create_private() {
-        let name = XorName::random();
+        let name = xor_name::rand::random();
         let tag = 43_000;
         let (authority_keypair, register) = &gen_priv_reg_replicas(None, name, tag, None, 1)[0];
 
@@ -289,7 +289,7 @@ mod tests {
         let authority_keypair2 = Keypair::new_ed25519(&mut OsRng);
         let authority2 = User::Key(authority_keypair2.public_key());
 
-        let name: XorName = rand::random();
+        let name: XorName = xor_name::rand::random();
         let tag = 43_000u64;
         let cap = u16::MAX;
 
@@ -387,7 +387,7 @@ mod tests {
 
     #[test]
     fn register_query_public_policy() -> eyre::Result<()> {
-        let name = XorName::random();
+        let name = xor_name::rand::random();
         let tag = 43_666;
 
         // one replica will allow write ops to anyone
@@ -451,7 +451,7 @@ mod tests {
 
     #[test]
     fn register_query_private_policy() -> eyre::Result<()> {
-        let name = XorName::random();
+        let name = xor_name::rand::random();
         let tag = 43_666;
 
         let authority_keypair1 = Keypair::new_ed25519(&mut OsRng);
@@ -579,7 +579,7 @@ mod tests {
     }
 
     fn create_public_reg_replicas(count: usize) -> Vec<(Keypair, Register)> {
-        let name = XorName::random();
+        let name = xor_name::rand::random();
         let tag = 43_000;
 
         gen_pub_reg_replicas(None, name, tag, None, count)
@@ -625,7 +625,7 @@ mod tests {
     fn generate_replicas(
         max_quantity: usize,
     ) -> impl Strategy<Value = Result<(Vec<Register>, Arc<Keypair>)>> {
-        let xorname = XorName::random();
+        let xorname = xor_name::rand::random();
         let tag = 45_000u64;
 
         let owner_keypair = Arc::new(Keypair::new_ed25519(&mut OsRng));
@@ -672,7 +672,7 @@ mod tests {
             _data in generate_reg_entry()
         ) {
             // Instantiate the same Register on two replicas
-            let name = XorName::random();
+            let name = xor_name::rand::random();
             let tag = 45_000u64;
             let owner_keypair = Keypair::new_ed25519(&mut OsRng);
             let policy = PublicPolicy {
@@ -702,7 +702,7 @@ mod tests {
             dataset in generate_dataset(1000)
         ) {
             // Instantiate the same Register on two replicas
-            let name = XorName::random();
+            let name = xor_name::rand::random();
             let tag = 43_000u64;
             let owner_keypair = Keypair::new_ed25519(&mut OsRng);
             let policy = PublicPolicy {
@@ -741,7 +741,7 @@ mod tests {
             dataset in generate_dataset(1000)
         ) {
             // Instantiate the same Register on two replicas
-            let name = XorName::random();
+            let name = xor_name::rand::random();
             let tag = 43_000u64;
             let owner_keypair = Keypair::new_ed25519(&mut OsRng);
             let policy = PublicPolicy {
@@ -881,7 +881,7 @@ mod tests {
             dataset in generate_dataset_and_probability(1000),
         ) {
             // Instantiate the same Register on two replicas
-            let name = XorName::random();
+            let name = xor_name::rand::random();
             let tag = 43_000u64;
             let owner_keypair = Keypair::new_ed25519(&mut OsRng);
             let policy = PublicPolicy {
@@ -1002,7 +1002,7 @@ mod tests {
             }
 
             // set up a replica that has nothing to do with the rest, random xor... different owner...
-            let xorname = XorName::random();
+            let xorname = xor_name::rand::random();
             let tag = 45_000u64;
             let cap = u16::MAX;
             let random_owner_keypair = Keypair::new_ed25519(&mut OsRng);

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -39,7 +39,7 @@ uhttp_uri = "~0.5"
 url = "2.2.0"
 urlencoding = "1.1.1"
 walkdir = "2.3.1"
-xor_name = "3.0.0"
+xor_name = "4.0.1"
 
   [dependencies.bls]
   package = "blsttc"

--- a/sn_api/src/app/register.rs
+++ b/sn_api/src/app/register.rs
@@ -44,7 +44,7 @@ impl Safe {
             self.dry_run_mode
         );
 
-        let xorname = name.unwrap_or_else(rand::random);
+        let xorname = name.unwrap_or_else(xor_name::rand::random);
         info!("Xorname for new Register storage: {:?}", &xorname);
 
         let scope = if private {

--- a/sn_api/src/app/resolver/mod.rs
+++ b/sn_api/src/app/resolver/mod.rs
@@ -607,7 +607,7 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_unsupported_with_media_type() -> Result<()> {
         let safe = new_safe_instance().await?;
-        let xorname = rand::random();
+        let xorname = xor_name::rand::random();
         let type_tag = 575_756_443;
         let xorurl = SafeUrl::encode(
             DataAddress::register(xorname, Scope::Public, type_tag),

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -41,7 +41,7 @@ structopt = "~0.3"
 tracing = "~0.1.26"
 tracing-subscriber = "~0.2.15"
 url = "2.2.2"
-xor_name = "3.0.0"
+xor_name = "4.0.1"
 
 [dependencies.bls]
 package = "blsttc"
@@ -89,7 +89,7 @@ predicates = "~2.0"
 criterion = "~0.3"
 walkdir = "2.3.1"
 multibase = "~0.9.1"
-xor_name = "2.0.0"
+xor_name = "4.0.1"
 
 [dev-dependencies.sn_cmd_test_utilities]
 path = "../sn_cmd_test_utilities"


### PR DESCRIPTION
This is a step towards integrating sn_dbc into safe_network.

Changes:
* bump bls_dkg from 0.9.0 to 0.9.2
* bump self_encryption from 0.27.1 to 0.27.4
* bump xor_name from 4.0.0 to 4.0.1
* code fixups to use updated deps

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
