### PR TITLE
refactor(node_state): move NodeState validations to NodeState struct

### DIFF
--- a/sn_interface/src/network_knowledge/errors.rs
+++ b/sn_interface/src/network_knowledge/errors.rs
@@ -57,6 +57,8 @@ pub enum Error {
     InvalidMessage,
     #[error("A signature share is invalid.")]
     InvalidSignatureShare,
+    #[error("A node has invalid relocation details")]
+    InvalidRelocationDetails,
     #[error("The secret key share is missing for public key {0:?}")]
     MissingSecretKeyShare(bls::PublicKey),
     #[error("Failed to send a message to {0}, {1}")]
@@ -84,7 +86,10 @@ pub enum Error {
     /// Timeout when trying to join the network
     #[error("Timeout when trying to join the network")]
     JoinTimeout,
-    /// Not enough in the section to perform Chunk operation
+    #[error("The node in question is not a member of the section")]
+    NotAMember,
+    #[error("Request does not match the section prefix")]
+    WrongSection,
     #[error("Not enough Adults available in Section({0:?}) to perform operation")]
     NoAdults(Prefix),
     /// Not Section PublicKey.

--- a/sn_node/src/node/core/mod.rs
+++ b/sn_node/src/node/core/mod.rs
@@ -28,18 +28,15 @@ pub(crate) use proposal::Proposal;
 pub(crate) use relocation::{check as relocation_check, ChurnId};
 use sn_interface::{
     network_knowledge::{
-        recommended_section_size, supermajority, NetworkKnowledge, NodeInfo, SectionKeyShare,
-        SectionKeysProvider,
+        recommended_section_size, split, supermajority, NetworkKnowledge, NodeInfo,
+        SectionKeyShare, SectionKeysProvider,
     },
     types::keys::ed25519::Digest256,
 };
 
 use super::{
-    api::cmds::Cmd,
-    dkg::DkgVoter,
-    handover::Handover,
-    membership::{split, Membership},
-    Elders, Event, NodeElderChange,
+    api::cmds::Cmd, dkg::DkgVoter, handover::Handover, membership::Membership, Elders, Event,
+    NodeElderChange,
 };
 
 use crate::node::{


### PR DESCRIPTION
This is part of the work to move membership history to NetworkKnowledge. By moving NodeState validations to the NodeState struct, we have less code in Membership and so, less code to move to NetworkKnowledge.