### PR TITLE
chore: fix &Vec -> &[] clippy warning

### DIFF
--- a/sn_client/benches/upload_bytes.rs
+++ b/sn_client/benches/upload_bytes.rs
@@ -47,7 +47,7 @@ fn random_vector(length: usize) -> Vec<u8> {
 }
 
 /// Grows a seed vector into a Bytes with specified length.
-fn grows_vec_to_bytes(seed: &Vec<u8>, length: usize) -> Bytes {
+fn grows_vec_to_bytes(seed: &[u8], length: usize) -> Bytes {
     let mut seed = seed.clone();
     let mut rng = OsRng;
     seed[0] = rng.gen::<u8>();


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
