### PR TITLE
fix: Node init and restart on error

### DIFF
--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -400,6 +400,25 @@ async fn run_node(config: Config) -> Result<()> {
             });
     }
 
+    // Simulate failed node starts, and ensure that
+    #[cfg(feature = "chaos")]
+    {
+        let our_pid = std::process::id();
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let x: f64 = rng.gen_range(0.0..1.0);
+
+        if !config.is_first() && x > 0.6 {
+            println!(
+                "[Chaos] (PID:{our_pid}): Startup chaos crash w/ x of: {}",
+                x
+            );
+
+            warn!("[Chaos] (PID:{our_pid}): ChaoticStartupCrash");
+            return Err(NodeError::ChaoticStartupCrash).map_err(ErrReport::msg);
+        }
+    }
+
     // This just keeps the node going as long as routing goes
     while let Some(event) = event_stream.next().await {
         trace!("Routing event! {:?}", event);

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -35,6 +35,9 @@ pub enum Error {
     AtMaxServiceCmdThroughput,
     #[error("Permit was not retrieved in 500 loops")]
     CouldNotGetPermitInTime,
+    #[cfg(feature = "chaos")]
+    #[error("[Chaos] feature flag induced a crash at startup")]
+    ChaoticStartupCrash,
     #[error("Node prioritisation semaphore was closed early.")]
     SemaphoreClosed,
     #[error("Only messages requiring auth accumulation should be sent via \"send_messages_to_all_nodes_or_directly_handle_for_accumulation\"")]

--- a/testnet/Cargo.toml
+++ b/testnet/Cargo.toml
@@ -13,6 +13,8 @@ version = "0.1.0"
 
 [features]
 default = []
+# required to pass on flag to node builds
+chaos = []
 
 [[bin]]
 path="bin.rs"

--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -101,14 +101,12 @@ async fn main() -> Result<()> {
         let mut build_args = vec!["build", "--release"];
 
         // Keep features consistent to avoid recompiling when possible
-        if cfg!(feature = "unstable-command-prioritisation") {
+        if cfg!(feature = "chaos") {
+            println!("*** Building testnet with CHAOS enabled. Watch out. ***");
             build_args.push("--features");
-            build_args.push("unstable-command-prioritisation");
+            build_args.push("chaos");
         }
-        if cfg!(feature = "unstable-no-connection-pooling") {
-            build_args.push("--features");
-            build_args.push("unstable-no-connection-pooling");
-        }
+
         if cfg!(feature = "unstable-wiremsg-debuginfo") {
             build_args.push("--features");
             build_args.push("unstable-wiremsg-debuginfo");


### PR DESCRIPTION
Previously an error from the node was not triggering the restart of the
node instance. (eg, ChurnJoinMiss).

Here, the node bin start process has been tweaked. Kepeing all
node processes within the sn_node spawned thread. But, each 'node'
with its own runtime, to aid in shutting down any background processes
between restarts.
