### PR TITLE
tests: disable node install test

### DIFF
--- a/sn_cli/tests/cli_node.rs
+++ b/sn_cli/tests/cli_node.rs
@@ -19,6 +19,7 @@ pub(crate) const SN_NODE_BIN_NAME: &str = "sn_node";
 pub(crate) const SN_NODE_BIN_NAME: &str = "sn_node.exe";
 
 #[test]
+#[ignore = "this test gets subject to rate limiting even with retries"]
 fn node_install_should_install_the_latest_version() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let safe_dir = temp_dir.child(".safe");


### PR DESCRIPTION
Sadly, this test is subject to rate limiting and sometimes fails, even with retries. It's not worth having the nightly release fail because of this test, so I'm just disabling it again.
