### PR TITLE
ci: revert nightly release run naming

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -1,4 +1,4 @@
-name: Scheduled Release Run
+name: Nightly Release Run
 
 on:
   schedule:


### PR DESCRIPTION
github ui cant manually trigger actions until they've run,
sor reverting this for now so we can trigger a release to debug
that flow

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
