### PR TITLE
Replication refactors

### DIFF
--- a/resources/test_symlinks/broken_rel_link.txt
+++ b/resources/test_symlinks/broken_rel_link.txt
@@ -1,1 +1,0 @@
-non-existing-target

--- a/resources/test_symlinks/file_outside
+++ b/resources/test_symlinks/file_outside
@@ -1,1 +1,0 @@
-../file_outside

--- a/resources/test_symlinks/sub/infinite_loop
+++ b/resources/test_symlinks/sub/infinite_loop
@@ -1,1 +1,0 @@
-infinite_loop

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -20,6 +20,10 @@ name = "client_files"
 [[example]]
 name = "network_split"
 
+[[example]]
+# is data retained over churn
+name = "churn"
+
 [features]
 default = []
 chaos = []

--- a/sn_client/examples/churn.rs
+++ b/sn_client/examples/churn.rs
@@ -143,7 +143,7 @@ pub async fn run_split() -> Result<()> {
 
     let mut all_data_put = vec![];
 
-    let files_to_put: i32 = 12;
+    let files_to_put: i32 = 10;
     for _i in 0..files_to_put {
         let (address, hash) = upload_data().await?;
         all_data_put.push((address, hash));
@@ -216,7 +216,7 @@ async fn upload_data() -> Result<(BytesAddress, [u8; 32])> {
     let config = ClientConfig::new(None, None, genesis_key, None, None, None, None).await;
     let client = Client::new(config, bootstrap_nodes, None).await?;
 
-    let bytes = random_bytes(1024 * 1024 * 3);
+    let bytes = random_bytes(1024 * 1024 * 10);
 
     let mut hasher = Sha3::v256();
     let mut output = [0; 32];

--- a/sn_client/examples/churn.rs
+++ b/sn_client/examples/churn.rs
@@ -143,7 +143,7 @@ pub async fn run_split() -> Result<()> {
 
     let mut all_data_put = vec![];
 
-    let files_to_put: i32 = 10;
+    let files_to_put: i32 = 40;
     for _i in 0..files_to_put {
         let (address, hash) = upload_data().await?;
         all_data_put.push((address, hash));

--- a/sn_client/examples/churn.rs
+++ b/sn_client/examples/churn.rs
@@ -36,12 +36,12 @@ const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
 const NODES_DIR: &str = "local-test-network";
 const INTERVAL: &str = "10000";
 const RUST_LOG: &str = "RUST_LOG";
-const ADDITIONAL_NODES_TO_SPLIT: u64 = 15;
+const ADDITIONAL_NODES_TO_SPLIT: u64 = 12;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // First lets build the network and testnet launcher, to ensure we're on the latest version
-    let args: Vec<&str> = vec!["build", "--release", "--features=test-utils"];
+    let args: Vec<&str> = vec!["build", "--release"];
 
     println!("Building current sn_node");
     let _child = Command::new("cargo")
@@ -105,6 +105,7 @@ pub async fn run_split() -> Result<()> {
     // Let's create an args array to pass to the network launcher tool
     let mut sn_launch_tool_args = vec![
         "sn_launch_tool",
+        "-yyyy", // RUST_LOG
         "--node-path",
         &arg_node_path,
         "--nodes-dir",
@@ -136,9 +137,9 @@ pub async fn run_split() -> Result<()> {
         .wrap_err("Error starting the testnet")?;
 
     // leave a longer interval with more nodes to allow for splits if using split amounts
-    let interval_duration = Duration::from_millis(*interval_as_int);
-    sleep(interval_duration).await;
-    println!("Done sleeping....");
+    let _interval_duration = Duration::from_millis(*interval_as_int);
+    // sleep(interval_duration).await;
+    // println!("Done sleeping....");
 
     let mut all_data_put = vec![];
 
@@ -166,7 +167,6 @@ pub async fn run_split() -> Result<()> {
         .and_then(|launch| launch.run())
         .wrap_err("Error adding nodes to the testnet")?;
 
-    // leave a longer interval with more nodes to allow for splits if using split amounts
     let interval_duration = Duration::from_millis(*interval_as_int);
 
     sleep(interval_duration).await;

--- a/sn_interface/src/messaging/serialisation/mod.rs
+++ b/sn_interface/src/messaging/serialisation/mod.rs
@@ -12,15 +12,13 @@ mod wire_msg_header;
 use xor_name::XorName;
 
 // highest priority, since we must sort out membership first of all
-pub(crate) const DKG_MSG_PRIORITY: i32 = 10;
+pub(crate) const DKG_MSG_PRIORITY: i32 = 8;
 // very high prio, since we must have correct contact details to the network
-pub(crate) const ANTIENTROPY_MSG_PRIORITY: i32 = 8;
+pub(crate) const ANTIENTROPY_MSG_PRIORITY: i32 = 6;
 // high prio as recipient can't do anything until they've joined. Needs to be lower than DKG (or else no split)
-pub(crate) const JOIN_RESPONSE_PRIORITY: i32 = 6;
+pub(crate) const JOIN_RESPONSE_PRIORITY: i32 = 4;
 // our joining to the network
-pub(crate) const JOIN_RELOCATE_MSG_PRIORITY: i32 = 4;
-// reporting dysfunction is somewhat critical, so not super low
-pub(crate) const DYSFUNCTION_MSG_PRIORITY: i32 = 2;
+pub(crate) const JOIN_RELOCATE_MSG_PRIORITY: i32 = 2;
 #[cfg(feature = "back-pressure")]
 // reporting backpressure isn't time critical, so fairly low
 pub(crate) const BACKPRESSURE_MSG_PRIORITY: i32 = 0;
@@ -120,12 +118,6 @@ impl MsgType {
                     | SystemMsg::HandoverVote(_),
                 ..
             } => JOIN_RELOCATE_MSG_PRIORITY,
-
-            // Inter-node comms for dysfunction detection
-            MsgType::System {
-                msg: SystemMsg::NodeEvent(NodeEvent::SuspiciousNodesDetected(_)),
-                ..
-            } => DYSFUNCTION_MSG_PRIORITY,
 
             #[cfg(feature = "back-pressure")]
             // Inter-node comms for backpressure

--- a/sn_interface/src/messaging/system/node_msgs.rs
+++ b/sn_interface/src/messaging/system/node_msgs.rs
@@ -71,8 +71,6 @@ pub enum NodeEvent {
         /// Whether store failed due to full
         full: bool,
     },
-    /// Inform Adults of a possible suspect node
-    SuspiciousNodesDetected(BTreeSet<XorName>),
 }
 
 /// Query originating at a node

--- a/sn_interface/src/messaging/system/node_msgs.rs
+++ b/sn_interface/src/messaging/system/node_msgs.rs
@@ -46,9 +46,7 @@ pub enum NodeCmd {
     /// Tells an Adult to store a replica of the data
     ReplicateData(Vec<ReplicatedData>),
     /// Tells an Adult to fetch and replicate data from the sender
-    SendReplicateDataAddress(Vec<ReplicatedDataAddress>),
-    /// Fetch the given replicated data we are missing
-    FetchReplicateData(Vec<ReplicatedDataAddress>),
+    SendAnyMissingRelevantData(Vec<ReplicatedDataAddress>),
     /// Sent to all promoted nodes (also sibling if any) after
     /// a completed transition to a new constellation.
     ReceiveMetadata {

--- a/sn_interface/src/types/log_markers.rs
+++ b/sn_interface/src/types/log_markers.rs
@@ -97,7 +97,6 @@ pub enum LogMarker {
     SendJoinsDisallowed,
     SendDKGUnderway,
     SendNodeApproval,
-    SendSuspiciousNodesDetected,
     // Approved to join
     ReceivedJoinApproval,
     // Connections

--- a/sn_interface/src/types/log_markers.rs
+++ b/sn_interface/src/types/log_markers.rs
@@ -50,7 +50,10 @@ pub enum LogMarker {
     ChunkQueryReceviedAtElder,
     ChunkQueryReceviedAtAdult,
     // Data reorganisation
+    RequestForAnyMissingData,
     DataReorganisationUnderway,
+    QueuingMissingReplicatedData,
+    SendingMissingReplicatedData,
     // Register
     RegisterWrite,
     RegisterQueryReceivedAtElder,

--- a/sn_node/src/dbs/chunk_store.rs
+++ b/sn_node/src/dbs/chunk_store.rs
@@ -36,6 +36,7 @@ impl ChunkStore {
     /// Used space of the dir is tracked
     pub(crate) fn new<P: AsRef<Path>>(root: P, used_space: UsedSpace) -> Result<Self> {
         let chunk_store_path = root.as_ref().join(CHUNK_DB_DIR);
+        // let mut file = tokio::fs::File::create_dir_all(chunk_store_path).await?;
 
         Ok(ChunkStore {
             bit_tree_depth: BIT_TREE_DEPTH,

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -397,7 +397,7 @@ impl Dispatcher {
     async fn try_processing_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
         match cmd {
             Cmd::CleanupPeerLinks => {
-                self.node.comm.cleanup_peers().await;
+                self.node.cleanup_non_elder_peers().await;
                 Ok(vec![])
             }
             Cmd::SignOutgoingSystemMsg { msg, dst } => {

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -230,23 +230,6 @@ impl Dispatcher {
                         error!("Error sending Propose Offline for dysfunctional nodes: {e:?}");
                     }
                 }
-
-                match dispatcher.node.notify_about_newly_suspect_nodes().await {
-                    Ok(suspect_cmds) => {
-                        for cmd in suspect_cmds {
-                            if let Err(e) = dispatcher
-                                .clone()
-                                .enqueue_and_handle_next_cmd_and_offshoots(cmd, None)
-                                .await
-                            {
-                                error!("Error processing suspect node cmds: {:?}", e);
-                            }
-                        }
-                    }
-                    Err(error) => {
-                        error!("Error getting suspect nodes: {error}");
-                    }
-                };
             }
         });
     }

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -15,9 +15,14 @@ use crate::node::{
 };
 #[cfg(feature = "back-pressure")]
 use sn_interface::messaging::DstLocation;
-use sn_interface::messaging::{system::SystemMsg, AuthKind, WireMsg};
 use sn_interface::types::{log_markers::LogMarker, Peer};
-
+use sn_interface::{
+    messaging::{
+        system::{NodeCmd, SystemMsg},
+        AuthKind, WireMsg,
+    },
+    types::ReplicatedDataAddress,
+};
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use tokio::time::MissedTickBehavior;
 use tokio::{sync::watch, time};
@@ -442,12 +447,13 @@ impl Dispatcher {
                 recipients,
                 wire_msg,
             } => self.send_msg(&recipients, recipients.len(), wire_msg).await,
-            Cmd::ThrottledSendBatchMsgs {
+            Cmd::ThrottledSendBatchData {
                 throttle_duration,
-                recipients,
-                mut wire_msgs,
+                recipient,
+                mut data_batches,
             } => {
-                self.send_throttled_batch_msgs(recipients, &mut wire_msgs, throttle_duration)
+                // TODO, if we have outgoing msg deduplication, we can put all relevant nodes in recipients here...
+                self.send_throttled_batch_data(recipient, &mut data_batches, throttle_duration)
                     .await
             }
             Cmd::SendMsgDeliveryGroup {
@@ -530,26 +536,55 @@ impl Dispatcher {
         Ok(cmds)
     }
 
-    async fn send_throttled_batch_msgs(
+    /// Sends a batch of data every `throttle_duration` so as not to overwhelm the nodes,
+    /// or cause too much memory pressure holding data in mem locally
+    async fn send_throttled_batch_data(
         &self,
-        recipients: Vec<Peer>,
-        messages: &mut Vec<WireMsg>,
+        recipient: Peer,
+        data_batches: &mut Vec<Vec<ReplicatedDataAddress>>,
         throttle_duration: Duration,
     ) -> Result<Vec<Cmd>> {
         let mut cmds = vec![];
-
         let mut interval = tokio::time::interval(throttle_duration);
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
             let _instant = interval.tick().await;
-            if let Some(message) = messages.pop() {
-                cmds.extend(
-                    self.send_msg(&recipients, recipients.len(), message)
-                        .await?,
-                )
+            if let Some(data_batch) = data_batches.pop() {
+                // get info for the WireMsg
+                let section_pk = self.node.section_key_by_name(&recipient.name()).await;
+                let src_section_pk = self.node.network_knowledge().section_key().await;
+                let our_info = &*self.node.info.read().await;
+                let dst = sn_interface::messaging::DstLocation::Node {
+                    name: recipient.name(),
+                    section_pk,
+                };
+
+                let mut data_to_send = vec![];
+
+                // grab the data we want to be sending
+                for data_address in data_batch {
+                    let data = self
+                        .node
+                        .data_storage
+                        .get_from_local_store(&data_address)
+                        .await?;
+                    data_to_send.push(data)
+                }
+
+                let system_msg = SystemMsg::NodeCmd(NodeCmd::ReplicateData(data_to_send));
+
+                let wire_msg = WireMsg::single_src(our_info, dst, system_msg, src_section_pk)?;
+
+                debug!(
+                    "{:?} batch to: {:?} w/ {:?} ",
+                    LogMarker::SendingMissingReplicatedData,
+                    recipient,
+                    wire_msg.msg_id()
+                );
+                cmds.extend(self.send_msg(&[recipient], 1, wire_msg).await?)
             } else {
-                info!("Finished sending a batch of messages");
+                info!("Finished queing sending a batch of messages");
                 break;
             }
         }

--- a/sn_node/src/node/core/comm/mod.rs
+++ b/sn_node/src/node/core/comm/mod.rs
@@ -92,7 +92,7 @@ impl Comm {
 
         let mut peers_to_cleanup = vec![];
         for (peer, session) in sessions.iter() {
-            if retain_peers.contains(&peer) {
+            if retain_peers.contains(peer) {
                 continue;
             }
             session.remove_expired().await;

--- a/sn_node/src/node/core/comm/mod.rs
+++ b/sn_node/src/node/core/comm/mod.rs
@@ -87,10 +87,14 @@ impl Comm {
         self.our_endpoint.public_addr()
     }
 
-    pub(crate) async fn cleanup_peers(&self) {
+    pub(crate) async fn cleanup_peers(&self, retain_peers: Vec<Peer>) {
         let sessions = self.sessions.read().await;
+
         let mut peers_to_cleanup = vec![];
         for (peer, session) in sessions.iter() {
+            if retain_peers.contains(&peer) {
+                continue;
+            }
             session.remove_expired().await;
             let is_connected = session.is_connected().await;
 

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -20,7 +20,7 @@ use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;
 use itertools::Itertools;
 use secured_linked_list::SecuredLinkedList;
-use std::{collections::BTreeSet, time::Duration};
+use std::time::Duration;
 use xor_name::XorName;
 
 impl Node {
@@ -33,13 +33,6 @@ impl Node {
         members: SectionPeers,
     ) -> Result<Vec<Cmd>> {
         let snapshot = self.state_snapshot().await;
-        let old_adults: BTreeSet<_> = self
-            .network_knowledge
-            .adults()
-            .await
-            .iter()
-            .map(|p| p.name())
-            .collect();
 
         let our_name = self.info.read().await.name();
         let signed_sap = SectionAuth {
@@ -58,10 +51,9 @@ impl Node {
             )
             .await?;
 
-        let mut cmds = self.try_reorganize_data(old_adults).await?;
-
         // always run this, only changes will trigger events
-        cmds.extend(self.update_self_for_new_node_state(snapshot).await?);
+        let mut cmds = self.update_self_for_new_node_state(snapshot).await?;
+        cmds.extend(self.try_reorganize_data().await?);
 
         Ok(cmds)
     }
@@ -486,11 +478,11 @@ mod tests {
     use sn_interface::network_knowledge::test_utils::{
         gen_addr, gen_section_authority_provider, section_signed,
     };
-
     use sn_interface::network_knowledge::{
         NetworkKnowledge, NodeInfo, SectionKeyShare, SectionKeysProvider,
     };
     use sn_interface::types::keys::ed25519;
+    use std::collections::BTreeSet;
 
     use assert_matches::assert_matches;
     use bls::SecretKey;

--- a/sn_node/src/node/core/messaging/handling/mod.rs
+++ b/sn_node/src/node/core/messaging/handling/mod.rs
@@ -44,12 +44,7 @@ use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;
 use itertools::Itertools;
 use sn_dysfunction::IssueType;
-use std::collections::BTreeSet;
-use tokio::time::Duration;
 use xor_name::XorName;
-
-const REPLICATION_BATCH_SIZE: usize = 50;
-const REPLICATION_MSG_THROTTLE_DURATION: Duration = Duration::from_secs(5);
 
 // Message handling
 impl Node {
@@ -698,117 +693,15 @@ impl Node {
                     Ok(cmds)
                 };
             }
-            SystemMsg::NodeCmd(NodeCmd::SendReplicateDataAddress(data_addresses)) => {
-                info!("ReplicateData MsgId: {:?}", msg_id);
+            SystemMsg::NodeCmd(NodeCmd::SendAnyMissingRelevantData(known_data_addresses)) => {
+                info!(
+                    "{:?} MsgId: {:?}",
+                    LogMarker::RequestForAnyMissingData,
+                    msg_id
+                );
 
-                return if self.is_elder().await {
-                    error!("Received unexpected message while Elder");
-                    Ok(vec![])
-                } else {
-                    // Collection of data addresses that we do not have
-                    let mut data_not_present = vec![];
-
-                    for data_address in data_addresses {
-                        // TODO: Check if the data name falls within our Xor namespace
-                        // Check if we already have the data
-                        match self.data_storage.get_from_local_store(&data_address).await {
-                            Err(crate::dbs::Error::NoSuchData(_))
-                            | Err(crate::dbs::Error::ChunkNotFound(_)) => {
-                                info!("to-be-replicated data is not present");
-
-                                // We do not have the data which we are supposed to have since the new reorg
-                                data_not_present.push(data_address);
-                            }
-                            Ok(_) => {
-                                info!("We already have the data that was asked to be replicated");
-                            }
-                            Err(e) => {
-                                error!("Error Sending FetchReplicateData for replication: {e}");
-                                return Ok(vec![]);
-                            }
-                        }
-                    }
-
-                    let section_pk = self.section_key_by_name(&sender.name()).await;
-                    let src_section_pk = self.network_knowledge().section_key().await;
-                    let our_info = &*self.info.read().await;
-                    let dst = sn_interface::messaging::DstLocation::Node {
-                        name: sender.name(),
-                        section_pk,
-                    };
-                    let mut wire_msgs = vec![];
-
-                    // Chunks the collection into REPLICATION_BATCH_SIZE addresses in a batch. This avoids memory
-                    // explosion in the network when the amount of data to be replicated is high
-                    for chunked_data_address in
-                        &data_not_present.into_iter().chunks(REPLICATION_BATCH_SIZE)
-                    {
-                        let system_msg = SystemMsg::NodeCmd(NodeCmd::FetchReplicateData(
-                            chunked_data_address.collect_vec(),
-                        ));
-
-                        wire_msgs.push(WireMsg::single_src(
-                            our_info,
-                            dst,
-                            system_msg,
-                            src_section_pk,
-                        )?);
-                    }
-
-                    let cmd = Cmd::ThrottledSendBatchMsgs {
-                        throttle_duration: REPLICATION_MSG_THROTTLE_DURATION,
-                        recipients: vec![sender],
-                        wire_msgs,
-                    };
-
-                    Ok(vec![cmd])
-                };
-            }
-            SystemMsg::NodeCmd(NodeCmd::FetchReplicateData(data_addresses)) => {
-                let mut cmds = vec![];
-                info!("FetchReplicateData MsgId: {:?}", msg_id);
-                return if self.is_elder().await {
-                    error!("Received unexpected message while Elder");
-                    Ok(vec![])
-                } else {
-                    // Chunk the full list into REPLICATION_BATCH_SIZE addresses a batch
-                    let mut addresses = vec![];
-                    for chunked_data_address in
-                        &data_addresses.into_iter().chunks(REPLICATION_BATCH_SIZE)
-                    {
-                        let data_address_collection = chunked_data_address.collect_vec();
-                        addresses.push(data_address_collection);
-                    }
-
-                    // Process each batch
-                    for chunked_addresses in addresses {
-                        let mut data_collection = vec![];
-                        for data_address in chunked_addresses {
-                            match self.data_storage.get_for_replication(data_address).await {
-                                Ok(data) => {
-                                    info!("Providing {data_address:?} for replication");
-
-                                    data_collection.push(data);
-                                }
-                                Err(e) => {
-                                    warn!("Error providing data for replication: {e}");
-                                    return Ok(vec![]);
-                                }
-                            }
-                        }
-
-                        cmds.push(Cmd::SignOutgoingSystemMsg {
-                            msg: SystemMsg::NodeCmd(NodeCmd::ReplicateData(data_collection)),
-                            dst: sn_interface::messaging::DstLocation::Node {
-                                name: sender.name(),
-                                section_pk: self.section_key_by_name(&sender.name()).await,
-                            },
-                        });
-                    }
-
-                    // Provide the requested data
-                    Ok(cmds)
-                };
+                self.get_missing_data_for_node(sender, known_data_addresses)
+                    .await
             }
             SystemMsg::NodeCmd(node_cmd) => {
                 self.send_event(Event::MessageReceived {

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -124,7 +124,11 @@ impl Node {
                 .pending_data_queries
                 .set(op_id, waiting_peers.clone(), None)
                 .await;
-            trace!("Node {:?}, reported data not found ", sending_node_pk);
+            trace!(
+                "Node {:?}, reported data not found {:?}",
+                sending_node_pk,
+                op_id
+            );
             return Ok(cmds);
         }
 

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -7,43 +7,140 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{api::cmds::Cmd, core::Node, Result};
-use sn_interface::types::log_markers::LogMarker;
+use itertools::Itertools;
+use sn_interface::data_copy_count;
+use sn_interface::types::{log_markers::LogMarker, Peer};
+use sn_interface::{
+    messaging::{
+        system::{NodeCmd, SystemMsg},
+        DstLocation,
+    },
+    types::ReplicatedDataAddress,
+};
 use std::collections::BTreeSet;
-use xor_name::XorName;
+use tokio::time::Duration;
+
+const REPLICATION_BATCH_SIZE: usize = 50;
+const REPLICATION_MSG_THROTTLE_DURATION: Duration = Duration::from_secs(5);
 
 impl Node {
-    /// Will reorganize data if we are an adult,
-    /// and there were changes to adults (any added or removed).
-    pub(crate) async fn try_reorganize_data(
+    /// Given a set of known data, we can calculate what more from what we have a
+    /// given node should be responsible for
+    #[instrument(skip(self, data_sender_has))]
+    pub(crate) async fn get_missing_data_for_node(
         &self,
-        old_adults: BTreeSet<XorName>,
+        sender: Peer,
+        data_sender_has: Vec<ReplicatedDataAddress>,
     ) -> Result<Vec<Cmd>> {
-        if self.is_elder().await {
-            // only adults carry out the ops in this method
-            return Ok(vec![]);
+        trace!("Getting missing data for node");
+        // Collection of data addresses that we do not have
+        let mut data_for_sender = vec![];
+        let data_i_have = self.data_storage.keys().await?;
+
+        let adults = self.network_knowledge.adults().await;
+        let adults_names = adults.iter().map(|p2p_node| p2p_node.name());
+
+        for data in data_i_have {
+            if data_sender_has.contains(&data) {
+                continue;
+            }
+
+            let holder_adult_list: BTreeSet<_> = adults_names
+                .clone()
+                .sorted_by(|lhs, rhs| data.name().cmp_distance(lhs, rhs))
+                .take(data_copy_count())
+                .collect();
+
+            if holder_adult_list.contains(&sender.name()) {
+                debug!("Our requester should hold: {:?}", data);
+                data_for_sender.push(data);
+            }
         }
 
-        let current_adults: BTreeSet<_> = self
-            .network_knowledge
-            .adults()
-            .await
-            .iter()
-            .map(|p| p.name())
-            .collect();
-        let added: BTreeSet<_> = current_adults.difference(&old_adults).copied().collect();
-        let removed: BTreeSet<_> = old_adults.difference(&current_adults).copied().collect();
+        let mut data_batches = vec![];
 
-        if added.is_empty() && removed.is_empty() {
-            // no adults added or removed, so nothing to do
+        // Chunks the collection into REPLICATION_BATCH_SIZE addresses in a batch. This avoids memory
+        // explosion in the network when the amount of data to be replicated is high
+        for chunked_data_address in &data_for_sender.into_iter().chunks(REPLICATION_BATCH_SIZE) {
+            let data_batch = chunked_data_address.collect_vec();
+            debug!(
+                "{:?} batch to: {:?} ",
+                LogMarker::QueuingMissingReplicatedData,
+                sender
+            );
+            data_batches.push(data_batch);
+        }
+
+        let cmd = Cmd::ThrottledSendBatchData {
+            throttle_duration: REPLICATION_MSG_THROTTLE_DURATION,
+            recipient: sender,
+
+            data_batches,
+        };
+
+        Ok(vec![cmd])
+    }
+
+    /// Will send a list of currently known/owned data to relevant nodes.
+    /// These nodes should send back anything missing (in batches).
+    /// Relevant nodes should be all _prior_ neighbours + _new_ elders.
+    #[instrument(skip(self))]
+    pub(crate) async fn ask_for_any_new_data(&self) -> Result<Vec<Cmd>> {
+        debug!("Querying section for any new data");
+        let data_i_have = self.data_storage.keys().await?;
+        let mut cmds = vec![];
+
+        let adults = self.network_knowledge.adults().await;
+        let adults_names = adults.iter().map(|p2p_node| p2p_node.name()).collect_vec();
+
+        let elders = self.network_knowledge.elders().await;
+        let my_name = self.info.read().await.name();
+
+        // find data targets that are not us.
+        let mut target_member_names = adults_names
+            .into_iter()
+            .sorted_by(|lhs, rhs| my_name.cmp_distance(lhs, rhs))
+            .filter(|peer| peer != &my_name)
+            .take(data_copy_count())
+            .collect::<BTreeSet<_>>();
+
+        trace!(
+            "nearest neighbours for data req: {}: {:?}",
+            target_member_names.len(),
+            target_member_names
+        );
+
+        // also send to our elders in case they are holding but were just promoted
+        for elder in elders {
+            let _existed = target_member_names.insert(elder.name());
+        }
+
+        let section_pk = self.network_knowledge.section_key().await;
+
+        for name in target_member_names {
+            trace!("Sending our data list to: {:?}", name);
+            cmds.push(Cmd::SignOutgoingSystemMsg {
+                msg: SystemMsg::NodeCmd(
+                    NodeCmd::SendAnyMissingRelevantData(data_i_have.clone()).clone(),
+                ),
+                dst: DstLocation::Node { name, section_pk },
+            })
+        }
+
+        Ok(cmds)
+    }
+
+    /// Will reorganize data if we are an adult,
+    /// and there were changes to adults (any added or removed).
+    pub(crate) async fn try_reorganize_data(&self) -> Result<Vec<Cmd>> {
+        // as an elder we dont want to get any more data for our name
+        // (elders will eventually be caching data in general)
+        if self.is_elder().await {
             return Ok(vec![]);
         }
 
         trace!("{:?}", LogMarker::DataReorganisationUnderway);
-        // we are an adult, and there were changes to adults
-        // so we reorganise the data stored in this section..:
-        let remaining = old_adults.intersection(&current_adults).copied().collect();
-        self.reorganize_data(added, removed, remaining)
-            .await
-            .map_err(super::Error::from)
+
+        self.ask_for_any_new_data().await
     }
 }

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -36,6 +36,7 @@ impl Node {
         // Collection of data addresses that we do not have
         let mut data_for_sender = vec![];
         let data_i_have = self.data_storage.keys().await?;
+        trace!("Our data got");
 
         if data_i_have.is_empty() {
             trace!("We have no data");

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -37,6 +37,11 @@ impl Node {
         let mut data_for_sender = vec![];
         let data_i_have = self.data_storage.keys().await?;
 
+        if data_i_have.is_empty() {
+            trace!("We have no data");
+            return Ok(vec![]);
+        }
+
         let adults = self.network_knowledge.adults().await;
         let adults_names = adults.iter().map(|p2p_node| p2p_node.name());
 
@@ -55,6 +60,11 @@ impl Node {
                 debug!("Our requester should hold: {:?}", data);
                 data_for_sender.push(data);
             }
+        }
+
+        if data_for_sender.is_empty() {
+            trace!("We have no data worth sending");
+            return Ok(vec![]);
         }
 
         let mut data_batches = vec![];

--- a/sn_node/src/node/core/mod.rs
+++ b/sn_node/src/node/core/mod.rs
@@ -289,6 +289,12 @@ impl Node {
             .await
     }
 
+    /// Removes any PeerLinks not from our section elders
+    pub(crate) async fn cleanup_non_elder_peers(&self) {
+        let elders = self.network_knowledge.elders().await;
+        self.comm.cleanup_peers(elders).await
+    }
+
     /// returns names that are relatively dysfunctional
     pub(crate) async fn get_dysfunctional_node_names(&self) -> Result<BTreeSet<XorName>> {
         self.dysfunction_tracking

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -75,6 +75,8 @@ pub enum Error {
     InvalidSectionChain(#[from] SecuredLinkedListError),
     #[error("Messaging protocol error: {0}")]
     Messaging(#[from] sn_interface::messaging::Error),
+    #[error("Membership error: {0}")]
+    Membership(#[from] crate::node::membership::Error),
     #[error("Invalid payload")]
     InvalidPayload,
     #[error("The section is currently set to not allow taking any new node")]

--- a/sn_node/src/node/membership/mod.rs
+++ b/sn_node/src/node/membership/mod.rs
@@ -14,7 +14,7 @@ use sn_consensus::{
 };
 
 #[derive(Debug, Error)]
-pub(crate) enum Error {
+pub enum Error {
     #[error("Consensus error while processing vote {0}")]
     Consensus(#[from] sn_consensus::Error),
     #[error("We are behind the voter, caller should request anti-entropy")]

--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -47,7 +47,7 @@ const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
 
 const BASE_TRACING_DIRECTIVES: &str = "testnet=info,sn_launch_tool=debug";
 const NODES_DIR: &str = "local-test-network";
-const DEFAULT_INTERVAL: &str = "10000";
+const DEFAULT_INTERVAL: &str = "1000";
 const DEFAULT_NODE_COUNT: u32 = 30;
 
 #[derive(Debug, StructOpt)]


### PR DESCRIPTION
commit e9571cd749e5e11bdd54bf557799804f942303f6 (HEAD -> ReplicationRefactors, origin/ReplicationRefactors)

    feat: streamline replication flows
    
    BREAKING CHANGE: changes replication messaging flows
    
    - Provide known data when asking for any new data on churn.
    this removes one round of messaging
    - Also ask elders in case of nodes promoted with required data
    - Elders can now respond to missing data requests
    - We dont pull the data until we're sending the throttled data batch,
    which should avoid keeping lots of data in memory while waiting to send
    batches

commit 855ee9489142912f432b94eb648d74c3627e6b47

    feat: remove suspicious node message flows.
    
    BREAKING CHANGE: These feel like they are a complex workaround for the fact
    that we dont have a high enough replication count, nor a
    reliable replication flow.
    
    Removing for some more simplicity

commit 36583635d6d69604c99434813e92b8b2954a737f

    chore: dont cleanup section elder PeerLinks