### PR TITLE
Misc cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,6 +3653,7 @@ dependencies = [
  "blsttc",
  "bytes",
  "cargo-husky",
+ "chrono",
  "color-eyre",
  "console-subscriber",
  "crdts",

--- a/sn_client/examples/network_split.rs
+++ b/sn_client/examples/network_split.rs
@@ -33,7 +33,7 @@ const SAFE_NODE_EXECUTABLE: &str = "sn_node";
 const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
 
 const NODES_DIR: &str = "local-test-network";
-const INTERVAL: &str = "10000";
+const INTERVAL: &str = "5000"; // milliseconds
 const RUST_LOG: &str = "RUST_LOG";
 const ADDITIONAL_NODES_TO_SPLIT: u64 = 15;
 
@@ -135,7 +135,7 @@ pub async fn run_split() -> Result<()> {
         .wrap_err("Error starting the testnet")?;
 
     // leave a longer interval with more nodes to allow for splits if using split amounts
-    let interval_duration = Duration::from_millis(*interval_as_int);
+    let interval_duration = Duration::from_millis(2 * interval_as_int);
     sleep(interval_duration).await;
     println!("Done sleeping....");
 
@@ -166,6 +166,7 @@ pub async fn run_split() -> Result<()> {
         .wrap_err("Error adding nodes to the testnet")?;
 
     // leave a longer interval with more nodes to allow for splits if using split amounts
+    let interval_duration = Duration::from_millis(interval_as_int * ADDITIONAL_NODES_TO_SPLIT / 10);
     sleep(interval_duration).await;
 
     // now we read the data
@@ -183,7 +184,7 @@ pub async fn run_split() -> Result<()> {
         while bytes.is_err() && attempts < 10 {
             attempts += 1;
             // do some retries to ensure we're not just timing out by chance
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(attempts)).await;
             bytes = client.read_bytes(address).await;
         }
 
@@ -236,7 +237,7 @@ async fn upload_data() -> Result<(XorName, [u8; 32])> {
     while bytes.is_err() && attempts < 10 {
         attempts += 1;
         // do some retries to ensure we're not just timing out by chance
-        sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(attempts)).await;
         bytes = client.read_bytes(address).await;
     }
 

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -103,8 +103,8 @@ impl Session {
             section_pk,
         };
 
-        let msg_kind = AuthKind::Service(auth);
-        let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
+        let auth_kind = AuthKind::Service(auth);
+        let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
 
         // The insertion of channel will be executed AFTER the completion of the `send_message`.
         let (sender, mut receiver) = channel::<CmdResponse>(elders_len);
@@ -223,8 +223,8 @@ impl Session {
             name: dst,
             section_pk,
         };
-        let msg_kind = AuthKind::Service(auth);
-        let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
+        let auth_kind = AuthKind::Service(auth);
+        let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
 
         send_msg_in_bg(self.clone(), elders, wire_msg, msg_id)?;
 
@@ -361,8 +361,8 @@ impl Session {
             name: dst_address,
             section_pk,
         };
-        let msg_kind = AuthKind::Service(auth);
-        let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
+        let auth_kind = AuthKind::Service(auth);
+        let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
 
         // When the client bootstrap using the nodes read from the config, the list is sorted
         // by socket addresses. To improve the efficiency, the `elders_or_adults` shall be sorted

--- a/sn_interface/src/messaging/serialisation/wire_msg_header.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg_header.rs
@@ -38,7 +38,7 @@ pub struct WireMsgHeader {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MsgEnvelope {
     pub msg_id: MsgId,
-    pub msg_kind: AuthKind,
+    pub auth_kind: AuthKind,
     pub dst_location: DstLocation,
 }
 
@@ -73,13 +73,13 @@ lazy_static! {
 
 impl WireMsgHeader {
     // Instantiate a WireMsgHeader as per current supported version.
-    pub fn new(msg_id: MsgId, msg_kind: AuthKind, dst_location: DstLocation) -> Self {
+    pub fn new(msg_id: MsgId, auth_kind: AuthKind, dst_location: DstLocation) -> Self {
         Self {
             //header_size: Self::max_size(),
             version: MESSAGING_PROTO_VERSION,
             msg_envelope: MsgEnvelope {
                 msg_id,
-                msg_kind,
+                auth_kind,
                 dst_location,
             },
         }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -37,6 +37,7 @@ bincode = "1.3.1"
 bls = { package = "blsttc", version = "6.0.0" }
 bls_dkg = "~0.10.3"
 bytes = { version = "1.0.1", features = ["serde"] }
+chrono = "0.4.19"
 color-eyre = "~0.6.0"
 console-subscriber = { version = "~0.1.0", optional = true }
 crdts = "7.0"

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -235,7 +235,7 @@ impl Network {
             ..Default::default()
         };
 
-        let _ = add_node(id, config, event_tx).await;
+        let _handle = tokio::task::spawn_local(add_node(id, config, event_tx));
 
         self.try_print_status();
     }

--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -28,9 +28,6 @@
 )]
 
 #[cfg(not(feature = "tokio-console"))]
-use eyre::Error;
-use eyre::{eyre, Context, ErrReport, Result};
-#[cfg(not(feature = "tokio-console"))]
 use sn_interface::LogFormatter;
 use sn_node::node::{
     add_connection_info, set_connection_info, Config, Error as NodeError, Event, MembershipEvent,
@@ -38,6 +35,9 @@ use sn_node::node::{
 };
 
 use color_eyre::{Section, SectionExt};
+#[cfg(not(feature = "tokio-console"))]
+use eyre::Error;
+use eyre::{eyre, Context, ErrReport, Result};
 use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
 use self_update::{cargo_crate_version, Status};
 use std::{fmt::Debug, fs::File, io, io::Write, path::Path, process::exit};

--- a/sn_node/src/node/api/cmds.rs
+++ b/sn_node/src/node/api/cmds.rs
@@ -78,8 +78,8 @@ pub(crate) enum Cmd {
         // original bytes to avoid reserializing for entropy checks
         original_bytes: Option<Bytes>,
     },
-    /// Handle a timeout previously scheduled with `ScheduleTimeout`.
-    HandleTimeout(u64),
+    /// Handle a timeout previously scheduled with `ScheduleDkgTimeout`.
+    HandleDkgTimeout(u64),
     /// Handle peer that's been detected as lost.
     HandlePeerLost(Peer),
     /// Handle agreement on a proposal.
@@ -122,9 +122,9 @@ pub(crate) enum Cmd {
         delivery_group_size: usize,
         wire_msg: WireMsg,
     },
-    /// Schedule a timeout after the given duration. When the timeout expires, a `HandleTimeout`
+    /// Schedule a timeout after the given duration. When the timeout expires, a `HandleDkgTimeout`
     /// cmd is raised. The token is used to identify the timeout.
-    ScheduleTimeout { duration: Duration, token: u64 },
+    ScheduleDkgTimeout { duration: Duration, token: u64 },
     /// Proposes peers as offline
     ProposeOffline(BTreeSet<XorName>),
     /// Send a signal to all Elders to
@@ -147,11 +147,11 @@ impl Cmd {
             HandleNodeLeft(_) => 10,
             ProposeOffline(_) => 10,
 
-            HandleTimeout(_) => 9,
+            HandleDkgTimeout(_) => 9,
             HandleNewNodeOnline(_) => 9,
             EnqueueDataForReplication { .. } => 9,
 
-            ScheduleTimeout { .. } => 8,
+            ScheduleDkgTimeout { .. } => 8,
             StartConnectivityTest(_) => 8,
             TestConnectivity(_) => 8,
 
@@ -171,8 +171,8 @@ impl fmt::Display for Cmd {
             Cmd::CleanupPeerLinks => {
                 write!(f, "CleanupPeerLinks")
             }
-            Cmd::HandleTimeout(_) => write!(f, "HandleTimeout"),
-            Cmd::ScheduleTimeout { .. } => write!(f, "ScheduleTimeout"),
+            Cmd::HandleDkgTimeout(_) => write!(f, "HandleDkgTimeout"),
+            Cmd::ScheduleDkgTimeout { .. } => write!(f, "ScheduleDkgTimeout"),
             #[cfg(not(feature = "test-utils"))]
             Cmd::HandleMsg { wire_msg, .. } => {
                 write!(f, "HandleMsg {:?}", wire_msg.msg_id())
@@ -193,11 +193,11 @@ impl fmt::Display for Cmd {
             Cmd::HandleNodeLeft(_) => write!(f, "HandleNodeLeft"),
             Cmd::HandleDkgOutcome { .. } => write!(f, "HandleDkgOutcome"),
             Cmd::HandleDkgFailure(_) => write!(f, "HandleDkgFailure"),
-            #[cfg(not(test))]
+            #[cfg(not(feature = "test-utils"))]
             Cmd::SendMsg { wire_msg, .. } => {
                 write!(f, "SendMsg {:?}", wire_msg.msg_id())
             }
-            #[cfg(test)]
+            #[cfg(feature = "test-utils")]
             Cmd::SendMsg { wire_msg, .. } => {
                 write!(
                     f,

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -6,11 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-mod background_tasks;
-
-use super::Cmd;
-
 use crate::node::{
+    api::Cmd,
     core::{DeliveryStatus, Node, Proposal},
     messages::WireMsgUtils,
     Result,
@@ -18,171 +15,36 @@ use crate::node::{
 
 use sn_interface::{
     messaging::{system::SystemMsg, AuthKind, WireMsg},
-    types::{log_markers::LogMarker, Peer, ReplicatedDataAddress},
+    types::Peer,
 };
 
-use dashmap::DashMap;
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use tokio::{sync::watch, sync::RwLock, time};
-use tracing::Instrument;
-
-// A command/subcommand id e.g. "963111461", "963111461.0"
-pub(crate) type CmdId = String;
 
 // Cmd Dispatcher.
+#[derive(Clone)]
 pub(crate) struct Dispatcher {
-    pub(crate) node: Node,
-    /// queue up all batch data to be replicated (as a result of churn events atm)
-    // TODO: This can probably be reworked into the general per peer msg queue, but as
-    // we need to pull data first before we form the WireMsg, we won't do that just now
-    pub(crate) pending_data_to_replicate_to_peers:
-        Arc<DashMap<ReplicatedDataAddress, Arc<RwLock<BTreeSet<Peer>>>>>,
-    cancel_timer_tx: watch::Sender<bool>,
-    cancel_timer_rx: watch::Receiver<bool>,
-}
-
-impl Drop for Dispatcher {
-    fn drop(&mut self) {
-        // Cancel all scheduled timers including any future ones.
-        let _res = self.cancel_timer_tx.send(true);
-    }
+    node: Arc<Node>,
+    dkg_timeout: Arc<DkgTimeout>,
 }
 
 impl Dispatcher {
-    pub(super) fn new(node: Node) -> Self {
+    pub(super) fn new(node: Arc<Node>) -> Self {
         let (cancel_timer_tx, cancel_timer_rx) = watch::channel(false);
-        Self {
-            node,
+        let dkg_timeout = Arc::new(DkgTimeout {
             cancel_timer_tx,
             cancel_timer_rx,
-            pending_data_to_replicate_to_peers: Arc::new(DashMap::new()),
-        }
-    }
-
-    /// Enqueues the given cmd and handles whatever cmd is in the next priority queue and triggers handling after any required waits for higher priority tasks
-    pub(super) async fn enqueue_and_handle_next_cmd_and_offshoots(
-        self: Arc<Self>,
-        cmd: Cmd,
-        cmd_id: Option<CmdId>,
-    ) -> Result<()> {
-        let _ = tokio::task::spawn_local(async {
-            let cmd_id: CmdId = cmd_id.unwrap_or_else(|| rand::random::<u32>().to_string());
-
-            self.handle_cmd_and_offshoots(cmd, Some(cmd_id)).await
-        });
-        Ok(())
-    }
-
-    /// Handles cmd and transitively queues any new cmds that are
-    /// produced during its handling. Trace logs will include the provided cmd id,
-    /// and any sub-cmds produced will have it as a common root cmd id.
-    /// If a cmd id string is not provided a random one will be generated.
-    pub(super) async fn handle_cmd_and_offshoots(
-        self: Arc<Self>,
-        cmd: Cmd,
-        cmd_id: Option<CmdId>,
-    ) -> Result<()> {
-        let cmd_id = cmd_id.unwrap_or_else(|| rand::random::<u32>().to_string());
-        let cmd_id_clone = cmd_id.clone();
-        let cmd_display = cmd.to_string();
-        let _task = tokio::task::spawn_local(async move {
-            match self.process_cmd(cmd, &cmd_id).await {
-                Ok(cmds) => {
-                    for (sub_cmd_count, cmd) in cmds.into_iter().enumerate() {
-                        let sub_cmd_id = format!("{}.{}", &cmd_id, sub_cmd_count);
-                        // Error here is only related to queueing, and so a dropped cmd will be logged
-                        let _result = self.clone().spawn_cmd_handling(cmd, sub_cmd_id);
-                    }
-                }
-                Err(err) => {
-                    error!("Failed to handle cmd {:?} with error {:?}", cmd_id, err);
-                }
-            }
         });
 
-        trace!(
-            "{:?} {} cmd_id={}",
-            LogMarker::CmdHandlingSpawned,
-            cmd_display,
-            &cmd_id_clone
-        );
-        Ok(())
+        Self { node, dkg_timeout }
     }
 
-    // Note: this indirecton is needed. Trying to call `spawn(self.handle_cmds(...))` directly
-    // inside `handle_cmds` causes compile error about type check cycle.
-    fn spawn_cmd_handling(self: Arc<Self>, cmd: Cmd, cmd_id: String) -> Result<()> {
-        let _task = tokio::task::spawn_local(
-            self.enqueue_and_handle_next_cmd_and_offshoots(cmd, Some(cmd_id)),
-        );
-        Ok(())
+    pub(crate) fn node(&self) -> Arc<Node> {
+        self.node.clone()
     }
 
     /// Handles a single cmd.
-    pub(super) async fn process_cmd(&self, cmd: Cmd, cmd_id: &str) -> Result<Vec<Cmd>> {
-        // Create a tracing span containing info about the current node. This is very useful when
-        // analyzing logs produced by running multiple nodes within the same process, for example
-        // from integration tests.
-        let span = {
-            let node = &self.node;
-
-            let prefix = node.network_knowledge().prefix().await;
-            let is_elder = node.is_elder().await;
-            let section_key = node.network_knowledge().section_key().await;
-            let age = node.info.read().await.age();
-            trace_span!(
-                "process_cmd",
-                name = %node.info.read().await.name(),
-                prefix = format_args!("({:b})", prefix),
-                age,
-                elder = is_elder,
-                cmd_id = %cmd_id,
-                section_key = ?section_key,
-                %cmd,
-            )
-        };
-
-        async {
-            let cmd_display = cmd.to_string();
-            trace!(
-                "{:?} {:?} - {}",
-                LogMarker::CmdProcessStart,
-                cmd_id,
-                cmd_display
-            );
-
-            let res = match self.try_processing_cmd(cmd).await {
-                Ok(outcome) => {
-                    trace!(
-                        "{:?} {:?} - {}",
-                        LogMarker::CmdProcessEnd,
-                        cmd_id,
-                        cmd_display
-                    );
-                    Ok(outcome)
-                }
-                Err(error) => {
-                    error!(
-                        "Error encountered when processing cmd (cmd_id {}): {:?}",
-                        cmd_id, error
-                    );
-                    trace!(
-                        "{:?} {}: {:?}",
-                        LogMarker::CmdProcessingError,
-                        cmd_display,
-                        error
-                    );
-                    Err(error)
-                }
-            };
-            res
-        }
-        .instrument(span)
-        .await
-    }
-
-    /// Actually process the cmd
-    async fn try_processing_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
+    pub(crate) async fn process_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
         match cmd {
             Cmd::CleanupPeerLinks => {
                 self.node.cleanup_non_elder_peers().await?;
@@ -253,9 +115,9 @@ impl Dispatcher {
                 data_batch,
             } => {
                 // we should queue this
-
                 for data in data_batch {
-                    if let Some(data_entry) = self.pending_data_to_replicate_to_peers.get_mut(&data)
+                    if let Some(data_entry) =
+                        self.node.pending_data_to_replicate_to_peers.get_mut(&data)
                     {
                         let peer_set = data_entry.value();
                         debug!("data already queued, adding peer");
@@ -265,11 +127,11 @@ impl Dispatcher {
                         let mut peer_set = BTreeSet::new();
                         let _existed = peer_set.insert(recipient);
                         let _existed = self
+                            .node
                             .pending_data_to_replicate_to_peers
                             .insert(data, Arc::new(RwLock::new(peer_set)));
                     }
                 }
-
                 Ok(vec![])
             }
             Cmd::SendMsgDeliveryGroup {
@@ -377,7 +239,7 @@ impl Dispatcher {
     }
 
     async fn handle_schedule_timeout(&self, duration: Duration, token: u64) -> Option<Cmd> {
-        let mut cancel_rx = self.cancel_timer_rx.clone();
+        let mut cancel_rx = self.dkg_timeout.cancel_timer_rx.clone();
 
         if *cancel_rx.borrow() {
             // Timers are already cancelled, do nothing.
@@ -389,4 +251,16 @@ impl Dispatcher {
             _ = cancel_rx.changed() => None,
         }
     }
+}
+
+impl Drop for Dispatcher {
+    fn drop(&mut self) {
+        // Cancel all scheduled timers including any future ones.
+        let _res = self.dkg_timeout.cancel_timer_tx.send(true);
+    }
+}
+
+struct DkgTimeout {
+    cancel_timer_tx: watch::Sender<bool>,
+    cancel_timer_rx: watch::Receiver<bool>,
 }

--- a/sn_node/src/node/api/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/api/flow_ctrl/cmd_ctrl.rs
@@ -1,0 +1,321 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::node::{
+    api::{
+        cmds::{Cmd, CmdJob},
+        dispatcher::Dispatcher,
+        event_channel::EventSender,
+    },
+    core::RateLimits,
+    CmdProcessEvent, Error, Event, Result,
+};
+
+use custom_debug::Debug;
+use priority_queue::PriorityQueue;
+use std::time::SystemTime;
+use std::{
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use tokio::{sync::RwLock, time::Instant};
+
+type Priority = i32;
+
+const MAX_RETRIES: usize = 1; // drops on first error..
+const SLEEP_TIME: Duration = Duration::from_millis(20);
+
+const ORDER: Ordering = Ordering::SeqCst;
+
+#[derive(Clone)]
+pub(crate) struct CmdCtrl {
+    cmd_queue: Arc<RwLock<PriorityQueue<EnqueuedJob, Priority>>>,
+    attempted: MsgThroughput,
+    monitoring: RateLimits,
+    stopped: Arc<RwLock<bool>>,
+    dispatcher: Dispatcher,
+    id_counter: Arc<AtomicU64>,
+    event_sender: EventSender,
+}
+
+impl CmdCtrl {
+    pub(crate) fn new(
+        dispatcher: Dispatcher,
+        monitoring: RateLimits,
+        event_sender: EventSender,
+    ) -> Self {
+        let session = Self {
+            cmd_queue: Arc::new(RwLock::new(PriorityQueue::new())),
+            attempted: MsgThroughput::default(),
+            monitoring,
+            stopped: Arc::new(RwLock::new(false)),
+            dispatcher,
+            id_counter: Arc::new(AtomicU64::new(0)),
+            event_sender,
+        };
+
+        let session_clone = session.clone();
+        let _ = tokio::task::spawn_local(async move { session_clone.keep_sending().await });
+
+        session
+    }
+
+    pub(crate) fn node(&self) -> Arc<crate::node::core::Node> {
+        self.dispatcher.node()
+    }
+
+    pub(crate) async fn extend(&self, cmds: Vec<Cmd>) -> Vec<Result<SendWatcher>> {
+        let mut results = vec![];
+
+        for cmd in cmds {
+            let _ = results.push(self.push(cmd).await);
+        }
+
+        results
+    }
+
+    pub(crate) async fn push(&self, cmd: Cmd) -> Result<SendWatcher> {
+        if self.stopped().await {
+            // should not happen (be reachable)
+            return Err(Error::InvalidState);
+        }
+
+        let priority = cmd.priority();
+
+        let (watcher, reporter) = status_watching();
+
+        let job = EnqueuedJob {
+            job: CmdJob::new(self.id_counter.fetch_add(1, ORDER), cmd, SystemTime::now()),
+            retries: 0,
+            reporter,
+        };
+
+        info!("Enqueued: {:?}", job.job);
+
+        let _ = self.cmd_queue.write().await.push(job, priority);
+
+        Ok(watcher)
+    }
+
+    // consume self
+    // NB that clones could still exist, however they would be in the disconnected state
+    // if only accessing via session map (as intended)
+    #[allow(unused)]
+    pub(crate) async fn stop(self) {
+        *self.stopped.write().await = true;
+        self.cmd_queue.write().await.clear();
+    }
+
+    // could be accessed via a clone
+    async fn stopped(&self) -> bool {
+        *self.stopped.read().await
+    }
+
+    async fn notify(&self, event: Event) {
+        self.event_sender.send(event).await
+    }
+
+    async fn keep_sending(&self) {
+        loop {
+            if self.stopped().await {
+                break;
+            }
+
+            let expected_rate = self.monitoring.max_cmds_per_s().await;
+            let actual_rate = self.attempted.value();
+            if actual_rate > expected_rate {
+                let diff = actual_rate - expected_rate;
+                let diff_ms = Duration::from_millis((diff * 1000_f64) as u64);
+                tokio::time::sleep(diff_ms).await;
+                continue;
+            } else if self.cmd_queue.read().await.is_empty() {
+                tokio::time::sleep(SLEEP_TIME).await;
+                continue;
+            }
+
+            #[cfg(feature = "test-utils")]
+            {
+                let queue = self.cmd_queue.read().await;
+                debug!("Cmd queue length: {}", queue.len());
+            }
+
+            let queue_res = { self.cmd_queue.write().await.pop() };
+            if let Some((mut enqueued, prio)) = queue_res {
+                if enqueued.retries >= MAX_RETRIES {
+                    // break this loop, report error to other nodes
+                    // await decision on how to continue
+
+                    // (or send event on a channel (to report error to other nodes), then sleep for a very long time, then try again?)
+
+                    enqueued
+                        .reporter
+                        .send(CtrlStatus::MaxRetriesReached(enqueued.retries));
+
+                    continue; // this means we will drop this cmd entirely!
+                }
+                let clone = self.clone();
+                let _ = tokio::task::spawn_local(async move {
+                    if enqueued.retries == 0 {
+                        clone
+                            .notify(Event::CmdProcessing(CmdProcessEvent::Started {
+                                job: enqueued.job.clone(),
+                                time: SystemTime::now(),
+                            }))
+                            .await;
+                    } else {
+                        clone
+                            .notify(Event::CmdProcessing(CmdProcessEvent::Retrying {
+                                job: enqueued.job.clone(),
+                                retry: enqueued.retries,
+                                time: SystemTime::now(),
+                            }))
+                            .await;
+                    }
+                    match clone
+                        .dispatcher
+                        .process_cmd(enqueued.job.cmd().clone())
+                        .await
+                    {
+                        Ok(cmds) => {
+                            enqueued.reporter.send(CtrlStatus::Finished);
+
+                            clone.monitoring.increment_cmds().await;
+
+                            // todo: handle the watchers..
+                            // todo: use parent cmd prio? factor for that q: are the subcmds always _part of the completion_ of the parent cmd, or can they also be unrelated to that?
+                            let _watchers = clone.extend(cmds).await;
+                            clone
+                                .notify(Event::CmdProcessing(CmdProcessEvent::Finished {
+                                    job: enqueued.job,
+                                    time: SystemTime::now(),
+                                }))
+                                .await;
+                        }
+                        Err(error) => {
+                            clone
+                                .notify(Event::CmdProcessing(CmdProcessEvent::Failed {
+                                    job: enqueued.job.clone(),
+                                    retry: enqueued.retries,
+                                    time: SystemTime::now(),
+                                    error: format!("{:?}", error),
+                                }))
+                                .await;
+                            enqueued.retries += 1;
+                            enqueued.reporter.send(CtrlStatus::Error(Arc::new(error)));
+                            let _ = clone.cmd_queue.write().await.push(enqueued, prio);
+                        }
+                    }
+                    clone.attempted.increment(); // both on fail and success
+                });
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MsgThroughput {
+    msgs: Arc<AtomicUsize>,
+    since: Instant,
+}
+
+impl Default for MsgThroughput {
+    fn default() -> Self {
+        Self {
+            msgs: Arc::new(AtomicUsize::new(0)),
+            since: Instant::now(),
+        }
+    }
+}
+
+impl MsgThroughput {
+    fn increment(&self) {
+        let _ = self.msgs.fetch_add(1, Ordering::SeqCst);
+    }
+
+    // msgs / s
+    fn value(&self) -> f64 {
+        let msgs = self.msgs.load(Ordering::SeqCst);
+        let seconds = (Instant::now() - self.since).as_secs();
+        msgs as f64 / f64::max(1.0, seconds as f64)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct EnqueuedJob {
+    job: CmdJob,
+    retries: usize,
+    reporter: StatusReporting,
+}
+
+impl PartialEq for EnqueuedJob {
+    fn eq(&self, other: &Self) -> bool {
+        self.job.id() == other.job.id()
+    }
+}
+
+impl Eq for EnqueuedJob {}
+
+impl std::hash::Hash for EnqueuedJob {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        //self.job.hash(state);
+        self.job.id().hash(state);
+        self.retries.hash(state);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum CtrlStatus {
+    Enqueued,
+    Finished,
+    Error(Arc<Error>),
+    MaxRetriesReached(usize),
+    #[allow(unused)]
+    WatcherDropped,
+}
+
+pub(crate) struct SendWatcher {
+    receiver: tokio::sync::watch::Receiver<CtrlStatus>,
+}
+
+impl SendWatcher {
+    /// Reads current status
+    #[allow(unused)]
+    pub(crate) fn status(&self) -> CtrlStatus {
+        self.receiver.borrow().clone()
+    }
+
+    /// Waits until a new status arrives.
+    #[allow(unused)]
+    pub(crate) async fn await_change(&mut self) -> CtrlStatus {
+        if self.receiver.changed().await.is_ok() {
+            self.receiver.borrow_and_update().clone()
+        } else {
+            CtrlStatus::WatcherDropped
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StatusReporting {
+    sender: tokio::sync::watch::Sender<CtrlStatus>,
+}
+
+impl StatusReporting {
+    fn send(&self, status: CtrlStatus) {
+        // todo: ok to drop error here?
+        let _ = self.sender.send(status);
+    }
+}
+
+fn status_watching() -> (SendWatcher, StatusReporting) {
+    let (sender, receiver) = tokio::sync::watch::channel(CtrlStatus::Enqueued);
+    (SendWatcher { receiver }, StatusReporting { sender })
+}

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -6,11 +6,17 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{Cmd, Dispatcher};
-use crate::node::{messages::WireMsgUtils, Result};
+mod cmd_ctrl;
 
-#[cfg(feature = "back-pressure")]
-use sn_interface::messaging::DstLocation;
+pub(crate) use self::cmd_ctrl::CmdCtrl;
+
+use crate::node::{
+    api::cmds::Cmd,
+    core::{MsgEvent, Node},
+    messages::WireMsgUtils,
+    Error, Result,
+};
+
 use sn_interface::{
     messaging::{
         system::{NodeCmd, SystemMsg},
@@ -20,7 +26,11 @@ use sn_interface::{
 };
 
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
-use tokio::{task::JoinHandle, time::MissedTickBehavior};
+use tokio::{
+    sync::mpsc,
+    task::{self, JoinHandle},
+    time::MissedTickBehavior,
+};
 
 const PROBE_INTERVAL: Duration = Duration::from_secs(30);
 #[cfg(feature = "back-pressure")]
@@ -30,11 +40,75 @@ const LINK_CLEANUP_INTERVAL: Duration = Duration::from_secs(120);
 const DATA_BATCH_INTERVAL: Duration = Duration::from_secs(1);
 const DYSFUNCTION_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 10); // every 10 minutes
 
-impl Dispatcher {
-    pub(crate) async fn start_network_probing(self: Arc<Self>) {
+#[derive(Clone)]
+pub(crate) struct FlowCtrl {
+    node: Arc<Node>,
+    cmd_ctrl: CmdCtrl,
+}
+
+impl FlowCtrl {
+    pub(crate) fn new(cmd_ctrl: CmdCtrl, incoming_conns: mpsc::Receiver<MsgEvent>) -> Self {
+        let node = cmd_ctrl.node();
+        let ctrl = Self { cmd_ctrl, node };
+
+        ctrl.clone().start_connection_listening(incoming_conns);
+        ctrl.clone().start_network_probing();
+        ctrl.clone().start_section_probing();
+        ctrl.clone().start_data_replication();
+        ctrl.clone().start_dysfunction_detection();
+        ctrl.clone().start_cleaning_peer_links();
+        #[cfg(feature = "back-pressure")]
+        ctrl.clone().start_backpressure_reporting();
+
+        ctrl
+    }
+
+    /// Does not await the completion of the cmd.
+    pub(crate) async fn fire_and_forget(&self, cmd: Cmd) -> Result<()> {
+        let _ = self.cmd_ctrl.push(cmd).await?;
+        Ok(())
+    }
+
+    /// Awaits the completion of the cmd.
+    #[allow(unused)]
+    pub(crate) async fn await_result(&self, cmd: Cmd) -> Result<()> {
+        use cmd_ctrl::CtrlStatus;
+
+        let mut watcher = self.cmd_ctrl.push(cmd).await?;
+
+        loop {
+            match watcher.await_change().await {
+                CtrlStatus::Finished => {
+                    return Ok(());
+                }
+                CtrlStatus::Enqueued => {
+                    // this block should be unreachable, as Enqueued is the initial state
+                    // but let's handle it anyway..
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    continue;
+                }
+                CtrlStatus::MaxRetriesReached(retries) => {
+                    return Err(Error::MaxCmdRetriesReached(retries));
+                }
+                CtrlStatus::WatcherDropped => {
+                    // the send job is dropped for some reason,
+                    return Err(Error::CmdJobWatcherDropped);
+                }
+                CtrlStatus::Error(error) => {
+                    continue; // await change on the same recipient again
+                }
+            }
+        }
+    }
+
+    fn start_connection_listening(self, incoming_conns: mpsc::Receiver<MsgEvent>) {
+        // Start listening to incoming connections.
+        let _handle = task::spawn_local(handle_connection_events(self, incoming_conns));
+    }
+
+    fn start_network_probing(self) {
         info!("Starting to probe network");
         let _handle = tokio::task::spawn_local(async move {
-            let dispatcher = self.clone();
             let mut interval = tokio::time::interval(PROBE_INTERVAL);
             interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
@@ -42,16 +116,12 @@ impl Dispatcher {
                 let _instant = interval.tick().await;
 
                 // Send a probe message if we are an elder
-                let node = &dispatcher.node;
+                let node = &self.node;
                 if node.is_elder().await && !node.network_knowledge().prefix().await.is_empty() {
                     match node.generate_probe_msg().await {
                         Ok(cmd) => {
                             info!("Sending probe msg");
-                            if let Err(e) = dispatcher
-                                .clone()
-                                .enqueue_and_handle_next_cmd_and_offshoots(cmd, None)
-                                .await
-                            {
+                            if let Err(e) = self.cmd_ctrl.push(cmd).await {
                                 error!("Error sending a probe msg to the network: {:?}", e);
                             }
                         }
@@ -62,10 +132,9 @@ impl Dispatcher {
         });
     }
 
-    pub(crate) async fn start_section_probing(self: Arc<Self>) {
+    fn start_section_probing(self) {
         info!("Starting to probe section");
         let _handle = tokio::task::spawn_local(async move {
-            let dispatcher = self.clone();
             let mut interval = tokio::time::interval(SECTION_PROBE_INTERVAL);
             interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
@@ -73,16 +142,12 @@ impl Dispatcher {
                 let _instant = interval.tick().await;
 
                 // Send a probe message to an elder
-                let node = &dispatcher.node;
+                let node = &self.node;
                 if !node.network_knowledge().prefix().await.is_empty() {
                     match node.generate_section_probe_msg().await {
                         Ok(cmd) => {
                             info!("Sending section probe msg");
-                            if let Err(e) = dispatcher
-                                .clone()
-                                .enqueue_and_handle_next_cmd_and_offshoots(cmd, None)
-                                .await
-                            {
+                            if let Err(e) = self.cmd_ctrl.push(cmd).await {
                                 error!("Error sending section probe msg: {:?}", e);
                             }
                         }
@@ -93,49 +158,24 @@ impl Dispatcher {
         });
     }
 
-    pub(crate) async fn start_cleaning_peer_links(self: Arc<Self>) {
-        info!("Starting cleaning up network links");
-        let _handle = tokio::task::spawn_local(async move {
-            let dispatcher = self.clone();
-            let mut interval = tokio::time::interval(LINK_CLEANUP_INTERVAL);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-            let _ = interval.tick().await;
-
-            loop {
-                let _ = interval.tick().await;
-                let cmd = Cmd::CleanupPeerLinks;
-                if let Err(e) = dispatcher
-                    .clone()
-                    .enqueue_and_handle_next_cmd_and_offshoots(cmd, None)
-                    .await
-                {
-                    error!(
-                        "Error requesting a cleaning up of unused PeerLinks: {:?}",
-                        e
-                    );
-                }
-            }
-        });
-    }
-
     /// Periodically loop over any pending data batches and queue up send_msg for those
-    pub(crate) async fn start_sending_any_data_batches(self: Arc<Self>) {
+    fn start_data_replication(self) {
         info!("Starting sending any queued data for replication in batches");
 
         let _handle: JoinHandle<Result<()>> = tokio::task::spawn_local(async move {
-            let dispatcher = self.clone();
             let mut interval = tokio::time::interval(DATA_BATCH_INTERVAL);
             interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-            let _ = interval.tick().await;
 
             loop {
+                let _ = interval.tick().await;
+
                 use rand::seq::IteratorRandom;
                 let mut rng = rand::rngs::OsRng;
-                let mut cmds = vec![];
                 let mut this_batch_address = None;
+                let node = &self.node;
 
                 // choose a data to replicate at random
-                if let Some(data_queued) = self
+                if let Some(data_queued) = node
                     .pending_data_to_replicate_to_peers
                     .iter()
                     .choose(&mut rng)
@@ -145,11 +185,11 @@ impl Dispatcher {
 
                 if let Some(address) = this_batch_address {
                     if let Some((data_address, data_recipients)) =
-                        self.pending_data_to_replicate_to_peers.remove(&address)
+                        node.pending_data_to_replicate_to_peers.remove(&address)
                     {
                         // get info for the WireMsg
-                        let src_section_pk = self.node.network_knowledge().section_key().await;
-                        let our_info = &*self.node.info.read().await;
+                        let src_section_pk = node.network_knowledge().section_key().await;
+                        let our_info = &*node.info.read().await;
 
                         let mut recipients = vec![];
 
@@ -168,8 +208,7 @@ impl Dispatcher {
                             section_pk: src_section_pk,
                         };
 
-                        let data_to_send = self
-                            .node
+                        let data_to_send = node
                             .data_storage
                             .get_from_local_store(&data_address)
                             .await?;
@@ -186,43 +225,51 @@ impl Dispatcher {
                             wire_msg.msg_id()
                         );
 
-                        cmds.extend(
-                            self.send_msg(&recipients, recipients.len(), wire_msg)
-                                .await?,
-                        )
+                        let cmd = Cmd::SendMsg {
+                            wire_msg,
+                            recipients: recipients.clone(),
+                        };
+
+                        if let Err(e) = self.cmd_ctrl.push(cmd).await {
+                            error!("Error in data replication loop: {:?}", e);
+                        }
                     }
                 }
-
-                for cmd in cmds {
-                    if let Err(e) = dispatcher
-                        .clone()
-                        .enqueue_and_handle_next_cmd_and_offshoots(cmd, None)
-                        .await
-                    {
-                        error!(
-                            "Error requesting a cleaning up of unused PeerLinks: {:?}",
-                            e
-                        );
-                    }
-                }
-
-                let _ = interval.tick().await;
             }
         });
     }
 
-    pub(crate) async fn check_for_dysfunction_periodically(self: Arc<Self>) {
+    fn start_cleaning_peer_links(self) {
+        info!("Starting cleaning up network links");
+        let _handle = tokio::task::spawn_local(async move {
+            let mut interval = tokio::time::interval(LINK_CLEANUP_INTERVAL);
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            let _ = interval.tick().await;
+
+            loop {
+                let _ = interval.tick().await;
+                if let Err(e) = self.cmd_ctrl.push(Cmd::CleanupPeerLinks).await {
+                    error!(
+                        "Error requesting a cleaning up of unused PeerLinks: {:?}",
+                        e
+                    );
+                }
+            }
+        });
+    }
+
+    fn start_dysfunction_detection(self) {
         info!("Starting dysfunction checking");
         let _handle = tokio::task::spawn_local(async move {
-            let dispatcher = self.clone();
             let mut interval = tokio::time::interval(DYSFUNCTION_CHECK_INTERVAL);
             interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
             loop {
                 let _instant = interval.tick().await;
 
-                let unresponsive_nodes = match dispatcher.node.get_dysfunctional_node_names().await
-                {
+                let node = &self.node;
+
+                let unresponsive_nodes = match node.get_dysfunctional_node_names().await {
                     Ok(nodes) => nodes,
                     Err(error) => {
                         error!("Error getting dysfunctional nodes: {error}");
@@ -232,10 +279,9 @@ impl Dispatcher {
 
                 if !unresponsive_nodes.is_empty() {
                     debug!("{:?} : {unresponsive_nodes:?}", LogMarker::ProposeOffline);
-                    let cmd = Cmd::ProposeOffline(unresponsive_nodes);
-                    if let Err(e) = dispatcher
-                        .clone()
-                        .enqueue_and_handle_next_cmd_and_offshoots(cmd, None)
+                    if let Err(e) = self
+                        .cmd_ctrl
+                        .push(Cmd::ProposeOffline(unresponsive_nodes))
                         .await
                     {
                         error!("Error sending Propose Offline for dysfunctional nodes: {e:?}");
@@ -253,10 +299,11 @@ impl Dispatcher {
     /// Worst case is after a split, nodes sending messaging from a sibling section to update us may not
     /// know about our load just now. Though that would only be AE messages... and if backpressure is working we should
     /// not be overloaded...
-    pub(crate) async fn report_backpressure_to_our_section_periodically(self: Arc<Self>) {
+    fn start_backpressure_reporting(self) {
+        use sn_interface::messaging::DstLocation;
+
         info!("Firing off backpressure reports");
         let _handle = tokio::task::spawn_local(async move {
-            let dispatcher = self.clone();
             let mut interval = tokio::time::interval(BACKPRESSURE_INTERVAL);
             interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
             let _ = interval.tick().await;
@@ -264,15 +311,18 @@ impl Dispatcher {
             loop {
                 let _ = interval.tick().await;
 
-                let members = dispatcher.node.network_knowledge().section_members().await;
-                let section_pk = dispatcher.node.network_knowledge().section_key().await;
+                let node = &self.node;
+                let our_info = node.info.read().await;
+                let our_name = our_info.name();
 
-                if let Some(load_report) = dispatcher.node.comm.tolerated_msgs_per_s().await {
+                let members = node.network_knowledge().section_members().await;
+                let section_pk = node.network_knowledge().section_key().await;
+
+                if let Some(load_report) = node.comm.tolerated_msgs_per_s().await {
                     trace!("New BackPressure report to disseminate: {:?}", load_report);
 
                     // TODO: use comms to send report to anyone connected? (can we ID end users there?)
                     for member in members {
-                        let our_name = dispatcher.node.info.read().await.name();
                         let peer = member.peer();
 
                         if peer.name() == our_name {
@@ -280,7 +330,7 @@ impl Dispatcher {
                         }
 
                         let wire_msg = match WireMsg::single_src(
-                            &*dispatcher.node.info.read().await,
+                            &our_info,
                             DstLocation::Node {
                                 name: peer.name(),
                                 section_pk,
@@ -303,11 +353,7 @@ impl Dispatcher {
                             recipients: vec![*peer],
                         };
 
-                        if let Err(e) = dispatcher
-                            .clone()
-                            .enqueue_and_handle_next_cmd_and_offshoots(cmd, None)
-                            .await
-                        {
+                        if let Err(e) = self.cmd_ctrl.push(cmd).await {
                             error!(
                                 "Error sending backpressure report to section member {:?}: {:?}",
                                 peer, e
@@ -318,9 +364,53 @@ impl Dispatcher {
             }
         });
     }
+}
 
-    pub(crate) async fn write_prefixmap_to_disk(self: Arc<Self>) {
-        info!("Writing our PrefixMap to disk");
-        self.clone().node.write_prefix_map().await
+// Listen for incoming connection events and handle them.
+async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Receiver<MsgEvent>) {
+    while let Some(event) = incoming_conns.recv().await {
+        match event {
+            MsgEvent::Received {
+                sender,
+                wire_msg,
+                original_bytes,
+            } => {
+                debug!(
+                    "New message ({} bytes) received from: {:?}",
+                    original_bytes.len(),
+                    sender
+                );
+
+                let span = {
+                    let node = &ctrl.node;
+                    trace_span!("handle_message", name = %node.info.read().await.name(), ?sender, msg_id = ?wire_msg.msg_id())
+                };
+                let _span_guard = span.enter();
+
+                trace!(
+                    "{:?} from {:?} length {}",
+                    LogMarker::DispatchHandleMsgCmd,
+                    sender,
+                    original_bytes.len(),
+                );
+
+                #[cfg(feature = "test-utils")]
+                let wire_msg = if let Ok(msg) = wire_msg.into_msg() {
+                    wire_msg.set_payload_debug(msg)
+                } else {
+                    wire_msg
+                };
+
+                let cmd = Cmd::HandleMsg {
+                    sender,
+                    wire_msg,
+                    original_bytes: Some(original_bytes),
+                };
+
+                let _res = ctrl.cmd_ctrl.push(cmd).await;
+            }
+        }
     }
+
+    error!("Fatal error, the stream for incoming connections has been unexpectedly closed. No new connections or messages can be received from the network from here on.");
 }

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -7,23 +7,25 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 pub(crate) mod cmds;
+pub(super) mod event;
+pub(super) mod event_channel;
+pub(super) mod flow_ctrl;
 #[cfg(test)]
 pub(crate) mod tests;
 
-pub(super) mod dispatcher;
-pub(super) mod event;
-pub(super) mod event_channel;
+mod dispatcher;
 
 use self::{
     cmds::Cmd,
     dispatcher::Dispatcher,
     event::{Elders, Event, MembershipEvent, NodeElderChange},
     event_channel::EventReceiver,
+    flow_ctrl::{CmdCtrl, FlowCtrl},
 };
 
 use crate::node::{
     cfg::keypair_storage::{get_reward_pk, store_network_keypair, store_new_reward_keypair},
-    core::{join_network, Comm, MsgEvent, Node, RateLimits},
+    core::{join_network, Comm, Node, RateLimits},
     error::{Error, Result},
     logging::{log_ctx::LogCtx, run_system_logger},
     messages::WireMsgUtils,
@@ -48,7 +50,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::{sync::mpsc, task};
+use tokio::sync::mpsc;
 use xor_name::{Prefix, XorName};
 
 /// Interface for sending and receiving messages to and from other nodes, in the role of a full
@@ -60,7 +62,8 @@ use xor_name::{Prefix, XorName};
 /// role, and can be `use sn_interface::messaging::SrcLocation::Node` or `use sn_interface::messaging::SrcLocation::Section`.
 #[allow(missing_debug_implementations)]
 pub struct NodeApi {
-    dispatcher: Arc<Dispatcher>,
+    node: Arc<Node>,
+    flow_ctrl: FlowCtrl,
 }
 
 static EVENT_CHANNEL_SIZE: usize = 20;
@@ -96,7 +99,7 @@ impl NodeApi {
         .map_err(|_| Error::JoinTimeout)??;
 
         // Network keypair may have to be changed due to naming criteria or network requirements.
-        let keypair_as_bytes = api.dispatcher.node.info.read().await.keypair.to_bytes();
+        let keypair_as_bytes = api.node.info.read().await.keypair.to_bytes();
         store_network_keypair(root_dir, keypair_as_bytes).await?;
 
         let our_pid = std::process::id();
@@ -115,7 +118,7 @@ impl NodeApi {
             our_pid, node_prefix, node_name, node_age, our_conn_info_json,
         );
 
-        run_system_logger(LogCtx::new(api.dispatcher.clone()), config.resource_logs).await;
+        run_system_logger(LogCtx::new(api.node.clone()), config.resource_logs).await;
 
         Ok((api, network_events))
     }
@@ -254,95 +257,74 @@ impl NodeApi {
                 root_storage_dir.to_path_buf(),
             )
             .await?;
+
             info!("{} Joined the network!", node.info.read().await.name());
             info!("Our AGE: {}", node.info.read().await.age());
 
             node
         };
 
-        let dispatcher = Arc::new(Dispatcher::new(node));
-
-        // Start listening to incoming connections.
-        let _handle = task::spawn_local(handle_connection_events(
-            dispatcher.clone(),
-            connection_event_rx,
-        ));
-
-        dispatcher.clone().start_network_probing().await;
-        dispatcher.clone().start_section_probing().await;
-        dispatcher
-            .clone()
-            .check_for_dysfunction_periodically()
-            .await;
-        dispatcher.clone().start_sending_any_data_batches().await;
-
-        #[cfg(feature = "back-pressure")]
-        dispatcher
-            .clone()
-            .report_backpressure_to_our_section_periodically()
-            .await;
-
-        dispatcher.clone().start_cleaning_peer_links().await;
-        dispatcher.clone().write_prefixmap_to_disk().await;
-
-        let api = Self { dispatcher };
+        let node = Arc::new(node);
+        let cmd_ctrl = CmdCtrl::new(Dispatcher::new(node.clone()), monitoring, event_sender);
+        let flow_ctrl = FlowCtrl::new(cmd_ctrl, connection_event_rx);
+        let api = Self { node, flow_ctrl };
 
         Ok((api, event_receiver))
     }
 
     /// Returns the current age of this node.
     pub async fn age(&self) -> u8 {
-        self.dispatcher.node.info.read().await.age()
+        self.node.info.read().await.age()
     }
 
     /// Returns the ed25519 public key of this node.
     pub async fn public_key(&self) -> PublicKey {
-        self.dispatcher.node.info.read().await.keypair.public
+        self.node.info.read().await.keypair.public
     }
 
     /// The name of this node.
     pub async fn name(&self) -> XorName {
-        self.dispatcher.node.info.read().await.name()
+        self.node.info.read().await.name()
     }
 
     /// Returns connection info of this node.
     pub async fn our_connection_info(&self) -> SocketAddr {
-        self.dispatcher.node.our_connection_info()
+        self.node.our_connection_info()
     }
 
     /// Returns the Section Signed Chain
     pub async fn section_chain(&self) -> SecuredLinkedList {
-        self.dispatcher.node.section_chain().await
+        self.node.section_chain().await
     }
 
     /// Returns the Section Chain's genesis key
     pub async fn genesis_key(&self) -> bls::PublicKey {
-        *self.dispatcher.node.network_knowledge().genesis_key()
+        *self.node.network_knowledge().genesis_key()
     }
 
     /// Prefix of our section
     pub async fn our_prefix(&self) -> Prefix {
-        self.dispatcher.node.network_knowledge().prefix().await
+        self.node.network_knowledge().prefix().await
     }
 
     /// Returns whether the node is Elder.
     pub async fn is_elder(&self) -> bool {
-        self.dispatcher.node.is_elder().await
+        self.node.is_elder().await
     }
 
     /// Returns the information of all the current section elders.
     pub async fn our_elders(&self) -> Vec<Peer> {
-        self.dispatcher.node.network_knowledge().elders().await
+        self.node.network_knowledge().elders().await
     }
 
     /// Returns the information of all the current section adults.
     pub async fn our_adults(&self) -> Vec<Peer> {
-        self.dispatcher.node.network_knowledge().adults().await
+        self.node.network_knowledge().adults().await
     }
 
     /// Returns the info about the section matching the name.
     pub async fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
-        self.dispatcher.node.matching_section(name).await
+        self.node.matching_section(name).await
     }
 
     /// Builds a WireMsg signed by this Node
@@ -353,7 +335,7 @@ impl NodeApi {
     ) -> Result<WireMsg> {
         let src_section_pk = *self.section_chain().await.last_key();
         WireMsg::single_src(
-            &self.dispatcher.node.info.read().await.clone(),
+            &self.node.info.read().await.clone(),
             dst,
             node_msg,
             src_section_pk,
@@ -369,11 +351,8 @@ impl NodeApi {
             wire_msg.msg_id()
         );
 
-        if let Some(cmd) = self.dispatcher.node.send_msg_to_nodes(wire_msg).await? {
-            self.dispatcher
-                .clone()
-                .enqueue_and_handle_next_cmd_and_offshoots(cmd, None)
-                .await?;
+        if let Some(cmd) = self.node.send_msg_to_nodes(wire_msg).await? {
+            self.flow_ctrl.fire_and_forget(cmd).await?;
         }
 
         Ok(())
@@ -382,53 +361,6 @@ impl NodeApi {
     /// Returns the current BLS public key set if this node has one, or
     /// `Error::MissingSecretKeyShare` otherwise.
     pub async fn public_key_set(&self) -> Result<bls::PublicKeySet> {
-        self.dispatcher.node.public_key_set().await
+        self.node.public_key_set().await
     }
-}
-
-// Listen for incoming connection events and handle them.
-async fn handle_connection_events(
-    dispatcher: Arc<Dispatcher>,
-    mut incoming_conns: mpsc::Receiver<MsgEvent>,
-) {
-    while let Some(event) = incoming_conns.recv().await {
-        match event {
-            MsgEvent::Received {
-                sender,
-                wire_msg,
-                original_bytes,
-            } => {
-                debug!(
-                    "New message ({} bytes) received from: {:?}",
-                    original_bytes.len(),
-                    sender
-                );
-
-                let span = {
-                    let node = &dispatcher.node;
-                    trace_span!("handle_message", name = %node.info.read().await.name(), ?sender, msg_id = ?wire_msg.msg_id())
-                };
-                let _span_guard = span.enter();
-
-                trace!(
-                    "{:?} from {:?} length {}",
-                    LogMarker::DispatchHandleMsgCmd,
-                    sender,
-                    original_bytes.len(),
-                );
-                let cmd = Cmd::HandleMsg {
-                    sender,
-                    wire_msg,
-                    original_bytes: Some(original_bytes),
-                };
-
-                let _handle = dispatcher
-                    .clone()
-                    .enqueue_and_handle_next_cmd_and_offshoots(cmd, None)
-                    .await;
-            }
-        }
-    }
-
-    error!("Fatal error, the stream for incoming connections has been unexpectedly closed. No new connections or messages can be received from the network from here on.");
 }

--- a/sn_node/src/node/core/api.rs
+++ b/sn_node/src/node/core/api.rs
@@ -126,7 +126,7 @@ impl Node {
     //   ---------------------------------- Mut ------------------------------------------
     // ----------------------------------------------------------------------------------------
 
-    pub(crate) async fn handle_timeout(&self, token: u64) -> Result<Vec<Cmd>> {
+    pub(crate) async fn handle_dkg_timeout(&self, token: u64) -> Result<Vec<Cmd>> {
         self.dkg_voter.handle_timeout(
             &self.info.read().await.clone(),
             token,

--- a/sn_node/src/node/core/bootstrap/join.rs
+++ b/sn_node/src/node/core/bootstrap/join.rs
@@ -443,7 +443,7 @@ impl<'a> Join<'a> {
             let (join_response, sender) = match event {
                 MsgEvent::Received {
                     sender, wire_msg, ..
-                } => match wire_msg.msg_kind() {
+                } => match wire_msg.auth_kind() {
                     AuthKind::Service(_) => continue,
                     AuthKind::NodeBlsShare(_) => {
                         trace!(

--- a/sn_node/src/node/core/comm/link.rs
+++ b/sn_node/src/node/core/comm/link.rs
@@ -82,7 +82,7 @@ impl Link {
         instance
     }
 
-    #[cfg(test)]
+    #[cfg(feature = "test-utils")]
     pub(crate) fn peer(&self) -> &Peer {
         &self.peer
     }

--- a/sn_node/src/node/core/comm/listener.rs
+++ b/sn_node/src/node/core/comm/listener.rs
@@ -69,7 +69,7 @@ impl MsgListener {
                         }
                     };
 
-                    let src_name = wire_msg.msg_kind().src().name();
+                    let src_name = wire_msg.auth_kind().src().name();
 
                     if first {
                         first = false;

--- a/sn_node/src/node/core/comm/peer_session.rs
+++ b/sn_node/src/node/core/comm/peer_session.rs
@@ -153,7 +153,7 @@ impl PeerSession {
                 continue;
             }
 
-            #[cfg(test)]
+            #[cfg(feature = "test-utils")]
             {
                 let queue = self.msg_queue.read().await;
                 debug!("Peer {} queue length: {}", self.link.peer(), queue.len());

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -209,14 +209,14 @@ impl Node {
             .collect::<BTreeSet<_>>();
 
         trace!(
-            "Chunk holders of {:?} are empty adults: {:?} and full adults: {:?}",
+            "Chunk holders of {:?} are non-full adults: {:?} and full adults: {:?}",
             target,
             candidates,
             full_adults
         );
 
         // Full adults that are close to the chunk, shall still be considered as candidates
-        // to allow chunks stored to empty adults can be queried when nodes become full.
+        // to allow chunks stored to non-full adults can be queried when nodes become full.
         let close_full_adults = if let Some(closest_empty) = candidates.iter().next() {
             full_adults
                 .iter()
@@ -255,7 +255,7 @@ impl Node {
             .collect::<BTreeSet<_>>();
 
         trace!(
-            "Target holders of {:?} are empty adults: {:?} and full adults that were ignored: {:?}",
+            "Target holders of {:?} are non-full adults: {:?} and full adults that were ignored: {:?}",
             target,
             candidates,
             full_adults

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -857,9 +857,9 @@ mod tests {
 
             let node_auth = NodeAuth::authorize(src_section_pk, &src_node_keypair, &payload);
 
-            let msg_kind = AuthKind::Node(node_auth.into_inner());
+            let auth_kind = AuthKind::Node(node_auth.into_inner());
 
-            let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
+            let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
 
             let src_location = SrcLocation::Node {
                 name: sender_name,

--- a/sn_node/src/node/core/messaging/handling/mod.rs
+++ b/sn_node/src/node/core/messaging/handling/mod.rs
@@ -188,7 +188,7 @@ impl Node {
                     }
                 };
 
-                let src_location = wire_msg.msg_kind().src();
+                let src_location = wire_msg.auth_kind().src();
 
                 if self.is_not_elder().await {
                     trace!("Redirecting from adult to section elders");

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -145,11 +145,11 @@ impl Node {
             response: query_response,
             correlation_id,
         };
-        let (msg_kind, payload) = self.ed_sign_client_msg(&msg).await?;
+        let (auth_kind, payload) = self.ed_sign_client_msg(&msg).await?;
 
         for peer in waiting_peers.iter() {
             let dst = DstLocation::EndUser(EndUser(peer.name()));
-            let wire_msg = WireMsg::new_msg(msg_id, payload.clone(), msg_kind.clone(), dst)?;
+            let wire_msg = WireMsg::new_msg(msg_id, payload.clone(), auth_kind.clone(), dst)?;
 
             debug!("Responding with the first query response to {:?}", dst);
 

--- a/sn_node/src/node/core/messaging/sending/dkg_start.rs
+++ b/sn_node/src/node/core/messaging/sending/dkg_start.rs
@@ -70,7 +70,13 @@ impl Node {
                 err
             })?;
 
+        #[cfg(feature = "test-utils")]
+        let node_msg_clone = node_msg.clone();
+
         let wire_msg = WireMsg::for_dst_accumulation(&key_share, src, dst, node_msg, section_key)?;
+
+        #[cfg(feature = "test-utils")]
+        let wire_msg = wire_msg.set_payload_debug(node_msg_clone);
 
         trace!(
             "Send {:?} for accumulation at dst to {:?}",

--- a/sn_node/src/node/core/messaging/sending/proposal.rs
+++ b/sn_node/src/node/core/messaging/sending/proposal.rs
@@ -76,6 +76,10 @@ impl Node {
             proposal: proposal.clone().into_msg(),
             sig_share: sig_share.clone(),
         };
+
+        #[cfg(feature = "test-utils")]
+        let node_msg_clone = node_msg.clone();
+
         // Name of the section_pk may not matches the section prefix.
         // Carry out a substitution to prevent the dst_location becomes other section.
         let section_key = self.network_knowledge.section_key().await;
@@ -88,6 +92,9 @@ impl Node {
             node_msg,
             section_key,
         )?;
+
+        #[cfg(feature = "test-utils")]
+        let wire_msg = wire_msg.set_payload_debug(node_msg_clone);
 
         let msg_id = wire_msg.msg_id();
 

--- a/sn_node/src/node/core/messaging/sending/services.rs
+++ b/sn_node/src/node/core/messaging/sending/services.rs
@@ -46,8 +46,8 @@ impl Node {
     async fn send_cmd_response(&self, target: Peer, msg: ServiceMsg) -> Result<Vec<Cmd>> {
         let dst = DstLocation::EndUser(EndUser(target.name()));
 
-        let (msg_kind, payload) = self.ed_sign_client_msg(&msg).await?;
-        let wire_msg = WireMsg::new_msg(MsgId::new(), payload, msg_kind, dst)?;
+        let (auth_kind, payload) = self.ed_sign_client_msg(&msg).await?;
+        let wire_msg = WireMsg::new_msg(MsgId::new(), payload, auth_kind, dst)?;
 
         let cmd = Cmd::SendMsg {
             recipients: vec![target],

--- a/sn_node/src/node/core/messaging/sending/system.rs
+++ b/sn_node/src/node/core/messaging/sending/system.rs
@@ -98,7 +98,7 @@ impl Node {
         let our_name = self.info.read().await.name();
         for recipient in recipients.into_iter() {
             if recipient.name() == our_name {
-                match wire_msg.msg_kind() {
+                match wire_msg.auth_kind() {
                     AuthKind::NodeBlsShare(_) => {
                         // do nothing, continue we should be accumulating this
                         handle = true;

--- a/sn_node/src/node/core/monitoring/event_rates.rs
+++ b/sn_node/src/node/core/monitoring/event_rates.rs
@@ -61,7 +61,6 @@ impl EventRates {
     }
 
     /// Count an "event" (something that happened).
-    #[allow(unused)]
     pub(super) async fn increment(&self) {
         // increments the latest entry, which represents current interval
         if let Some(entry) = self.samples.read().await.back() {

--- a/sn_node/src/node/core/monitoring/mod.rs
+++ b/sn_node/src/node/core/monitoring/mod.rs
@@ -59,7 +59,6 @@ impl RateLimits {
         instance
     }
 
-    #[allow(unused)]
     pub(crate) async fn increment_cmds(&self) {
         self.cmd_rates.increment().await;
     }
@@ -69,7 +68,6 @@ impl RateLimits {
         self.msg_rates.increment().await;
     }
 
-    #[allow(unused)]
     pub(crate) async fn max_cmds_per_s(&self) -> f64 {
         self.cmd_rates.max_events_per_s().await
     }

--- a/sn_node/src/node/dkg/session.rs
+++ b/sn_node/src/node/dkg/session.rs
@@ -492,7 +492,7 @@ impl Session {
 
     fn reset_timer(&mut self) -> Cmd {
         self.timer_token = next_timer_token();
-        Cmd::ScheduleTimeout {
+        Cmd::ScheduleDkgTimeout {
             duration: DKG_PROGRESS_INTERVAL,
             token: self.timer_token,
         }
@@ -689,7 +689,7 @@ mod tests {
                     self.outcome = Some(outcome.public_key_set.public_key());
                     Ok(vec![])
                 }
-                Cmd::ScheduleTimeout { .. } => Ok(vec![]),
+                Cmd::ScheduleDkgTimeout { .. } => Ok(vec![]),
                 other_cmd => {
                     bail!("Unexpected cmd: {:?}", other_cmd)
                 }

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -33,8 +33,10 @@ pub enum Error {
     // section keys are not in chain.
     #[error("Dkg prefix is shorter than our prefix, so dropping the message.")]
     InvalidDkgPrefix,
-    #[error("Max amount of service cmds being handled, dropping cmd.")]
-    AtMaxServiceCmdThroughput,
+    #[error("Max retries reached for processing cmd, cmd dropped.")]
+    MaxCmdRetriesReached(usize),
+    #[error("Cmd job watcher dropped for some unknown reason.")]
+    CmdJobWatcherDropped,
     #[error("Permit was not retrieved in 500 loops")]
     CouldNotGetPermitInTime,
     #[cfg(feature = "chaos")]

--- a/sn_node/src/node/logging/log_ctx.rs
+++ b/sn_node/src/node/logging/log_ctx.rs
@@ -6,21 +6,21 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::api::dispatcher::Dispatcher;
+use crate::node::core::Node;
 
 use std::sync::Arc;
 use xor_name::Prefix;
 
 pub(crate) struct LogCtx {
-    cmds_dispatcher: Arc<Dispatcher>,
+    node: Arc<Node>,
 }
 
 impl LogCtx {
-    pub(crate) fn new(cmds_dispatcher: Arc<Dispatcher>) -> Self {
-        Self { cmds_dispatcher }
+    pub(crate) fn new(node: Arc<Node>) -> Self {
+        Self { node }
     }
 
     pub(crate) async fn prefix(&self) -> Prefix {
-        self.cmds_dispatcher.node.network_knowledge().prefix().await
+        self.node.network_knowledge().prefix().await
     }
 }

--- a/sn_node/src/node/messages/mod.rs
+++ b/sn_node/src/node/messages/mod.rs
@@ -51,13 +51,13 @@ impl WireMsgUtils for WireMsg {
         let msg_payload =
             WireMsg::serialize_msg_payload(&msg).map_err(|_| Error::InvalidMessage)?;
 
-        let msg_kind = AuthKind::NodeBlsShare(
+        let auth_kind = AuthKind::NodeBlsShare(
             bls_share_authorize(src_section_pk, src_name, key_share, &msg_payload).into_inner(),
         );
 
-        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, msg_kind, dst)?;
+        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth_kind, dst)?;
 
-        #[cfg(test)]
+        #[cfg(feature = "test-utils")]
         let wire_msg = wire_msg.set_payload_debug(msg);
 
         Ok(wire_msg)
@@ -73,13 +73,13 @@ impl WireMsgUtils for WireMsg {
         let msg_payload =
             WireMsg::serialize_msg_payload(&msg).map_err(|_| Error::InvalidMessage)?;
 
-        let msg_kind = AuthKind::Node(
+        let auth_kind = AuthKind::Node(
             NodeAuth::authorize(src_section_pk, &node.keypair, &msg_payload).into_inner(),
         );
 
-        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, msg_kind, dst)?;
+        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth_kind, dst)?;
 
-        #[cfg(test)]
+        #[cfg(feature = "test-utils")]
         let wire_msg = wire_msg.set_payload_debug(msg);
 
         Ok(wire_msg)

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -24,7 +24,10 @@ mod messages;
 
 pub use self::{
     api::{
-        event::{Elders, Event, MembershipEvent, MessagingEvent, NodeElderChange},
+        event::{
+            CmdProcessEvent, DataEvent, Elders, Event, MembershipEvent, MessagingEvent,
+            NodeElderChange,
+        },
         event_channel::EventReceiver,
         NodeApi,
     },


### PR DESCRIPTION
misc cleanup and fixes
- Complete `msg_kind` => `auth_kind` renaming.
- Fix broken `routing_stress` startup.
- Clarify context of `HandleTimeout` and `ScheduleTimeout` by
inserting `Dkg`.
- Tweak `network_split` example.
- Set various things, such as payload debug, under `test-utils` flag.
- Fix comments/logs: the opposite group of `full` adults are
`non-full`, not `empty`.