### PR TITLE
chore(misc): misc cleanup and fixes

### DIFF
--- a/sn_client/examples/network_split.rs
+++ b/sn_client/examples/network_split.rs
@@ -33,7 +33,7 @@ const SAFE_NODE_EXECUTABLE: &str = "sn_node";
 const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
 
 const NODES_DIR: &str = "local-test-network";
-const INTERVAL: &str = "10000";
+const INTERVAL: &str = "5000"; // milliseconds
 const RUST_LOG: &str = "RUST_LOG";
 const ADDITIONAL_NODES_TO_SPLIT: u64 = 15;
 
@@ -135,7 +135,7 @@ pub async fn run_split() -> Result<()> {
         .wrap_err("Error starting the testnet")?;
 
     // leave a longer interval with more nodes to allow for splits if using split amounts
-    let interval_duration = Duration::from_millis(*interval_as_int);
+    let interval_duration = Duration::from_millis(2 * interval_as_int);
     sleep(interval_duration).await;
     println!("Done sleeping....");
 
@@ -166,6 +166,7 @@ pub async fn run_split() -> Result<()> {
         .wrap_err("Error adding nodes to the testnet")?;
 
     // leave a longer interval with more nodes to allow for splits if using split amounts
+    let interval_duration = Duration::from_millis(interval_as_int * ADDITIONAL_NODES_TO_SPLIT / 10);
     sleep(interval_duration).await;
 
     // now we read the data
@@ -183,7 +184,7 @@ pub async fn run_split() -> Result<()> {
         while bytes.is_err() && attempts < 10 {
             attempts += 1;
             // do some retries to ensure we're not just timing out by chance
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(attempts)).await;
             bytes = client.read_bytes(address).await;
         }
 
@@ -236,7 +237,7 @@ async fn upload_data() -> Result<(XorName, [u8; 32])> {
     while bytes.is_err() && attempts < 10 {
         attempts += 1;
         // do some retries to ensure we're not just timing out by chance
-        sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(attempts)).await;
         bytes = client.read_bytes(address).await;
     }
 

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -103,8 +103,8 @@ impl Session {
             section_pk,
         };
 
-        let msg_kind = AuthKind::Service(auth);
-        let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
+        let auth_kind = AuthKind::Service(auth);
+        let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
 
         // The insertion of channel will be executed AFTER the completion of the `send_message`.
         let (sender, mut receiver) = channel::<CmdResponse>(elders_len);
@@ -223,8 +223,8 @@ impl Session {
             name: dst,
             section_pk,
         };
-        let msg_kind = AuthKind::Service(auth);
-        let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
+        let auth_kind = AuthKind::Service(auth);
+        let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
 
         send_msg_in_bg(self.clone(), elders, wire_msg, msg_id)?;
 
@@ -361,8 +361,8 @@ impl Session {
             name: dst_address,
             section_pk,
         };
-        let msg_kind = AuthKind::Service(auth);
-        let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
+        let auth_kind = AuthKind::Service(auth);
+        let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
 
         // When the client bootstrap using the nodes read from the config, the list is sorted
         // by socket addresses. To improve the efficiency, the `elders_or_adults` shall be sorted

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -65,11 +65,11 @@ impl WireMsg {
     pub fn new_msg(
         msg_id: MsgId,
         payload: Bytes,
-        msg_kind: AuthKind,
+        auth_kind: AuthKind,
         dst_location: DstLocation,
     ) -> Result<Self> {
         Ok(Self {
-            header: WireMsgHeader::new(msg_id, msg_kind, dst_location),
+            header: WireMsgHeader::new(msg_id, auth_kind, dst_location),
             payload,
             #[cfg(feature = "test-utils")]
             payload_debug: None,
@@ -118,7 +118,7 @@ impl WireMsg {
 
     /// Deserialize the payload from this WireMsg returning a MsgType instance.
     pub fn into_msg(&self) -> Result<MsgType> {
-        match self.header.msg_envelope.msg_kind.clone() {
+        match self.header.msg_envelope.auth_kind.clone() {
             #[cfg(any(feature = "chunks", feature = "registers"))]
             AuthKind::Service(auth) => {
                 let msg: ServiceMsg = rmp_serde::from_slice(&self.payload).map_err(|err| {
@@ -184,8 +184,8 @@ impl WireMsg {
     }
 
     /// Return the kind of this message
-    pub fn msg_kind(&self) -> &AuthKind {
-        &self.header.msg_envelope.msg_kind
+    pub fn auth_kind(&self) -> &AuthKind {
+        &self.header.msg_envelope.auth_kind
     }
 
     /// Return the priority of this message
@@ -216,7 +216,7 @@ impl WireMsg {
     /// Return the source section PublicKey for this
     /// message if it's a NodeMsg
     pub fn src_section_pk(&self) -> Option<BlsPublicKey> {
-        match &self.header.msg_envelope.msg_kind {
+        match &self.header.msg_envelope.auth_kind {
             AuthKind::Node(node_signed) => Some(node_signed.section_pk),
             AuthKind::NodeBlsShare(bls_share_signed) => Some(bls_share_signed.section_pk),
             _ => None,
@@ -305,9 +305,9 @@ mod tests {
         let payload = WireMsg::serialize_msg_payload(&msg)?;
         let node_auth = NodeAuth::authorize(src_section_pk, &src_node_keypair, &payload);
 
-        let msg_kind = AuthKind::Node(node_auth.clone().into_inner());
+        let auth_kind = AuthKind::Node(node_auth.clone().into_inner());
 
-        let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
+        let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
         let serialized = wire_msg.serialize()?;
 
         // test deserialisation of header
@@ -355,9 +355,9 @@ mod tests {
         };
         let auth_proof = AuthorityProof::verify(auth.clone(), &payload).unwrap();
 
-        let msg_kind = AuthKind::Service(auth);
+        let auth_kind = AuthKind::Service(auth);
 
-        let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
+        let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
         let serialized = wire_msg.serialize()?;
 
         // test deserialisation of header

--- a/sn_interface/src/messaging/serialisation/wire_msg_header.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg_header.rs
@@ -38,7 +38,7 @@ pub struct WireMsgHeader {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MsgEnvelope {
     pub msg_id: MsgId,
-    pub msg_kind: AuthKind,
+    pub auth_kind: AuthKind,
     pub dst_location: DstLocation,
 }
 
@@ -73,13 +73,13 @@ lazy_static! {
 
 impl WireMsgHeader {
     // Instantiate a WireMsgHeader as per current supported version.
-    pub fn new(msg_id: MsgId, msg_kind: AuthKind, dst_location: DstLocation) -> Self {
+    pub fn new(msg_id: MsgId, auth_kind: AuthKind, dst_location: DstLocation) -> Self {
         Self {
             //header_size: Self::max_size(),
             version: MESSAGING_PROTO_VERSION,
             msg_envelope: MsgEnvelope {
                 msg_id,
-                msg_kind,
+                auth_kind,
                 dst_location,
             },
         }

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -235,7 +235,7 @@ impl Network {
             ..Default::default()
         };
 
-        let _ = add_node(id, config, event_tx).await;
+        let _handle = tokio::task::spawn_local(add_node(id, config, event_tx));
 
         self.try_print_status();
     }

--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -28,9 +28,6 @@
 )]
 
 #[cfg(not(feature = "tokio-console"))]
-use eyre::Error;
-use eyre::{eyre, Context, ErrReport, Result};
-#[cfg(not(feature = "tokio-console"))]
 use sn_interface::LogFormatter;
 use sn_node::node::{
     add_connection_info, set_connection_info, Config, Error as NodeError, Event, MembershipEvent,
@@ -38,6 +35,9 @@ use sn_node::node::{
 };
 
 use color_eyre::{Section, SectionExt};
+#[cfg(not(feature = "tokio-console"))]
+use eyre::Error;
+use eyre::{eyre, Context, ErrReport, Result};
 use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
 use self_update::{cargo_crate_version, Status};
 use std::{fmt::Debug, fs::File, io, io::Write, path::Path, process::exit};

--- a/sn_node/src/node/api/cmds.rs
+++ b/sn_node/src/node/api/cmds.rs
@@ -92,8 +92,8 @@ pub(crate) enum Cmd {
         // original bytes to avoid reserializing for entropy checks
         original_bytes: Option<Bytes>,
     },
-    /// Handle a timeout previously scheduled with `ScheduleTimeout`.
-    HandleTimeout(u64),
+    /// Handle a timeout previously scheduled with `ScheduleDkgTimeout`.
+    HandleDkgTimeout(u64),
     /// Handle peer that's been detected as lost.
     HandlePeerLost(Peer),
     /// Handle agreement on a proposal.
@@ -136,9 +136,9 @@ pub(crate) enum Cmd {
         delivery_group_size: usize,
         wire_msg: WireMsg,
     },
-    /// Schedule a timeout after the given duration. When the timeout expires, a `HandleTimeout`
+    /// Schedule a timeout after the given duration. When the timeout expires, a `HandleDkgTimeout`
     /// cmd is raised. The token is used to identify the timeout.
-    ScheduleTimeout { duration: Duration, token: u64 },
+    ScheduleDkgTimeout { duration: Duration, token: u64 },
     /// Proposes peers as offline
     ProposeOffline(BTreeSet<XorName>),
     /// Send a signal to all Elders to
@@ -161,14 +161,15 @@ impl Cmd {
             HandleNodeLeft(_) => 10,
             ProposeOffline(_) => 10,
 
-            HandleTimeout(_) => 9,
+            HandleDkgTimeout(_) => 9,
             HandleNewNodeOnline(_) => 9,
             EnqueueDataForReplication { .. } => 9,
 
-            ScheduleTimeout { .. } => 8,
+            ScheduleDkgTimeout { .. } => 8,
             StartConnectivityTest(_) => 8,
             TestConnectivity(_) => 8,
 
+            // See [`MsgType`] for the priority constants and the range of possible values.
             HandleMsg { wire_msg, .. } => wire_msg.priority(),
             SendMsg { wire_msg, .. } => wire_msg.priority(),
             SignOutgoingSystemMsg { msg, .. } => msg.priority(),
@@ -185,8 +186,8 @@ impl fmt::Display for Cmd {
             Cmd::CleanupPeerLinks => {
                 write!(f, "CleanupPeerLinks")
             }
-            Cmd::HandleTimeout(_) => write!(f, "HandleTimeout"),
-            Cmd::ScheduleTimeout { .. } => write!(f, "ScheduleTimeout"),
+            Cmd::HandleDkgTimeout(_) => write!(f, "HandleDkgTimeout"),
+            Cmd::ScheduleDkgTimeout { .. } => write!(f, "ScheduleDkgTimeout"),
             #[cfg(not(feature = "test-utils"))]
             Cmd::HandleMsg { wire_msg, .. } => {
                 write!(f, "HandleMsg {:?}", wire_msg.msg_id())
@@ -207,11 +208,11 @@ impl fmt::Display for Cmd {
             Cmd::HandleNodeLeft(_) => write!(f, "HandleNodeLeft"),
             Cmd::HandleDkgOutcome { .. } => write!(f, "HandleDkgOutcome"),
             Cmd::HandleDkgFailure(_) => write!(f, "HandleDkgFailure"),
-            #[cfg(not(test))]
+            #[cfg(not(feature = "test-utils"))]
             Cmd::SendMsg { wire_msg, .. } => {
                 write!(f, "SendMsg {:?}", wire_msg.msg_id())
             }
-            #[cfg(test)]
+            #[cfg(feature = "test-utils")]
             Cmd::SendMsg { wire_msg, .. } => {
                 write!(
                     f,

--- a/sn_node/src/node/core/api.rs
+++ b/sn_node/src/node/core/api.rs
@@ -126,7 +126,7 @@ impl Node {
     //   ---------------------------------- Mut ------------------------------------------
     // ----------------------------------------------------------------------------------------
 
-    pub(crate) async fn handle_timeout(&self, token: u64) -> Result<Vec<Cmd>> {
+    pub(crate) async fn handle_dkg_timeout(&self, token: u64) -> Result<Vec<Cmd>> {
         self.dkg_voter.handle_timeout(
             &self.info.read().await.clone(),
             token,

--- a/sn_node/src/node/core/bootstrap/join.rs
+++ b/sn_node/src/node/core/bootstrap/join.rs
@@ -443,7 +443,7 @@ impl<'a> Join<'a> {
             let (join_response, sender) = match event {
                 MsgEvent::Received {
                     sender, wire_msg, ..
-                } => match wire_msg.msg_kind() {
+                } => match wire_msg.auth_kind() {
                     AuthKind::Service(_) => continue,
                     AuthKind::NodeBlsShare(_) => {
                         trace!(

--- a/sn_node/src/node/core/comm/link.rs
+++ b/sn_node/src/node/core/comm/link.rs
@@ -82,7 +82,7 @@ impl Link {
         instance
     }
 
-    #[cfg(test)]
+    #[cfg(feature = "test-utils")]
     pub(crate) fn peer(&self) -> &Peer {
         &self.peer
     }

--- a/sn_node/src/node/core/comm/listener.rs
+++ b/sn_node/src/node/core/comm/listener.rs
@@ -69,7 +69,7 @@ impl MsgListener {
                         }
                     };
 
-                    let src_name = wire_msg.msg_kind().src().name();
+                    let src_name = wire_msg.auth_kind().src().name();
 
                     if first {
                         first = false;

--- a/sn_node/src/node/core/comm/peer_session.rs
+++ b/sn_node/src/node/core/comm/peer_session.rs
@@ -153,7 +153,7 @@ impl PeerSession {
                 continue;
             }
 
-            #[cfg(test)]
+            #[cfg(feature = "test-utils")]
             {
                 let queue = self.msg_queue.read().await;
                 debug!("Peer {} queue length: {}", self.link.peer(), queue.len());

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -209,14 +209,14 @@ impl Node {
             .collect::<BTreeSet<_>>();
 
         trace!(
-            "Chunk holders of {:?} are empty adults: {:?} and full adults: {:?}",
+            "Chunk holders of {:?} are non-full adults: {:?} and full adults: {:?}",
             target,
             candidates,
             full_adults
         );
 
         // Full adults that are close to the chunk, shall still be considered as candidates
-        // to allow chunks stored to empty adults can be queried when nodes become full.
+        // to allow chunks stored to non-full adults can be queried when nodes become full.
         let close_full_adults = if let Some(closest_empty) = candidates.iter().next() {
             full_adults
                 .iter()
@@ -255,7 +255,7 @@ impl Node {
             .collect::<BTreeSet<_>>();
 
         trace!(
-            "Target holders of {:?} are empty adults: {:?} and full adults that were ignored: {:?}",
+            "Target holders of {:?} are non-full adults: {:?} and full adults that were ignored: {:?}",
             target,
             candidates,
             full_adults

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -857,9 +857,9 @@ mod tests {
 
             let node_auth = NodeAuth::authorize(src_section_pk, &src_node_keypair, &payload);
 
-            let msg_kind = AuthKind::Node(node_auth.into_inner());
+            let auth_kind = AuthKind::Node(node_auth.into_inner());
 
-            let wire_msg = WireMsg::new_msg(msg_id, payload, msg_kind, dst_location)?;
+            let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
 
             let src_location = SrcLocation::Node {
                 name: sender_name,

--- a/sn_node/src/node/core/messaging/handling/mod.rs
+++ b/sn_node/src/node/core/messaging/handling/mod.rs
@@ -188,7 +188,7 @@ impl Node {
                     }
                 };
 
-                let src_location = wire_msg.msg_kind().src();
+                let src_location = wire_msg.auth_kind().src();
 
                 if self.is_not_elder().await {
                     trace!("Redirecting from adult to section elders");

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -145,11 +145,11 @@ impl Node {
             response: query_response,
             correlation_id,
         };
-        let (msg_kind, payload) = self.ed_sign_client_msg(&msg).await?;
+        let (auth_kind, payload) = self.ed_sign_client_msg(&msg).await?;
 
         for peer in waiting_peers.iter() {
             let dst = DstLocation::EndUser(EndUser(peer.name()));
-            let wire_msg = WireMsg::new_msg(msg_id, payload.clone(), msg_kind.clone(), dst)?;
+            let wire_msg = WireMsg::new_msg(msg_id, payload.clone(), auth_kind.clone(), dst)?;
 
             debug!("Responding with the first query response to {:?}", dst);
 

--- a/sn_node/src/node/core/messaging/sending/dkg_start.rs
+++ b/sn_node/src/node/core/messaging/sending/dkg_start.rs
@@ -70,7 +70,13 @@ impl Node {
                 err
             })?;
 
+        #[cfg(feature = "test-utils")]
+        let node_msg_clone = node_msg.clone();
+
         let wire_msg = WireMsg::for_dst_accumulation(&key_share, src, dst, node_msg, section_key)?;
+
+        #[cfg(feature = "test-utils")]
+        let wire_msg = wire_msg.set_payload_debug(node_msg_clone);
 
         trace!(
             "Send {:?} for accumulation at dst to {:?}",

--- a/sn_node/src/node/core/messaging/sending/proposal.rs
+++ b/sn_node/src/node/core/messaging/sending/proposal.rs
@@ -76,6 +76,10 @@ impl Node {
             proposal: proposal.clone().into_msg(),
             sig_share: sig_share.clone(),
         };
+
+        #[cfg(feature = "test-utils")]
+        let node_msg_clone = node_msg.clone();
+
         // Name of the section_pk may not matches the section prefix.
         // Carry out a substitution to prevent the dst_location becomes other section.
         let section_key = self.network_knowledge.section_key().await;
@@ -88,6 +92,9 @@ impl Node {
             node_msg,
             section_key,
         )?;
+
+        #[cfg(feature = "test-utils")]
+        let wire_msg = wire_msg.set_payload_debug(node_msg_clone);
 
         let msg_id = wire_msg.msg_id();
 

--- a/sn_node/src/node/core/messaging/sending/services.rs
+++ b/sn_node/src/node/core/messaging/sending/services.rs
@@ -46,8 +46,8 @@ impl Node {
     async fn send_cmd_response(&self, target: Peer, msg: ServiceMsg) -> Result<Vec<Cmd>> {
         let dst = DstLocation::EndUser(EndUser(target.name()));
 
-        let (msg_kind, payload) = self.ed_sign_client_msg(&msg).await?;
-        let wire_msg = WireMsg::new_msg(MsgId::new(), payload, msg_kind, dst)?;
+        let (auth_kind, payload) = self.ed_sign_client_msg(&msg).await?;
+        let wire_msg = WireMsg::new_msg(MsgId::new(), payload, auth_kind, dst)?;
 
         let cmd = Cmd::SendMsg {
             recipients: vec![target],

--- a/sn_node/src/node/core/messaging/sending/system.rs
+++ b/sn_node/src/node/core/messaging/sending/system.rs
@@ -98,7 +98,7 @@ impl Node {
         let our_name = self.info.read().await.name();
         for recipient in recipients.into_iter() {
             if recipient.name() == our_name {
-                match wire_msg.msg_kind() {
+                match wire_msg.auth_kind() {
                     AuthKind::NodeBlsShare(_) => {
                         // do nothing, continue we should be accumulating this
                         handle = true;

--- a/sn_node/src/node/dkg/session.rs
+++ b/sn_node/src/node/dkg/session.rs
@@ -492,7 +492,7 @@ impl Session {
 
     fn reset_timer(&mut self) -> Cmd {
         self.timer_token = next_timer_token();
-        Cmd::ScheduleTimeout {
+        Cmd::ScheduleDkgTimeout {
             duration: DKG_PROGRESS_INTERVAL,
             token: self.timer_token,
         }
@@ -689,7 +689,7 @@ mod tests {
                     self.outcome = Some(outcome.public_key_set.public_key());
                     Ok(vec![])
                 }
-                Cmd::ScheduleTimeout { .. } => Ok(vec![]),
+                Cmd::ScheduleDkgTimeout { .. } => Ok(vec![]),
                 other_cmd => {
                     bail!("Unexpected cmd: {:?}", other_cmd)
                 }

--- a/sn_node/src/node/messages/mod.rs
+++ b/sn_node/src/node/messages/mod.rs
@@ -51,13 +51,13 @@ impl WireMsgUtils for WireMsg {
         let msg_payload =
             WireMsg::serialize_msg_payload(&msg).map_err(|_| Error::InvalidMessage)?;
 
-        let msg_kind = AuthKind::NodeBlsShare(
+        let auth_kind = AuthKind::NodeBlsShare(
             bls_share_authorize(src_section_pk, src_name, key_share, &msg_payload).into_inner(),
         );
 
-        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, msg_kind, dst)?;
+        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth_kind, dst)?;
 
-        #[cfg(test)]
+        #[cfg(feature = "test-utils")]
         let wire_msg = wire_msg.set_payload_debug(msg);
 
         Ok(wire_msg)
@@ -73,13 +73,13 @@ impl WireMsgUtils for WireMsg {
         let msg_payload =
             WireMsg::serialize_msg_payload(&msg).map_err(|_| Error::InvalidMessage)?;
 
-        let msg_kind = AuthKind::Node(
+        let auth_kind = AuthKind::Node(
             NodeAuth::authorize(src_section_pk, &node.keypair, &msg_payload).into_inner(),
         );
 
-        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, msg_kind, dst)?;
+        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth_kind, dst)?;
 
-        #[cfg(test)]
+        #[cfg(feature = "test-utils")]
         let wire_msg = wire_msg.set_payload_debug(msg);
 
         Ok(wire_msg)


### PR DESCRIPTION
- Complete `msg_kind` => `auth_kind` renaming.
- Fix broken `routing_stress` startup.
- Clarify context of `HandleTimeout` and `ScheduleTimeout` by
inserting `Dkg`.
- Tweak `network_split` example.
- Set various things, such as payload debug, under `test-utils` flag.
- Fix comments/logs: the opposite group of `full` adults are
`non-full`, not `empty`.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
