### PR TITLE
chore: refactor CleanUpPeerLinks

### DIFF
--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -48,7 +48,7 @@ use tracing_subscriber::filter::EnvFilter;
 
 #[cfg(not(feature = "tokio-console"))]
 const MODULE_NAME: &str = "sn_node";
-const BOOTSTRAP_RETRY_TIME_SEC: u64 = 60;
+const BOOTSTRAP_RETRY_TIME_SEC: u64 = 30;
 
 fn main() -> Result<()> {
     color_eyre::install()?;

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -58,20 +58,6 @@ impl Node {
         Ok(cmds)
     }
 
-    /// see if a client is waiting in the pending queries for a response
-    /// If not, we could remove its link eg.
-    pub(crate) async fn pending_data_queries_contains_client(&self, peer: &Peer) -> bool {
-        // now we check if our peer is still waiting...
-        for (_op_id, peer_vec) in self.pending_data_queries.get_items().await {
-            let vec = peer_vec.object;
-            if vec.contains(peer) {
-                return true;
-            }
-        }
-
-        false
-    }
-
     /// Handle data read
     /// Records response in liveness tracking
     /// Forms a response to send to the requester


### PR DESCRIPTION
The if statement could hold the lock on each until it's done. here we get
our bool statements before the if, meaning no locks should be held.

This may hopefully prevent deadlock on PeerSessions read/write

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
