### PR TITLE
tests(back_pressure): add unit tests to verify basic logic

### DIFF
--- a/sn/src/node/core/comm/back_pressure/load_monitoring.rs
+++ b/sn/src/node/core/comm/back_pressure/load_monitoring.rs
@@ -21,11 +21,12 @@ pub(crate) const INITIAL_MSGS_PER_S: f64 = 100.0;
 
 const ONE_MINUTE_AS_SECONDS: u64 = 60;
 
-const SAMPLING_INTERVAL_ONE: Duration = Duration::from_secs(ONE_MINUTE_AS_SECONDS);
-const SAMPLING_INTERVAL_FIVE: Duration = Duration::from_secs(5 * ONE_MINUTE_AS_SECONDS);
-const SAMPLING_INTERVAL_FIFTEEN: Duration = Duration::from_secs(15 * ONE_MINUTE_AS_SECONDS);
+pub(crate) const SAMPLING_INTERVAL_ONE: Duration = Duration::from_secs(ONE_MINUTE_AS_SECONDS);
+pub(crate) const SAMPLING_INTERVAL_FIVE: Duration = Duration::from_secs(5 * ONE_MINUTE_AS_SECONDS);
+pub(crate) const SAMPLING_INTERVAL_FIFTEEN: Duration =
+    Duration::from_secs(15 * ONE_MINUTE_AS_SECONDS);
 
-const INITIAL_MSGS_PER_MINUTE: f64 = ONE_MINUTE_AS_SECONDS as f64 * INITIAL_MSGS_PER_S; // unit: msgs per minute
+pub(crate) const INITIAL_MSGS_PER_MINUTE: f64 = ONE_MINUTE_AS_SECONDS as f64 * INITIAL_MSGS_PER_S; // unit: msgs per minute
 const MAX_CPU_LOAD: f64 = 0.8; // unit: percent
 const DEFAULT_LOAD_PER_MSG: f64 = MAX_CPU_LOAD / INITIAL_MSGS_PER_S; // unit: percent-seconds per msg
 
@@ -35,10 +36,10 @@ const ORDER: Ordering = Ordering::SeqCst;
 
 #[derive(Clone)]
 pub(crate) struct LoadMonitoring {
-    system: Arc<RwLock<System>>,
-    load_sample: Arc<RwLock<LoadAvg>>,
-    msg_samples: BTreeMap<Duration, MsgCount>,
-    msgs_per_s: BTreeMap<Duration, Arc<RwLock<f64>>>,
+    pub(crate) system: Arc<RwLock<System>>,
+    pub(crate) load_sample: Arc<RwLock<LoadAvg>>,
+    pub(crate) msg_samples: BTreeMap<Duration, MsgCount>,
+    pub(crate) msgs_per_s: BTreeMap<Duration, Arc<RwLock<f64>>>,
 }
 
 /// We have background tasks which update values at specific intervals,
@@ -185,7 +186,7 @@ fn normalize(load: LoadAvg) -> LoadAvg {
 }
 
 #[derive(Clone)]
-struct MsgCount {
+pub(crate) struct MsgCount {
     running: Arc<AtomicUsize>,
     snapshot: Arc<AtomicUsize>,
 }

--- a/sn/src/node/core/comm/back_pressure/mod.rs
+++ b/sn/src/node/core/comm/back_pressure/mod.rs
@@ -163,3 +163,188 @@ impl BackPressure {
         *self.last_eviction.write().await = now;
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::network_knowledge::test_utils::gen_addr;
+    use eyre::Result;
+    use load_monitoring::{
+        MsgCount, INITIAL_MSGS_PER_MINUTE, SAMPLING_INTERVAL_FIFTEEN, SAMPLING_INTERVAL_FIVE,
+        SAMPLING_INTERVAL_ONE,
+    };
+    use sysinfo::{LoadAvg, RefreshKind, System, SystemExt};
+    use tokio::{sync::RwLock, time::Instant};
+    use xor_name;
+
+    #[tokio::test]
+    // Do not trigger tolerated_msgs_per_s() if called by the same peer within the MIN_REPORT_INTERVAL
+    async fn report_intervals() -> Result<()> {
+        let back_pressure = setup_backpressure();
+        let peer = Peer::new(xor_name::rand::random(), gen_addr());
+        let _ = back_pressure
+            .our_reports
+            .write()
+            .await
+            .insert(peer, (Instant::now(), 20 as f64));
+        assert_eq!(None, back_pressure.tolerated_msgs_per_s(&peer).await);
+
+        // after MIN_REPORT_INTERVAL
+        let _ = back_pressure
+            .our_reports
+            .write()
+            .await
+            .insert(peer, (Instant::now() - MIN_REPORT_INTERVAL, 20 as f64));
+        assert_eq!(
+            Some(SANITY_MAX_PER_S_AND_PEER),
+            back_pressure.tolerated_msgs_per_s(&peer).await
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    // Remove entries from our_reports if it's last_seen > REPORT_TTL
+    async fn evict_old_reports() -> Result<()> {
+        let mut back_pressure = setup_backpressure();
+        let peer1 = Peer::new(xor_name::rand::random(), gen_addr());
+        let peer2 = Peer::new(xor_name::rand::random(), gen_addr());
+
+        let mut our_reports: OutgoingReports = OutgoingReports::new();
+        let _ = our_reports.insert(peer1, (Instant::now(), 10 as f64));
+
+        // last_seen > REPORT_TTL; peer2 will be evicted
+        let _ = our_reports.insert(peer2, (Instant::now() - REPORT_TTL, 30 as f64));
+        back_pressure.our_reports = Arc::new(RwLock::new(our_reports));
+        back_pressure.evict_expired(Instant::now()).await;
+
+        assert_ne!(None, back_pressure.our_reports.read().await.get(&peer1));
+        assert_eq!(None, back_pressure.our_reports.read().await.get(&peer2));
+        Ok(())
+    }
+
+    #[tokio::test]
+    // If new peer, just add it to our_reports but don't update sender (return None)
+    async fn new_peer_with_insignificant_change() -> Result<()> {
+        let backpressure = setup_backpressure();
+        let peer = Peer::new(xor_name::rand::random(), gen_addr());
+        let now = Instant::now();
+        let msgs_per_s = backpressure.try_get_new_value(&peer, now).await;
+
+        assert_eq!(None, msgs_per_s);
+        assert_eq!(
+            Some((now, SANITY_MAX_PER_S_AND_PEER)),
+            backpressure.our_reports.read().await.get(&peer).copied()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    // record_change = true, update_sender = true.
+    async fn old_peer_with_significant_change() -> Result<()> {
+        let backpressure = setup_backpressure();
+        let peer = Peer::new(xor_name::rand::random(), gen_addr());
+        let now = Instant::now();
+
+        // change_ratio <= 0.95
+        let _ = backpressure
+            .our_reports
+            .write()
+            .await
+            .insert(peer, (now, 110 as f64));
+        let msgs_per_s = backpressure.try_get_new_value(&peer, now).await;
+        assert_eq!(Some(SANITY_MAX_PER_S_AND_PEER), msgs_per_s);
+        assert_eq!(
+            Some((now, SANITY_MAX_PER_S_AND_PEER)),
+            backpressure.our_reports.read().await.get(&peer).copied()
+        );
+
+        // change_ratio >= 1.1
+        let _ = backpressure
+            .our_reports
+            .write()
+            .await
+            .insert(peer, (now, 85 as f64));
+        let msgs_per_s = backpressure.try_get_new_value(&peer, now).await;
+        assert_eq!(Some(SANITY_MAX_PER_S_AND_PEER), msgs_per_s);
+        assert_eq!(
+            Some((now, SANITY_MAX_PER_S_AND_PEER)),
+            backpressure.our_reports.read().await.get(&peer).copied()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    // record_change = false, update_sender = false.
+    async fn old_peer_with_insignificant_change() -> Result<()> {
+        let backpressure = setup_backpressure();
+        let peer = Peer::new(xor_name::rand::random(), gen_addr());
+        let now = Instant::now();
+
+        // !(change_ratio <= 0.95)
+        let report = (now, 105 as f64);
+        let _ = backpressure.our_reports.write().await.insert(peer, report);
+        let msgs_per_s = backpressure.try_get_new_value(&peer, now).await;
+        assert_eq!(None, msgs_per_s);
+        assert_eq!(
+            Some(report),
+            backpressure.our_reports.read().await.get(&peer).copied()
+        );
+
+        // !(change_ratio >= 1.1)
+        let report = (now, 95 as f64);
+        let _ = backpressure.our_reports.write().await.insert(peer, report);
+        let msgs_per_s = backpressure.try_get_new_value(&peer, now).await;
+        assert_eq!(None, msgs_per_s);
+        assert_eq!(
+            Some(report),
+            backpressure.our_reports.read().await.get(&peer).copied()
+        );
+
+        Ok(())
+    }
+
+    fn setup_backpressure() -> BackPressure {
+        let mut system = System::new_with_specifics(RefreshKind::new());
+        system.refresh_cpu();
+
+        let mut msg_samples = BTreeMap::new();
+        let _ = msg_samples.insert(SAMPLING_INTERVAL_ONE, MsgCount::new());
+        let _ = msg_samples.insert(SAMPLING_INTERVAL_FIVE, MsgCount::new());
+        let _ = msg_samples.insert(SAMPLING_INTERVAL_FIFTEEN, MsgCount::new());
+
+        let mut msgs_per_s = BTreeMap::new();
+        let _ = msgs_per_s.insert(
+            SAMPLING_INTERVAL_ONE,
+            Arc::new(RwLock::new(INITIAL_MSGS_PER_MINUTE)),
+        );
+        let _ = msgs_per_s.insert(
+            SAMPLING_INTERVAL_FIVE,
+            Arc::new(RwLock::new(5.0 * INITIAL_MSGS_PER_MINUTE)),
+        );
+        let _ = msgs_per_s.insert(
+            SAMPLING_INTERVAL_FIFTEEN,
+            Arc::new(RwLock::new(15.0 * INITIAL_MSGS_PER_MINUTE)),
+        );
+
+        let load_avg = LoadAvg {
+            one: 10 as f64,
+            five: 10 as f64,
+            fifteen: 10 as f64,
+        };
+        let load_sample = Arc::new(RwLock::new(load_avg));
+
+        let monitoring = LoadMonitoring {
+            system: Arc::new(RwLock::new(system)),
+            load_sample,
+            msg_samples,
+            msgs_per_s,
+        };
+
+        BackPressure {
+            monitoring,
+            our_reports: Arc::new(RwLock::new(OutgoingReports::new())),
+            last_eviction: Arc::new(RwLock::new(Instant::now())),
+        }
+    }
+}


### PR DESCRIPTION
Unit tests for back_pressure module.

- `report_intervals()`: test to make sure `tolerated_msgs_per_s()` is not spammed.
- `evict_old_reports()`: tests if old entries are removed from `our_reports`.
- `new_peer_with_insignificant_change()`: tests if new peer is added to `our_reports` without sending any backpressure message to it.
- `old_peer_with_significant_change()`: tests if `our_report` is updated and backpressure message is sent to the peer if its backpressure value has changed significantly.
- `old_peer_with_insignificant_change()`: test to make sure nothing happens when the backpressure value is not changed significantly for a peer.