### PR TITLE
chore: upgrade blsttc to 6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "bls_dkg"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a884ec529fbf542a46666b09f7581d27167013ca1189db578f4b9d962c32bf5"
+checksum = "defbd49a1a2f8ab594dfbf50d4b5066027128ef8aee77e5c12f41194fec86262"
 dependencies = [
  "aes 0.7.5",
  "bincode",
@@ -457,15 +457,16 @@ dependencies = [
 
 [[package]]
 name = "blsttc"
-version = "5.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b61b4b62f51c2203fd8e3166d054719ca540a0e4fb01b05f764d8cce5e4267"
+checksum = "614686247957f68bfda9f2409175490b2e46d8778b484d042bf26cf9f8fb3eca"
 dependencies = [
  "blst",
  "blstrs",
  "ff",
  "getrandom 0.2.6",
  "group",
+ "hex",
  "hex_fmt",
  "pairing",
  "rand 0.8.5",
@@ -981,14 +982,13 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.3.4"
+version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
+checksum = "391b56fbd302e585b7a9494fb70e40949567b1cf9003a8e4a6041a1687c26573"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown 0.12.1",
  "lock_api",
- "parking_lot_core 0.9.3",
  "serde",
 ]
 
@@ -3103,7 +3103,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.10",
+ "semver 1.0.9",
 ]
 
 [[package]]
@@ -3187,9 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "secured_linked_list"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173f7e9ec189f0cd8d349f73a7abbe954557b3ca848ce1289465feb27afa3c31"
+checksum = "19e061cddee0a14a0b0abec9eb1d26064ed96cd1bee1ec9a05e232cea2447509"
 dependencies = [
  "bincode",
  "blsttc",
@@ -3253,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.10"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "semver-parser"
@@ -3629,9 +3629,9 @@ dependencies = [
 
 [[package]]
 name = "sn_consensus"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374362b956d03d65cd84c8f8f50c49b671c260b7304408933b799c3452c8047d"
+checksum = "7b853378b69e183aa1157180e77b7b240395100af1f1ebc234b27fb9818d4511"
 dependencies = [
  "bincode",
  "blsttc",
@@ -3643,9 +3643,9 @@ dependencies = [
 
 [[package]]
 name = "sn_dbc"
-version = "3.3.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de111a6c6650124aaaacefbaf846c856139c774af6882f3369a556d00694b5d5"
+checksum = "95d374fe6b8f0cc571d4038bab286d7383704a49abde9fda9485db9b7f681865"
 dependencies = [
  "bincode",
  "bls_ringct",

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bincode = "1.3.3"
-bls = { package = "blsttc", version = "5.2.0" }
+bls = { package = "blsttc", version = "6.0.0" }
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "~0.6"
 dirs-next = "2.0.0"
@@ -40,7 +40,7 @@ serde = "1.0.123"
 serde_json = "1.0.62"
 sha3 = "~0.9"
 sn_client = { path = "../sn_client", version = "^0.66.2" }
-sn_dbc = { version = "3.2.0", features = [ "serdes" ] }
+sn_dbc = { version = "4.0.0", features = ["serdes"] }
 sn_interface = { path = "../sn_interface", version = "^0.6.2" }
 thiserror = "1.0.23"
 time = { version = "~0.3.4", features = ["formatting"] }

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 ansi_term = "~0.12"
 bincode = "1.3.3"
-bls = { package = "blsttc", version = "5.2.0" }
+bls = { package = "blsttc", version = "6.0.0" }
 bytes = { version = "1.0.1", features = ["serde"] }
 chrono = "~0.4"
 color-eyre = "~0.6"
@@ -38,7 +38,7 @@ relative-path = "1.3.2"
 reqwest = { version = "~0.11", default-features = false, features = [ "rustls-tls" ] }
 rmp-serde = "1.0.0"
 sn_api = { path = "../sn_api", version = "^0.64.2", default-features=false, features = ["app", "authd_client"] }
-sn_dbc = { version = "3.2.0", features = [ "serdes" ] }
+sn_dbc = { version = "4.0.0", features = [ "serdes" ] }
 sn_launch_tool = "~0.9.4"
 serde = "1.0.123"
 serde_json = "1.0.62"

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -36,8 +36,8 @@ tokio-console = ["console-subscriber"]
 backoff = { version = "~0.4.0", features = [ "tokio" ] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
-bls = { package = "blsttc", version = "5.2.0" }
-bls_dkg = "~0.10.2"
+bls = { package = "blsttc", version = "6.0.0" }
+bls_dkg = "~0.10.3"
 bytes = { version = "1.0.1", features = ["serde"] }
 console-subscriber = { version = "~0.1.0", optional = true }
 crdts = "7.0"
@@ -59,14 +59,14 @@ qp2p = "~0.28.3"
 rand = "~0.8.5"
 rayon = "1.5.1"
 rmp-serde = "1.0.0"
-secured_linked_list = "~0.5.1"
+secured_linked_list = "~0.5.2"
 self_encryption = "~0.27.4"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
 sled = "~0.34.6"
-sn_dbc = { version = "3.2.0", features = ["serdes"] }
+sn_dbc = { version = "4.0.0", features = [ "serdes" ] }
 sn_interface = { path = "../sn_interface", version = "^0.6.2" }
 structopt = "~0.3.17"
 strum = "~0.23.0"

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -22,8 +22,8 @@ test-utils=["proptest"]
 backoff = { version = "~0.4.0", features = ["tokio"] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
-bls = { package = "blsttc", version = "5.2.0" }
-bls_dkg = "~0.10.2"
+bls = { package = "blsttc", version = "6.0.0" }
+bls_dkg = "~0.10.3"
 bytes = { version = "1.0.1", features = ["serde"] }
 console-subscriber = { version = "~0.1.0", optional = true }
 crdts = "7.0"
@@ -47,15 +47,15 @@ rand = "~0.8.5"
 rand-07 = { package = "rand", version = "0.7.3" } # required till ed25519-dalek upgrades to rand v0.8
 rayon = "1.5.1"
 rmp-serde = "1.0.0"
-secured_linked_list = "~0.5.1"
+secured_linked_list = "~0.5.2"
 self_encryption = "~0.27.1"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
 sled = "~0.34.6"
-sn_consensus = "2.0.0"
-sn_dbc = { version = "3.1.2", features = [ "serdes" ] }
+sn_consensus = "2.1.1"
+sn_dbc = { version = "4.0.0", features = ["serdes"] }
 strum = "~0.23.0"
 strum_macros = "~0.23.1"
 tempfile = "3.2.0"

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -34,8 +34,8 @@ tokio-console = ["console-subscriber"]
 backoff = { version = "~0.4.0", features = [ "tokio" ] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
-bls = { package = "blsttc", version = "5.2.0" }
-bls_dkg = "~0.10.2"
+bls = { package = "blsttc", version = "6.0.0" }
+bls_dkg = "~0.10.3"
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "~0.6.0"
 console-subscriber = { version = "~0.1.0", optional = true }
@@ -61,10 +61,10 @@ rand-07 = { package = "rand", version = "~0.7.3" }
 rayon = "1.5.1"
 resource_proof = "1.0.38"
 rmp-serde = "1.0.0"
-secured_linked_list = "~0.5.0"
+secured_linked_list = "~0.5.2"
 self_encryption = "~0.27.4"
-sn_consensus = "2.0.0"
-sn_dbc = { version = "3.2.0", features = ["serdes"] }
+sn_consensus = "2.1.1"
+sn_dbc = { version = "4.0.0", features = ["serdes"] }
 sn_dysfunction = { path = "../sn_dysfunction", version = "^0.5.0" }
 sn_interface = { path = "../sn_interface", version = "^0.6.2" }
 serde = { version = "1.0.111", features = ["derive", "rc"] }


### PR DESCRIPTION
There were various other crates that had to be upgraded in this process:
* secured_linked_list to v0.5.2 because it was also upgraded to reference v6.0.0 of blsttc
* bls_dkg to v0.10.3 because it was also upgraded to reference v6.0.0 of blsttc
* sn_consensus to v2.1.1 because it was also upgraded to reference v6.0.0 of blsttc
* sn_dbc to v4.0.0 because it was also upgraded to reference v6.0.0 of blsttc
