### PR TITLE
feat(api): first and basic implementation of Wallet reissue API and related CLI cmds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,9 +191,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47594e438a243791dba58124b6669561f5baa14cb12046641d8008bf035e5a25"
+checksum = "f523b4e98ba6897ae90994bc18423d9877c54f9047b06a00ddc8122a957b1c70"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a671c9ae99531afdd5d3ee8340b8da547779430689947144c140fc74a740244"
+checksum = "d3ddbd16eabff8b45f21b98671fddcc93daaa7ac4c84f8473693437226040de5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -262,15 +262,15 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.4.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -1303,7 +1303,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
  "libc",
- "miniz_oxide 0.5.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1995,9 +1995,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.123"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "linked-hash-map"
@@ -2125,16 +2125,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2353,9 +2343,9 @@ checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "memchr",
 ]
@@ -2471,6 +2461,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pbkdf2"
@@ -3185,19 +3181,20 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
+checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
 dependencies = [
  "byteorder",
  "num-traits",
+ "paste",
 ]
 
 [[package]]
 name = "rmp-serde"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3eedffbfcc6a428f230c04baf8f59bd73c1781361e4286111fe900849aaddaf"
+checksum = "25786b0d276110195fa3d6f3f31299900cf71dfbd6c28450f3f58a0e7f7a347e"
 dependencies = [
  "byteorder",
  "rmp",
@@ -3750,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "sn_dbc"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8918feff87846610e12ba27f439ea2cd894ceb25ac1b8f4eadca963cb4f46021"
+checksum = "318c5547001c54950de81627a28195f36eee334f9eb38c3c904aab48f73d57ea"
 dependencies = [
  "bls_ringct",
  "blsttc 5.2.0",

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -47,14 +47,14 @@ xor_name = "4.0.1"
 
   [dependencies.bls]
   package = "blsttc"
-  version = "3.1.0"
+  version = "3.4.0"
 
   [dependencies.bytes]
   version = "1.0.1"
   features = [ "serde" ]
 
   [dependencies.sn_dbc]
-  version = "3.0.0"
+  version = "3.1.0"
   features = [ "serdes" ]
 
   [dependencies.ed25519-dalek]

--- a/sn_api/src/app/helpers.rs
+++ b/sn_api/src/app/helpers.rs
@@ -44,9 +44,9 @@ pub fn parse_tokens_amount(amount_str: &str) -> Result<Token> {
                 Error::InvalidAmount(format!("Invalid tokens amount '{}', the minimum possible amount is one nano token (0.000000001)", amount_str))
             }
             SafeNdError::FailedToParse(msg) => {
-                Error::InvalidAmount(format!("Invalid tokens amount '{}' ({})", amount_str, msg))
+                Error::InvalidAmount(format!("Invalid tokens amount '{}': {}", amount_str, msg))
             },
-            _ => Error::InvalidAmount(format!("Invalid tokens amount '{}'", amount_str)),
+            other_err => Error::InvalidAmount(format!("Invalid tokens amount '{}': {:?}", amount_str, other_err)),
         }
     })
 }

--- a/sn_api/src/errors.rs
+++ b/sn_api/src/errors.rs
@@ -10,6 +10,7 @@ use super::ipc::IpcError;
 use super::nrs::NrsMap;
 use super::safeurl::{Error as UrlError, SafeUrl, XorUrl};
 use sn_client::Error as ClientError;
+use sn_dbc::Error as DbcError;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -92,8 +93,8 @@ pub enum Error {
     /// InvalidMediaType
     #[error("InvalidMediaType: {0}")]
     InvalidMediaType(String),
-    /// NotEnoughBalance
-    #[error("NotEnoughBalance: {0}")]
+    /// Not enough balance to perform a transaction
+    #[error("Not enough balance: {0}")]
     NotEnoughBalance(String),
     /// NrsNameAlreadyExists
     #[error("NrsNameAlreadyExists: {0}")]
@@ -107,12 +108,18 @@ pub enum Error {
     /// UrlError
     #[error("UrlError: {0}")]
     UrlError(#[from] UrlError),
+    /// DbcError
+    #[error("DbcError: {0}")]
+    DbcError(#[from] DbcError),
     /// UnversionedContentError
     #[error("UnversionedContentError: {0}")]
     UnversionedContentError(String),
     /// Content may have been correctly stored on the network, but verification failed
     #[error("Content may have been correctly stored on the network, but verification failed: {0}")]
     ContentUploadVerificationFailed(XorUrl),
+    /// DbcReissueError
+    #[error("DbcReissueError: {0}")]
+    DbcReissueError(String),
     /// NotImplementedError
     #[error("NotImplementedError: {0}")]
     NotImplementedError(String),

--- a/sn_cli/src/subcommands/dog.rs
+++ b/sn_cli/src/subcommands/dog.rs
@@ -132,7 +132,9 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
                 }
                 SafeData::Multimap { .. }
                 | SafeData::PrivateRegister { .. }
-                | SafeData::PublicRegister { .. } => unimplemented!(),
+                | SafeData::PublicRegister { .. } => {
+                    println!("Type of content not supported yet by 'dog' command.")
+                }
             }
         }
         println!();

--- a/sn_cli/tests/cli_wallet.rs
+++ b/sn_cli/tests/cli_wallet.rs
@@ -104,14 +104,6 @@ fn calling_safe_wallet_reissue() -> Result<()> {
     ))
     .success();
 
-    safe_cmd(["wallet", "balance", &wallet_xorurl], Some(0))?
-        .assert()
-        .stdout(format!(
-            "Wallet at \"{}\" has a total balance of 5.080000000 safecoins\n",
-            wallet_xorurl
-        ))
-        .success();
-
     Ok(())
 }
 
@@ -156,6 +148,8 @@ fn calling_safe_wallet_deposit_reissued() -> Result<()> {
         Some(0),
     )?;
 
+    // Let's check the balance to make sure the deposited DBC was being
+    // serialised (by the reissue cmd) and deserialised (by the deposit cmd) correctly
     safe_cmd(["wallet", "balance", &wallet_xorurl], Some(0))?
         .assert()
         .stdout(format!(


### PR DESCRIPTION
This is a follow up PR (2nd PR) to PR #1097 , introducing first and basic implementation of Wallet reissue API and CLI cmd.
- Reissue an output DBC from a Wallet (using [sn_dbc::TransactionBuilder](https://github.com/maidsafe/sn_dbc/blob/d275810f33376acc34cf7fd3f8045f585b264791/src/builder.rs#L36)) for a provided amount
- Reissue the change DBC which is automatically stored in the source Wallet the reissue was made from
- Spent DBCs are automatically soft-removed from the source Wallet (Multimap)
- Reissued DBCs are all bearer at this instance

The CLI `wallet reissue` and `wallet deposit` commands are currently compatible with the DBC's generated and printed out by the [mint-repl](https://github.com/maidsafe/sn_dbc#mint-repl-example) and [DBC Playground](https://github.com/maidsafe/sn_dbc_examples) output, once a DBC is generated by those example apps, it can be deposited in a Wallet and check its balance, e.g. the following commands deposit the genesis DBC into a Wallet on Safe, check its total balance, and reissue a DBC from the Wallet for 3.77 safecoins:
```
$ safe wallet create
Wallet created at: "safe://hyryynyen8rzu4umhifw6j7chbr5wthr1osfb3qcc78n1498zrpd8wsm4y5my84y"

$ safe wallet balance safe://hyryynyen8rzu4umhifw6j7chbr5wthr1osfb3qcc78n1498zrpd8wsm4y5my84y
Wallet at "safe://hyryynyen8rzu4umhifw6j7chbr5wthr1osfb3qcc78n1498zrpd8wsm4y5my84y" has a total balance of 0.000000000 safecoins

$ safe wallet deposit --name my-first-dbc safe://hyryynyen8rzu4umhifw6j7chbr5wthr1osfb3qcc78n1498zrpd8wsm4y5my84y c4a1953dfa419234b8ab9a...
Spendable DBC deposited with name 'my-first-dbc' in Wallet located at "safe://hyryynyen8rzu4umhifw6j7chbr5wthr1osfb3qcc78n1498zrpd8wsm4y5my84y"

$ safe wallet balance safe://hyryynyen8rzu4umhifw6j7chbr5wthr1osfb3qcc78n1498zrpd8wsm4y5my84y
Wallet at "safe://hyryynyen8rzu4umhifw6j7chbr5wthr1osfb3qcc78n1498zrpd8wsm4y5my84y" has a total balance of 18446744073.709551615 safecoins

$ safe wallet reissue 3.77 --from safe://hyryynyen8rzu4umhifw6j7chbr5wthr1osfb3qcc78n1498zrpd8wsm4y5my84y
Success. Reissued DBC with 3.77 safecoins:
-------- DBC DATA --------
0000000000000000d3dfd5b56aeea1b906c82.......bb11e30f382dda25700000000
--------------------------

$ safe wallet balance safe://hyryynyen8rzu4umhifw6j7chbr5wthr1osfb3qcc78n1498zrpd8wsm4y5my84y
Wallet at "safe://hyryynyen8rzu4umhifw6j7chbr5wthr1osfb3qcc78n1498zrpd8wsm4y5my84y" has a total balance of 18446744069.939551615 safecoins
```

As next steps to work on in separate PRs:
- Verification of generated Tx and spentproofs upon reissuing DBCs (depends on spentbook implementation and messaging to be available)
- Log input DBCs as spent on the network's spentbook upon reissuing DBCs (depends on spentbook implementation and messaging to be available)
- Verification of spentproofs upon depositing DBCs in Wallets (depends on spentbook implementation and messaging to be available)
- Use of input decoys in the transactions upon reissuing DBCs
- Support for non-bearer DBCs
- Review how exactly we want to serialise and store the Wallets, currently using Private Register+Chunks
- The sn-api unit tests can be improved if test DBCs can be generated with different amounts. Generate test DBCs from an amount and SK instead of deserialising a hard-coded serialised DBC. Hard-coded serialised DBCs are currently generated with sn_dbc mint-repl example.