### PR TITLE
ci: droplet run now uses sn_client instead of safe_network package fo…

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -211,7 +211,7 @@ jobs:
           test-run-name: nightly-e2e-client-${{ matrix.os }}
           profile: ci
           junit-path: junit.xml
-          package: safe_network
+          package: sn_client
           release: true
           features: test-utils
           filters: client


### PR DESCRIPTION
…r client tests

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
