### PR TITLE
fix: detect changes to safe_network crate

### DIFF
--- a/resources/scripts/bump_version.sh
+++ b/resources/scripts/bump_version.sh
@@ -39,20 +39,25 @@ function determine_which_crates_have_changes() {
     echo "smart-release has determined sn_dysfunction crate has changes"
     sn_dysfunction_has_changes=true
   fi
+
+  has_changes=$(crate_has_changes "safe_network")
   if [[ $has_changes == "true" ]]; then
     echo "smart-release has determined safe_network crate has changes"
     safe_network_has_changes=true
   fi
+
   has_changes=$(crate_has_changes "sn_api")
   if [[ $has_changes == "true" ]]; then
     echo "smart-release has determined sn_api crate has changes"
     sn_api_has_changes=true
   fi
+
   has_changes=$(crate_has_changes "sn_cli")
   if [[ $has_changes == "true" ]]; then
     echo "smart-release has determined sn_cli crate has changes"
     sn_cli_has_changes=true
   fi
+
   if [[ $sn_dysfunction_has_changes == false ]] && \
      [[ $safe_network_has_changes == false ]] && \
      [[ $sn_api_has_changes == false ]] && \


### PR DESCRIPTION
When the release process was updated for the dysfunction crate, the part of the script that detects
which crate has changes wasn't correctly updated.

This meant we weren't detecting changes in the safe_network crate and last night's release commit
didn't have any crates listed in the commit message.
