### PR TITLE
Remove redundant warning about restarting authd

### DIFF
--- a/sn/src/node/cfg/config_handler.rs
+++ b/sn/src/node/cfg/config_handler.rs
@@ -25,7 +25,7 @@ use tracing::{debug, warn, Level};
 const CONFIG_FILE: &str = "node.config";
 const CONNECTION_INFO_FILE: &str = "node_connection_info.config";
 const DEFAULT_ROOT_DIR_NAME: &str = "root_dir";
-const DEFAULT_MAX_CAPACITY: usize = 2 * 1024 * 1024 * 1024;
+const DEFAULT_MAX_CAPACITY: usize = 10 * 1024 * 1024 * 1024;        /// changed from default 2GB
 
 /// Node configuration
 #[derive(Default, Clone, Debug, Serialize, Deserialize, StructOpt)]

--- a/sn_cli/src/subcommands/networks.rs
+++ b/sn_cli/src/subcommands/networks.rs
@@ -67,7 +67,7 @@ pub async fn networks_commander(
                 "Successfully switched to '{}' network in your system!",
                 network_name
             );
-            println!("If you need write access to the '{}' network, you'll need to restart authd (safe auth restart), unlock a Safe and re-authorise the CLI again", network_name);
+          
         }
         Some(NetworksSubCommands::Check {}) => {
             println!("Checking current setup network connection information...");


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
For a long time now a spurious warning has been emitted when changing networks.
```
Successfully switched to 'comnet' network in your system!
If you need write access to the 'comnet' network, you'll need to restart authd (safe auth restart), unlock a Safe and re-authorise the CLI again
```

This warning has been irrelevant ever since the auth crate functionality was subsumed into other crates.

Remove line 70 of  /sn_cli/src/subcommands/networks.rs