### PR TITLE
ci: increase alert threshold

### DIFF
--- a/.github/workflows/benchmark_prs.yml
+++ b/.github/workflows/benchmark_prs.yml
@@ -104,8 +104,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Enable alert commit comment
           comment-on-alert: true
-          # 150% regression will result in alert
-          alert-threshold: '150%'
+          # 200% regression will result in alert
+          alert-threshold: '200%'
 
 
       ###############


### PR DESCRIPTION
we were seeing fails when no related code was touched,
this should hopefully keep that noise from affecting the CI too badly

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
