### PR TITLE
fix: output version info in sn publish stage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,10 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - shell: bash
+        id: versioning
+        run: |
+          ./resources/scripts/output_versioning_info.sh
       - name: cargo login
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
       - name: cargo publish


### PR DESCRIPTION
This wasn't included previously because the safe_network crate used to be the first crate published and it didn't require other version numbers.
