### PR TITLE
chore(node): dont hold comms session lock over session cleanup

### DIFF
--- a/sn_node/src/node/core/comm/mod.rs
+++ b/sn_node/src/node/core/comm/mod.rs
@@ -106,9 +106,12 @@ impl Comm {
         // TODO: check if we need to remove client conns manually, or if we can assume they're disconnected...
         // Perhaps above a threshold we cleanup non-section conns?
         if !peers_to_cleanup.is_empty() {
-            let mut sessions_write_guard = self.sessions.write().await;
             for peer in peers_to_cleanup {
-                if let Some(session) = sessions_write_guard.remove(&peer) {
+                let mut sessions_write_guard = self.sessions.write().await;
+                let perhaps_peer = sessions_write_guard.remove(&peer);
+                drop(sessions_write_guard);
+
+                if let Some(session) = perhaps_peer {
                     session.disconnect().await
                 };
             }


### PR DESCRIPTION
It's still not clear if this is where we may be deadlocking. But moving to hold the lock over a shorter duration certainly seems sensible

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
