### PR TITLE
ci: prevent sn_cli being published incorrectly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
       - name: publish sn_client
         run: |
           commit_message="${{ github.event.head_commit.message }}"
-          if [[ $commit_message == *"sn_client"* ]]; then
+          if [[ $commit_message == *"sn_client-"* ]]; then
             ./resources/scripts/publish_crate_with_retries.sh "sn_client"
           fi
       - name: publish sn_api
@@ -234,6 +234,6 @@ jobs:
       - name: publish sn_cli
         run: |
           commit_message="${{ github.event.head_commit.message }}"
-          if [[ $commit_message == *"sn_cli"* ]]; then
+          if [[ $commit_message == *"sn_cli-"* ]]; then
             ./resources/scripts/publish_crate_with_retries.sh "sn_cli"
           fi


### PR DESCRIPTION
In the last release run, the release failed because it attempted to publish sn_cli, which did not
have its version bumped.

The reason was because the test for doing a publish is to check the commit message contains the
crate name, and it just so happens that "sn_cli" is contained in "sn_client". In the case of this
release, sn_client had changes, but sn_cli didn't, so the attempted publish of sn_cli failed.
