### PR TITLE
ci: additional check in version bumping process

### DIFF
--- a/resources/scripts/bump_version.sh
+++ b/resources/scripts/bump_version.sh
@@ -31,7 +31,8 @@ function perform_smart_release_dry_run() {
 
 function crate_has_changes() {
   local crate_name="$1"
-  if [[ $dry_run_output == *"WOULD auto-bump provided package '$crate_name'"* ]]; then
+  if [[ $dry_run_output == *"WOULD auto-bump provided package '$crate_name'"* ]] || \
+     [[ $dry_run_output == *"WOULD auto-bump dependent package '$crate_name'"* ]]; then
     echo "true"
   else
     echo "false"


### PR DESCRIPTION
Previously we were checking for a particular piece of text in the smart-release output, but it turns
out there can also be other text that indicates that a crate will have changes. Not sure how it was
missed until this point.
