### PR TITLE
fix: use correct crate name/path in publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,7 +247,7 @@ jobs:
             # doesn't become available on crates.io immediately, so this script will use a retry
             # loop.
             ./resources/scripts/publish_crate.sh \
-              "safe_network" "${{ steps.versioning.outputs.sn_dysfunction_version }}" "sn_dysfunction"
+              "sn" "${{ steps.versioning.outputs.sn_dysfunction_version }}" "sn_dysfunction"
           fi
 
   publish_sn_api:


### PR DESCRIPTION
This needs to be the directory of the crate in the workspace and not the actual name.
