### PR TITLE
ci: nightly improvements and fix release process issues

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -155,7 +155,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ssh-secret-key: ${{ secrets.SSH_SECRET_KEY  }}
-          node-count: ${{ github.event.inputs.node-count || 15 }}
+          node-count: ${{ github.event.inputs.node-count || 30 }}
           node-path: /tmp/sn_node
       # The other jobs in the workflow have the testnet launch as a dependency, but they go ahead
       # even if this job fails. It would be better if the whole workflow is abandoned if we don't
@@ -274,7 +274,7 @@ jobs:
     name: cli tests
     if: ${{ always() }} # give the suite a chance to run, even if the api tests fail.
     runs-on: ${{ matrix.os }}
-    needs: [api, client]
+    needs: launch-testnet
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
           destination_dir: ''
 
   publish:
-    name: publish sn_dysfunction
+    name: publish
     runs-on: ubuntu-latest
     needs: [gh_release]
     if: |
@@ -220,19 +220,20 @@ jobs:
           if [[ $commit_message == *"sn_node"* ]]; then
             # The sn_node crate is dependent on sn_dysfunction and sn_interface and sometimes the
             # new version doesn't become available on crates.io immediately, so this script will use
-            # a retry loop.
-            # The script can only check for one dependent crate, but since this process is
-            # sequential, we'll check for sn_dysfunction.
+            # a retry loop. The script can only check for one dependent crate, but since this
+            # process is sequential, we'll check for sn_interface, since this was the preceding
+            # crate and is less likely than sn_dysfunction to be available.
             ./resources/scripts/publish_crate.sh \
-              "sn_node" "${{ steps.versioning.outputs.sn_dysfunction_version }}" "sn_dysfunction"
+              "sn_node" "${{ steps.versioning.outputs.sn_interface_version }}" "sn_interface"
           fi
       - name: publish sn_client
         run: |
           commit_message="${{ github.event.head_commit.message }}"
           if [[ $commit_message == *"sn_client"* ]]; then
             # sn_client is dependent on sn_interface.
-            ./resources/scripts/publish_crate.sh \
-              "sn_client" "${{ steps.versioning.outputs.sn_interface_version }}" "sn_interface"
+            # We already waited for sn_interface to be published in the last step, so we can just go
+            # ahead and attempt the publish without the retry script.
+            cd sn_client && cargo publish --allow-dirty
           fi
       - name: publish sn_api
         run: |
@@ -247,8 +248,6 @@ jobs:
         run: |
           commit_message="${{ github.event.head_commit.message }}"
           if [[ $commit_message == *"sn_cli"* ]]; then
-            # sn_cli is dependent on sn_api and sometimes the new version doesn't
-            # become available on crates.io immediately, so this script will use a retry loop.
             ./resources/scripts/publish_crate.sh \
               "sn_cli" "${{ steps.versioning.outputs.sn_api_version }}" "sn_api"
           fi

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ gha-build-arm-unknown-linux-musleabi: arm-unknown-linux-musleabi
 gha-build-armv7-unknown-linux-musleabihf: armv7-unknown-linux-musleabihf
 gha-build-aarch64-unknown-linux-musl: aarch64-unknown-linux-musl
 
+.ONESHELL:
 arm-unknown-linux-musleabi:
+	# The outer process that calls this, i.e., the build agent on Github Actions, must be performing
+	# set +e, because even if the compilation fails it just continues and no error is reported.
+	@set -e
 	rm -rf target
 	rm -rf artifacts
 	mkdir artifacts
@@ -35,7 +39,11 @@ arm-unknown-linux-musleabi:
 		--no-default-features --features testing
 	find target/arm-unknown-linux-musleabi/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 
+.ONESHELL:
 armv7-unknown-linux-musleabihf:
+	# The outer process that calls this, i.e., the build agent on Github Actions, must be performing
+	# set +e, because even if the compilation fails it just continues and no error is reported.
+	@set -e
 	rm -rf target
 	rm -rf artifacts
 	mkdir artifacts
@@ -45,7 +53,11 @@ armv7-unknown-linux-musleabihf:
 		--no-default-features --features testing
 	find target/armv7-unknown-linux-musleabihf/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 
+.ONESHELL:
 aarch64-unknown-linux-musl:
+	# The outer process that calls this, i.e., the build agent on Github Actions, must be performing
+	# set +e, because even if the compilation fails it just continues and no error is reported.
+	@set -e
 	rm -rf target
 	rm -rf artifacts
 	mkdir artifacts

--- a/sn_node/src/node/cfg/config_handler.rs
+++ b/sn_node/src/node/cfg/config_handler.rs
@@ -25,7 +25,10 @@ use tracing::{debug, warn, Level};
 const CONFIG_FILE: &str = "node.config";
 const CONNECTION_INFO_FILE: &str = "node_connection_info.config";
 const DEFAULT_ROOT_DIR_NAME: &str = "root_dir";
+#[cfg(not(target_arch = "arm"))]
 const DEFAULT_MAX_CAPACITY: usize = 10 * 1024 * 1024 * 1024; // 10GB
+#[cfg(any(target_arch = "arm", target_arch = "armv7"))]
+const DEFAULT_MAX_CAPACITY: usize = usize::MAX; // This will be 2^32 on these architectures.
 
 /// Node configuration
 #[derive(Default, Clone, Debug, Serialize, Deserialize, StructOpt)]


### PR DESCRIPTION
A few changes for things spotted in the last nightly/release run:

* Use `usize::MAX` for max capacity on ARM/ARMv7. A change to use a max capacity of 10GB wouldn't
  compile on these 32-bit architectures, since the value exceeded 2^32.
* Exit on error if ARM builds fail. Even though compilation failed, the release process didn't
  report an error for the failure. The outer process must be disabling the `set -e` effect.
* During the publishing process, instruct `sn_node` to wait on `sn_interface` rather than
  `sn_dysfunction`, since `sn_interface` is published immediately before `sn_node`. The last release
  failed when it tried to publish `sn_node` because `sn_interface` wasn't available yet.
* Use 30 nodes in the testnet for the nightly run.
* Run the CLI test suite in parallel with the API and client tests. Previously we didn't try this
  because we never knew if the network would handle the load.
