### PR TITLE
ci: add sn_dysfunction to release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,8 @@ jobs:
         shell: bash
         run: |
           ./resources/scripts/insert_changelog_entry.py \
+            --sn-dysfunction-version "${{ steps.versioning.outputs.sn_dysfunction_version }}"
+          ./resources/scripts/insert_changelog_entry.py \
             --sn-version "${{ steps.versioning.outputs.sn_version }}"
           ./resources/scripts/insert_changelog_entry.py \
             --sn-api-version "${{ steps.versioning.outputs.sn_api_version }}"
@@ -189,8 +191,8 @@ jobs:
   # message needs to be checked at the point of publishing. The reason is because of the dependencies
   # between the publishing jobs. If one of the jobs doesn't run because its `if` condition was evaluated
   # to false, the next job won't run, regardless of whether its `if` condition would evaluate to true.
-  publish_sn:
-    name: publish safe network
+  publish_sn_dysfunction:
+    name: publish sn_dysfunction
     runs-on: ubuntu-latest
     needs: [gh_release]
     if: |
@@ -210,9 +212,38 @@ jobs:
       - name: cargo publish
         run: |
           commit_message="${{ github.event.head_commit.message }}"
+          if [[ $commit_message == *"sn_dysfunction"* ]]; then
+            # The sn_dysfunction crate doesn't have any dependencies so we can go ahead and publish.
+            cd sn_dysfunction && cargo publish --allow-dirty
+          fi
+
+  publish_sn:
+    name: publish safe network
+    runs-on: ubuntu-latest
+    needs: [publish_sn_dysfunction]
+    if: |
+      github.repository_owner == 'maidsafe' &&
+      startsWith(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: cargo login
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+      - name: cargo publish
+        run: |
+          commit_message="${{ github.event.head_commit.message }}"
           if [[ $commit_message == *"safe_network"* ]]; then
-            # The safe_network crate doesn't have any dependencies so we can go ahead and publish
-            cd sn && cargo publish --allow-dirty
+            # The safe_network crate is dependent on sn_dysfunction and sometimes the new version
+            # doesn't become available on crates.io immediately, so this script will use a retry
+            # loop.
+            ./resources/scripts/publish_crate.sh \
+              "safe_network" "${{ steps.versioning.outputs.sn_dysfunction_version }}" "sn_dysfunction"
           fi
 
   publish_sn_api:

--- a/resources/scripts/get_release_description.sh
+++ b/resources/scripts/get_release_description.sh
@@ -16,6 +16,10 @@ fi
 read -r -d '' release_description << 'EOF'
 Command line interface for the Safe Network. Refer to [Safe CLI User Guide](https://github.com/maidsafe/sn_cli/blob/master/README.md) for detailed instructions.
 
+## Safe Node Dysfunction Changelog
+
+__SN_DYSFUNCTION_CHANGELOG_TEXT__
+
 ## Safe Network Changelog
 
 __SN_CHANGELOG_TEXT__

--- a/resources/scripts/insert_changelog_entry.py
+++ b/resources/scripts/insert_changelog_entry.py
@@ -25,7 +25,10 @@ def insert_changelog_entry(entry, pattern):
     with open("release_description.md", "w") as file:
         file.write(release_description)
 
-def main(sn_version, sn_api_version, sn_cli_version):
+def main(sn_dysfunction_version, sn_version, sn_api_version, sn_cli_version):
+    if sn_dysfunction_version:
+        sn_changelog_entry = get_changelog_entry("sn_dysfunction/CHANGELOG.md", sn_dysfunction_version)
+        insert_changelog_entry(sn_changelog_entry, "__SN_DYSFUNCTION_CHANGELOG_TEXT__")
     if sn_version:
         sn_changelog_entry = get_changelog_entry("sn/CHANGELOG.md", sn_version)
         insert_changelog_entry(sn_changelog_entry, "__SN_CHANGELOG_TEXT__")
@@ -37,16 +40,19 @@ def main(sn_version, sn_api_version, sn_cli_version):
         insert_changelog_entry(sn_cli_changelog_entry, "__SN_CLI_CHANGELOG_TEXT__")
 
 if __name__ == "__main__":
+    sn_dysfunction_version = ""
     sn_version = ""
     sn_api_version = ""
     sn_cli_version = ""
     opts, args = getopt.getopt(
         sys.argv[1:],
         "",
-        ["sn-version=", "sn-api-version=", "sn-cli-version="]
+        ["sn-dysfunction-version=", "sn-version=", "sn-api-version=", "sn-cli-version="]
     )
     for opt, arg in opts:
-        if opt in "--sn-version":
+        if opt in "--sn-dysfunction-version":
+            sn_dysfunction_version = arg
+        elif opt in "--sn-version":
             sn_version = arg
         elif opt in "--sn-api-version":
             sn_api_version = arg

--- a/resources/scripts/output_versioning_info.sh
+++ b/resources/scripts/output_versioning_info.sh
@@ -1,28 +1,33 @@
 #!/usr/bin/env bash
 
 function build_release_name() {
-    gh_release_name="Safe Network v$sn_version/"
-    gh_release_name="${gh_release_name}Safe API v$sn_api_version/"
-    gh_release_name="${gh_release_name}Safe CLI v$sn_cli_version"
+  gh_release_name="Safe Node Dysfunction v$sn_dysfunction_version/"
+  gh_release_name="${gh_release_name}Safe Network v$sn_version/"
+  gh_release_name="${gh_release_name}Safe API v$sn_api_version/"
+  gh_release_name="${gh_release_name}Safe CLI v$sn_cli_version"
 }
 
 function build_release_tag_name() {
-    gh_release_tag_name="$sn_version-"
-    gh_release_tag_name="${gh_release_tag_name}$sn_api_version-"
-    gh_release_tag_name="${gh_release_tag_name}$sn_cli_version"
+  gh_release_tag_name="$sn_dysfunction_version-"
+  gh_release_tag_name="${gh_release_tag_name}$sn_version-"
+  gh_release_tag_name="${gh_release_tag_name}$sn_api_version-"
+  gh_release_tag_name="${gh_release_tag_name}$sn_cli_version"
 }
 
 function output_version_info() {
-    echo "::set-output name=sn_version::$sn_version"
-    echo "::set-output name=sn_api_version::$sn_api_version"
-    echo "::set-output name=sn_cli_version::$sn_cli_version"
-    echo "::set-output name=gh_release_name::$gh_release_name"
-    echo "::set-output name=gh_release_tag_name::$gh_release_tag_name"
+  echo "::set-output name=sn_dysfunction_version::$sn_dysfunction_version"
+  echo "::set-output name=sn_version::$sn_version"
+  echo "::set-output name=sn_api_version::$sn_api_version"
+  echo "::set-output name=sn_cli_version::$sn_cli_version"
+  echo "::set-output name=gh_release_name::$gh_release_name"
+  echo "::set-output name=gh_release_tag_name::$gh_release_tag_name"
 }
 
 gh_release_name=""
 gh_release_tag_name=""
 commit_message=$(git log --oneline --pretty=format:%s | head -n 1)
+sn_dysfunction_version=$( \
+  grep "^version" < sn_dysfunction/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
 sn_version=$(grep "^version" < sn/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
 sn_api_version=$(grep "^version" < sn_api/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
 sn_cli_version=$(grep "^version" < sn_cli/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')

--- a/sn_dysfunction/README.md
+++ b/sn_dysfunction/README.md
@@ -1,0 +1,3 @@
+# Safe Network Dysfunctional Node Detection
+
+This crate provides the `sn_node` binary with mechanisms for detecting dysfunction in the running node.


### PR DESCRIPTION
The release workflow is extended to include the dysfunction crate. Add dysfunction to:

* Version bumping
* Version outputs for release process
* The release changelog
* Publishing as the first crate

A basic README was also added to the dysfunction crate as this seems to be a prerequisite for a
publish.

Got the OK from Josh to merge this one, so I'll go ahead and merge it so I can do the first publish of dysfunction.