### PR TITLE
fix(client): check Register permissions on ops locally to prevent failures when broadcasted to the network

### DIFF
--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -34,7 +34,7 @@ impl Client {
     #[instrument(skip(self), level = "debug")]
     async fn send_cmd_with_retry_count(&self, cmd: DataCmd, retry_count: f32) -> Result<(), Error> {
         let client_pk = self.public_key();
-        let dst_name = cmd.dst_name(); // let msg = ServiceMsg::Cmd(cmd.clone());
+        let dst_name = cmd.dst_name();
 
         let debug_cmd = format!("{:?}", cmd);
 
@@ -90,7 +90,6 @@ impl Client {
                 tokio::time::sleep(delay).await;
             } else {
                 // we're done trying
-
                 break res;
             }
         }

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -286,10 +286,7 @@ impl Session {
                     correlation_id,
                     ..
                 } => {
-                    warn!(
-                        "CmdError was received for {correlation_id:?} received is: {:?}",
-                        error
-                    );
+                    warn!("CmdError was received for {correlation_id:?}: {:?}", error);
                     Self::send_cmd_response(cmds, correlation_id, src_peer.addr(), Some(error));
                 }
                 ServiceMsg::CmdAck { correlation_id } => {

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -120,6 +120,7 @@ impl Session {
         }
 
         let expected_acks = std::cmp::max(1, elders_len * 2 / 3);
+
         // We are not wait for the receive of majority of cmd Acks.
         // This could be further strict to wait for ALL the Acks get received.
         // The period is expected to have AE completed, hence no extra wait is required.
@@ -134,7 +135,7 @@ impl Session {
                 Ok((src, None)) => {
                     received_ack += 1;
                     trace!(
-                        "received CmdAck of {:?} from {:?}, so far {:?} / {:?}",
+                        "received CmdAck of {:?} from {:?}, so far {} / {}",
                         msg_id,
                         src,
                         received_ack,
@@ -148,7 +149,7 @@ impl Session {
                 Ok((src, Some(error))) => {
                     received_err += 1;
                     error!(
-                        "received error response {:?} of cmd {:?} from {:?}, so far {:?} vs. {:?}",
+                        "received error response {:?} of cmd {:?} from {:?}, so far {} acks vs. {} errors",
                         error, msg_id, src, received_ack, received_err
                     );
                     if received_err >= expected_acks {
@@ -164,13 +165,13 @@ impl Session {
             attempts += 1;
             if attempts >= expected_cmd_ack_wait_attempts {
                 warn!(
-                    "Terminated with insufficient CmdAcks for {:?}, {:?} / {:?} acks received",
+                    "Terminated with insufficient CmdAcks for {:?}, {} / {} acks received",
                     msg_id, received_ack, expected_acks
                 );
                 break;
             }
             trace!(
-                "current ack waiting loop count {:?}/{:?}",
+                "current ack waiting loop count {}/{}",
                 attempts,
                 expected_cmd_ack_wait_attempts
             );

--- a/sn_node/src/node/core/messaging/handling/mod.rs
+++ b/sn_node/src/node/core/messaging/handling/mod.rs
@@ -653,7 +653,8 @@ impl Node {
                     "Processing CouldNotStoreData event with MsgId: {:?}",
                     msg_id
                 );
-                return if self.is_elder().await {
+
+                if self.is_elder().await {
                     if full {
                         let changed = self
                             .set_storage_level(&node_id, StorageLevel::from(StorageLevel::MAX)?)
@@ -667,7 +668,7 @@ impl Node {
                 } else {
                     error!("Received unexpected message while Adult");
                     Ok(vec![])
-                };
+                }
             }
             SystemMsg::NodeEvent(NodeEvent::SuspiciousNodesDetected(suspects)) => {
                 info!(

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -186,7 +186,10 @@ impl Node {
                     .await
             }
             _ => {
-                warn!("!!!! Unexpected ServiceMsg received in routing. Was not sent to node layer: {:?}", msg);
+                warn!(
+                    "!!!! Unexpected ServiceMsg received, and it was not handled: {:?}",
+                    msg
+                );
                 return Ok(vec![]);
             }
         };


### PR DESCRIPTION
Resolve PR #836.

Note that commands creating a Register don't fail as the network doesn't return any type of errors (by design) but only an ACK that the message was delivered to the section. However, we can perform checks locally on CRDT operations, like in the case of a Register operation, so any permissions issue is detected locally on the client side before the operation is sent/broadcasted to the network. This PR, does simply that, it makes sure the permissions are checked locally when building the Register CRDT operation.