### PR TITLE
fix: node install command to use correct version

### DIFF
--- a/sn_cli/src/operations/helpers.rs
+++ b/sn_cli/src/operations/helpers.rs
@@ -165,10 +165,12 @@ fn set_exec_perms(file_path: PathBuf) -> Result<()> {
 
 /// Gets the version number from the full version number string.
 ///
-/// The `release_version` input is in the form "0.51.6-0.46.2-0.39.1", which is the safe_network,
-/// sn_api, sn_cli versions, respectively. This function will return the safe_network part.
+/// The `release_version` input is in the form "0.1.1-0.51.6-0.46.2-0.39.1", which is the
+/// sn_dysfunction, safe_network, sn_api, sn_cli versions, respectively. This function will return
+/// the safe_network part.
 fn get_version_from_release_version(release_version: &str) -> Result<String> {
     let mut parts = release_version.split('-');
+    parts.next();
     let version = parts
         .next()
         .ok_or_else(|| {

--- a/sn_cli/tests/cli_node.rs
+++ b/sn_cli/tests/cli_node.rs
@@ -19,7 +19,6 @@ pub(crate) const SN_NODE_BIN_NAME: &str = "sn_node";
 pub(crate) const SN_NODE_BIN_NAME: &str = "sn_node.exe";
 
 #[test]
-#[ignore = "unfortunately this test is subject to rate limiting from the Github API"]
 fn node_install_should_install_the_latest_version() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let safe_dir = temp_dir.child(".safe");

--- a/sn_cmd_test_utilities/src/lib.rs
+++ b/sn_cmd_test_utilities/src/lib.rs
@@ -442,6 +442,7 @@ pub mod util {
 
     fn get_version_from_release_version(release_version: &str) -> Result<String> {
         let mut parts = release_version.split('-');
+        parts.next();
         let version = parts
             .next()
             .ok_or_else(|| {


### PR DESCRIPTION
With the addition on the dysfunction crate, this introduced a new version number into the tag name.
The parsing had to be updated for this.

I've also re-enabled the test that would have caught this. It shouldn't be as much of a problem with
nextest, which has the ability to retry tests. I've seen the rate limited stuff passing ok on
retries. If we see it fail, we can disable it again.
