### PR TITLE
WIP: experimenting to reduce CI times

### DIFF
--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -47,7 +47,7 @@ const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
 
 const BASE_TRACING_DIRECTIVES: &str = "testnet=info,sn_launch_tool=debug";
 const NODES_DIR: &str = "local-test-network";
-const DEFAULT_INTERVAL: &str = "10000";
+const DEFAULT_INTERVAL: &str = "5000";
 const DEFAULT_NODE_COUNT: u32 = 30;
 
 #[derive(Debug, StructOpt)]
@@ -94,7 +94,7 @@ async fn main() -> Result<()> {
     // got resoved within the new version of Rust.
     #[cfg(not(target_os = "windows"))]
     // For Windows guys, rember to use
-    // `cargo build --release --features=test-utils --bins`
+    // `cargo build --release --bins`
     // before executing the testnet.exe.
     {
         let cmd_args = Cmd::from_args();


### PR DESCRIPTION
Slow tests:

```
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_add_a_url
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_add_dir
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_add_existing_name
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_add_from_raw
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_create_from_dst_path_with_trailing_slash
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_create_from_dst_path_without_trailing_slash
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_create_from_folder_with_trailing_slash
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_create_from_folder_without_trailing_slash
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_create_from_get_empty_folder
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_get
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_get_with_version
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_remove_path
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_sync
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_sync_dry_run
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_sync_target_path_with_trailing_slash
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_sync_target_path_without_trailing_slash
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_sync_update_nrs_unversioned_link
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_sync_update_nrs_with_xorurl
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_sync_with_delete
SLOW [> 60.000s] sn_api app::files::tests::test_files_container_version
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_add_with_subname
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_associate_with_invalid_url
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_associate_with_multiple_subnames
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_associate_with_non_versioned_files_container_link
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_associate_with_non_versioned_nrs_container_link
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_associate_with_subname
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_associate_with_topname
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_conflicting_names
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_create
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_create_with_duplicate_topname
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_get_when_topname_has_no_link
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_get_with_duplicate_subname_versions
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_get_with_nrs_map_container_link
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_get_with_topname_link
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_remove_with_subname
SLOW [> 60.000s] sn_api app::nrs::tests::test_nrs_remove_with_topname
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_files_container
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_public_file_from_nrs_url
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_range_from_files_container
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_resolvable_container
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_resolvable_map_data
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_should_resolve_linked_content_when_nrsurl_is_used_and_topname_has_a_link
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_map_container_when_nrsurl_is_used_and_topname_has_no_link
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_map_container_when_xorurl_is_used_and_topname_has_link
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_map_container_when_xorurl_is_used_and_topname_has_no_link
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_url_when_input_url_and_target_url_have_paths
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_url_when_input_url_has_path
SLOW [> 60.000s] sn_api app::resolver::tests::test_fetch_should_resolve_subname_to_specific_version
SLOW [> 60.000s] sn_api app::wallet::tests::test_wallet_deposit_reissued_dbc
SLOW [> 60.000s] sn_api app::wallet::tests::test_wallet_get
SLOW [> 60.000s] sn_api app::wallet::tests::test_wallet_reissue_with_multiple_input_dbcs
SLOW [> 60.000s] sn_api app::wallet::tests::test_wallet_reissue_with_non_compatible_content
SLOW [> 60.000s] sn_api app::wallet::tests::test_wallet_reissue_with_single_input_dbc
SLOW [>120.000s] sn_api app::files::tests::test_files_container_sync_update_nrs_unversioned_link
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_add_with_subname
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_associate_with_invalid_url
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_associate_with_multiple_subnames
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_associate_with_non_versioned_files_container_link
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_associate_with_non_versioned_nrs_container_link
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_associate_with_subname
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_associate_with_topname
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_conflicting_names
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_create_with_duplicate_topname
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_get_when_topname_has_no_link
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_get_with_duplicate_subname_versions
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_get_with_nrs_map_container_link
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_get_with_topname_link
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_remove_with_subname
SLOW [>120.000s] sn_api app::nrs::tests::test_nrs_remove_with_topname
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_public_file_from_nrs_url
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_range_from_files_container
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_resolvable_container
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_resolvable_map_data
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_should_resolve_linked_content_when_nrsurl_is_used_and_topname_has_a_link
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_map_container_when_nrsurl_is_used_and_topname_has_no_link
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_map_container_when_xorurl_is_used_and_topname_has_link
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_map_container_when_xorurl_is_used_and_topname_has_no_link
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_url_when_input_url_and_target_url_have_paths
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_url_when_input_url_has_path
SLOW [>120.000s] sn_api app::resolver::tests::test_fetch_should_resolve_subname_to_specific_version
SLOW [>180.000s] sn_api app::nrs::tests::test_nrs_associate_with_multiple_subnames
SLOW [>180.000s] sn_api app::nrs::tests::test_nrs_associate_with_subname
SLOW [>180.000s] sn_api app::nrs::tests::test_nrs_get_when_topname_has_no_link
SLOW [>180.000s] sn_api app::nrs::tests::test_nrs_get_with_duplicate_subname_versions
SLOW [>180.000s] sn_api app::nrs::tests::test_nrs_remove_with_subname
SLOW [>180.000s] sn_api app::resolver::tests::test_fetch_range_from_files_container
SLOW [>180.000s] sn_api app::resolver::tests::test_fetch_resolvable_container
SLOW [>180.000s] sn_api app::resolver::tests::test_fetch_should_resolve_linked_content_when_nrsurl_is_used_and_topname_has_a_link
SLOW [>180.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_map_container_when_nrsurl_is_used_and_topname_has_no_link
SLOW [>180.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_map_container_when_xorurl_is_used_and_topname_has_link
SLOW [>180.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_url_when_input_url_and_target_url_have_paths
SLOW [>180.000s] sn_api app::resolver::tests::test_fetch_should_resolve_nrs_url_when_input_url_has_path
SLOW [>180.000s] sn_api app::resolver::tests::test_fetch_should_resolve_subname_to_specific_version
```