### PR TITLE
fix: use supported referencing style

### DIFF
--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -79,7 +79,7 @@ url = "2.2.0"
 walkdir = "2"
 xor_name = "4.0.1"
 file-rotate = "~0.6.0"
-sn_dysfunction = { path = "../sn_dysfunction", version = "~0.1.1" }
+sn_dysfunction = { path = "../sn_dysfunction", version = "^0.1.1" }
 sn_consensus = "1.16.0"
 
 [dependencies.backoff]


### PR DESCRIPTION
Currently smart-release doesn't support the `~` style of reference; the `^` style must be used. This
caused the last nightly run to fail at version bumping.
