### PR TITLE
chore: remove test_logger from ae_ tests to get them running

### DIFF
--- a/sn/src/client/client_api/file_apis.rs
+++ b/sn/src/client/client_api/file_apis.rs
@@ -689,7 +689,9 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ae_checks_file_test() -> Result<()> {
-        init_test_logger();
+        // TODO: Fix these tests: why do the test loggers conflict when
+        // only running ae_ tests? (and cause this/register tests to fail...)
+        // init_test_logger();
         let _outer_span = tracing::info_span!("ae_checks_file_test").entered();
         let client = create_test_client_with(None, None, false).await?;
         store_and_read(&client, 10 * 1024 * 1024, Scope::Private).await

--- a/sn/src/client/client_api/register_apis.rs
+++ b/sn/src/client/client_api/register_apis.rs
@@ -783,7 +783,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ae_checks_register_test() -> Result<()> {
-        init_test_logger();
+        // TODO: Fix these tests: why do the test loggers conflict when
+        // only running ae_ tests? (and cause this/file tests to fail...)
+        // init_test_logger();
+
         let _outer_span = tracing::info_span!("ae_checks_register_test").entered();
         let client = create_test_client_with(None, None, false).await?;
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
