### PR TITLE
ci: incorporate sn_client and sn_node in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,9 +95,7 @@ jobs:
       - name: generate release description first pass
         shell: bash
         run: |
-          ./resources/scripts/get_release_description.sh \
-            "${{ steps.versioning.outputs.sn_version }}" \
-            "${{ steps.versioning.outputs.sn_cli_version }}" > release_description.md
+          ./resources/scripts/get_release_description.sh > release_description.md
 
       # The second pass uses Python to extract the changelog entries for this version.
       # Python can easily do a string replace and avoid all the pain with newlines you get in Bash.
@@ -105,16 +103,8 @@ jobs:
       - name: generate release description second pass
         shell: bash
         run: |
-          ./resources/scripts/insert_changelog_entry.py \
-            --sn-interface-version "${{ steps.versioning.outputs.sn_interface_version }}"
-          ./resources/scripts/insert_changelog_entry.py \
-            --sn-dysfunction-version "${{ steps.versioning.outputs.sn_dysfunction_version }}"
-          ./resources/scripts/insert_changelog_entry.py \
-            --sn-version "${{ steps.versioning.outputs.sn_version }}"
-          ./resources/scripts/insert_changelog_entry.py \
-            --sn-api-version "${{ steps.versioning.outputs.sn_api_version }}"
-          ./resources/scripts/insert_changelog_entry.py \
-            --sn-cli-version "${{ steps.versioning.outputs.sn_cli_version }}"
+          pip install toml
+          ./resources/scripts/insert_changelog_entry.py
 
       - name: create github release
         id: create_release
@@ -188,12 +178,7 @@ jobs:
           source_dir: deploy/prod/safe
           destination_dir: ''
 
-  # At first glance, it seems like it would be possible to check the commit message in the `if` condition
-  # for the presence of the crate name, by using `contains`. However, this doesn't work, so the commit
-  # message needs to be checked at the point of publishing. The reason is because of the dependencies
-  # between the publishing jobs. If one of the jobs doesn't run because its `if` condition was evaluated
-  # to false, the next job won't run, regardless of whether its `if` condition would evaluate to true.
-  publish_sn_dysfunction:
+  publish:
     name: publish sn_dysfunction
     runs-on: ubuntu-latest
     needs: [gh_release]
@@ -209,141 +194,60 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - shell: bash
+        id: versioning
+        run: |
+          ./resources/scripts/output_versioning_info.sh
       - name: cargo login
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-      - name: cargo publish
+      - name: publish sn_dysfunction
         run: |
           commit_message="${{ github.event.head_commit.message }}"
           if [[ $commit_message == *"sn_dysfunction"* ]]; then
             # The sn_dysfunction crate doesn't have any dependencies so we can go ahead and publish.
             cd sn_dysfunction && cargo publish --allow-dirty
           fi
-
-  # At first glance, it seems like it would be possible to check the commit message in the `if` condition
-  # for the presence of the crate name, by using `contains`. However, this doesn't work, so the commit
-  # message needs to be checked at the point of publishing. The reason is because of the dependencies
-  # between the publishing jobs. If one of the jobs doesn't run because its `if` condition was evaluated
-  # to false, the next job won't run, regardless of whether its `if` condition would evaluate to true.
-  publish_sn_interface:
-    name: publish sn_interface
-    runs-on: ubuntu-latest
-    needs: [gh_release]
-    if: |
-      github.repository_owner == 'maidsafe' &&
-      startsWith(github.event.head_commit.message, 'chore(release):')
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: cargo login
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-      - name: cargo publish
+      - name: publish sn_interface
         run: |
           commit_message="${{ github.event.head_commit.message }}"
           if [[ $commit_message == *"sn_interface"* ]]; then
             # The sn_interface crate doesn't have any dependencies so we can go ahead and publish.
             cd sn_interface && cargo publish --allow-dirty
           fi
-
-  publish_sn:
-    name: publish safe network
-    runs-on: ubuntu-latest
-    needs: [publish_sn_dysfunction, publish_sn_interface]
-    if: |
-      github.repository_owner == 'maidsafe' &&
-      startsWith(github.event.head_commit.message, 'chore(release):')
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - shell: bash
-        id: versioning
-        run: |
-          ./resources/scripts/output_versioning_info.sh
-      - name: cargo login
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-      - name: cargo publish
+      - name: publish sn_node
         run: |
           commit_message="${{ github.event.head_commit.message }}"
-          if [[ $commit_message == *"safe_network"* ]]; then
-            # The sn_node crate is dependent on sn_dysfunction and sn_interface and sometimes the new version
-            # doesn't become available on crates.io immediately, so this script will use a retry
-            # loop.
+          if [[ $commit_message == *"sn_node"* ]]; then
+            # The sn_node crate is dependent on sn_dysfunction and sn_interface and sometimes the
+            # new version doesn't become available on crates.io immediately, so this script will use
+            # a retry loop.
+            # The script can only check for one dependent crate, but since this process is
+            # sequential, we'll check for sn_dysfunction.
             ./resources/scripts/publish_crate.sh \
-              "sn" "${{ steps.versioning.outputs.sn_dysfunction_version }}" "sn_dysfunction"
-            ./resources/scripts/publish_crate.sh \
-              "sn" "${{ steps.versioning.outputs.sn_interface_version }}" "sn_interface"
+              "sn_node" "${{ steps.versioning.outputs.sn_dysfunction_version }}" "sn_dysfunction"
           fi
-
-  publish_sn_api:
-    name: publish sn_api
-    runs-on: ubuntu-latest
-    needs: [publish_sn]
-    if: |
-      github.repository_owner == 'maidsafe' &&
-      startsWith(github.event.head_commit.message, 'chore(release):')
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - shell: bash
-        id: versioning
+      - name: publish sn_client
         run: |
-          ./resources/scripts/output_versioning_info.sh
-      - name: cargo login
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-      - name: cargo publish
+          commit_message="${{ github.event.head_commit.message }}"
+          if [[ $commit_message == *"sn_client"* ]]; then
+            # sn_client is dependent on sn_interface.
+            ./resources/scripts/publish_crate.sh \
+              "sn_client" "${{ steps.versioning.outputs.sn_interface_version }}" "sn_interface"
+          fi
+      - name: publish sn_api
         run: |
           commit_message="${{ github.event.head_commit.message }}"
           if [[ $commit_message == *"sn_api"* ]]; then
-            # The sn_api crate is dependent on safe_network and sometimes the new version doesn't
-            # become available on crates.io immediately, so this script will use a retry loop.
+            # sn_api is dependent on sn_interface and sn_client, but we should be able to check just
+            # for sn_client.
             ./resources/scripts/publish_crate.sh \
-              "sn_api" "${{ steps.versioning.outputs.sn_version }}" "safe_network"
+              "sn_api" "${{ steps.versioning.outputs.sn_client_version }}" "sn_client"
           fi
-
-  publish_sn_cli:
-    name: publish sn_cli
-    runs-on: ubuntu-latest
-    needs: [publish_sn_api]
-    if: |
-      github.repository_owner == 'maidsafe' &&
-      startsWith(github.event.head_commit.message, 'chore(release):')
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - shell: bash
-        id: versioning
-        run: |
-          ./resources/scripts/output_versioning_info.sh
-      - name: cargo login
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-      - name: cargo publish
+      - name: publish sn_cli
         run: |
           commit_message="${{ github.event.head_commit.message }}"
           if [[ $commit_message == *"sn_cli"* ]]; then
-            # The sn_cli crate is dependent on sn_api and sometimes the new version doesn't
+            # sn_cli is dependent on sn_api and sometimes the new version doesn't
             # become available on crates.io immediately, so this script will use a retry loop.
             ./resources/scripts/publish_crate.sh \
               "sn_cli" "${{ steps.versioning.outputs.sn_api_version }}" "sn_api"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := bash
-SN_NODE_VERSION := $(shell grep "^version" < sn/Cargo.toml | head -n 1 | awk '{ print $$3 }' | sed 's/\"//g')
+SN_NODE_VERSION := $(shell grep "^version" < sn_node/Cargo.toml | head -n 1 | awk '{ print $$3 }' | sed 's/\"//g')
 SN_CLI_VERSION := $(shell grep "^version" < sn_cli/Cargo.toml | head -n 1 | awk '{ print $$3 }' | sed 's/\"//g')
 UNAME_S := $(shell uname -s)
 DEPLOY_PATH := deploy

--- a/resources/scripts/get_release_description.sh
+++ b/resources/scripts/get_release_description.sh
@@ -1,20 +1,24 @@
 #!/usr/bin/env bash
 
-sn_version=$1
-if [[ -z "$sn_version" ]]; then
-    echo "You must supply a version number for sn_node"
-    exit 1
-fi
-
-sn_cli_version=$2
-if [[ -z "$sn_cli_version" ]]; then
-    echo "You must supply a version number for sn_cli"
-    exit 1
-fi
+sn_dysfunction_version=$( \
+  grep "^version" < sn_dysfunction/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+sn_interface_version=$( \
+  grep "^version" < sn_interface/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+sn_client_version=$( \
+  grep "^version" < sn_client/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+sn_node_version=$(grep "^version" < sn_node/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+sn_api_version=$(grep "^version" < sn_api/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+sn_cli_version=$(grep "^version" < sn_cli/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
 
 # The single quotes around EOF is to stop attempted variable and backtick expansion.
 read -r -d '' release_description << 'EOF'
-Command line interface for the Safe Network. Refer to [Safe CLI User Guide](https://github.com/maidsafe/sn_cli/blob/master/README.md) for detailed instructions.
+This release of Safe Network consists of:
+* Safe Node Dysfunction v__SN_DYSFUNCTION_VERSION__
+* Safe Network Interface v__SN_INTERFACE_VERSION__
+* Safe Client v__SN_CLIENT_VERSION__
+* Safe Node v__SN_NODE_VERSION__
+* Safe API v__SN_API_VERSION__
+* Safe CLI v__SN_CLI_VERSION__
 
 ## Safe Network Interface Changelog
 
@@ -24,9 +28,13 @@ __SN_INTERFACE_CHANGELOG_TEXT__
 
 __SN_DYSFUNCTION_CHANGELOG_TEXT__
 
-## Safe Network Changelog
+## Safe Node Changelog
 
-__SN_CHANGELOG_TEXT__
+__SN_NODE_CHANGELOG_TEXT__
+
+## Safe Client Changelog
+
+__SN_CLIENT_CHANGELOG_TEXT__
 
 ## Safe API Changelog
 
@@ -92,40 +100,40 @@ tar.gz: SN_CLI_TAR_AARCH64_CHECKSUM
 EOF
 
 sn_zip_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-unknown-linux-musl.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-x86_64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 sn_zip_macos_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-apple-darwin.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-x86_64-apple-darwin.zip" | \
     awk '{ print $1 }')
 sn_zip_win_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-pc-windows-msvc.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-x86_64-pc-windows-msvc.zip" | \
     awk '{ print $1 }')
 sn_zip_arm_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-arm-unknown-linux-musleabi.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-arm-unknown-linux-musleabi.zip" | \
     awk '{ print $1 }')
 sn_zip_armv7_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-armv7-unknown-linux-musleabihf.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-armv7-unknown-linux-musleabihf.zip" | \
     awk '{ print $1 }')
 sn_zip_aarch64_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-aarch64-unknown-linux-musl.zip" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-aarch64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 sn_tar_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-unknown-linux-musl.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-x86_64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_macos_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-apple-darwin.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-x86_64-apple-darwin.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_win_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-x86_64-pc-windows-msvc.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-x86_64-pc-windows-msvc.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_arm_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-arm-unknown-linux-musleabi.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-arm-unknown-linux-musleabi.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_armv7_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-armv7-unknown-linux-musleabihf.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-armv7-unknown-linux-musleabihf.tar.gz" | \
     awk '{ print $1 }')
 sn_tar_aarch64_checksum=$(sha256sum \
-    "./deploy/prod/sn_node/sn_node-$sn_version-aarch64-unknown-linux-musl.tar.gz" | \
+    "./deploy/prod/sn_node/sn_node-$sn_node_version-aarch64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 
 sn_cli_zip_linux_checksum=$(sha256sum \
@@ -164,6 +172,13 @@ sn_cli_tar_armv7_checksum=$(sha256sum \
 sn_cli_tar_aarch64_checksum=$(sha256sum \
     "./deploy/prod/safe/sn_cli-$sn_cli_version-aarch64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
+
+release_description=$(sed "s/__SN_DYSFUNCTION_VERSION__/$sn_dysfunction_version/g" <<< "$release_description")
+release_description=$(sed "s/__SN_INTERFACE_VERSION__/$sn_interface_version/g" <<< "$release_description")
+release_description=$(sed "s/__SN_CLIENT_VERSION__/$sn_client_version/g" <<< "$release_description")
+release_description=$(sed "s/__SN_NODE_VERSION__/$sn_node_version/g" <<< "$release_description")
+release_description=$(sed "s/__SN_API_VERSION__/$sn_api_version/g" <<< "$release_description")
+release_description=$(sed "s/__SN_CLI_VERSION__/$sn_cli_version/g" <<< "$release_description")
 
 release_description=$(sed "s/SN_ZIP_LINUX_CHECKSUM/$sn_zip_linux_checksum/g" <<< "$release_description")
 release_description=$(sed "s/SN_ZIP_MACOS_CHECKSUM/$sn_zip_macos_checksum/g" <<< "$release_description")

--- a/resources/scripts/insert_changelog_entry.py
+++ b/resources/scripts/insert_changelog_entry.py
@@ -4,8 +4,11 @@
 # put that into the release description. This gets very painful in Bash because the entry
 # contains newline characters.
 
-import getopt
-import sys
+import toml
+
+def get_crate_version(crate_name):
+    manifest = toml.load(f"{crate_name}/Cargo.toml")
+    return manifest["package"]["version"]
 
 def get_changelog_entry(changelog_path, version):
     sn_changelog_content = ""
@@ -25,16 +28,25 @@ def insert_changelog_entry(entry, pattern):
     with open("release_description.md", "w") as file:
         file.write(release_description)
 
-def main(sn_interface_version, sn_dysfunction_version, sn_version, sn_api_version, sn_cli_version):
+def main(
+        sn_interface_version,
+        sn_dysfunction_version,
+        sn_client_version,
+        sn_node_version,
+        sn_api_version,
+        sn_cli_version):
     if sn_interface_version:
-        sn_changelog_entry = get_changelog_entry("sn_interface/CHANGELOG.md", sn_interface_version)
-        insert_changelog_entry(sn_changelog_entry, "__SN_INTERFACE_CHANGELOG_TEXT__")
+        sn_node_changelog_entry = get_changelog_entry("sn_interface/CHANGELOG.md", sn_interface_version)
+        insert_changelog_entry(sn_node_changelog_entry, "__SN_INTERFACE_CHANGELOG_TEXT__")
     if sn_dysfunction_version:
-        sn_changelog_entry = get_changelog_entry("sn_dysfunction/CHANGELOG.md", sn_dysfunction_version)
-        insert_changelog_entry(sn_changelog_entry, "__SN_DYSFUNCTION_CHANGELOG_TEXT__")
-    if sn_version:
-        sn_changelog_entry = get_changelog_entry("sn/CHANGELOG.md", sn_version)
-        insert_changelog_entry(sn_changelog_entry, "__SN_CHANGELOG_TEXT__")
+        sn_node_changelog_entry = get_changelog_entry("sn_dysfunction/CHANGELOG.md", sn_dysfunction_version)
+        insert_changelog_entry(sn_node_changelog_entry, "__SN_DYSFUNCTION_CHANGELOG_TEXT__")
+    if sn_client_version:
+        sn_client_changelog_entry = get_changelog_entry("sn_client/CHANGELOG.md", sn_client_version)
+        insert_changelog_entry(sn_client_changelog_entry, "__SN_CLIENT_CHANGELOG_TEXT__")
+    if sn_node_version:
+        sn_node_changelog_entry = get_changelog_entry("sn_node/CHANGELOG.md", sn_node_version)
+        insert_changelog_entry(sn_node_changelog_entry, "__SN_NODE_CHANGELOG_TEXT__")
     if sn_api_version:
         sn_api_changelog_entry = get_changelog_entry("sn_api/CHANGELOG.md", sn_api_version)
         insert_changelog_entry(sn_api_changelog_entry, "__SN_API_CHANGELOG_TEXT__")
@@ -43,25 +55,16 @@ def main(sn_interface_version, sn_dysfunction_version, sn_version, sn_api_versio
         insert_changelog_entry(sn_cli_changelog_entry, "__SN_CLI_CHANGELOG_TEXT__")
 
 if __name__ == "__main__":
-    sn_interface_version = ""
-    sn_dysfunction_version = ""
-    sn_version = ""
-    sn_api_version = ""
-    sn_cli_version = ""
-    opts, args = getopt.getopt(
-        sys.argv[1:],
-        "",
-        ["sn-interface-version=", "sn-dysfunction-version=", "sn-version=", "sn-api-version=", "sn-cli-version="]
-    )
-    for opt, arg in opts:
-        if opt in "--sn-interface-version":
-            sn_interface_version = arg
-        if opt in "--sn-dysfunction-version":
-            sn_dysfunction_version = arg
-        elif opt in "--sn-version":
-            sn_version = arg
-        elif opt in "--sn-api-version":
-            sn_api_version = arg
-        elif opt in "--sn-cli-version":
-            sn_cli_version = arg
-    main(sn_interface_version, sn_dysfunction_version, sn_version, sn_api_version, sn_cli_version)
+    sn_interface_version = get_crate_version("sn_interface")
+    sn_dysfunction_version = get_crate_version("sn_dysfunction")
+    sn_client_version = get_crate_version("sn_client")
+    sn_node_version = get_crate_version("sn_node")
+    sn_api_version = get_crate_version("sn_api")
+    sn_cli_version = get_crate_version("sn_client")
+    main(
+        sn_interface_version,
+        sn_dysfunction_version,
+        sn_client_version,
+        sn_node_version,
+        sn_api_version,
+        sn_cli_version)

--- a/resources/scripts/output_versioning_info.sh
+++ b/resources/scripts/output_versioning_info.sh
@@ -1,17 +1,38 @@
 #!/usr/bin/env bash
 
+sn_dysfunction_version=""
+sn_interface_version=""
+sn_client_version=""
+sn_node_version=""
+sn_api_version=""
+sn_cli_version=""
+
+function get_crate_versions() {
+  sn_dysfunction_version=$( \
+    grep "^version" < sn_dysfunction/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+  sn_interface_version=$( \
+    grep "^version" < sn_interface/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+  sn_client_version=$( \
+    grep "^version" < sn_client/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+  sn_node_version=$(grep "^version" < sn_node/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+  sn_api_version=$(grep "^version" < sn_api/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+  sn_cli_version=$(grep "^version" < sn_cli/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+}
+
 function build_release_name() {
-  gh_release_name="Safe Node Dysfunction v$sn_dysfunction_version/"
-  gh_release_name="${gh_release_name}Safe Network Interface v$sn_interface_version/"
-  gh_release_name="${gh_release_name}Safe Network v$sn_version/"
-  gh_release_name="${gh_release_name}Safe API v$sn_api_version/"
-  gh_release_name="${gh_release_name}Safe CLI v$sn_cli_version"
+  gh_release_name="Safe Network v$sn_dysfunction_version/"
+  gh_release_name="${gh_release_name}v$sn_interface_version/"
+  gh_release_name="${gh_release_name}v$sn_client_version/"
+  gh_release_name="${gh_release_name}v$sn_node_version/"
+  gh_release_name="${gh_release_name}v$sn_api_version/"
+  gh_release_name="${gh_release_name}v$sn_cli_version"
 }
 
 function build_release_tag_name() {
   gh_release_tag_name="$sn_interface_version-"
   gh_release_tag_name="${gh_release_tag_name}$sn_dysfunction_version-"
-  gh_release_tag_name="${gh_release_tag_name}$sn_version-"
+  gh_release_tag_name="${gh_release_tag_name}$sn_client_version-"
+  gh_release_tag_name="${gh_release_tag_name}$sn_node_version-"
   gh_release_tag_name="${gh_release_tag_name}$sn_api_version-"
   gh_release_tag_name="${gh_release_tag_name}$sn_cli_version"
 }
@@ -19,7 +40,8 @@ function build_release_tag_name() {
 function output_version_info() {
   echo "::set-output name=sn_dysfunction_version::$sn_dysfunction_version"
   echo "::set-output name=sn_interface_version::$sn_interface_version"
-  echo "::set-output name=sn_version::$sn_version"
+  echo "::set-output name=sn_client_version::$sn_client_version"
+  echo "::set-output name=sn_node_version::$sn_node_version"
   echo "::set-output name=sn_api_version::$sn_api_version"
   echo "::set-output name=sn_cli_version::$sn_cli_version"
   echo "::set-output name=gh_release_name::$gh_release_name"
@@ -29,13 +51,7 @@ function output_version_info() {
 gh_release_name=""
 gh_release_tag_name=""
 commit_message=$(git log --oneline --pretty=format:%s | head -n 1)
-sn_dysfunction_version=$( \
-  grep "^version" < sn_dysfunction/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
-sn_interface_version=$( \
-  grep "^version" < sn_interface/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
-sn_version=$(grep "^version" < sn/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
-sn_api_version=$(grep "^version" < sn_api/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
-sn_cli_version=$(grep "^version" < sn_cli/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+get_crate_versions
 build_release_name
 build_release_tag_name
 output_version_info

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -16,8 +16,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bincode = "1.3.3"
+bls = { package = "blsttc", version = "3.4.0" }
+bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "~0.6"
 dirs-next = "2.0.0"
+ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 env_logger = "~0.8"
 futures = "~0.3"
 hex = "~0.4"
@@ -31,47 +34,23 @@ rand = "~0.7"
 rand_core = "~0.5"
 relative-path = "1.3.2"
 rmp-serde = "1.0.0"
+pbkdf2 = { version = "~0.7", default-features = false }
 serde = "1.0.123"
 serde_json = "1.0.62"
 sha3 = "~0.9"
 sn_client = { path = "../sn_client", version = "^0.62.0" }
+sn_dbc = { version = "3.1.0", features = [ "serdes" ] }
 sn_interface = { path = "../sn_interface", version = "^0.1.1" }
 thiserror = "1.0.23"
 time = { version = "~0.3.4", features = ["formatting"] }
+tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 tracing = "~0.1.26"
+tokio = { version = "1.6.0", features = ["rt"] }
 uhttp_uri = "~0.5"
 url = "2.2.0"
 urlencoding = "1.1.1"
 walkdir = "2.3.1"
 xor_name = "4.0.1"
-
-  [dependencies.bls]
-  package = "blsttc"
-  version = "3.4.0"
-
-  [dependencies.bytes]
-  version = "1.0.1"
-  features = [ "serde" ]
-
-  [dependencies.sn_dbc]
-  version = "3.1.0"
-  features = [ "serdes" ]
-
-  [dependencies.ed25519-dalek]
-  version = "1.0.1"
-  features = [ "serde" ]
-
-  [dependencies.pbkdf2]
-  version = "~0.7"
-  default-features = false
-
-  [dependencies.tokio]
-  version = "1.6.0"
-  features = [ "rt" ]
-
-  [dependencies.tiny-keccak]
-  version = "2.0.2"
-  features = [ "sha3" ]
 
 [features]
 authenticator = [ ]
@@ -84,8 +63,5 @@ default = [ "testing", "authenticator", "authd_client", "app" ]
 assert_matches = "1.3"
 anyhow = "1.0.38"
 proptest = "1.0.0"
+tokio = { version = "1.6.0", features = ["macros"] }
 tracing-subscriber = "~0.3.1"
-
-  [dev-dependencies.tokio]
-  version = "1.6.0"
-  features = [ "macros" ]

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -18,51 +18,35 @@ path = "src/main.rs"
 [dependencies]
 ansi_term = "~0.12"
 bincode = "1.3.3"
+bls = { package = "blsttc", version = "3.1.0" }
+bytes = { version = "1.0.1", features = ["serde"] }
 chrono = "~0.4"
 color-eyre = "~0.6"
+comfy-table = "5.0.1"
 console = "~0.14"
 dirs-next = "2.0.0"
+ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 hex = "~0.4"
 human-panic = "1.0.3"
 isatty = "~0.1"
 num-traits = "~0.2"
 percent-encoding = "2.1.0"
 pretty-hex = "~0.2"
-comfy-table = "5.0.1"
 rand = "~0.7"
 rcgen = "~0.7"
 relative-path = "1.3.2"
+reqwest = { version = "~0.11", default-features = false, features = [ "rustls-tls" ] }
 sn_api = { path = "../sn_api", version = "^0.58.2", default-features=false, features = ["app", "authd_client"] }
 sn_launch_tool = "~0.9.4"
 serde = "1.0.123"
 serde_json = "1.0.62"
 serde_yaml = "~0.8"
 structopt = "~0.3"
+tokio = { version = "1.6.0", features = ["macros"] }
 tracing = "~0.1.26"
 tracing-subscriber = "~0.2.15"
 url = "2.2.2"
 xor_name = "4.0.1"
-
-[dependencies.bls]
-package = "blsttc"
-version = "3.1.0"
-
-[dependencies.bytes]
-version = "1.0.1"
-features = [ "serde" ]
-
-[dependencies.ed25519-dalek]
-version = "1.0.1"
-features = [ "serde" ]
-
-[dependencies.reqwest]
-version = "~0.11"
-default-features = false
-features = [ "rustls-tls" ]
-
-[dependencies.tokio]
-version = "1.6.0"
-features = [ "macros" ]
 
 [dependencies.self_update]
 version = "~0.28.0"

--- a/sn_cli/src/operations/helpers.rs
+++ b/sn_cli/src/operations/helpers.rs
@@ -165,11 +165,12 @@ fn set_exec_perms(file_path: PathBuf) -> Result<()> {
 
 /// Gets the version number from the full version number string.
 ///
-/// The `release_version` input is in the form "0.1.0-0.1.1-0.51.6-0.46.2-0.39.1", which is the
-/// sn_dysfunction, sn_interface, safe_network, sn_api, sn_cli versions, respectively. This
+/// The `release_version` input is in the form "0.1.0-0.1.1-0.62.0-0.51.6-0.46.2-0.39.1", which is the
+/// sn_dysfunction, sn_interface, sn_client, sn_node, sn_api, sn_cli versions, respectively. This
 /// function will return the safe_network part.
 fn get_version_from_release_version(release_version: &str) -> Result<String> {
     let mut parts = release_version.split('-');
+    parts.next();
     parts.next();
     parts.next();
     let version = parts

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -23,7 +23,6 @@ required-features = ["test-utils"]
 name = "network_split"
 required-features = ["test-utils"]
 
-
 [features]
 default = []
 chaos = []
@@ -33,6 +32,7 @@ test-utils = ["sn_interface/test-utils", "sn_interface/proptest"]
 tokio-console = ["console-subscriber"]
 
 [dependencies]
+backoff = { version = "~0.4.0", features = [ "tokio" ] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "3.1.0" }
@@ -41,7 +41,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 console-subscriber = { version = "~0.1.0", optional = true }
 crdts = "7.0"
 custom_debug = "~0.5.0"
-dashmap = {version = "5.1.0", features = [ "serde" ]}
+dashmap = { version = "5.1.0", features = [ "serde" ] }
 dirs-next = "2.0.0"
 ed25519 = { version = "1.2.0", features = ["serde_bytes"] }
 ed25519-dalek = { version = "1.0.0", features = ["serde"] }
@@ -60,12 +60,12 @@ rayon = "1.5.1"
 rmp-serde = "1.0.0"
 secured_linked_list = "~0.5.0"
 self_encryption = "~0.27.4"
-sn_interface = { path = "../sn_interface", version = "^0.1.1" }
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
 sled = "~0.34.6"
+sn_interface = { path = "../sn_interface", version = "^0.1.1" }
 structopt = "~0.3.17"
 strum = "~0.23.0"
 strum_macros = "~0.23.1"
@@ -80,32 +80,25 @@ url = "2.2.0"
 walkdir = "2"
 xor_name = "4.0.1"
 
-[dependencies.backoff]
-version = "~0.4.0"
-features = [ "tokio" ]
-
 [dependencies.tokio]
 version = "1.17.0"
 features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 
 [dev-dependencies]
 criterion = { version = "~0.3", features = ["async_tokio"] }
+grep="~0.2.8"
 proptest = "1.0.0"
 rand = { version = "~0.7.3", features = ["small_rng"] }
 rand_xorshift = "~0.2.0"
+sn_launch_tool = "~0.9.7"
 termcolor="1.1.2"
 tokio-util = { version = "~0.6.7", features = ["time"] }
 walkdir = "2"
-grep="~0.2.8"
-sn_launch_tool = "~0.9.7"
-
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"
 default-features = false # Disable features which are enabled by default
 features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt", "run-cargo-check"]
-
-
 
 [package.metadata.cargo-udeps.ignore]
 development = ["cargo-husky"]

--- a/sn_cmd_test_utilities/src/lib.rs
+++ b/sn_cmd_test_utilities/src/lib.rs
@@ -444,6 +444,7 @@ pub mod util {
         let mut parts = release_version.split('-');
         parts.next();
         parts.next();
+        parts.next();
         let version = parts
             .next()
             .ok_or_else(|| {

--- a/sn_dysfunction/Cargo.toml
+++ b/sn_dysfunction/Cargo.toml
@@ -14,21 +14,15 @@ version = "0.1.1"
 default = []
 
 [dependencies]
-xor_name = "4.0.1"
-dashmap = {version = "5.1.0", features = [ "serde" ]}
-tracing = "~0.1.26"
-rand = "~0.8"
+dashmap = { version = "5.1.0", features = [ "serde" ] }
 eyre = "~0.6.5"
+rand = "~0.8"
 thiserror = "1.0.23"
-
-[dependencies.tokio]
-version = "1.17.0"
-features = ["sync"]
+tokio = { version = "1.0.23", features = [ "sync" ] }
+tracing = "~0.1.26"
+xor_name = "4.0.1"
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 proptest = "~1.0.0"
-
-[dev-dependencies.tokio]
-version = "1.17.0"
-features = ["sync", "macros", "rt-multi-thread"]
+tokio = { version = "1.17.0", features = [ "macros", "rt-multi-thread", "sync" ] }
+tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -10,14 +10,13 @@ readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
 version = "0.1.1"
 
-
 [features]
 default = []
 back-pressure = []
 test-utils=["proptest"]
 
-
 [dependencies]
+backoff = { version = "~0.4.0", features = ["tokio"] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "3.1.0" }
@@ -26,7 +25,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 console-subscriber = { version = "~0.1.0", optional = true }
 crdts = "7.0"
 custom_debug = "~0.5.0"
-dashmap = {version = "5.1.0", features = [ "serde" ]}
+dashmap = {version = "5.1.0", features = ["serde"]}
 dirs-next = "2.0.0"
 ed25519 = { version = "1.2.0", features = ["serde_bytes"] }
 ed25519-dalek = { version = "1.0.0", features = ["serde"] }
@@ -39,6 +38,7 @@ lazy_static = "1"
 multibase = "~0.9.1"
 num_cpus = "1.13.0"
 priority-queue = "1.2.1"
+proptest = { version ="1.0.0", optional =true }
 qp2p = "~0.28.3"
 rand = "~0.7.3"
 rayon = "1.5.1"
@@ -50,6 +50,7 @@ serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
 sled = "~0.34.6"
+sn_consensus = "1.16.0"
 strum = "~0.23.0"
 strum_macros = "~0.23.1"
 tempfile = "3.2.0"
@@ -60,17 +61,10 @@ tracing-core = "~0.1.21"
 uluru="3.0.0"
 url = "2.2.0"
 xor_name = "4.0.1"
-sn_consensus = "1.16.0"
-proptest = {version ="1.0.0", optional =true}
 
 [dependencies.tokio]
 version = "~1.17.0"
 features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
-
-
-[dependencies.backoff]
-version = "~0.4.0"
-features = [ "tokio" ]
 
 [dev-dependencies]
 rand = { version = "~0.7.3", features = ["small_rng"] }
@@ -81,8 +75,6 @@ tokio-util = { version = "0.6.7", features = ["time"] }
 version = "1.5.0"
 default-features = false # Disable features which are enabled by default
 features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt", "run-cargo-check"]
-
-
 
 [package.metadata.cargo-udeps.ignore]
 development = ["cargo-husky"]

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -28,6 +28,7 @@ test-utils = ["sn_interface/test-utils", "sn_interface/proptest"]
 tokio-console = ["console-subscriber"]
 
 [dependencies]
+backoff = { version = "~0.4.0", features = [ "tokio" ] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "3.1.0" }
@@ -42,6 +43,7 @@ dirs-next = "2.0.0"
 ed25519 = { version = "1.2.0", features = ["serde_bytes"] }
 ed25519-dalek = { version = "1.0.0", features = ["serde"] }
 eyre = "~0.6.5"
+file-rotate = "~0.6.0"
 futures = "~0.3.13"
 hex = "~0.4.3"
 hex_fmt = "~0.3.0"
@@ -57,6 +59,8 @@ resource_proof = "1.0.38"
 rmp-serde = "1.0.0"
 secured_linked_list = "~0.5.0"
 self_encryption = "~0.27.4"
+sn_consensus = "1.16.0"
+sn_dysfunction = { path = "../sn_dysfunction", version = "^0.1.1" }
 sn_interface = { path = "../sn_interface", version = "^0.1.0" }
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
@@ -78,13 +82,6 @@ uluru="3.0.0"
 url = "2.2.0"
 walkdir = "2"
 xor_name = "4.0.1"
-file-rotate = "~0.6.0"
-sn_dysfunction = { path = "../sn_dysfunction", version = "^0.1.1" }
-sn_consensus = "1.16.0"
-
-[dependencies.backoff]
-version = "~0.4.0"
-features = [ "tokio" ]
 
 [dependencies.self_update]
 version = "~0.28.0"
@@ -105,13 +102,10 @@ tokio-util = { version = "~0.6.7", features = ["time"] }
 walkdir = "2"
 yansi = "~0.5.0"
 
-
 [dev-dependencies.cargo-husky]
 version = "1.5.0"
 default-features = false # Disable features which are enabled by default
 features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt", "run-cargo-check"]
-
-
 
 [package.metadata.cargo-udeps.ignore]
 development = ["cargo-husky"]


### PR DESCRIPTION
- 3cf6d6c03 **chore: tidy references in cargo manifests**

  All references are organised alphabetically, and random usage of long-form references are removed in
  favour of the short-form version, unless the long-form style is justified, e.g., when lots of
  features are being used.

- fabb6b8b4 **ci: incorporate sn_client and sn_node in release process**

  The `sn_client` and `sn_node` crates had to be included for publishing in the release process.

  There were a few other changes I made to support this:

  * The title of the release, with all the crate names, was getting too large. I changed it to just
    include the version numbers. The description of the release now includes the list of crates and
    the version numbers they relate to.
  * Stop passing the version numbers around for the changelog generation. We can just read them from
    the Cargo manifest.
  * Change crate publishing to a sequential process, rather than have different jobs.
