### PR TITLE
Back pressure debug

### DIFF
--- a/sn_interface/src/types/log_markers.rs
+++ b/sn_interface/src/types/log_markers.rs
@@ -26,7 +26,7 @@ pub enum LogMarker {
     ProposalAgreed,
     // Handover
     HandoverConsensusTrigger,
-    HandoverMsgToBeHandled,
+    HandoverMsgBeingHandled,
     HandoverConsensusTermination,
     // Malice
     DeviantsDetected,

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -19,7 +19,7 @@ name = "routing_stress"
 required-features = ["test-utils"]
 
 [features]
-default = ["back-pressure"]
+default = []
 chaos = []
 back-pressure = ["sn_interface/back-pressure"]
 unstable-wiremsg-debuginfo = []

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -19,7 +19,7 @@ name = "routing_stress"
 required-features = ["test-utils"]
 
 [features]
-default = []
+default = ["back-pressure"]
 chaos = []
 back-pressure = ["sn_interface/back-pressure"]
 unstable-wiremsg-debuginfo = []

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -268,6 +268,13 @@ impl NodeApi {
             .clone()
             .check_for_dysfunction_periodically()
             .await;
+
+        #[cfg(feature = "back-pressure")]
+        dispatcher
+            .clone()
+            .report_backpressure_to_our_section_periodically()
+            .await;
+
         dispatcher.clone().start_cleaning_peer_links().await;
         dispatcher.clone().write_prefixmap_to_disk().await;
 

--- a/sn_node/src/node/core/comm/back_pressure/mod.rs
+++ b/sn_node/src/node/core/comm/back_pressure/mod.rs
@@ -8,35 +8,27 @@
 
 mod load_monitoring;
 
-use sn_interface::types::Peer;
-
 use self::load_monitoring::{LoadMonitoring, INITIAL_MSGS_PER_S};
 
-use itertools::Itertools;
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::sync::Arc;
 use tokio::{sync::RwLock, time::Instant};
-
-const MIN_REPORT_INTERVAL: Duration = Duration::from_secs(60);
-const REPORT_TTL: Duration = Duration::from_secs(300); // 5 minutes
 
 const SANITY_MAX_PER_S_AND_PEER: f64 = INITIAL_MSGS_PER_S;
 const SANITY_MIN_PER_S_AND_PEER: f64 = 1.0; // 1 every s
 
-type OutgoingReports = BTreeMap<Peer, (Instant, f64)>;
+type OutgoingReport = (Instant, f64);
 
 #[derive(Clone)]
 pub(crate) struct BackPressure {
     monitoring: LoadMonitoring,
-    our_reports: Arc<RwLock<OutgoingReports>>,
-    last_eviction: Arc<RwLock<Instant>>,
+    last_report: Arc<RwLock<Option<OutgoingReport>>>,
 }
 
 impl BackPressure {
     pub(crate) fn new() -> Self {
         Self {
             monitoring: LoadMonitoring::new(),
-            our_reports: Arc::new(RwLock::new(OutgoingReports::new())),
-            last_eviction: Arc::new(RwLock::new(Instant::now())),
+            last_report: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -45,36 +37,15 @@ impl BackPressure {
     }
 
     /// Sent to nodes calling us, if the value has changed significantly.
-    pub(crate) async fn tolerated_msgs_per_s(&self, caller: &Peer) -> Option<f64> {
+    pub(crate) async fn tolerated_msgs_per_s(&self, sessions_count: usize) -> Option<f64> {
         let now = Instant::now();
-        let sent = { self.our_reports.read().await.get(caller).copied() };
-        let tolerated_msgs_per_s = match sent {
-            Some((then, _)) => {
-                // do not refresh too often
-                if now > then && now - then > MIN_REPORT_INTERVAL {
-                    self.try_get_new_value(caller, now).await
-                } else {
-                    return None; // send None if too short time has elapsed
-                }
-            }
-            None => self.try_get_new_value(caller, now).await,
-        };
-
+        let tolerated_msgs_per_s = self.try_get_new_value(sessions_count, now).await;
         tolerated_msgs_per_s
     }
 
-    async fn try_get_new_value(&self, caller: &Peer, now: Instant) -> Option<f64> {
-        // first, try evict expired (placed in this block, we reduce the frequency of this check)
-        let last_eviction = { *self.last_eviction.read().await };
-        // only try evict when there's any likelihood of there being any expired..
-        if now > last_eviction && now - last_eviction > REPORT_TTL {
-            self.evict_expired(now).await;
-        }
-
-        // then measure stuff
-
+    async fn try_get_new_value(&self, sessions_count: usize, now: Instant) -> Option<f64> {
         let msgs_per_s = 10.0 * self.monitoring.msgs_per_s().await;
-        let num_callers = { self.our_reports.read().await.len() as f64 };
+        let num_callers = sessions_count as f64;
 
         // avoid divide by 0 errors
         let msgs_per_s_and_peer = msgs_per_s / f64::max(1.0, num_callers);
@@ -88,7 +59,7 @@ impl BackPressure {
         debug!("Number of callers {:?}", num_callers);
         debug!("Msgs per s and peer {:?}", msgs_per_s_and_peer);
 
-        let prev = self.our_reports.read().await.get(caller).copied();
+        let prev = *self.last_report.read().await;
 
         // bound update rates by require some minimum level of change
         let significant_change = |change_ratio| {
@@ -96,7 +67,7 @@ impl BackPressure {
             0.95 >= change_ratio || change_ratio >= 1.1 || change_ratio == 0.0
         };
 
-        let (record_changes, update_sender) = if let Some((_, previous)) = prev {
+        let (record_changes, worthwhile_reporting) = if let Some((_, previous)) = prev {
             let change_ratio = msgs_per_s_and_peer / previous;
             if significant_change(change_ratio) {
                 // we want to store the value, and update the node
@@ -125,41 +96,14 @@ impl BackPressure {
         };
 
         if record_changes {
-            let _ = self
-                .our_reports
-                .write()
-                .await
-                .insert(*caller, (now, msgs_per_s_and_peer));
+            debug!("Recording changes");
+            *self.last_report.write().await = Some((now, msgs_per_s_and_peer));
         }
 
-        if update_sender {
+        if worthwhile_reporting {
             Some(msgs_per_s_and_peer)
         } else {
             None
         }
-    }
-
-    async fn evict_expired(&self, now: Instant) {
-        let expired = {
-            self.our_reports
-                .read()
-                .await
-                .iter()
-                .filter_map(|(key, (last_seen, _))| {
-                    let last_seen = *last_seen;
-                    if now > last_seen && now - last_seen > REPORT_TTL {
-                        Some(*key)
-                    } else {
-                        None
-                    }
-                })
-                .collect_vec()
-        };
-
-        for id in expired {
-            let _prev = self.our_reports.write().await.remove(&id);
-        }
-
-        *self.last_eviction.write().await = now;
     }
 }

--- a/sn_node/src/node/core/comm/mod.rs
+++ b/sn_node/src/node/core/comm/mod.rs
@@ -146,8 +146,9 @@ impl Comm {
 
     #[cfg(feature = "back-pressure")]
     /// Returns our caller-specific tolerated msgs per s, if the value has changed significantly.
-    pub(crate) async fn tolerated_msgs_per_s(&self, caller: &Peer) -> Option<f64> {
-        self.back_pressure.tolerated_msgs_per_s(caller).await
+    pub(crate) async fn tolerated_msgs_per_s(&self) -> Option<f64> {
+        let sessions = self.sessions.read().await.len();
+        self.back_pressure.tolerated_msgs_per_s(sessions).await
     }
 
     #[cfg(feature = "back-pressure")]

--- a/sn_node/src/node/core/dbc_spentbook.rs
+++ b/sn_node/src/node/core/dbc_spentbook.rs
@@ -1,0 +1,201 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{delivery_group, Comm, Node};
+
+use crate::node::{
+    api::cmds::Cmd,
+    error::{Error, Result},
+    Event,
+};
+use crate::UsedSpace;
+use sn_interface::messaging::WireMsg;
+use sn_interface::network_knowledge::{
+    NetworkKnowledge, NodeInfo, SectionAuthorityProvider, SectionKeyShare,
+};
+use sn_interface::types::log_markers::LogMarker;
+
+use secured_linked_list::SecuredLinkedList;
+use std::{collections::BTreeSet, net::SocketAddr, path::PathBuf};
+use tokio::sync::mpsc;
+use xor_name::XorName;
+
+impl Node {
+    // Creates `Core` for the first node in the network
+    pub(crate) async fn first_node(
+        comm: Comm,
+        mut node: NodeInfo,
+        event_tx: mpsc::Sender<Event>,
+        used_space: UsedSpace,
+        root_storage_dir: PathBuf,
+        genesis_sk_set: bls::SecretKeySet,
+    ) -> Result<Self> {
+        // make sure the Node has the correct local addr as Comm
+        node.addr = comm.our_connection_info();
+
+        let (section, section_key_share) =
+            NetworkKnowledge::first_node(node.peer(), genesis_sk_set).await?;
+        Self::new(
+            comm,
+            node,
+            section,
+            Some(section_key_share),
+            event_tx,
+            used_space,
+            root_storage_dir,
+        )
+        .await
+    }
+
+    pub(crate) async fn relocate(
+        &self,
+        mut new_node: NodeInfo,
+        new_section: NetworkKnowledge,
+    ) -> Result<()> {
+        // we first try to relocate section info.
+        self.network_knowledge.relocated_to(new_section).await?;
+
+        // make sure the new Node has the correct local addr as Comm
+        new_node.addr = self.comm.our_connection_info();
+
+        let mut our_node = self.info.write().await;
+        *our_node = new_node;
+
+        Ok(())
+    }
+
+    pub(crate) fn network_knowledge(&self) -> &NetworkKnowledge {
+        &self.network_knowledge
+    }
+
+    pub(crate) async fn section_chain(&self) -> SecuredLinkedList {
+        self.network_knowledge.section_chain().await
+    }
+
+    /// Is this node an elder?
+    pub(crate) async fn is_elder(&self) -> bool {
+        self.network_knowledge
+            .is_elder(&self.info.read().await.name())
+            .await
+    }
+
+    pub(crate) async fn is_not_elder(&self) -> bool {
+        !self.is_elder().await
+    }
+
+    /// Returns connection info of this node.
+    pub(crate) fn our_connection_info(&self) -> SocketAddr {
+        self.comm.our_connection_info()
+    }
+
+    /// Returns the current BLS public key set
+    pub(crate) async fn public_key_set(&self) -> Result<bls::PublicKeySet> {
+        Ok(self.key_share().await?.public_key_set)
+    }
+
+    /// Returns the SAP of the section matching the name.
+    pub(crate) async fn matching_section(
+        &self,
+        name: &XorName,
+    ) -> Result<SectionAuthorityProvider> {
+        self.network_knowledge
+            .section_by_name(name)
+            .map_err(Error::from)
+    }
+
+    /// Returns our key share in the current BLS group if this node is a member of one, or
+    /// `Error::MissingSecretKeyShare` otherwise.
+    pub(crate) async fn key_share(&self) -> Result<SectionKeyShare> {
+        let section_key = self.network_knowledge.section_key().await;
+        self.section_keys_provider
+            .key_share(&section_key)
+            .await
+            .map_err(Error::from)
+    }
+
+    pub(crate) async fn send_event(&self, event: Event) {
+        // Note: cloning the sender to avoid mutable access. Should have negligible cost.
+        if self.event_tx.clone().send(event).await.is_err() {
+            error!("Event receiver has been closed");
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------
+    //   ---------------------------------- Mut ------------------------------------------
+    // ----------------------------------------------------------------------------------------
+
+    pub(crate) async fn handle_timeout(&self, token: u64) -> Result<Vec<Cmd>> {
+        self.dkg_voter.handle_timeout(
+            &self.info.read().await.clone(),
+            token,
+            self.network_knowledge().section_key().await,
+        )
+    }
+
+    // Send message to peers on the network.
+    pub(crate) async fn send_msg_to_nodes(&self, mut wire_msg: WireMsg) -> Result<Option<Cmd>> {
+        let dst_location = wire_msg.dst_location();
+        let (targets, dg_size) = delivery_group::delivery_targets(
+            dst_location,
+            &self.info.read().await.name(),
+            &self.network_knowledge,
+        )
+        .await?;
+
+        let target_name = dst_location.name();
+
+        // To avoid loop: if destination is to Node, targets are multiple, self is an elder,
+        //     self section prefix matches the destination name, then don't carry out a relay.
+        if self.is_elder().await
+            && targets.len() > 1
+            && dst_location.is_to_node()
+            && self.network_knowledge.prefix().await.matches(&target_name)
+        {
+            // This actually means being an elder, but we don't know the member yet. Which most likely
+            // happens during the join process that a node's name is changed.
+            // we just drop the message
+            return Ok(None);
+        }
+
+        trace!(
+            "relay {:?} to first {:?} of {:?} (Section PK: {:?})",
+            wire_msg,
+            dg_size,
+            targets,
+            wire_msg.src_section_pk(),
+        );
+
+        let dst_pk = self.section_key_by_name(&target_name).await;
+        wire_msg.set_dst_section_pk(dst_pk);
+
+        let cmd = Cmd::SendMsgDeliveryGroup {
+            recipients: targets.into_iter().collect(),
+            delivery_group_size: dg_size,
+            wire_msg,
+        };
+
+        Ok(Some(cmd))
+    }
+
+    // Generate a new section info based on the current set of members, but
+    // excluding the ones in the provided list. And if the outcome list of candidates
+    // differs from the current elders, trigger a DKG.
+    pub(crate) async fn promote_and_demote_elders_except(
+        &self,
+        excluded_names: &BTreeSet<XorName>,
+    ) -> Result<Vec<Cmd>> {
+        debug!("{}", LogMarker::TriggeringPromotionAndDemotion);
+        let mut cmds = vec![];
+        // TODO: move `promote_and_demote_elders` to Membership
+        for session_id in self.promote_and_demote_elders(excluded_names).await {
+            cmds.extend(self.send_dkg_start(session_id).await?);
+        }
+
+        Ok(cmds)
+    }
+}

--- a/sn_node/src/node/core/messaging/handling/handover.rs
+++ b/sn_node/src/node/core/messaging/handling/handover.rs
@@ -89,11 +89,7 @@ impl Node {
         &self,
         signed_vote: SignedVote<SapCandidate>,
     ) -> Result<Vec<Cmd>> {
-        debug!(
-            ">>> {}: {:?}",
-            LogMarker::HandoverMsgToBeHandled,
-            signed_vote
-        );
+        debug!("{}", LogMarker::HandoverMsgBeingHandled);
 
         self.check_signed_vote_saps(&signed_vote)?;
 
@@ -104,11 +100,11 @@ impl Node {
                 let mut cmds = self.handle_vote(&mut state, signed_vote).await;
                 if let Some(candidates_sap) = state.consensus_value() {
                     debug!(
-                        ">>> {}: {:?}",
+                        "{}: {:?}",
                         LogMarker::HandoverConsensusTermination,
                         candidates_sap
                     );
-                    // NB TOTO make sure error has to be swallowed
+                    // NB TODO make sure error has to be swallowed
                     let bcast_cmds = self.broadcast_handover_decision(candidates_sap).await;
                     cmds.extend(bcast_cmds);
                 }
@@ -116,7 +112,7 @@ impl Node {
                 Ok(cmds)
             }
             None => {
-                trace!(">>> Non-elder node unexpectedly received handover Vote msg, ignoring...");
+                trace!("Non-elder node unexpectedly received handover Vote msg, ignoring...");
                 Ok(vec![])
             }
         }

--- a/sn_node/src/node/core/messaging/handling/mod.rs
+++ b/sn_node/src/node/core/messaging/handling/mod.rs
@@ -62,26 +62,6 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         let mut cmds = vec![];
 
-        // Apply backpressure if needed.
-        #[cfg(feature = "back-pressure")]
-        if let Some(load_report) = self.comm.tolerated_msgs_per_s(&sender).await {
-            let msg_src = wire_msg.msg_kind().src();
-            if !msg_src.is_end_user() {
-                trace!("Sending BackPressure: {}", load_report);
-                let src_section_pk = self.network_knowledge().section_key().await;
-
-                cmds.push(Cmd::SendMsg {
-                    wire_msg: WireMsg::single_src(
-                        &*self.info.read().await,
-                        msg_src.to_dst(),
-                        SystemMsg::BackPressure(load_report),
-                        src_section_pk,
-                    )?,
-                    recipients: vec![sender],
-                })
-            }
-        }
-
         // Deserialize the payload of the incoming message
         let msg_id = wire_msg.msg_id();
         // payload needed for aggregation


### PR DESCRIPTION
Previously we had backpressure running in response to every single message that came in. 

This was somehow disrupting section formation and DKG. Moving it to an optional feature helped stabilise the base test cases in `main` w/ the membership changes.

Here, I look to reenable backpressure as a default feature. 

I've moved it away from being triggered on _every_ incoming message, to be a periodic check on a loop over an interval.

It also now _only_ fires back pressure messages to the same section. 

(As things stand, intersection comms is currently limited to AE messages flows which should not overwhelm our nodes if backpressure within the section - which is where most messages arise - is working properly).

(We _could_ fire backpressure to every connected node peer eg, but we don't know if they are clients so may be wasting time there...)