### PR TITLE
chore(messaging): rename MsgKind -> AuthKind

### DIFF
--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -19,7 +19,7 @@ use sn_interface::at_least_one_correct_elder;
 use sn_interface::messaging::{
     data::{CmdError, ServiceMsg},
     system::{KeyedSig, SectionAuth, SystemMsg},
-    AuthorityProof, DstLocation, MsgId, MsgKind, MsgType, ServiceAuth, WireMsg,
+    AuthKind, AuthorityProof, DstLocation, MsgId, MsgType, ServiceAuth, WireMsg,
 };
 use sn_interface::network_knowledge::utils::compare_and_write_prefix_map_to_disk;
 use sn_interface::network_knowledge::SectionAuthorityProvider;
@@ -322,7 +322,7 @@ impl Session {
                 let wire_msg = WireMsg::new_msg(
                     msg_id,
                     payload,
-                    MsgKind::ServiceMsg(auth.into_inner()),
+                    AuthKind::Service(auth.into_inner()),
                     dst_location,
                 )?;
 

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -11,7 +11,7 @@ use super::{QueryResult, Session};
 use crate::{connections::CmdResponse, Error, Result};
 use sn_interface::messaging::{
     data::{CmdError, DataQuery, QueryResponse},
-    DstLocation, MsgId, MsgKind, ServiceAuth, WireMsg,
+    AuthKind, DstLocation, MsgId, ServiceAuth, WireMsg,
 };
 use sn_interface::network_knowledge::prefix_map::NetworkPrefixMap;
 use sn_interface::types::{Peer, PeerLinks, PublicKey, SendToOneError};
@@ -101,7 +101,7 @@ impl Session {
             section_pk,
         };
 
-        let msg_kind = MsgKind::ServiceMsg(auth);
+        let msg_kind = AuthKind::Service(auth);
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
 
         let elders_len = elders.len();
@@ -231,7 +231,7 @@ impl Session {
             name: dst,
             section_pk,
         };
-        let msg_kind = MsgKind::ServiceMsg(auth);
+        let msg_kind = AuthKind::Service(auth);
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
 
         send_msg(self.clone(), elders, wire_msg, msg_id).await?;
@@ -369,7 +369,7 @@ impl Session {
             name: dst_address,
             section_pk,
         };
-        let msg_kind = MsgKind::ServiceMsg(auth);
+        let msg_kind = AuthKind::Service(auth);
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
 
         // When the client bootstrap using the nodes read from the config, the list is sorted

--- a/sn_interface/src/messaging/auth_kind.rs
+++ b/sn_interface/src/messaging/auth_kind.rs
@@ -17,38 +17,38 @@ use serde::{Deserialize, Serialize};
 /// recognised we can ask for a longer chain that can be recognised).
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum MsgKind {
+pub enum AuthKind {
     /// A data message, with the requesting peer's authority.
     ///
     /// Authority is needed to access private data, such as reading or writing a private file.
-    ServiceMsg(ServiceAuth),
+    Service(ServiceAuth),
 
     /// A message from a Node with its own independent authority.
     ///
     /// Node authority is needed when nodes send messages directly to other nodes.
     // FIXME: is the above true? What does is the recieving node validating against?
-    NodeAuthMsg(NodeAuth),
+    Node(NodeAuth),
 
     /// A message from an Elder node with its share of the section authority.
     ///
     /// Section share authority is needed for messages related to section administration, such as
     /// DKG and relocation.
-    NodeBlsShareAuthMsg(BlsShareAuth),
+    NodeBlsShare(BlsShareAuth),
 }
 
-impl MsgKind {
+impl AuthKind {
     /// The src location of the msg.
     pub fn src(&self) -> SrcLocation {
         match self {
-            Self::NodeBlsShareAuthMsg(auth) => SrcLocation::Node {
+            Self::NodeBlsShare(auth) => SrcLocation::Node {
                 name: auth.src_name,
                 section_pk: auth.sig_share.public_key_set.public_key(),
             },
-            Self::NodeAuthMsg(auth) => SrcLocation::Node {
+            Self::Node(auth) => SrcLocation::Node {
                 name: crate::types::PublicKey::Ed25519(auth.node_ed_pk).into(),
                 section_pk: auth.section_pk,
             },
-            Self::ServiceMsg(auth) => SrcLocation::EndUser(super::EndUser(auth.public_key.into())),
+            Self::Service(auth) => SrcLocation::EndUser(super::EndUser(auth.public_key.into())),
         }
     }
 }

--- a/sn_interface/src/messaging/mod.rs
+++ b/sn_interface/src/messaging/mod.rs
@@ -36,18 +36,18 @@ mod location;
 // Message ID definition
 mod msg_id;
 // Types of messages and corresponding source authorities
-mod msg_kind;
+mod auth_kind;
 // SectionAuthorityProvider
 mod sap;
 
 pub use self::{
+    auth_kind::AuthKind,
     authority::{
         AuthorityProof, BlsShareAuth, NodeAuth, SectionAuth, ServiceAuth, VerifyAuthority,
     },
     errors::{Error, Result},
     location::{DstLocation, EndUser, SrcLocation},
     msg_id::{MsgId, MESSAGE_ID_LEN},
-    msg_kind::MsgKind,
     sap::SectionAuthorityProvider,
     serialisation::{MsgType, NodeMsgAuthority, WireMsg},
 };

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -10,7 +10,7 @@ use super::wire_msg_header::WireMsgHeader;
 use crate::messaging::{
     data::{ServiceError, ServiceMsg},
     system::SystemMsg,
-    AuthorityProof, DstLocation, Error, MsgId, MsgKind, MsgType, NodeMsgAuthority, Result,
+    AuthKind, AuthorityProof, DstLocation, Error, MsgId, MsgType, NodeMsgAuthority, Result,
     ServiceAuth,
 };
 use bls::PublicKey as BlsPublicKey;
@@ -65,7 +65,7 @@ impl WireMsg {
     pub fn new_msg(
         msg_id: MsgId,
         payload: Bytes,
-        msg_kind: MsgKind,
+        msg_kind: AuthKind,
         dst_location: DstLocation,
     ) -> Result<Self> {
         Ok(Self {
@@ -119,7 +119,7 @@ impl WireMsg {
     /// Deserialize the payload from this WireMsg returning a MsgType instance.
     pub fn into_msg(&self) -> Result<MsgType> {
         match self.header.msg_envelope.msg_kind.clone() {
-            MsgKind::ServiceMsg(auth) => {
+            AuthKind::Service(auth) => {
                 let msg: ServiceMsg = rmp_serde::from_slice(&self.payload).map_err(|err| {
                     Error::FailedToParse(format!("Data message payload as Msgpack: {}", err))
                 })?;
@@ -141,7 +141,7 @@ impl WireMsg {
                     msg,
                 })
             }
-            MsgKind::NodeAuthMsg(node_signed) => {
+            AuthKind::Node(node_signed) => {
                 let msg: SystemMsg = rmp_serde::from_slice(&self.payload).map_err(|err| {
                     Error::FailedToParse(format!("Node signed message payload as Msgpack: {}", err))
                 })?;
@@ -156,7 +156,7 @@ impl WireMsg {
                     msg,
                 })
             }
-            MsgKind::NodeBlsShareAuthMsg(bls_share_signed) => {
+            AuthKind::NodeBlsShare(bls_share_signed) => {
                 let msg: SystemMsg = rmp_serde::from_slice(&self.payload).map_err(|err| {
                     Error::FailedToParse(format!(
                         "Node message payload (BLS share signed) as Msgpack: {}",
@@ -188,7 +188,7 @@ impl WireMsg {
     }
 
     /// Return the kind of this message
-    pub fn msg_kind(&self) -> &MsgKind {
+    pub fn msg_kind(&self) -> &AuthKind {
         &self.header.msg_envelope.msg_kind
     }
 
@@ -216,8 +216,8 @@ impl WireMsg {
     /// message if it's a NodeMsg
     pub fn src_section_pk(&self) -> Option<BlsPublicKey> {
         match &self.header.msg_envelope.msg_kind {
-            MsgKind::NodeAuthMsg(node_signed) => Some(node_signed.section_pk),
-            MsgKind::NodeBlsShareAuthMsg(bls_share_signed) => Some(bls_share_signed.section_pk),
+            AuthKind::Node(node_signed) => Some(node_signed.section_pk),
+            AuthKind::NodeBlsShare(bls_share_signed) => Some(bls_share_signed.section_pk),
             _ => None,
         }
     }
@@ -284,7 +284,7 @@ mod tests {
         let payload = WireMsg::serialize_msg_payload(&node_msg)?;
         let node_auth = NodeAuth::authorize(src_section_pk, &src_node_keypair, &payload);
 
-        let msg_kind = MsgKind::NodeAuthMsg(node_auth.clone().into_inner());
+        let msg_kind = AuthKind::Node(node_auth.clone().into_inner());
 
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
         let serialized = wire_msg.serialize()?;
@@ -335,7 +335,7 @@ mod tests {
         };
         let auth_proof = AuthorityProof::verify(auth.clone(), &payload).unwrap();
 
-        let msg_kind = MsgKind::ServiceMsg(auth);
+        let msg_kind = AuthKind::Service(auth);
 
         let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
         let serialized = wire_msg.serialize()?;

--- a/sn_interface/src/messaging/serialisation/wire_msg_header.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg_header.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::messaging::{DstLocation, Error, MsgId, MsgKind, Result};
+use crate::messaging::{AuthKind, DstLocation, Error, MsgId, Result};
 use bincode::{
     config::{BigEndian, FixintEncoding, WithOtherEndian, WithOtherIntEncoding},
     Options,
@@ -38,7 +38,7 @@ pub struct WireMsgHeader {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MsgEnvelope {
     pub msg_id: MsgId,
-    pub msg_kind: MsgKind,
+    pub msg_kind: AuthKind,
     pub dst_location: DstLocation,
 }
 
@@ -73,7 +73,7 @@ lazy_static! {
 
 impl WireMsgHeader {
     // Instantiate a WireMsgHeader as per current supported version.
-    pub fn new(msg_id: MsgId, msg_kind: MsgKind, dst_location: DstLocation) -> Self {
+    pub fn new(msg_id: MsgId, msg_kind: AuthKind, dst_location: DstLocation) -> Self {
         Self {
             //header_size: Self::max_size(),
             version: MESSAGING_PROTO_VERSION,

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -14,7 +14,7 @@ use crate::node::{
     Error, Result,
 };
 use sn_interface::elder_count;
-use sn_interface::messaging::{system::SystemMsg, MsgKind, WireMsg};
+use sn_interface::messaging::{system::SystemMsg, AuthKind, WireMsg};
 use sn_interface::types::{log_markers::LogMarker, Peer};
 
 use itertools::Itertools;
@@ -426,11 +426,11 @@ impl Dispatcher {
         wire_msg: WireMsg,
     ) -> Result<Vec<Cmd>> {
         let cmds = match wire_msg.msg_kind() {
-            MsgKind::NodeAuthMsg(_) | MsgKind::NodeBlsShareAuthMsg(_) => {
+            AuthKind::Node(_) | AuthKind::NodeBlsShare(_) => {
                 self.deliver_msgs(recipients, delivery_group_size, wire_msg)
                     .await?
             }
-            MsgKind::ServiceMsg(_) => {
+            AuthKind::Service(_) => {
                 // we should never be sending such a msg to more than one recipient
                 // need refactors further up to solve in a nicer way
                 if recipients.len() > 1 {

--- a/sn_node/src/node/api/tests/mod.rs
+++ b/sn_node/src/node/api/tests/mod.rs
@@ -27,7 +27,7 @@ use sn_interface::messaging::{
         JoinAsRelocatedRequest, JoinRequest, JoinResponse, KeyedSig, MembershipState,
         NodeState as NodeStateMsg, RelocateDetails, ResourceProofResponse, SectionAuth, SystemMsg,
     },
-    AuthorityProof, DstLocation, MsgId, MsgKind, MsgType, NodeAuth,
+    AuthKind, AuthorityProof, DstLocation, MsgId, MsgType, NodeAuth,
     SectionAuth as MsgKindSectionAuth, WireMsg,
 };
 #[cfg(feature = "test-utils")]

--- a/sn_node/src/node/core/bootstrap/join.rs
+++ b/sn_node/src/node/core/bootstrap/join.rs
@@ -17,7 +17,7 @@ use sn_interface::messaging::{
         JoinRejectionReason, JoinRequest, JoinResponse, ResourceProofResponse, SectionAuth,
         SystemMsg,
     },
-    DstLocation, MsgKind, MsgType, NodeAuth, WireMsg,
+    AuthKind, DstLocation, MsgType, NodeAuth, WireMsg,
 };
 use sn_interface::network_knowledge::{
     prefix_map::NetworkPrefixMap, NetworkKnowledge, NodeInfo, SectionAuthUtils, MIN_ADULT_AGE,
@@ -435,8 +435,8 @@ impl<'a> Join<'a> {
                 MsgEvent::Received {
                     sender, wire_msg, ..
                 } => match wire_msg.msg_kind() {
-                    MsgKind::ServiceMsg(_) => continue,
-                    MsgKind::NodeBlsShareAuthMsg(_) => {
+                    AuthKind::Service(_) => continue,
+                    AuthKind::NodeBlsShare(_) => {
                         trace!(
                             "Bootstrap message discarded: sender: {:?} wire_msg: {:?}",
                             sender,
@@ -444,7 +444,7 @@ impl<'a> Join<'a> {
                         );
                         continue;
                     }
-                    MsgKind::NodeAuthMsg(NodeAuth { .. }) => match wire_msg.into_msg() {
+                    AuthKind::Node(NodeAuth { .. }) => match wire_msg.into_msg() {
                         Ok(MsgType::System {
                             msg: SystemMsg::JoinResponse(resp),
                             ..

--- a/sn_node/src/node/core/comm/mod.rs
+++ b/sn_node/src/node/core/comm/mod.rs
@@ -624,7 +624,7 @@ mod tests {
     use qp2p::Config;
     use rand::rngs::OsRng;
     use sn_interface::messaging::data::{DataQuery, ServiceMsg};
-    use sn_interface::messaging::{DstLocation, MsgId, MsgKind, ServiceAuth};
+    use sn_interface::messaging::{AuthKind, DstLocation, MsgId, ServiceAuth};
     use sn_interface::types::{ChunkAddress, Keypair, Peer};
     use std::{net::Ipv4Addr, time::Duration};
     use tokio::{net::UdpSocket, sync::mpsc, time};
@@ -863,12 +863,8 @@ mod tests {
             signature: src_keypair.sign(&payload),
         };
 
-        let wire_msg = WireMsg::new_msg(
-            MsgId::new(),
-            payload,
-            MsgKind::ServiceMsg(auth),
-            dst_location,
-        )?;
+        let wire_msg =
+            WireMsg::new_msg(MsgId::new(), payload, AuthKind::Service(auth), dst_location)?;
 
         Ok(wire_msg)
     }

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -497,7 +497,7 @@ mod tests {
 
     use crate::UsedSpace;
     use sn_interface::messaging::{
-        AuthorityProof, DstLocation, MsgId, MsgKind, MsgType, NodeAuth,
+        AuthKind, AuthorityProof, DstLocation, MsgId, MsgType, NodeAuth,
         SectionAuth as SectionAuthMsg,
     };
     #[cfg(feature = "test-utils")]
@@ -837,7 +837,7 @@ mod tests {
 
             let node_auth = NodeAuth::authorize(src_section_pk, &src_node_keypair, &payload);
 
-            let msg_kind = MsgKind::NodeAuthMsg(node_auth.into_inner());
+            let msg_kind = AuthKind::Node(node_auth.into_inner());
 
             let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
 

--- a/sn_node/src/node/core/messaging/sending/services.rs
+++ b/sn_node/src/node/core/messaging/sending/services.rs
@@ -9,7 +9,7 @@
 use crate::node::{api::cmds::Cmd, core::Node, Result};
 use sn_interface::messaging::{
     data::{CmdError, ServiceMsg},
-    DstLocation, EndUser, MsgId, MsgKind, ServiceAuth, WireMsg,
+    AuthKind, DstLocation, EndUser, MsgId, ServiceAuth, WireMsg,
 };
 use sn_interface::types::{Peer, PublicKey, Signature};
 
@@ -58,12 +58,12 @@ impl Node {
     pub(crate) async fn ed_sign_client_msg(
         &self,
         client_msg: &ServiceMsg,
-    ) -> Result<(MsgKind, Bytes)> {
+    ) -> Result<(AuthKind, Bytes)> {
         let keypair = self.info.read().await.keypair.clone();
         let payload = WireMsg::serialize_msg_payload(client_msg)?;
         let signature = keypair.sign(&payload);
 
-        let msg = MsgKind::ServiceMsg(ServiceAuth {
+        let msg = AuthKind::Service(ServiceAuth {
             public_key: PublicKey::Ed25519(keypair.public),
             signature: Signature::Ed25519(signature),
         });

--- a/sn_node/src/node/core/messaging/sending/system.rs
+++ b/sn_node/src/node/core/messaging/sending/system.rs
@@ -9,7 +9,7 @@
 use crate::node::{api::cmds::Cmd, core::Node, messages::WireMsgUtils, Error, Result};
 use sn_interface::messaging::{
     system::{SectionAuth, SystemMsg},
-    DstLocation, MsgKind, WireMsg,
+    AuthKind, DstLocation, WireMsg,
 };
 use sn_interface::network_knowledge::NodeState;
 use sn_interface::types::{log_markers::LogMarker, Peer};
@@ -96,7 +96,7 @@ impl Node {
         for recipient in recipients.into_iter() {
             if recipient.name() == our_name {
                 match wire_msg.msg_kind() {
-                    MsgKind::NodeBlsShareAuthMsg(_) => {
+                    AuthKind::NodeBlsShare(_) => {
                         // do nothing, continue we should be accumulating this
                         handle = true;
                     }

--- a/sn_node/src/node/messages/mod.rs
+++ b/sn_node/src/node/messages/mod.rs
@@ -13,7 +13,7 @@ pub(super) use self::msg_authority::NodeMsgAuthorityUtils;
 use crate::node::{Error, Result};
 use sn_interface::messaging::{
     system::{SigShare, SystemMsg},
-    AuthorityProof, BlsShareAuth, DstLocation, MsgId, MsgKind, NodeAuth, WireMsg,
+    AuthKind, AuthorityProof, BlsShareAuth, DstLocation, MsgId, NodeAuth, WireMsg,
 };
 
 use bls::PublicKey as BlsPublicKey;
@@ -52,7 +52,7 @@ impl WireMsgUtils for WireMsg {
         let msg_payload =
             WireMsg::serialize_msg_payload(&node_msg).map_err(|_| Error::InvalidMessage)?;
 
-        let msg_kind = MsgKind::NodeBlsShareAuthMsg(
+        let msg_kind = AuthKind::NodeBlsShare(
             bls_share_authorize(src_section_pk, src_name, key_share, &msg_payload).into_inner(),
         );
 
@@ -74,7 +74,7 @@ impl WireMsgUtils for WireMsg {
         let msg_payload =
             WireMsg::serialize_msg_payload(&node_msg).map_err(|_| Error::InvalidMessage)?;
 
-        let msg_kind = MsgKind::NodeAuthMsg(
+        let msg_kind = AuthKind::Node(
             NodeAuth::authorize(src_section_pk, &node.keypair, &msg_payload).into_inner(),
         );
 


### PR DESCRIPTION
This feels more correct given that the kind is actually about the authority that
the message carries.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
