### PR TITLE
fix: use the config verbosity if no env var present

### DIFF
--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -229,7 +229,7 @@ async fn run_node() -> Result<()> {
             tracing_subscriber::fmt()
                 .with_thread_names(true)
                 .with_ansi(false)
-                .with_env_filter(EnvFilter::from_default_env())
+                .with_env_filter(filter)
                 .with_target(false)
                 .event_format(LogFormatter::default())
                 .init();


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
