### PR TITLE
fix: node install command to use correct version

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -97,6 +97,13 @@ To do so, follow these steps:
   dependent crate has been published on crates.io. Make sure you update your newly added job to
   reference the correct dependent crate. No changes should be required for the publishing script
   itself.
+* Update the `node install` command to select the correct version number for `sn_node`. Since the GH
+  release tag name has the versions of all the crates in it, the correct version number has to be
+  selected during the command. Update these:
+    - Update `get_version_from_release_version` `sn_cli/src/operations/helpers.rs` to select the
+      correct version number.
+    - Update `get_version_from_release_version` `sn_cmd_test_utilities/src/lib.rs` to select the
+      correct version number.
 
 Unfortunately it's quite hard to test the changes without actually running the release process, so
 it will probably take a few commits and release cycles before it works properly.

--- a/sn_cli/src/operations/helpers.rs
+++ b/sn_cli/src/operations/helpers.rs
@@ -165,11 +165,12 @@ fn set_exec_perms(file_path: PathBuf) -> Result<()> {
 
 /// Gets the version number from the full version number string.
 ///
-/// The `release_version` input is in the form "0.1.1-0.51.6-0.46.2-0.39.1", which is the
-/// sn_dysfunction, safe_network, sn_api, sn_cli versions, respectively. This function will return
-/// the safe_network part.
+/// The `release_version` input is in the form "0.1.0-0.1.1-0.51.6-0.46.2-0.39.1", which is the
+/// sn_dysfunction, sn_interface, safe_network, sn_api, sn_cli versions, respectively. This
+/// function will return the safe_network part.
 fn get_version_from_release_version(release_version: &str) -> Result<String> {
     let mut parts = release_version.split('-');
+    parts.next();
     parts.next();
     let version = parts
         .next()

--- a/sn_cli/tests/cli_node.rs
+++ b/sn_cli/tests/cli_node.rs
@@ -19,7 +19,7 @@ pub(crate) const SN_NODE_BIN_NAME: &str = "sn_node";
 pub(crate) const SN_NODE_BIN_NAME: &str = "sn_node.exe";
 
 #[test]
-#[ignore = "this test gets subject to rate limiting even with retries"]
+#[ignore = "this test gets subject to rate limiting so even with retries it's susceptible to failure"]
 fn node_install_should_install_the_latest_version() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let safe_dir = temp_dir.child(".safe");

--- a/sn_cmd_test_utilities/src/lib.rs
+++ b/sn_cmd_test_utilities/src/lib.rs
@@ -443,6 +443,7 @@ pub mod util {
     fn get_version_from_release_version(release_version: &str) -> Result<String> {
         let mut parts = release_version.split('-');
         parts.next();
+        parts.next();
         let version = parts
             .next()
             .ok_or_else(|| {


### PR DESCRIPTION
When we added the new `sn_interface` crate, we forgot to update these functions for selecting the
version number of sn_node. This would have been caught by our test for this command, but
unfortunately that test can't run because it's subject to random failures due to rate limiting from
the Github API.

The README for the release process is also updated to include this as a step.
