### PR TITLE
chore: misc cleanup

### DIFF
--- a/log_cmds_inspector/bin.rs
+++ b/log_cmds_inspector/bin.rs
@@ -6,16 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use eyre::{bail, Error, Result};
-use grep::matcher::Matcher;
-use grep::regex::RegexMatcher;
-use grep::searcher::sinks::UTF8;
-use grep::searcher::Searcher;
 use sn_interface::types::log_markers::LogMarker;
-use std::str::FromStr;
+
+use eyre::{bail, Error, Result};
+use grep::{matcher::Matcher, regex::RegexMatcher, searcher::sinks::UTF8, searcher::Searcher};
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
+    str::FromStr,
 };
 use structopt::{clap::AppSettings::ColoredHelp, StructOpt};
 use strum::IntoEnumIterator;

--- a/sn_api/src/app/auth.rs
+++ b/sn_api/src/app/auth.rs
@@ -15,9 +15,11 @@ use crate::{
     ipc::{IpcMsg, IpcResp},
     Error, Result,
 };
+
+use sn_interface::types::Keypair;
+
 use log::{debug, info};
 use serde_json::json;
-use sn_interface::types::Keypair;
 use std::path::{Path, PathBuf};
 
 // Method for requesting application's authorisation

--- a/sn_api/src/app/keys.rs
+++ b/sn_api/src/app/keys.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 MaidSafe.net limited.
+// Copyright 2022 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
@@ -8,8 +8,10 @@
 
 use super::Safe;
 use crate::{Error, Result, SafeUrl};
-use hex::encode;
+
 use sn_interface::types::{Keypair, SecretKey};
+
+use hex::encode;
 use std::path::Path;
 use xor_name::XorName;
 
@@ -81,10 +83,11 @@ pub fn deserialize_keypair(path: impl AsRef<Path>) -> Result<Keypair> {
 #[cfg(test)]
 mod tests {
     use super::{Safe, SafeUrl};
+    use sn_interface::types::Keypair;
+
     use assert_fs::prelude::*;
     use color_eyre::{eyre::eyre, Result};
     use predicates::prelude::*;
-    use sn_interface::types::Keypair;
     use xor_name::XorName;
 
     #[test]

--- a/sn_api/src/app/mod.rs
+++ b/sn_api/src/app/mod.rs
@@ -38,10 +38,9 @@ use crate::NodeConfig;
 use sn_client::{Client, ClientConfig, DEFAULT_OPERATION_TIMEOUT};
 use sn_dbc::Owner;
 use sn_interface::types::Keypair;
-use tracing::debug;
 
-use std::path::Path;
-use std::time::Duration;
+use std::{path::Path, time::Duration};
+use tracing::debug;
 
 const APP_NOT_CONNECTED: &str = "Application is not connected to the network";
 

--- a/sn_api/src/app/multimap.rs
+++ b/sn_api/src/app/multimap.rs
@@ -11,9 +11,10 @@ use super::register::EntryHash;
 use crate::safeurl::{ContentType, SafeUrl, XorUrl};
 use crate::{Error, Result, Safe};
 
+use sn_interface::types::DataAddress;
+
 use log::debug;
 use rand::Rng;
-use sn_interface::types::DataAddress;
 use std::collections::BTreeSet;
 use xor_name::XorName;
 

--- a/sn_api/src/app/register.rs
+++ b/sn_api/src/app/register.rs
@@ -10,15 +10,18 @@ pub use sn_interface::types::register::{Entry, EntryHash};
 
 use crate::safeurl::{ContentType, SafeUrl, XorUrl};
 use crate::{Error, Result, Safe};
-use sn_interface::messaging::data::Error as ErrorMsg;
+
+use sn_client::Error as ClientError;
+use sn_interface::{
+    messaging::data::Error as ErrorMsg,
+    types::{
+        register::{Permissions, Policy, User},
+        DataAddress, Error as SafeNdError, RegisterAddress,
+    },
+};
 
 use log::debug;
 use rand::Rng;
-use sn_client::Error as ClientError;
-use sn_interface::types::{
-    register::{Permissions, Policy, User},
-    DataAddress, Error as SafeNdError, RegisterAddress,
-};
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::info;
 use xor_name::XorName;

--- a/sn_api/src/app/resolver/mod.rs
+++ b/sn_api/src/app/resolver/mod.rs
@@ -245,9 +245,10 @@ mod tests {
         app::test_helpers::{new_safe_instance, random_nrs_name, TestDataFilesContainer},
         SafeUrl,
     };
+    use sn_interface::types::DataAddress;
+
     use anyhow::{anyhow, bail, Context, Result};
     use bytes::Bytes;
-    use sn_interface::types::DataAddress;
     use std::io::Read;
 
     #[tokio::test]

--- a/sn_api/src/app/test_helpers.rs
+++ b/sn_api/src/app/test_helpers.rs
@@ -7,11 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{ipc::NodeConfig, Safe, SafeUrl};
+
+use sn_dbc::Owner;
+use sn_interface::types::{Keypair, PublicKey};
+
 use anyhow::{anyhow, bail, Context, Result};
 use bls::SecretKey;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use sn_dbc::Owner;
-use sn_interface::types::{Keypair, PublicKey};
 use std::{
     collections::{BTreeSet, HashMap},
     env::var,

--- a/sn_api/src/authenticator/mod.rs
+++ b/sn_api/src/authenticator/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 MaidSafe.net limited.
+// Copyright 2022 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
@@ -10,11 +10,13 @@ use crate::{
     ipc::{req::AuthReq, resp::AuthGranted},
     Result, SafeAuthReq,
 };
+
+use sn_client::api::Client;
+use sn_interface::types::{Keypair, RegisterAddress};
+
 use hmac::Hmac;
 use rand_07::{rngs::StdRng, SeedableRng};
 use sha3::Sha3_256;
-use sn_client::api::Client;
-use sn_interface::types::{Keypair, RegisterAddress};
 use std::{
     collections::HashSet,
     net::SocketAddr,
@@ -511,9 +513,10 @@ impl SafeAuthenticator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sn_interface::types::PublicKey;
+
     use anyhow::{Context, Result};
     use proptest::prelude::*;
-    use sn_interface::types::PublicKey;
 
     #[test]
     fn get_deterministic_pk_from_known_seed() -> Result<()> {

--- a/sn_api/src/errors.rs
+++ b/sn_api/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 MaidSafe.net limited.
+// Copyright 2022 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
@@ -6,12 +6,16 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::ipc::IpcError;
-use super::nrs::NrsMap;
-use super::safeurl::{Error as UrlError, SafeUrl, XorUrl};
+use super::{
+    ipc::IpcError,
+    nrs::NrsMap,
+    safeurl::{Error as UrlError, SafeUrl, XorUrl},
+};
+
 use sn_client::Error as ClientError;
 use sn_dbc::Error as DbcError;
 use sn_interface::types::Error as InterfaceError;
+
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/sn_api/src/ipc/resp.rs
+++ b/sn_api/src/ipc/resp.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 MaidSafe.net limited.
+// Copyright 2022 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
@@ -7,8 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{IpcError, NodeConfig};
-use serde::{Deserialize, Serialize};
 use sn_interface::types::Keypair;
+
+use serde::{Deserialize, Serialize};
 
 /// IPC response.
 #[allow(clippy::large_enum_variant)]

--- a/sn_api/src/lib.rs
+++ b/sn_api/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 MaidSafe.net limited.
+// Copyright 2022 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/sn_api/src/safeurl/mod.rs
+++ b/sn_api/src/safeurl/mod.rs
@@ -14,14 +14,16 @@ mod version_hash;
 mod xorurl_media_types;
 
 pub use errors::{Error, Result};
+pub use version_hash::VersionHash;
+
+use sn_interface::types::{DataAddress, RegisterAddress};
+
 use multibase::{decode as base_decode, encode as base_encode, Base};
 use serde::{Deserialize, Serialize};
-use sn_interface::types::{DataAddress, RegisterAddress};
 use std::fmt;
 use tracing::{info, trace, warn};
 use url::Url;
 use url_parts::UrlParts;
-pub use version_hash::VersionHash;
 use xor_name::{XorName, XOR_NAME_LEN};
 use xorurl_media_types::{MEDIA_TYPE_CODES, MEDIA_TYPE_STR};
 
@@ -1138,9 +1140,10 @@ impl fmt::Display for SafeUrl {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sn_interface::types::register::EntryHash;
+
     use color_eyre::{eyre::bail, eyre::eyre, Result};
     use rand::Rng;
-    use sn_interface::types::register::EntryHash;
 
     macro_rules! verify_expected_result {
             ($result:expr, $pattern:pat $(if $cond:expr)?) => {

--- a/sn_api/src/safeurl/version_hash.rs
+++ b/sn_api/src/safeurl/version_hash.rs
@@ -6,11 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use sn_interface::types::register::EntryHash;
+
 use multibase::Base;
 use serde::{Deserialize, Serialize};
-use sn_interface::types::register::EntryHash;
-use std::convert::TryInto;
 use std::{
+    convert::TryInto,
     fmt::{self, Display},
     str::FromStr,
 };

--- a/sn_client/examples/churn.rs
+++ b/sn_client/examples/churn.rs
@@ -9,24 +9,22 @@
 //! sn_node provides the interface to Safe routing.  The resulting executable is the node
 //! for the Safe network.
 
-use dirs_next::home_dir;
+use sn_client::{utils::test_utils::read_network_conn_info, Client, ClientConfig};
+use sn_interface::types::utils::random_bytes;
 use sn_launch_tool::Launch;
+
+use dirs_next::home_dir;
+use eyre::{eyre, Context, Result};
 use std::{
     path::PathBuf,
     process::{Command, Stdio},
 };
 use structopt::StructOpt;
+use tiny_keccak::{Hasher, Sha3};
 use tokio::fs::create_dir_all;
 use tokio::time::{sleep, Duration};
 use tracing::{debug, info};
 use xor_name::XorName;
-
-use tiny_keccak::{Hasher, Sha3};
-
-use eyre::{eyre, Context, Result};
-use sn_client::{utils::test_utils::read_network_conn_info, Client, ClientConfig};
-
-use sn_interface::types::utils::random_bytes;
 
 #[cfg(not(target_os = "windows"))]
 const SAFE_NODE_EXECUTABLE: &str = "sn_node";

--- a/sn_client/examples/network_split.rs
+++ b/sn_client/examples/network_split.rs
@@ -9,24 +9,22 @@
 //! sn_node provides the interface to Safe routing.  The resulting executable is the node
 //! for the Safe network.
 
-use dirs_next::home_dir;
+use sn_client::{utils::test_utils::read_network_conn_info, Client, ClientConfig};
+use sn_interface::types::utils::random_bytes;
 use sn_launch_tool::Launch;
+
+use dirs_next::home_dir;
+use eyre::{eyre, Context, Result};
 use std::{
     path::PathBuf,
     process::{Command, Stdio},
 };
 use structopt::StructOpt;
+use tiny_keccak::{Hasher, Sha3};
 use tokio::fs::create_dir_all;
 use tokio::time::{sleep, Duration};
 use tracing::{debug, info};
 use xor_name::XorName;
-
-use tiny_keccak::{Hasher, Sha3};
-
-use eyre::{eyre, Context, Result};
-use sn_client::{utils::test_utils::read_network_conn_info, Client, ClientConfig};
-
-use sn_interface::types::utils::random_bytes;
 
 #[cfg(not(target_os = "windows"))]
 const SAFE_NODE_EXECUTABLE: &str = "sn_node";

--- a/sn_client/examples/put_get.rs
+++ b/sn_client/examples/put_get.rs
@@ -9,15 +9,12 @@
 //! sn_node provides the interface to Safe routing.  The resulting executable is the node
 //! for the Safe network.
 
+use sn_client::{utils::test_utils::read_network_conn_info, Client, ClientConfig, Error, Result};
+use sn_interface::{init_logger, types::utils::random_bytes};
+
+use tiny_keccak::{Hasher, Sha3};
 use tokio::time::{sleep, Duration, Instant};
 use tracing::{debug, warn};
-
-use sn_client::{Client, ClientConfig, Error, Result};
-use sn_interface::init_logger;
-use sn_interface::types::utils::random_bytes;
-use tiny_keccak::{Hasher, Sha3};
-
-use sn_client::utils::test_utils::read_network_conn_info;
 use xor_name::XorName;
 
 #[tokio::main]

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -8,13 +8,17 @@
 
 use super::Client;
 use crate::Error;
+
+use sn_interface::{
+    messaging::{
+        data::{DataCmd, ServiceMsg},
+        ServiceAuth, WireMsg,
+    },
+    types::{PublicKey, Signature},
+};
+
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use bytes::Bytes;
-use sn_interface::messaging::{
-    data::{DataCmd, ServiceMsg},
-    ServiceAuth, WireMsg,
-};
-use sn_interface::types::{PublicKey, Signature};
 use tokio::time::Duration;
 use xor_name::XorName;
 

--- a/sn_client/src/api/data/pac_man.rs
+++ b/sn_client/src/api/data/pac_man.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 MaidSafe.net limited.
+// Copyright 2022 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
@@ -7,12 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{Error, Result};
+use sn_interface::types::Chunk;
+
 use bincode::serialize;
 use bytes::Bytes;
 use rayon::prelude::*;
 use self_encryption::{DataMap, EncryptedChunk};
 use serde::{Deserialize, Serialize};
-use sn_interface::types::Chunk;
 use std::path::Path;
 use xor_name::XorName;
 

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -11,8 +11,11 @@ use super::{
     Client,
 };
 use crate::{api::data::DataMapLevel, Error, Result};
-use sn_interface::messaging::data::{DataCmd, DataQuery, QueryResponse};
-use sn_interface::types::{Chunk, ChunkAddress};
+
+use sn_interface::{
+    messaging::data::{DataCmd, DataQuery, QueryResponse},
+    types::{Chunk, ChunkAddress},
+};
 
 use bincode::deserialize;
 use bytes::Bytes;
@@ -317,14 +320,12 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::test_utils::create_test_client_with;
     use crate::{
         api::file_apis::LargeFile,
-        utils::test_utils::{create_test_client, init_logger},
+        utils::test_utils::{create_test_client, create_test_client_with, init_logger},
         Client,
     };
-    use sn_interface::types::log_markers::LogMarker;
-    use sn_interface::types::utils::random_bytes;
+    use sn_interface::types::{log_markers::LogMarker, utils::random_bytes};
 
     use bytes::Bytes;
     use eyre::Result;

--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -16,14 +16,16 @@ mod spentbook_apis;
 pub use register_apis::RegisterWriteAheadLog;
 
 use crate::{connections::Session, errors::Error, ClientConfig};
+
 use sn_dbc::{rng, Owner};
-use sn_interface::messaging::{
-    data::{CmdError, DataQuery, RegisterQuery, ServiceMsg},
-    ServiceAuth, WireMsg,
+use sn_interface::{
+    messaging::{
+        data::{CmdError, DataQuery, RegisterQuery, ServiceMsg},
+        ServiceAuth, WireMsg,
+    },
+    network_knowledge::{prefix_map::NetworkPrefixMap, utils::read_prefix_map_from_disk},
+    types::{Chunk, Keypair, Peer, PublicKey, RegisterAddress},
 };
-use sn_interface::network_knowledge::prefix_map::NetworkPrefixMap;
-use sn_interface::network_knowledge::utils::read_prefix_map_from_disk;
-use sn_interface::types::{Chunk, Keypair, Peer, PublicKey, RegisterAddress};
 
 use bytes::Bytes;
 use itertools::Itertools;
@@ -293,9 +295,9 @@ mod tests {
     use crate::utils::test_utils::{
         create_test_client, create_test_client_with, get_dbc_owner_from_secret_key_hex,
     };
+    use sn_interface::{init_logger, types::utils::random_bytes};
+
     use eyre::Result;
-    use sn_interface::init_logger;
-    use sn_interface::types::utils::random_bytes;
     use std::{
         collections::HashSet,
         net::{IpAddr, Ipv4Addr, SocketAddr},

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -8,13 +8,17 @@
 
 use super::Client;
 use crate::{connections::QueryResult, errors::Error};
+
+use sn_interface::{
+    messaging::{
+        data::{DataQuery, ServiceMsg},
+        ServiceAuth, WireMsg,
+    },
+    types::{PublicKey, Signature},
+};
+
 use bytes::Bytes;
 use rand::Rng;
-use sn_interface::messaging::{
-    data::{DataQuery, ServiceMsg},
-    ServiceAuth, WireMsg,
-};
-use sn_interface::types::{PublicKey, Signature};
 use tracing::{debug, info_span};
 
 // We divide the total query timeout by this number.

--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -9,13 +9,16 @@
 use super::Client;
 
 use crate::Error;
-use sn_interface::messaging::data::{
-    CreateRegister, DataCmd, DataQuery, EditRegister, QueryResponse, RegisterCmd, RegisterQuery,
-    SignedRegisterCreate, SignedRegisterEdit,
-};
-use sn_interface::types::{
-    register::{Action, Entry, EntryHash, Permissions, Policy, Register, User},
-    RegisterAddress as Address,
+
+use sn_interface::{
+    messaging::data::{
+        CreateRegister, DataCmd, DataQuery, EditRegister, QueryResponse, RegisterCmd,
+        RegisterQuery, SignedRegisterCreate, SignedRegisterEdit,
+    },
+    types::{
+        register::{Action, Entry, EntryHash, Permissions, Policy, Register, User},
+        RegisterAddress as Address,
+    },
 };
 
 use std::collections::BTreeSet;
@@ -249,19 +252,23 @@ fn section_auth() -> sn_interface::messaging::SectionAuth {
 
 #[cfg(test)]
 mod tests {
-    use crate::retry_loop_for_pattern;
     use crate::{
+        retry_loop_for_pattern,
         utils::test_utils::{create_test_client, create_test_client_with, init_logger},
         Error,
     };
+
+    use sn_interface::{
+        messaging::data::Error as ErrorMsg,
+        types::{
+            log_markers::LogMarker,
+            register::{Action, EntryHash, Permissions, Policy, User},
+            Keypair,
+        },
+    };
+
     use eyre::{bail, eyre, Result};
     use rand::Rng;
-    use sn_interface::messaging::data::Error as ErrorMsg;
-    use sn_interface::types::{
-        log_markers::LogMarker,
-        register::{Action, EntryHash, Permissions, Policy, User},
-        Keypair,
-    };
     use std::{
         collections::{BTreeMap, BTreeSet},
         time::Instant,

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -9,11 +9,12 @@
 use super::Client;
 
 use crate::Error;
+
 use sn_dbc::{KeyImage, RingCtTransaction, SpentProofShare};
-use sn_interface::messaging::data::{
-    DataCmd, DataQuery, QueryResponse, SpentbookCmd, SpentbookQuery,
+use sn_interface::{
+    messaging::data::{DataCmd, DataQuery, QueryResponse, SpentbookCmd, SpentbookQuery},
+    types::SpentbookAddress,
 };
-use sn_interface::types::SpentbookAddress;
 
 use xor_name::XorName;
 

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -15,15 +15,19 @@ use crate::{
     },
     Error, Result,
 };
-use sn_interface::at_least_one_correct_elder;
-use sn_interface::messaging::{
-    data::{CmdError, ServiceMsg},
-    system::{KeyedSig, SectionAuth, SystemMsg},
-    AuthKind, AuthorityProof, DstLocation, MsgId, MsgType, ServiceAuth, WireMsg,
+
+use sn_interface::{
+    at_least_one_correct_elder,
+    messaging::{
+        data::{CmdError, ServiceMsg},
+        system::{KeyedSig, SectionAuth, SystemMsg},
+        AuthKind, AuthorityProof, DstLocation, MsgId, MsgType, ServiceAuth, WireMsg,
+    },
+    network_knowledge::{
+        utils::compare_and_write_prefix_map_to_disk, NetworkKnowledge, SectionAuthorityProvider,
+    },
+    types::{log_markers::LogMarker, Peer},
 };
-use sn_interface::network_knowledge::utils::compare_and_write_prefix_map_to_disk;
-use sn_interface::network_knowledge::{NetworkKnowledge, SectionAuthorityProvider};
-use sn_interface::types::{log_markers::LogMarker, Peer};
 
 use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -9,9 +9,14 @@
 use super::{QueryResult, Session};
 
 use crate::{connections::CmdResponse, Error, Result};
-use sn_interface::messaging::{
-    data::{CmdError, DataQuery, QueryResponse},
-    AuthKind, DstLocation, MsgId, ServiceAuth, WireMsg,
+
+use sn_interface::{
+    messaging::{
+        data::{CmdError, DataQuery, QueryResponse},
+        AuthKind, DstLocation, MsgId, ServiceAuth, WireMsg,
+    },
+    network_knowledge::{prefix_map::NetworkPrefixMap, supermajority},
+    types::{Peer, PeerLinks, SendToOneError},
 };
 
 use backoff::{backoff::Backoff, ExponentialBackoff};
@@ -21,8 +26,6 @@ use futures::future::join_all;
 use qp2p::{Close, Config as QuicP2pConfig, ConnectionError, Endpoint, SendError};
 use rand::{rngs::OsRng, seq::SliceRandom};
 use secured_linked_list::SecuredLinkedList;
-use sn_interface::network_knowledge::{prefix_map::NetworkPrefixMap, supermajority};
-use sn_interface::types::{Peer, PeerLinks, SendToOneError};
 use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{
     sync::mpsc::{channel, Sender},
@@ -680,10 +683,11 @@ pub(crate) async fn create_safe_dir() -> Result<PathBuf, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use eyre::{eyre, Result};
     use sn_interface::network_knowledge::test_utils::{
         gen_section_authority_provider, section_signed,
     };
+
+    use eyre::{eyre, Result};
     use std::net::Ipv4Addr;
     use xor_name::Prefix;
 

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -9,12 +9,14 @@
 mod listeners;
 mod messaging;
 
-use sn_interface::messaging::{
-    data::{CmdError, OperationId, QueryResponse},
-    MsgId,
+use sn_interface::{
+    messaging::{
+        data::{CmdError, OperationId, QueryResponse},
+        MsgId,
+    },
+    network_knowledge::prefix_map::NetworkPrefixMap,
+    types::PeerLinks,
 };
-use sn_interface::network_knowledge::prefix_map::NetworkPrefixMap;
-use sn_interface::types::PeerLinks;
 
 use dashmap::DashMap;
 use qp2p::Endpoint;

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -6,15 +6,18 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use bls::PublicKey;
 pub use sn_interface::messaging::data::Error as ErrorMsg;
-use sn_interface::messaging::{
-    data::{CmdError, OperationId, QueryResponse},
-    Error as MessagingError, MsgId,
+
+use sn_interface::{
+    messaging::{
+        data::{CmdError, OperationId, QueryResponse},
+        Error as MessagingError, MsgId,
+    },
+    types::Error as DtError,
 };
-use sn_interface::types::Error as DtError;
-use std::io;
-use std::net::SocketAddr;
+
+use bls::PublicKey;
+use std::{io, net::SocketAddr};
 use thiserror::Error;
 
 /// Specialisation of `std::Result` for Client.

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -67,8 +67,7 @@ mod errors;
 // Export public API.
 pub use api::{Client, RegisterWriteAheadLog};
 pub use config_handler::{ClientConfig, DEFAULT_ACK_WAIT, DEFAULT_OPERATION_TIMEOUT};
-pub use errors::ErrorMsg;
-pub use errors::{Error, Result};
+pub use errors::{Error, ErrorMsg, Result};
 pub use qp2p::Config as QuicP2pConfig;
 
 /// Client trait and related constants.
@@ -84,9 +83,9 @@ mod testnet_grep;
 #[cfg(test)]
 mod tests {
     use crate::testnet_grep::search_testnet_results_per_node;
+    use sn_interface::{network_knowledge::elder_count, types::log_markers::LogMarker};
+
     use eyre::Result;
-    use sn_interface::network_knowledge::elder_count;
-    use sn_interface::types::log_markers::LogMarker;
 
     // Check that with one split we have 14 elders.
     // This is intended to be run, just after split, in order to confirm splits are functioning correctly

--- a/sn_client/src/testnet_grep/mod.rs
+++ b/sn_client/src/testnet_grep/mod.rs
@@ -8,24 +8,16 @@
 
 use sn_interface::types::log_markers::LogMarker;
 
-use grep::matcher::Matcher;
-use grep::regex::RegexMatcher;
-use grep::searcher::sinks::UTF8;
-use grep::searcher::Searcher;
-use std::path::PathBuf;
-
-use std::collections::BTreeMap;
-use walkdir::WalkDir;
-
-use std::string::ToString;
-
-use eyre::{bail, Error, Result};
-
-use eyre::eyre;
-
 use dirs_next::home_dir;
-
+use eyre::{bail, eyre, Error, Result};
+use grep::{
+    matcher::Matcher,
+    regex::RegexMatcher,
+    searcher::{sinks::UTF8, Searcher},
+};
+use std::{collections::BTreeMap, path::PathBuf, string::ToString};
 use strum::IntoEnumIterator;
+use walkdir::WalkDir;
 
 // line number and the match
 pub(crate) type Matches = Vec<(u64, String)>;

--- a/sn_client/src/utils/mod.rs
+++ b/sn_client/src/utils/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 MaidSafe.net limited.
+// Copyright 2022 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
@@ -57,9 +57,8 @@ pub fn bin_data_format(data: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use sn_interface::types::utils::random_bytes;
-
     use super::*;
+    use sn_interface::types::utils::random_bytes;
 
     const SIZE: usize = 10;
 

--- a/sn_client/src/utils/test_utils/mod.rs
+++ b/sn_client/src/utils/test_utils/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 MaidSafe.net limited.
+// Copyright 2022 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
@@ -9,23 +9,25 @@
 #[cfg(test)]
 mod test_client;
 
-use crate::Error;
-#[cfg(test)]
-use backoff::ExponentialBackoff;
-use dirs_next::home_dir;
-use eyre::{eyre, Context, Result};
-#[cfg(test)]
-pub use sn_interface::init_logger;
-use sn_interface::types::PublicKey;
-#[cfg(test)]
-use std::future::Future;
-#[cfg(test)]
-use std::time::Duration;
-use std::{collections::BTreeSet, fs::File, io::BufReader, net::SocketAddr, path::Path};
 #[cfg(test)]
 pub use test_client::{
     create_test_client, create_test_client_with, get_dbc_owner_from_secret_key_hex,
 };
+
+#[cfg(test)]
+pub use sn_interface::init_logger;
+
+use crate::Error;
+
+use sn_interface::types::PublicKey;
+
+#[cfg(test)]
+use backoff::ExponentialBackoff;
+use dirs_next::home_dir;
+use eyre::{eyre, Context, Result};
+use std::{collections::BTreeSet, fs::File, io::BufReader, net::SocketAddr, path::Path};
+#[cfg(test)]
+use std::{future::Future, time::Duration};
 
 ///
 pub type ClientResult<T> = Result<T, Error>;

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{error::Result, get_mean_of, std_deviation, DysfunctionDetection, OperationId};
+
 use std::collections::{BTreeMap, BTreeSet};
 use xor_name::XorName;
 
@@ -282,12 +283,14 @@ impl DysfunctionDetection {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::init_test_logger;
-    use crate::{detection::IssueType, DysfunctionDetection, DysfunctionSeverity};
+    use crate::{
+        detection::IssueType, tests::init_test_logger, DysfunctionDetection, DysfunctionSeverity,
+    };
+    use sn_interface::messaging::data::OperationId;
+
     use eyre::bail;
     use proptest::prelude::*;
     use rand::Rng;
-    use sn_interface::messaging::data::OperationId;
     use tokio::runtime::Runtime;
     use xor_name::{rand::random as random_xorname, XorName};
 

--- a/sn_dysfunction/src/lib.rs
+++ b/sn_dysfunction/src/lib.rs
@@ -46,18 +46,21 @@ extern crate tracing;
 mod detection;
 mod error;
 
-use xor_name::XorName;
-
-use crate::error::Result;
-use dashmap::DashMap;
-use sn_interface::messaging::data::OperationId;
-use std::collections::{BTreeSet, VecDeque};
-use std::sync::Arc;
-use std::time::Instant;
-use tokio::sync::RwLock;
+pub use detection::{DysfunctionSeverity, IssueType};
 
 pub use crate::error::Error;
-pub use detection::{DysfunctionSeverity, IssueType};
+use crate::error::Result;
+
+use sn_interface::messaging::data::OperationId;
+
+use dashmap::DashMap;
+use std::{
+    collections::{BTreeSet, VecDeque},
+    sync::Arc,
+    time::Instant,
+};
+use tokio::sync::RwLock;
+use xor_name::XorName;
 
 /// Some reproducible xorname derived from the operation. This is a permanent reference needed for logging all dysfunction.
 type NodeIdentifier = XorName;
@@ -273,10 +276,10 @@ fn std_deviation(data: &[f32]) -> Option<f32> {
 #[cfg(test)]
 mod tests {
     use super::{DysfunctionDetection, IssueType};
-    use eyre::Error;
     use sn_interface::messaging::data::OperationId;
-    use std::collections::BTreeSet;
-    use std::sync::Once;
+
+    use eyre::Error;
+    use std::{collections::BTreeSet, sync::Once};
     use xor_name::{rand::random as random_xorname, XorName};
 
     type Result<T, E = Error> = std::result::Result<T, E>;

--- a/sn_interface/src/types/utils/mod.rs
+++ b/sn_interface/src/types/utils/mod.rs
@@ -6,13 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::errors::convert_bincode_error;
-// use sn_interface::network_knowledge::prefix_map::NetworkPrefixMap;
-use super::{Error, Result};
+use super::{errors::convert_bincode_error, Error, Result};
+
 use bytes::Bytes;
 use multibase::{self, Base};
-use rand::rngs::OsRng;
-use rand::Rng;
+use rand::{rngs::OsRng, Rng};
 use rayon::current_num_threads;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 

--- a/sn_node/benches/data_storage.rs
+++ b/sn_node/benches/data_storage.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 MaidSafe.net limited.
+// Copyright 2022 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
@@ -6,23 +6,24 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use sn_interface::{
+    messaging::data::{CreateRegister, SignedRegisterCreate},
+    types::{
+        register::{Policy, User},
+        Chunk, Keypair, RegisterCmd, ReplicatedData,
+    },
+};
+use sn_node::{
+    node::{cfg::config_handler::Config, DataStorage},
+    UsedSpace,
+};
+
 use criterion::{BenchmarkId, Criterion};
 use eyre::{Result, WrapErr};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use sn_interface::messaging::data::{CreateRegister, SignedRegisterCreate};
-use sn_interface::types::{
-    register::{Policy, User},
-    Chunk, Keypair,
-};
-use sn_interface::types::{RegisterCmd, ReplicatedData};
-use sn_node::node::cfg::config_handler::Config;
-use sn_node::node::DataStorage;
-use sn_node::UsedSpace;
-use std::path::Path;
+use std::{collections::BTreeMap, path::Path};
 use tempfile::tempdir;
 use tokio::runtime::Runtime;
-
-use std::collections::BTreeMap;
 
 // sample size is _NOT_ the number of times the command is run...
 // https://bheisler.github.io/criterion.rs/book/analysis.html#measurement

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -8,6 +8,15 @@
 
 #![recursion_limit = "256"]
 
+use sn_interface::{
+    messaging::{data::Error::FailedToWriteFile, system::SystemMsg, DstLocation, MsgId},
+    types::Cache,
+};
+use sn_node::node::{
+    create_test_max_capacity_and_root_storage, Config, Event as RoutingEvent, NodeApi,
+    NodeElderChange,
+};
+
 use bls::PublicKey;
 use eyre::{eyre, Context, Error, Result};
 use futures::{
@@ -20,7 +29,6 @@ use rand::{
     distributions::{Distribution, WeightedIndex},
     Rng,
 };
-
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs::File,
@@ -37,15 +45,6 @@ use tokio_util::time::delay_queue::DelayQueue;
 use tracing_subscriber::EnvFilter;
 use xor_name::{Prefix, XorName};
 use yansi::{Color, Style};
-
-use sn_interface::messaging::{
-    data::Error::FailedToWriteFile, system::SystemMsg, DstLocation, MsgId,
-};
-use sn_interface::types::Cache;
-use sn_node::node::{
-    create_test_max_capacity_and_root_storage, Config, Event as RoutingEvent, NodeApi,
-    NodeElderChange,
-};
 
 // Minimal delay between two consecutive prints of the network status.
 const MIN_PRINT_DELAY: Duration = Duration::from_millis(500);

--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -27,24 +27,24 @@
     unused_results
 )]
 
-use color_eyre::{Section, SectionExt};
 #[cfg(not(feature = "tokio-console"))]
-use eyre::Error;
-
-use eyre::{eyre, Context, ErrReport, Result};
-use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
+use sn_interface::LogFormatter;
 use sn_node::node::{
     add_connection_info, set_connection_info, Config, Error as NodeError, Event, NodeApi,
 };
 
-use self_update::{cargo_crate_version, Status};
+use color_eyre::{Section, SectionExt};
 #[cfg(not(feature = "tokio-console"))]
-use sn_interface::LogFormatter;
-use std::{fmt::Debug, fs::File, io, path::Path};
-use std::{io::Write, process::exit};
+use eyre::Error;
+use eyre::{eyre, Context, ErrReport, Result};
+use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
+use self_update::{cargo_crate_version, Status};
+use std::{fmt::Debug, fs::File, io, io::Write, path::Path, process::exit};
 use structopt::{clap, StructOpt};
-use tokio::sync::RwLockReadGuard;
-use tokio::time::{sleep, Duration};
+use tokio::{
+    sync::RwLockReadGuard,
+    time::{sleep, Duration},
+};
 use tracing::{self, debug, error, info, trace, warn};
 
 #[cfg(not(feature = "tokio-console"))]

--- a/sn_node/src/dbs/chunk_store.rs
+++ b/sn_node/src/dbs/chunk_store.rs
@@ -178,9 +178,9 @@ fn list_files_in(path: &Path) -> Result<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use sn_interface::types::utils::random_bytes;
 
-    use super::*;
     use futures::future::join_all;
     use rayon::prelude::*;
     use tempfile::tempdir;

--- a/sn_node/src/dbs/errors.rs
+++ b/sn_node/src/dbs/errors.rs
@@ -6,10 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_interface::messaging::data::Error as ErrorMsg;
-use sn_interface::types::{
-    convert_dt_error_to_error_msg, DataAddress, PublicKey, ReplicatedDataAddress,
+use sn_interface::{
+    messaging::data::Error as ErrorMsg,
+    types::{convert_dt_error_to_error_msg, DataAddress, PublicKey, ReplicatedDataAddress},
 };
+
 use std::io;
 use thiserror::Error;
 use xor_name::XorName;

--- a/sn_node/src/dbs/event_store.rs
+++ b/sn_node/src/dbs/event_store.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{deserialise, serialise, Error, Result};
+
 use serde::{de::DeserializeOwned, Serialize};
 use sled::{Db, Tree};
 use std::{fmt::Debug, marker::PhantomData};
@@ -79,6 +80,7 @@ mod test {
     use super::EventStore;
     use crate::node::{Error, Result};
     use sn_interface::types::Token;
+
     use std::path::Path;
     use tempfile::tempdir;
     use xor_name::XorName;

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -47,8 +47,6 @@ pub use dbs::UsedSpace;
 
 pub mod node;
 
-// pub(crate) use sn_interface::{data_copy_count, at_least_one_correct_elder, max_num_faulty_elders}
-
 #[cfg(test)]
 #[ctor::ctor]
 fn test_setup() {

--- a/sn_node/src/node/api/cmds.rs
+++ b/sn_node/src/node/api/cmds.rs
@@ -7,19 +7,19 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{core::Proposal, XorName};
-use sn_interface::network_knowledge::{SectionAuthorityProvider, SectionKeyShare};
-use sn_interface::types::Peer;
+
+use sn_consensus::Generation;
 use sn_interface::{
     messaging::{
         system::{DkgFailureSigSet, KeyedSig, NodeState, SectionAuth, SystemMsg},
         DstLocation, WireMsg,
     },
-    types::ReplicatedDataAddress,
+    network_knowledge::{SectionAuthorityProvider, SectionKeyShare},
+    types::{Peer, ReplicatedDataAddress},
 };
 
 use bytes::Bytes;
 use custom_debug::Debug;
-use sn_consensus::Generation;
 use std::{
     collections::BTreeSet,
     fmt,

--- a/sn_node/src/node/api/dispatcher/background_tasks.rs
+++ b/sn_node/src/node/api/dispatcher/background_tasks.rs
@@ -6,20 +6,21 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::Cmd;
+use super::{Cmd, Dispatcher};
 use crate::node::{messages::WireMsgUtils, Result};
+
 #[cfg(feature = "back-pressure")]
 use sn_interface::messaging::DstLocation;
-use sn_interface::messaging::{
-    system::{NodeCmd, SystemMsg},
-    WireMsg,
+use sn_interface::{
+    messaging::{
+        system::{NodeCmd, SystemMsg},
+        WireMsg,
+    },
+    types::log_markers::LogMarker,
 };
-use sn_interface::types::log_markers::LogMarker;
-use std::{collections::BTreeSet, sync::Arc, time::Duration};
-use tokio::task::JoinHandle;
-use tokio::time::MissedTickBehavior;
 
-use super::Dispatcher;
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use tokio::{task::JoinHandle, time::MissedTickBehavior};
 
 const PROBE_INTERVAL: Duration = Duration::from_secs(30);
 #[cfg(feature = "back-pressure")]

--- a/sn_node/src/node/api/dispatcher/mod.rs
+++ b/sn_node/src/node/api/dispatcher/mod.rs
@@ -7,18 +7,21 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 mod background_tasks;
+
 use super::Cmd;
+
 use crate::node::{
     core::{DeliveryStatus, Node, Proposal},
     messages::WireMsgUtils,
     Result,
 };
-use dashmap::DashMap;
-use sn_interface::types::{log_markers::LogMarker, Peer};
+
 use sn_interface::{
     messaging::{system::SystemMsg, AuthKind, WireMsg},
-    types::ReplicatedDataAddress,
+    types::{log_markers::LogMarker, Peer, ReplicatedDataAddress},
 };
+
+use dashmap::DashMap;
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use tokio::{sync::watch, sync::RwLock, time};
 use tracing::Instrument;

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -6,10 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+pub(crate) mod cmds;
 #[cfg(test)]
 pub(crate) mod tests;
-
-pub(crate) mod cmds;
 
 pub(super) mod dispatcher;
 pub(super) mod event;
@@ -31,9 +30,12 @@ use crate::node::{
     Config, Peer,
 };
 use crate::UsedSpace;
-use sn_interface::messaging::{system::SystemMsg, DstLocation, WireMsg};
-use sn_interface::network_knowledge::{NodeInfo, SectionAuthorityProvider, MIN_ADULT_AGE};
-use sn_interface::types::{keys::ed25519, log_markers::LogMarker, PublicKey as TypesPublicKey};
+
+use sn_interface::{
+    messaging::{system::SystemMsg, DstLocation, WireMsg},
+    network_knowledge::{NodeInfo, SectionAuthorityProvider, MIN_ADULT_AGE},
+    types::{keys::ed25519, log_markers::LogMarker, PublicKey as TypesPublicKey},
+};
 
 use ed25519_dalek::PublicKey;
 use itertools::Itertools;

--- a/sn_node/src/node/api/tests/mod.rs
+++ b/sn_node/src/node/api/tests/mod.rs
@@ -20,24 +20,25 @@ use crate::node::{
     messages::WireMsgUtils,
     Error, Event, Result as RoutingResult,
 };
-use sn_interface::messaging::{
-    system::{
-        JoinAsRelocatedRequest, JoinRequest, JoinResponse, KeyedSig, MembershipState,
-        NodeMsgAuthorityUtils, NodeState as NodeStateMsg, RelocateDetails, ResourceProofResponse,
-        SectionAuth, SystemMsg,
-    },
-    AuthKind, AuthorityProof, DstLocation, MsgId, MsgType, NodeAuth,
-    SectionAuth as MsgKindSectionAuth, WireMsg,
-};
-use sn_interface::network_knowledge::{
-    recommended_section_size, supermajority, test_utils::*, NetworkKnowledge, NodeInfo, NodeState,
-    SectionAuthorityProvider, SectionKeyShare, FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE,
-    MIN_ADULT_AGE,
-};
-use sn_interface::types::{keyed_signed, SecretKeySet};
-use sn_interface::{elder_count, init_logger};
 
-use sn_interface::types::{keys::ed25519, Keypair, Peer, PublicKey};
+use sn_interface::{
+    elder_count, init_logger,
+    messaging::{
+        system::{
+            JoinAsRelocatedRequest, JoinRequest, JoinResponse, KeyedSig, MembershipState,
+            NodeMsgAuthorityUtils, NodeState as NodeStateMsg, RelocateDetails,
+            ResourceProofResponse, SectionAuth, SystemMsg,
+        },
+        AuthKind, AuthorityProof, DstLocation, MsgId, MsgType, NodeAuth,
+        SectionAuth as MsgKindSectionAuth, WireMsg,
+    },
+    network_knowledge::{
+        recommended_section_size, supermajority, test_utils::*, NetworkKnowledge, NodeInfo,
+        NodeState, SectionAuthorityProvider, SectionKeyShare, FIRST_SECTION_MAX_AGE,
+        FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
+    },
+    types::{keyed_signed, keys::ed25519, Keypair, Peer, PublicKey, SecretKeySet},
+};
 
 use assert_matches::assert_matches;
 use bls_dkg::message::Message;

--- a/sn_node/src/node/core/api.rs
+++ b/sn_node/src/node/core/api.rs
@@ -14,11 +14,12 @@ use crate::node::{
     Event,
 };
 use crate::UsedSpace;
-use sn_interface::messaging::WireMsg;
-use sn_interface::network_knowledge::{
-    NetworkKnowledge, NodeInfo, SectionAuthorityProvider, SectionKeyShare,
+
+use sn_interface::{
+    messaging::WireMsg,
+    network_knowledge::{NetworkKnowledge, NodeInfo, SectionAuthorityProvider, SectionKeyShare},
+    types::log_markers::LogMarker,
 };
-use sn_interface::types::log_markers::LogMarker;
 
 use secured_linked_list::SecuredLinkedList;
 use std::{collections::BTreeSet, net::SocketAddr, path::PathBuf};

--- a/sn_node/src/node/core/bootstrap/join.rs
+++ b/sn_node/src/node/core/bootstrap/join.rs
@@ -7,23 +7,26 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{read_prefix_map_from_disk, UsedRecipientSaps};
+
 use crate::node::{
     core::{Comm, DeliveryStatus, MsgEvent},
     messages::WireMsgUtils,
     Error, Result,
 };
-use sn_interface::messaging::{
-    system::{
-        JoinRejectionReason, JoinRequest, JoinResponse, ResourceProofResponse, SectionAuth,
-        SystemMsg,
-    },
-    AuthKind, DstLocation, MsgType, NodeAuth, WireMsg,
-};
-use sn_interface::network_knowledge::{
-    prefix_map::NetworkPrefixMap, NetworkKnowledge, NodeInfo, SectionAuthUtils, MIN_ADULT_AGE,
-};
 
-use sn_interface::types::{keys::ed25519, log_markers::LogMarker, Peer};
+use sn_interface::{
+    messaging::{
+        system::{
+            JoinRejectionReason, JoinRequest, JoinResponse, ResourceProofResponse, SectionAuth,
+            SystemMsg,
+        },
+        AuthKind, DstLocation, MsgType, NodeAuth, WireMsg,
+    },
+    network_knowledge::{
+        prefix_map::NetworkPrefixMap, NetworkKnowledge, NodeInfo, SectionAuthUtils, MIN_ADULT_AGE,
+    },
+    types::{keys::ed25519, log_markers::LogMarker, Peer},
+};
 
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use bls::PublicKey as BlsPublicKey;
@@ -512,12 +515,12 @@ mod tests {
 
     use crate::node::{messages::WireMsgUtils, Error as RoutingError, MIN_ADULT_AGE};
 
-    use sn_interface::network_knowledge::{test_utils::*, NodeState};
-
-    use sn_interface::elder_count;
-    use sn_interface::init_logger;
-    use sn_interface::messaging::SectionAuthorityProvider as SectionAuthorityProviderMsg;
-    use sn_interface::types::PublicKey;
+    use sn_interface::{
+        elder_count, init_logger,
+        messaging::SectionAuthorityProvider as SectionAuthorityProviderMsg,
+        network_knowledge::{test_utils::*, NodeState},
+        types::PublicKey,
+    };
 
     use assert_matches::assert_matches;
     use eyre::{eyre, Error, Result};

--- a/sn_node/src/node/core/bootstrap/mod.rs
+++ b/sn_node/src/node/core/bootstrap/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use relocate::JoiningAsRelocated;
 #[cfg(not(test))]
 use crate::node::Error;
 use crate::node::Result;
+
 use sn_interface::network_knowledge::prefix_map::NetworkPrefixMap;
 
 use bls::PublicKey as BlsPublicKey;

--- a/sn_node/src/node/core/bootstrap/relocate.rs
+++ b/sn_node/src/node/core/bootstrap/relocate.rs
@@ -9,12 +9,17 @@
 use super::UsedRecipientSaps;
 
 use crate::node::{api::cmds::Cmd, messages::WireMsgUtils, Error, Result};
-use sn_interface::messaging::{
-    system::{JoinAsRelocatedRequest, JoinAsRelocatedResponse, NodeState, SectionAuth, SystemMsg},
-    DstLocation, WireMsg,
+
+use sn_interface::{
+    messaging::{
+        system::{
+            JoinAsRelocatedRequest, JoinAsRelocatedResponse, NodeState, SectionAuth, SystemMsg,
+        },
+        DstLocation, WireMsg,
+    },
+    network_knowledge::{NodeInfo, SectionAuthorityProvider},
+    types::{keys::ed25519, Peer, PublicKey},
 };
-use sn_interface::network_knowledge::{NodeInfo, SectionAuthorityProvider};
-use sn_interface::types::{keys::ed25519, Peer, PublicKey};
 
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::{Keypair, Signature};

--- a/sn_node/src/node/core/comm/listener.rs
+++ b/sn_node/src/node/core/comm/listener.rs
@@ -8,12 +8,13 @@
 
 use super::MsgEvent;
 
-use sn_interface::messaging::WireMsg;
-use sn_interface::types::{log_markers::LogMarker, Peer};
+use sn_interface::{
+    messaging::WireMsg,
+    types::{log_markers::LogMarker, Peer},
+};
 
 use qp2p::ConnectionIncoming;
-use tokio::sync::mpsc;
-use tokio::task;
+use tokio::{sync::mpsc, task};
 use tracing::Instrument;
 
 #[derive(Debug)]

--- a/sn_node/src/node/core/comm/mod.rs
+++ b/sn_node/src/node/core/comm/mod.rs
@@ -16,24 +16,26 @@ mod peer_session;
 #[cfg(feature = "back-pressure")]
 use self::back_pressure::BackPressure;
 
-use self::link::Link;
-use self::listener::{ListenerEvent, MsgListener};
-use self::peer_session::{PeerSession, SendWatcher};
+use self::{
+    link::Link,
+    listener::{ListenerEvent, MsgListener},
+    peer_session::{PeerSession, SendWatcher},
+};
 
-use crate::node::core::comm::peer_session::SendStatus;
-use crate::node::error::{Error, Result};
+use crate::node::{
+    core::comm::peer_session::SendStatus,
+    error::{Error, Result},
+};
+
 use sn_dysfunction::DysfunctionDetection;
-use sn_interface::messaging::WireMsg;
-use sn_interface::types::Peer;
+use sn_interface::{messaging::WireMsg, types::Peer};
 
 use bytes::Bytes;
+use dashmap::DashMap;
 use futures::stream::{FuturesUnordered, StreamExt};
 use qp2p::{Endpoint, IncomingConnections};
-use std::time::Duration;
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{sync::mpsc, task};
-
-use dashmap::DashMap;
 
 // Communication component of the node to interact with other nodes.
 #[derive(Clone)]
@@ -610,13 +612,19 @@ pub(crate) enum DeliveryStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use sn_interface::{
+        messaging::{
+            data::{DataQuery, ServiceMsg},
+            AuthKind, DstLocation, MsgId, ServiceAuth,
+        },
+        types::{ChunkAddress, Keypair, Peer},
+    };
+
     use assert_matches::assert_matches;
     use eyre::Result;
     use futures::future;
     use qp2p::Config;
-    use sn_interface::messaging::data::{DataQuery, ServiceMsg};
-    use sn_interface::messaging::{AuthKind, DstLocation, MsgId, ServiceAuth};
-    use sn_interface::types::{ChunkAddress, Keypair, Peer};
     use std::{net::Ipv4Addr, time::Duration};
     use tokio::{net::UdpSocket, sync::mpsc, time};
 

--- a/sn_node/src/node/core/comm/peer_session.rs
+++ b/sn_node/src/node/core/comm/peer_session.rs
@@ -9,6 +9,7 @@
 use super::Link;
 
 use crate::node::{Error, Result};
+
 use sn_interface::messaging::MsgId;
 
 use bytes::Bytes;

--- a/sn_node/src/node/core/data/records/capacity.rs
+++ b/sn_node/src/node/core/data/records/capacity.rs
@@ -7,8 +7,9 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{Prefix, XorName};
-use itertools::Itertools;
 use sn_interface::messaging::data::StorageLevel;
+
+use itertools::Itertools;
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -16,16 +16,20 @@ use crate::node::{
     messages::WireMsgUtils,
     Error, Result,
 };
+
+use sn_dysfunction::IssueType;
+use sn_interface::{
+    data_copy_count,
+    messaging::{
+        data::{CmdError, DataQuery, MetadataExchange, StorageLevel},
+        system::{NodeCmd, NodeQuery, SystemMsg},
+        AuthorityProof, DstLocation, EndUser, MsgId, ServiceAuth, WireMsg,
+    },
+    types::{log_markers::LogMarker, Peer, PublicKey, ReplicatedData},
+};
+
 use dashmap::DashSet;
 use itertools::Itertools;
-use sn_dysfunction::IssueType;
-use sn_interface::data_copy_count;
-use sn_interface::messaging::{
-    data::{CmdError, DataQuery, MetadataExchange, StorageLevel},
-    system::{NodeCmd, NodeQuery, SystemMsg},
-    AuthorityProof, DstLocation, EndUser, MsgId, ServiceAuth, WireMsg,
-};
-use sn_interface::types::{log_markers::LogMarker, Peer, PublicKey, ReplicatedData};
 use std::{cmp::Ordering, collections::BTreeSet, sync::Arc};
 use tracing::info;
 use xor_name::XorName;

--- a/sn_node/src/node/core/data/storage/chunks.rs
+++ b/sn_node/src/node/core/data/storage/chunks.rs
@@ -8,8 +8,11 @@
 
 use crate::dbs::{convert_to_error_msg, ChunkStore, Error, Result};
 use crate::UsedSpace;
-use sn_interface::messaging::system::NodeQueryResponse;
-use sn_interface::types::{log_markers::LogMarker, Chunk, ChunkAddress};
+
+use sn_interface::{
+    messaging::system::NodeQueryResponse,
+    types::{log_markers::LogMarker, Chunk, ChunkAddress},
+};
 
 use std::{
     fmt::{self, Display, Formatter},

--- a/sn_node/src/node/core/data/storage/errors.rs
+++ b/sn_node/src/node/core/data/storage/errors.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_interface::messaging::data::Error as ErrorMsg;
-use sn_interface::types::convert_dt_error_to_error_msg;
+use sn_interface::{messaging::data::Error as ErrorMsg, types::convert_dt_error_to_error_msg};
+
 use std::io;
 use thiserror::Error;
 use xor_name::XorName;

--- a/sn_node/src/node/core/data/storage/mod.rs
+++ b/sn_node/src/node/core/data/storage/mod.rs
@@ -9,20 +9,22 @@
 mod chunks;
 mod registers;
 
-use crate::{dbs::Result, UsedSpace};
-
-use sn_interface::messaging::{
-    data::{DataQuery, Error, RegisterQuery, RegisterStoreExport, StorageLevel},
-    system::NodeQueryResponse,
-};
-use sn_interface::types::{
-    register::User, RegisterAddress, ReplicatedData, ReplicatedDataAddress, SPENTBOOK_TYPE_TAG,
-};
-
 pub(crate) use chunks::ChunkStorage;
 pub(crate) use registers::RegisterStorage;
 
+use crate::{dbs::Result, UsedSpace};
+
 use sn_dbc::SpentProofShare;
+use sn_interface::{
+    messaging::{
+        data::{DataQuery, Error, RegisterQuery, RegisterStoreExport, StorageLevel},
+        system::NodeQueryResponse,
+    },
+    types::{
+        register::User, RegisterAddress, ReplicatedData, ReplicatedDataAddress, SPENTBOOK_TYPE_TAG,
+    },
+};
+
 use std::{path::Path, sync::Arc};
 use tokio::sync::RwLock;
 
@@ -210,20 +212,22 @@ mod tests {
     use crate::dbs::Error;
     use crate::node::core::data::DataStorage;
     use crate::UsedSpace;
+
+    use sn_interface::{
+        messaging::{data::DataQuery, system::NodeQueryResponse},
+        types::{
+            register::User, utils::random_bytes, Chunk, ChunkAddress, ReplicatedData,
+            ReplicatedDataAddress,
+        },
+    };
+
     use eyre::Result;
     use proptest::{
         collection::SizeRange,
         prelude::{any, prop_oneof, proptest},
         strategy::Strategy,
     };
-    use sn_interface::messaging::data::DataQuery;
-    use sn_interface::messaging::system::NodeQueryResponse;
-    use sn_interface::types::register::User;
-    use sn_interface::types::utils::random_bytes;
-    use sn_interface::types::{Chunk, ChunkAddress, ReplicatedData, ReplicatedDataAddress};
-    use std::cmp::max;
-    use std::collections::BTreeMap;
-    use std::{thread, time::Duration};
+    use std::{cmp::max, collections::BTreeMap, thread, time::Duration};
     use tempfile::tempdir;
     use tokio::runtime::Runtime;
     use xor_name::XorName;

--- a/sn_node/src/node/core/data/storage/registers.rs
+++ b/sn_node/src/node/core/data/storage/registers.rs
@@ -9,18 +9,21 @@
 use crate::dbs::{
     convert_to_error_msg, Error, EventStore, LruCache, Result, UsedSpace, SLED_FLUSH_TIME_MS,
 };
-use sn_interface::messaging::{
-    data::{
-        CreateRegister, EditRegister, ExtendRegister, OperationId, RegisterCmd, RegisterQuery,
-        RegisterStoreExport, ReplicatedRegisterLog, SignedRegisterCreate, SignedRegisterEdit,
-        SignedRegisterExtend,
+
+use sn_interface::{
+    messaging::{
+        data::{
+            CreateRegister, EditRegister, ExtendRegister, OperationId, RegisterCmd, RegisterQuery,
+            RegisterStoreExport, ReplicatedRegisterLog, SignedRegisterCreate, SignedRegisterEdit,
+            SignedRegisterExtend,
+        },
+        system::NodeQueryResponse,
+        SectionAuth, ServiceAuth, VerifyAuthority,
     },
-    system::NodeQueryResponse,
-    SectionAuth, ServiceAuth, VerifyAuthority,
-};
-use sn_interface::types::{
-    register::{Action, EntryHash, Permissions, Policy, Register, User},
-    DataAddress, Keypair, PublicKey, RegisterAddress, SPENTBOOK_TYPE_TAG,
+    types::{
+        register::{Action, EntryHash, Permissions, Policy, Register, User},
+        DataAddress, Keypair, PublicKey, RegisterAddress, SPENTBOOK_TYPE_TAG,
+    },
 };
 
 use bincode::serialize;
@@ -735,12 +738,17 @@ mod test {
 
     use crate::node::{Error, Result};
     use crate::UsedSpace;
-    use sn_interface::messaging::{
-        data::{RegisterCmd, RegisterQuery},
-        system::NodeQueryResponse,
+
+    use sn_interface::{
+        messaging::{
+            data::{RegisterCmd, RegisterQuery},
+            system::NodeQueryResponse,
+        },
+        types::{
+            register::{EntryHash, Policy, User},
+            Keypair,
+        },
     };
-    use sn_interface::types::register::{EntryHash, Policy};
-    use sn_interface::types::{register::User, Keypair};
 
     use rand::Rng;
     use tempfile::tempdir;

--- a/sn_node/src/node/core/delivery_group.rs
+++ b/sn_node/src/node/core/delivery_group.rs
@@ -7,10 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{Error, Result};
-use sn_interface::elder_count;
-use sn_interface::messaging::DstLocation;
-use sn_interface::network_knowledge::{supermajority, NetworkKnowledge};
-use sn_interface::types::Peer;
+
+use sn_interface::{
+    elder_count,
+    messaging::DstLocation,
+    network_knowledge::{supermajority, NetworkKnowledge},
+    types::Peer,
+};
 
 use itertools::Itertools;
 use std::{cmp, iter};
@@ -170,16 +173,19 @@ async fn get_peer(name: &XorName, network_knowledge: &NetworkKnowledge) -> Optio
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sn_interface::network_knowledge::test_utils::section_signed;
-    use sn_interface::types::keys::ed25519;
+
+    use sn_interface::{
+        network_knowledge::{
+            test_utils::section_signed,
+            test_utils::{gen_addr, gen_section_authority_provider},
+            NodeState, SectionAuthorityProvider, MIN_ADULT_AGE,
+        },
+        types::keys::ed25519,
+    };
 
     use eyre::{ContextCompat, Result};
     use rand::seq::IteratorRandom;
     use secured_linked_list::SecuredLinkedList;
-    use sn_interface::network_knowledge::{
-        test_utils::{gen_addr, gen_section_authority_provider},
-        NodeState, SectionAuthorityProvider, MIN_ADULT_AGE,
-    };
     use xor_name::Prefix;
 
     #[tokio::test]

--- a/sn_node/src/node/core/messaging/handling/agreement.rs
+++ b/sn_node/src/node/core/messaging/handling/agreement.rs
@@ -11,13 +11,16 @@ use crate::node::{
     core::{relocation::ChurnId, Node, Proposal},
     Event, Result,
 };
+
 use sn_consensus::Generation;
-use sn_interface::messaging::system::{KeyedSig, MembershipState, SectionAuth};
-use sn_interface::network_knowledge::SectionAuthUtils;
-use sn_interface::network_knowledge::{
-    NodeState, SapCandidate, SectionAuthorityProvider, MIN_ADULT_AGE,
+use sn_interface::{
+    messaging::system::{KeyedSig, MembershipState, SectionAuth},
+    network_knowledge::{
+        NodeState, SapCandidate, SectionAuthUtils, SectionAuthorityProvider, MIN_ADULT_AGE,
+    },
+    types::log_markers::LogMarker,
 };
-use sn_interface::types::log_markers::LogMarker;
+
 use std::{cmp, collections::BTreeSet};
 
 // Agreement

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -7,13 +7,15 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{api::cmds::Cmd, core::Node, messages::WireMsgUtils, Error, Event, Result};
-use sn_interface::messaging::{
-    system::{KeyedSig, SectionAuth, SectionPeers, SystemMsg},
-    MsgId, MsgType, SrcLocation, WireMsg,
-};
 
-use sn_interface::network_knowledge::SectionAuthorityProvider;
-use sn_interface::types::{log_markers::LogMarker, Peer, PublicKey};
+use sn_interface::{
+    messaging::{
+        system::{KeyedSig, SectionAuth, SectionPeers, SystemMsg},
+        MsgId, MsgType, SrcLocation, WireMsg,
+    },
+    network_knowledge::SectionAuthorityProvider,
+    types::{log_markers::LogMarker, Peer, PublicKey},
+};
 
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use bls::PublicKey as BlsPublicKey;
@@ -466,28 +468,30 @@ impl Node {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use crate::node::{
         api::tests::create_comm, create_test_max_capacity_and_root_storage, MIN_ADULT_AGE,
     };
     use crate::UsedSpace;
-    use sn_interface::elder_count;
-    use sn_interface::messaging::{
-        AuthKind, AuthorityProof, DstLocation, MsgId, MsgType, NodeAuth, NodeMsgAuthority,
-        SectionAuth as SectionAuthMsg,
+
+    use sn_interface::{
+        elder_count,
+        messaging::{
+            AuthKind, AuthorityProof, DstLocation, MsgId, MsgType, NodeAuth, NodeMsgAuthority,
+            SectionAuth as SectionAuthMsg,
+        },
+        network_knowledge::{
+            test_utils::{gen_addr, gen_section_authority_provider, section_signed},
+            NetworkKnowledge, NodeInfo, SectionKeyShare, SectionKeysProvider,
+        },
+        types::keys::ed25519,
     };
-    use sn_interface::network_knowledge::test_utils::{
-        gen_addr, gen_section_authority_provider, section_signed,
-    };
-    use sn_interface::network_knowledge::{
-        NetworkKnowledge, NodeInfo, SectionKeyShare, SectionKeysProvider,
-    };
-    use sn_interface::types::keys::ed25519;
-    use std::collections::BTreeSet;
 
     use assert_matches::assert_matches;
     use bls::SecretKey;
     use eyre::{Context, Result};
     use secured_linked_list::SecuredLinkedList;
+    use std::collections::BTreeSet;
     use tokio::sync::mpsc;
     use xor_name::Prefix;
 

--- a/sn_node/src/node/core/messaging/handling/dkg.rs
+++ b/sn_node/src/node/core/messaging/handling/dkg.rs
@@ -13,12 +13,15 @@ use crate::node::{
     messages::WireMsgUtils,
     Error, Result,
 };
-use sn_interface::messaging::{
-    system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SystemMsg},
-    DstLocation, WireMsg,
+
+use sn_interface::{
+    messaging::{
+        system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SystemMsg},
+        DstLocation, WireMsg,
+    },
+    network_knowledge::{SectionAuthorityProvider, SectionKeyShare},
+    types::{log_markers::LogMarker, Peer},
 };
-use sn_interface::network_knowledge::{SectionAuthorityProvider, SectionKeyShare};
-use sn_interface::types::{log_markers::LogMarker, Peer};
 
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::message::Message as DkgMessage;

--- a/sn_node/src/node/core/messaging/handling/handover.rs
+++ b/sn_node/src/node/core/messaging/handling/handover.rs
@@ -6,24 +6,24 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::node::{
+    api::cmds::Cmd,
+    core::{Node, Proposal, SystemMsg},
+    handover::{Error as HandoverError, Handover},
+    membership::{elder_candidates, try_split_dkg},
+    Error, Peer, Result,
+};
+
 use sn_consensus::{Generation, SignedVote, VoteResponse};
+use sn_interface::{
+    messaging::system::{NodeState, SectionAuth},
+    network_knowledge::SapCandidate,
+    types::log_markers::LogMarker,
+    SectionAuthorityProvider,
+};
+
 use std::collections::{BTreeMap, BTreeSet};
 use xor_name::{Prefix, XorName};
-
-use crate::node::core::SystemMsg;
-use crate::node::handover::Error as HandoverError;
-use crate::node::handover::Handover;
-use crate::node::Peer;
-use crate::node::{api::cmds::Cmd, core::Node, Error, Result};
-
-use crate::node::core::Proposal;
-use sn_interface::messaging::system::NodeState;
-use sn_interface::messaging::system::SectionAuth;
-use sn_interface::network_knowledge::SapCandidate;
-use sn_interface::types::log_markers::LogMarker;
-use sn_interface::SectionAuthorityProvider;
-
-use crate::node::membership::{elder_candidates, try_split_dkg};
 
 impl Node {
     /// helper to handle a handover vote

--- a/sn_node/src/node/core/messaging/handling/join.rs
+++ b/sn_node/src/node/core/messaging/handling/join.rs
@@ -11,13 +11,16 @@ use crate::node::{
     core::{relocation::RelocateDetailsUtils, Node},
     Result,
 };
-use sn_interface::elder_count;
-use sn_interface::messaging::system::{
-    JoinAsRelocatedRequest, JoinAsRelocatedResponse, JoinRejectionReason, JoinRequest,
-    JoinResponse, MembershipState, NodeState, SystemMsg,
+
+use sn_interface::{
+    elder_count,
+    messaging::system::{
+        JoinAsRelocatedRequest, JoinAsRelocatedResponse, JoinRejectionReason, JoinRequest,
+        JoinResponse, MembershipState, NodeState, SystemMsg,
+    },
+    network_knowledge::{SectionAuthUtils, FIRST_SECTION_MAX_AGE, MIN_ADULT_AGE},
+    types::{log_markers::LogMarker, Peer},
 };
-use sn_interface::network_knowledge::{SectionAuthUtils, FIRST_SECTION_MAX_AGE, MIN_ADULT_AGE};
-use sn_interface::types::{log_markers::LogMarker, Peer};
 
 use bls::PublicKey as BlsPublicKey;
 use std::vec;

--- a/sn_node/src/node/core/messaging/handling/left.rs
+++ b/sn_node/src/node/core/messaging/handling/left.rs
@@ -1,4 +1,15 @@
-use std::collections::BTreeSet;
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::node::{
+    api::cmds::Cmd,
+    core::{relocation::ChurnId, Node, Result},
+};
 
 use sn_interface::{
     messaging::system::{KeyedSig, SectionAuth},
@@ -6,10 +17,7 @@ use sn_interface::{
     types::log_markers::LogMarker,
 };
 
-use crate::node::{
-    api::cmds::Cmd,
-    core::{relocation::ChurnId, Node, Result},
-};
+use std::collections::BTreeSet;
 
 impl Node {
     pub(crate) async fn handle_node_left(

--- a/sn_node/src/node/core/messaging/handling/membership.rs
+++ b/sn_node/src/node/core/messaging/handling/membership.rs
@@ -6,16 +6,19 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::collections::BTreeSet;
-use std::vec;
+use crate::node::{
+    api::cmds::Cmd,
+    core::{Node, Result},
+    membership,
+};
 
 use sn_consensus::{Generation, SignedVote, VoteResponse};
-use sn_interface::messaging::system::{KeyedSig, NodeState, SectionAuth, SystemMsg};
-use sn_interface::types::{log_markers::LogMarker, Peer};
+use sn_interface::{
+    messaging::system::{KeyedSig, NodeState, SectionAuth, SystemMsg},
+    types::{log_markers::LogMarker, Peer},
+};
 
-use crate::node::api::cmds::Cmd;
-use crate::node::core::{Node, Result};
-use crate::node::membership;
+use std::{collections::BTreeSet, vec};
 
 // Message handling
 impl Node {

--- a/sn_node/src/node/core/messaging/handling/mod.rs
+++ b/sn_node/src/node/core/messaging/handling/mod.rs
@@ -28,17 +28,20 @@ use crate::node::{
     messages::WireMsgUtils,
     Error, Event, MessageReceived, Result, MIN_LEVEL_WHEN_FULL,
 };
-use sn_interface::messaging::{
-    data::{ServiceMsg, StorageLevel},
-    signature_aggregator::Error as AggregatorError,
-    system::{
-        JoinResponse, NodeCmd, NodeEvent, NodeMsgAuthorityUtils, NodeQuery,
-        Proposal as ProposalMsg, SystemMsg,
+
+use sn_interface::{
+    messaging::{
+        data::{ServiceMsg, StorageLevel},
+        signature_aggregator::Error as AggregatorError,
+        system::{
+            JoinResponse, NodeCmd, NodeEvent, NodeMsgAuthorityUtils, NodeQuery,
+            Proposal as ProposalMsg, SystemMsg,
+        },
+        AuthorityProof, DstLocation, MsgId, MsgType, NodeMsgAuthority, SectionAuth, WireMsg,
     },
-    AuthorityProof, DstLocation, MsgId, MsgType, NodeMsgAuthority, SectionAuth, WireMsg,
+    network_knowledge::NetworkKnowledge,
+    types::{log_markers::LogMarker, Peer, PublicKey},
 };
-use sn_interface::network_knowledge::NetworkKnowledge;
-use sn_interface::types::{log_markers::LogMarker, Peer, PublicKey};
 
 use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;

--- a/sn_node/src/node/core/messaging/handling/proposals.rs
+++ b/sn_node/src/node/core/messaging/handling/proposals.rs
@@ -7,12 +7,15 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{api::cmds::Cmd, core::Proposal, dkg::SigShare, Result};
-use sn_interface::messaging::{
-    signature_aggregator::{Error as AggregatorError, SignatureAggregator},
-    MsgId,
+
+use sn_interface::{
+    messaging::{
+        signature_aggregator::{Error as AggregatorError, SignatureAggregator},
+        MsgId,
+    },
+    network_knowledge::NetworkKnowledge,
+    types::Peer,
 };
-use sn_interface::network_knowledge::NetworkKnowledge;
-use sn_interface::types::Peer;
 
 // Insert the proposal into the proposal aggregator and handle it if aggregated.
 pub(crate) async fn handle_proposal(

--- a/sn_node/src/node/core/messaging/handling/relocation.rs
+++ b/sn_node/src/node/core/messaging/handling/relocation.rs
@@ -15,12 +15,13 @@ use crate::node::{
     },
     Event, Result,
 };
-use sn_interface::elder_count;
-use sn_interface::messaging::system::{
-    MembershipState, NodeState as NodeStateMsg, RelocateDetails, SectionAuth,
+
+use sn_interface::{
+    elder_count,
+    messaging::system::{MembershipState, NodeState as NodeStateMsg, RelocateDetails, SectionAuth},
+    network_knowledge::NodeState,
+    types::log_markers::LogMarker,
 };
-use sn_interface::network_knowledge::NodeState;
-use sn_interface::types::log_markers::LogMarker;
 
 use std::collections::BTreeSet;
 use xor_name::XorName;

--- a/sn_node/src/node/core/messaging/handling/resource_proof.rs
+++ b/sn_node/src/node/core/messaging/handling/resource_proof.rs
@@ -11,8 +11,11 @@ use crate::node::{
     core::{Node, RESOURCE_PROOF_DATA_SIZE, RESOURCE_PROOF_DIFFICULTY},
     Error, Result,
 };
-use sn_interface::messaging::system::{JoinResponse, ResourceProofResponse, SystemMsg};
-use sn_interface::types::{keys::ed25519, log_markers::LogMarker, Peer};
+
+use sn_interface::{
+    messaging::system::{JoinResponse, ResourceProofResponse, SystemMsg},
+    types::{keys::ed25519, log_markers::LogMarker, Peer},
+};
 
 use ed25519_dalek::Verifier;
 use xor_name::XorName;

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -7,25 +7,28 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{api::cmds::Cmd, core::Node, Error, Result};
-use sn_interface::data_copy_count;
-use sn_interface::messaging::{
-    data::{
-        CmdError, DataCmd, DataQuery, EditRegister, Error as ErrorMsg, ServiceMsg,
-        SignedRegisterEdit, SpentbookCmd,
-    },
-    system::{NodeQueryResponse, SystemMsg},
-    AuthorityProof, DstLocation, EndUser, MsgId, ServiceAuth, WireMsg,
-};
-use sn_interface::types::{
-    log_markers::LogMarker,
-    register::{Permissions, Policy, Register, User},
-    Keypair, Peer, PublicKey, RegisterCmd, ReplicatedData, SPENTBOOK_TYPE_TAG,
-};
 
-use bytes::Bytes;
 use sn_dbc::{
     Hash, IndexedSignatureShare, KeyImage, RingCtTransaction, SpentProofContent, SpentProofShare,
 };
+use sn_interface::{
+    data_copy_count,
+    messaging::{
+        data::{
+            CmdError, DataCmd, DataQuery, EditRegister, Error as ErrorMsg, ServiceMsg,
+            SignedRegisterEdit, SpentbookCmd,
+        },
+        system::{NodeQueryResponse, SystemMsg},
+        AuthorityProof, DstLocation, EndUser, MsgId, ServiceAuth, WireMsg,
+    },
+    types::{
+        log_markers::LogMarker,
+        register::{Permissions, Policy, Register, User},
+        Keypair, Peer, PublicKey, RegisterCmd, ReplicatedData, SPENTBOOK_TYPE_TAG,
+    },
+};
+
+use bytes::Bytes;
 use std::collections::{BTreeMap, BTreeSet};
 use xor_name::XorName;
 

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -7,16 +7,17 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{api::cmds::Cmd, core::Node, Result};
-use itertools::Itertools;
-use sn_interface::data_copy_count;
-use sn_interface::types::{log_markers::LogMarker, Peer};
+
 use sn_interface::{
+    data_copy_count,
     messaging::{
         system::{NodeCmd, SystemMsg},
         DstLocation,
     },
-    types::ReplicatedDataAddress,
+    types::{log_markers::LogMarker, Peer, ReplicatedDataAddress},
 };
+
+use itertools::Itertools;
 use std::collections::BTreeSet;
 
 impl Node {

--- a/sn_node/src/node/core/messaging/sending/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/sending/anti_entropy.rs
@@ -11,8 +11,11 @@ use crate::node::{
     core::{Node, StateSnapshot},
     Result,
 };
-use sn_interface::messaging::system::{NodeCmd, SystemMsg};
-use sn_interface::types::{log_markers::LogMarker, Peer};
+
+use sn_interface::{
+    messaging::system::{NodeCmd, SystemMsg},
+    types::{log_markers::LogMarker, Peer},
+};
 
 use bls::PublicKey as BlsPublicKey;
 use xor_name::Prefix;

--- a/sn_node/src/node/core/messaging/sending/approval.rs
+++ b/sn_node/src/node/core/messaging/sending/approval.rs
@@ -7,9 +7,12 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{api::cmds::Cmd, core::Node};
-use sn_interface::messaging::system::{JoinResponse, SectionAuth, SystemMsg};
-use sn_interface::network_knowledge::NodeState;
-use sn_interface::types::log_markers::LogMarker;
+
+use sn_interface::{
+    messaging::system::{JoinResponse, SectionAuth, SystemMsg},
+    network_knowledge::NodeState,
+    types::log_markers::LogMarker,
+};
 
 impl Node {
     // Send `NodeApproval` to a joining node which makes it a section member

--- a/sn_node/src/node/core/messaging/sending/dkg_start.rs
+++ b/sn_node/src/node/core/messaging/sending/dkg_start.rs
@@ -7,12 +7,14 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{api::cmds::Cmd, core::Node, messages::WireMsgUtils, Result};
-use sn_interface::messaging::{
-    system::{DkgSessionId, SystemMsg},
-    DstLocation, WireMsg,
+
+use sn_interface::{
+    messaging::{
+        system::{DkgSessionId, SystemMsg},
+        DstLocation, WireMsg,
+    },
+    types::{log_markers::LogMarker, Peer},
 };
-use sn_interface::types::log_markers::LogMarker;
-use sn_interface::types::Peer;
 
 use xor_name::XorName;
 

--- a/sn_node/src/node/core/messaging/sending/handover.rs
+++ b/sn_node/src/node/core/messaging/sending/handover.rs
@@ -6,14 +6,16 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_consensus::SignedVote;
-use tracing::warn;
-
 use crate::node::{api::cmds::Cmd, core::Node, core::Proposal, Result};
-use sn_interface::messaging::system::SectionAuth;
-use sn_interface::messaging::system::SystemMsg;
-use sn_interface::network_knowledge::{SapCandidate, SectionAuthorityProvider};
-use sn_interface::types::log_markers::LogMarker;
+
+use sn_consensus::SignedVote;
+use sn_interface::{
+    messaging::system::{SectionAuth, SystemMsg},
+    network_knowledge::{SapCandidate, SectionAuthorityProvider},
+    types::log_markers::LogMarker,
+};
+
+use tracing::warn;
 
 impl Node {
     /// Make a handover consensus proposal vote for a sap candidate

--- a/sn_node/src/node/core/messaging/sending/proposal.rs
+++ b/sn_node/src/node/core/messaging/sending/proposal.rs
@@ -12,9 +12,12 @@ use crate::node::{
     messages::WireMsgUtils,
     Result,
 };
-use sn_interface::messaging::{system::SystemMsg, DstLocation, WireMsg};
-use sn_interface::network_knowledge::SectionKeyShare;
-use sn_interface::types::Peer;
+
+use sn_interface::{
+    messaging::{system::SystemMsg, DstLocation, WireMsg},
+    network_knowledge::SectionKeyShare,
+    types::Peer,
+};
 
 impl Node {
     /// Send proposal to all our elders.

--- a/sn_node/src/node/core/messaging/sending/services.rs
+++ b/sn_node/src/node/core/messaging/sending/services.rs
@@ -7,11 +7,14 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{api::cmds::Cmd, core::Node, Result};
-use sn_interface::messaging::{
-    data::{CmdError, ServiceMsg},
-    AuthKind, DstLocation, EndUser, MsgId, ServiceAuth, WireMsg,
+
+use sn_interface::{
+    messaging::{
+        data::{CmdError, ServiceMsg},
+        AuthKind, DstLocation, EndUser, MsgId, ServiceAuth, WireMsg,
+    },
+    types::{Peer, PublicKey, Signature},
 };
-use sn_interface::types::{Peer, PublicKey, Signature};
 
 use bytes::Bytes;
 use ed25519_dalek::Signer;

--- a/sn_node/src/node/core/messaging/sending/system.rs
+++ b/sn_node/src/node/core/messaging/sending/system.rs
@@ -7,12 +7,15 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{api::cmds::Cmd, core::Node, messages::WireMsgUtils, Error, Result};
-use sn_interface::messaging::{
-    system::{SectionAuth, SystemMsg},
-    AuthKind, DstLocation, WireMsg,
+
+use sn_interface::{
+    messaging::{
+        system::{SectionAuth, SystemMsg},
+        AuthKind, DstLocation, WireMsg,
+    },
+    network_knowledge::NodeState,
+    types::{log_markers::LogMarker, Peer},
 };
-use sn_interface::network_knowledge::NodeState;
-use sn_interface::types::{log_markers::LogMarker, Peer};
 
 use bls::PublicKey as BlsPublicKey;
 use xor_name::XorName;

--- a/sn_node/src/node/core/mod.rs
+++ b/sn_node/src/node/core/mod.rs
@@ -19,19 +19,15 @@ mod split_barrier;
 
 /// DataStorage apis.
 pub use self::data::DataStorage;
-use self::split_barrier::SplitBarrier;
+
 pub(crate) use bootstrap::{join_network, JoiningAsRelocated};
 pub(crate) use comm::{Comm, DeliveryStatus, MsgEvent};
 pub(crate) use data::MIN_LEVEL_WHEN_FULL;
 pub(crate) use proposal::Proposal;
 #[cfg(test)]
 pub(crate) use relocation::{check as relocation_check, ChurnId};
-use sn_interface::{
-    network_knowledge::{
-        supermajority, NetworkKnowledge, NodeInfo, SectionKeyShare, SectionKeysProvider,
-    },
-    types::keys::ed25519::Digest256,
-};
+
+use self::{data::Capacity, split_barrier::SplitBarrier};
 
 use super::{
     api::cmds::Cmd, dkg::DkgVoter, handover::Handover, membership::Membership, Elders, Event,
@@ -43,23 +39,27 @@ use crate::node::{
     membership::elder_candidates,
     membership::try_split_dkg,
 };
-use sn_interface::messaging::{
-    data::OperationId,
-    signature_aggregator::SignatureAggregator,
-    system::{DkgSessionId, NodeState, SystemMsg},
-    AuthorityProof, SectionAuth, SectionAuthorityProvider,
-};
-use sn_interface::types::{log_markers::LogMarker, Cache, Peer};
-
 use crate::UsedSpace;
-use sn_interface::network_knowledge::utils::compare_and_write_prefix_map_to_disk;
+
+use sn_dysfunction::{DysfunctionDetection, DysfunctionSeverity, IssueType};
+use sn_interface::{
+    messaging::{
+        data::OperationId,
+        signature_aggregator::SignatureAggregator,
+        system::{DkgSessionId, NodeState, SystemMsg},
+        AuthorityProof, SectionAuth, SectionAuthorityProvider,
+    },
+    network_knowledge::utils::compare_and_write_prefix_map_to_disk,
+    network_knowledge::{
+        supermajority, NetworkKnowledge, NodeInfo, SectionKeyShare, SectionKeysProvider,
+    },
+    types::{keys::ed25519::Digest256, log_markers::LogMarker, Cache, Peer},
+};
 
 use backoff::ExponentialBackoff;
 use dashmap::DashSet;
-use data::Capacity;
 use itertools::Itertools;
 use resource_proof::ResourceProof;
-use sn_dysfunction::{DysfunctionDetection, DysfunctionSeverity, IssueType};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     path::PathBuf,

--- a/sn_node/src/node/core/proposal.rs
+++ b/sn_node/src/node/core/proposal.rs
@@ -7,9 +7,12 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{dkg::SigShare, Result};
+
 use sn_consensus::Generation;
-use sn_interface::messaging::system::{Proposal as ProposalMsg, SectionAuth};
-use sn_interface::network_knowledge::{NodeState, SectionAuthorityProvider};
+use sn_interface::{
+    messaging::system::{Proposal as ProposalMsg, SectionAuth},
+    network_knowledge::{NodeState, SectionAuthorityProvider},
+};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq)]
@@ -63,15 +66,13 @@ impl Proposal {
     }
 }
 
-// impl Proposal {
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sn_interface::network_knowledge::test_utils::gen_section_authority_provider;
+
     use eyre::Result;
     use serde::Serialize;
-    use sn_interface::network_knowledge::test_utils::gen_section_authority_provider;
     use std::fmt::Debug;
     use xor_name::Prefix;
 

--- a/sn_node/src/node/core/relocation.rs
+++ b/sn_node/src/node/core/relocation.rs
@@ -8,10 +8,12 @@
 
 //! Relocation related types and utilities.
 
-use sn_interface::elder_count;
-use sn_interface::messaging::system::RelocateDetails;
-use sn_interface::network_knowledge::{recommended_section_size, NetworkKnowledge, NodeState};
-use sn_interface::types::{keys::ed25519, Peer};
+use sn_interface::{
+    elder_count,
+    messaging::system::RelocateDetails,
+    network_knowledge::{recommended_section_size, NetworkKnowledge, NodeState},
+    types::{keys::ed25519, Peer},
+};
 
 use ed25519_dalek::{Signature, Verifier};
 use std::{
@@ -168,16 +170,17 @@ fn trailing_zeros(bytes: &[u8]) -> u32 {
 mod tests {
     use super::*;
 
-    use sn_interface::elder_count;
-    use sn_interface::network_knowledge::test_utils::section_signed;
-    use sn_interface::types::SecretKeySet;
+    use sn_interface::{
+        elder_count,
+        network_knowledge::{test_utils::section_signed, SectionAuthorityProvider, MIN_ADULT_AGE},
+        types::SecretKeySet,
+    };
 
     use eyre::Result;
     use itertools::Itertools;
     use proptest::{collection::SizeRange, prelude::*};
     use rand::{rngs::SmallRng, Rng, SeedableRng};
     use secured_linked_list::SecuredLinkedList;
-    use sn_interface::network_knowledge::{SectionAuthorityProvider, MIN_ADULT_AGE};
     use std::net::SocketAddr;
     use xor_name::{Prefix, XOR_NAME_LEN};
 

--- a/sn_node/src/node/core/split_barrier.rs
+++ b/sn_node/src/node/core/split_barrier.rs
@@ -7,15 +7,15 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::dkg::KeyedSig;
-use sn_consensus::Generation;
-use sn_interface::messaging::system::SectionAuth;
-use sn_interface::network_knowledge::SectionAuthorityProvider;
-use std::collections::BTreeMap;
-use xor_name::Prefix;
-type Entry = (SectionAuth<SectionAuthorityProvider>, KeyedSig);
-use std::sync::Arc;
 
+use sn_consensus::Generation;
+use sn_interface::{messaging::system::SectionAuth, network_knowledge::SectionAuthorityProvider};
+
+use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::RwLock;
+use xor_name::Prefix;
+
+type Entry = (SectionAuth<SectionAuthorityProvider>, KeyedSig);
 
 // Helper structure to make sure we process a split by updating info about both our section and the
 // sibling section at the same time.

--- a/sn_node/src/node/dkg/dkg_msgs_utils.rs
+++ b/sn_node/src/node/dkg/dkg_msgs_utils.rs
@@ -6,13 +6,17 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_interface::messaging::system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, NodeState};
-use sn_interface::network_knowledge::supermajority;
-use sn_interface::types::keys::ed25519::{self, Digest256, Keypair, Verifier};
-use std::collections::{BTreeMap, BTreeSet};
-use std::net::SocketAddr;
-
 use sn_consensus::Generation;
+use sn_interface::{
+    messaging::system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, NodeState},
+    network_knowledge::supermajority,
+    types::keys::ed25519::{self, Digest256, Keypair, Verifier},
+};
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::SocketAddr,
+};
 use tiny_keccak::{Hasher, Sha3};
 use xor_name::{Prefix, XorName};
 

--- a/sn_node/src/node/dkg/session.rs
+++ b/sn_node/src/node/dkg/session.rs
@@ -12,12 +12,15 @@ use crate::node::{
     messages::WireMsgUtils,
     Result,
 };
-use sn_interface::messaging::{
-    system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SystemMsg},
-    DstLocation, WireMsg,
+
+use sn_interface::{
+    messaging::{
+        system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SystemMsg},
+        DstLocation, WireMsg,
+    },
+    network_knowledge::{NodeInfo, SectionAuthorityProvider, SectionKeyShare},
+    types::{keys::ed25519, log_markers::LogMarker, Peer, PublicKey},
 };
-use sn_interface::network_knowledge::{NodeInfo, SectionAuthorityProvider, SectionKeyShare};
-use sn_interface::types::{keys::ed25519, log_markers::LogMarker, Peer, PublicKey};
 
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::{
@@ -500,11 +503,16 @@ impl Session {
 mod tests {
     use super::*;
     use crate::node::dkg::voter::DkgVoter;
-    use sn_interface::elder_count;
-    use sn_interface::messaging::system::{MembershipState, NodeState};
-    use sn_interface::messaging::MsgType;
-    use sn_interface::network_knowledge::{test_utils::gen_addr, NodeInfo, MIN_ADULT_AGE};
-    use sn_interface::types::keys::ed25519::{self, proptesting::arbitrary_keypair};
+
+    use sn_interface::{
+        elder_count,
+        messaging::{
+            system::{MembershipState, NodeState},
+            MsgType,
+        },
+        network_knowledge::{test_utils::gen_addr, NodeInfo, MIN_ADULT_AGE},
+        types::keys::ed25519::{self, proptesting::arbitrary_keypair},
+    };
 
     use assert_matches::assert_matches;
     use eyre::{bail, ContextCompat, Result};

--- a/sn_node/src/node/dkg/voter.rs
+++ b/sn_node/src/node/dkg/voter.rs
@@ -7,18 +7,18 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{api::cmds::Cmd, dkg::session::Session, messages::WireMsgUtils, Result};
+
 use sn_interface::{
     messaging::{
         system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SystemMsg},
         DstLocation, WireMsg,
     },
-    types::keys::ed25519::Digest256,
+    network_knowledge::{supermajority, NodeInfo, SectionAuthorityProvider, SectionKeyShare},
+    types::{
+        keys::ed25519::{self, Digest256},
+        Peer,
+    },
 };
-
-use sn_interface::network_knowledge::{
-    supermajority, NodeInfo, SectionAuthorityProvider, SectionKeyShare,
-};
-use sn_interface::types::{keys::ed25519, Peer};
 
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::{message::Message as DkgMessage, KeyGen};

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -9,12 +9,14 @@
 use super::Prefix;
 
 use crate::node::handover::Error as HandoverError;
-use sn_interface::messaging::data::Error as ErrorMsg;
-use sn_interface::types::{convert_dt_error_to_error_msg, DataAddress, Peer, PublicKey};
+
+use sn_interface::{
+    messaging::data::Error as ErrorMsg,
+    types::{convert_dt_error_to_error_msg, DataAddress, Peer, PublicKey},
+};
 
 use secured_linked_list::error::Error as SecuredLinkedListError;
-use std::io;
-use std::net::SocketAddr;
+use std::{io, net::SocketAddr};
 use thiserror::Error;
 use xor_name::XorName;
 

--- a/sn_node/src/node/handover/handover_consensus.rs
+++ b/sn_node/src/node/handover/handover_consensus.rs
@@ -1,18 +1,24 @@
-use bls::{PublicKeySet, SecretKeyShare};
-use core::fmt::Debug;
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
-use tracing::info;
-
-use sn_consensus::consensus::{Consensus, VoteResponse};
-use sn_consensus::vote::{Ballot, SignedVote, Vote};
-use sn_consensus::Decision;
-use sn_consensus::Generation;
-use sn_consensus::NodeId;
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
 
 use super::errors::{Error, Result};
 
+use sn_consensus::{
+    consensus::{Consensus, VoteResponse},
+    vote::{Ballot, SignedVote, Vote},
+    Decision, Generation, NodeId,
+};
 use sn_interface::network_knowledge::SapCandidate;
+
+use bls::{PublicKeySet, SecretKeyShare};
+use core::fmt::Debug;
+use std::{cmp::Ordering, collections::BTreeMap};
+use tracing::info;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Handover {

--- a/sn_node/src/node/membership/mod.rs
+++ b/sn_node/src/node/membership/mod.rs
@@ -1,20 +1,25 @@
-use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
-
-use bls_dkg::{PublicKeySet, SecretKeyShare};
-use core::fmt::Debug;
-use sn_interface::messaging::system::DkgSessionId;
-use sn_interface::{
-    messaging::system::{MembershipState, NodeState},
-    network_knowledge::{partition_by_prefix, recommended_section_size, SectionAuthorityProvider},
-    types::log_markers::LogMarker,
-};
-
-use thiserror::Error;
-use xor_name::{Prefix, XorName};
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
 
 use sn_consensus::{
     Ballot, Consensus, Decision, Generation, NodeId, SignedVote, Vote, VoteResponse,
 };
+use sn_interface::{
+    messaging::system::{DkgSessionId, MembershipState, NodeState},
+    network_knowledge::{partition_by_prefix, recommended_section_size, SectionAuthorityProvider},
+    types::log_markers::LogMarker,
+};
+
+use bls_dkg::{PublicKeySet, SecretKeyShare};
+use core::fmt::Debug;
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+use thiserror::Error;
+use xor_name::{Prefix, XorName};
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/sn_node/src/node/messages/mod.rs
+++ b/sn_node/src/node/messages/mod.rs
@@ -7,13 +7,16 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{Error, Result};
-use sn_interface::messaging::{
-    system::{SigShare, SystemMsg},
-    AuthKind, AuthorityProof, BlsShareAuth, DstLocation, MsgId, NodeAuth, WireMsg,
+
+use sn_interface::{
+    messaging::{
+        system::{SigShare, SystemMsg},
+        AuthKind, AuthorityProof, BlsShareAuth, DstLocation, MsgId, NodeAuth, WireMsg,
+    },
+    network_knowledge::{NodeInfo, SectionKeyShare},
 };
 
 use bls::PublicKey as BlsPublicKey;
-use sn_interface::network_knowledge::{NodeInfo, SectionKeyShare};
 use xor_name::XorName;
 
 // Utilities for WireMsg.

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -10,22 +10,17 @@
 
 /// Node Configuration
 pub mod cfg;
+
+pub(crate) mod handover;
+pub(crate) mod membership;
+
 // Node public API
 mod api;
-
 mod core;
-
-pub use self::core::DataStorage;
-
 mod dkg;
-// mod ed25519;
 mod error;
-pub(crate) mod handover;
 mod logging;
-pub(crate) mod membership;
 mod messages;
-
-use sn_interface::types::Peer;
 
 pub use self::{
     api::{
@@ -34,17 +29,21 @@ pub use self::{
         NodeApi,
     },
     cfg::config_handler::{add_connection_info, set_connection_info, Config},
+    core::DataStorage,
     error::{Error, Result},
+    test_utils::*,
 };
-pub use qp2p::{Config as NetworkConfig, SendStream};
+
 pub use sn_interface::network_knowledge::{
     FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
 };
+
+pub use qp2p::{Config as NetworkConfig, SendStream};
 pub use xor_name::{Prefix, XorName, XOR_NAME_LEN}; // TODO remove pub on API update
 
-pub use test_utils::*;
-
 pub(crate) use self::core::MIN_LEVEL_WHEN_FULL;
+
+use sn_interface::types::Peer;
 
 mod test_utils {
     use super::cfg::config_handler::Config;

--- a/sn_node/src/node/tests/bootstrap.rs
+++ b/sn_node/src/node/tests/bootstrap.rs
@@ -8,15 +8,18 @@
 
 mod utils;
 
+use crate::node::routing_api::{Config, Event, NodeElderChange};
+
+use sn_interface::elder_count;
+
 use anyhow::{Error, Result};
 use ed25519_dalek::Keypair;
 use futures::future;
-use crate::node::routing_api::{Config, Event, NodeElderChange};
 use std::collections::HashSet;
 use tokio::time;
 use utils::*;
 use xor_name::XOR_NAME_LEN;
-use sn_interface::elder_count;
+
 
 /*
 #[tokio::test(flavor = "multi_thread")]

--- a/sn_node/src/node/tests/drop.rs
+++ b/sn_node/src/node/tests/drop.rs
@@ -9,10 +9,14 @@
 mod utils;
 
 use self::utils::*;
+
+use crate::node::routing_api::routing::{Event, NodeElderChange};
+
+use sn_interface::messaging::{Aggregation, DstLocation, Itinerary, SrcLocation};
+
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
-use sn_interface::messaging::{Aggregation, DstLocation, Itinerary, SrcLocation};
-use crate::node::routing_api::routing::{Event, NodeElderChange};
+
 /*
 #[tokio::test(flavor = "multi_thread")]
 async fn test_node_drop() -> Result<()> {

--- a/sn_node/src/node/tests/messages.rs
+++ b/sn_node/src/node/tests/messages.rs
@@ -8,21 +8,21 @@
 
 mod utils;
 
-use anyhow::{anyhow, format_err, Result};
-use bytes::Bytes;
-use qp2p::QuicP2p;
-use sn_interface::types::Keypair;
-use sn_interface::messaging::client::ServiceMsg;
-use sn_interface::messaging::{
+use crate::node::{Config, Error, Event, NodeElderChange};
+
+use sn_interface::{types::Keypair, messaging::{
     client::{ServiceMsg, ClientSig, Query, TransferQuery},
     location::{Aggregation, Itinerary},
     DstLocation, MsgId, SrcLocation,
-};
-use crate::node::routing_api::{Config, Error, Event, NodeElderChange};
+}};
+
+use anyhow::{anyhow, format_err, Result};
+use bytes::Bytes;
+use qp2p::QuicP2p;
 use std::net::{IpAddr, Ipv4Addr};
 use utils::*;
 use xor_name::XorName;
-use crate::routing;
+
 /*
 #[tokio::test(flavor = "multi_thread")]
 async fn test_messages_client_node() -> Result<()> {


### PR DESCRIPTION
- Organise usings
- Add missing license headers
- Update license years

As it would take too long to go through all files, a partial cleanup
of the code base is made here.
It is based on where the using of `sn_interface` has been introduced,
as it was a low hanging fruit to cover many occurrences of duplication
in many files.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
