### PR TITLE
feat: deposit owned dbcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "arrayvec"
@@ -191,9 +191,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc47084705629d09d15060d70a8dbfce479c842303d05929ce29c74c995916ae"
+checksum = "33d590cacd53140ff87cc2e192eb22fc3dc23c5b3f93b0d4f020677f98e8c629"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2efed1c501becea07ce48118786ebcf229531d0d3b28edf224a720020d9e106"
+checksum = "cf4d047478b986f14a13edad31a009e2e05cb241f9805d0d75e4cba4e129ad4d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1785,9 +1785,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -2467,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2656,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -2818,7 +2818,7 @@ checksum = "d7fa2d386df8533b02184941c76ae2e0d0c1d053f5d43339169d80f21275fc5e"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.9",
+ "time 0.3.10",
  "yasna",
 ]
 
@@ -3036,9 +3036,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
 
 [[package]]
 name = "rusty-fork"
@@ -3383,7 +3383,7 @@ dependencies = [
  "sn_dbc",
  "sn_interface",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.10",
  "tiny-keccak",
  "tokio",
  "tracing",
@@ -3788,9 +3788,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3974,9 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "82501a4c1c0330d640a6e176a3d6a204f5ec5237aca029029d21864a902e27b0"
 dependencies = [
  "itoa 1.0.2",
  "libc",
@@ -4150,9 +4150,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -4195,9 +4195,9 @@ checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -4219,7 +4219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.9",
+ "time 0.3.10",
  "tracing-subscriber 0.3.11",
 ]
 
@@ -4498,9 +4498,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -4768,7 +4768,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
 dependencies = [
- "time 0.3.9",
+ "time 0.3.10",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4498,9 +4498,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"

--- a/sn_api/src/app/keys.rs
+++ b/sn_api/src/app/keys.rs
@@ -9,6 +9,7 @@
 use super::Safe;
 use crate::{Error, Result, SafeUrl};
 
+use bls::SecretKey as BlsSecretKey;
 use sn_interface::types::{Keypair, SecretKey};
 
 use hex::encode;
@@ -49,22 +50,24 @@ impl Safe {
         Ok((keypair, url))
     }
 
-    /// Serializes a `Keypair` to a file at a given path.
-    ///
-    /// A utility to help callers working with keypairs avoid using serde or bincode directly.
+    /// Serializes a `SecretKey` to hex in a file at a given path.
     ///
     /// If the path already exists it will be overwritten.
-    pub fn serialize_keypair(&self, keypair: &Keypair, path: impl AsRef<Path>) -> Result<()> {
-        let serialized = sn_interface::types::utils::serialise(&keypair)?;
-        std::fs::write(&path, serialized)?;
+    pub fn serialize_bls_key(
+        &self,
+        secret_key: &BlsSecretKey,
+        path: impl AsRef<Path>,
+    ) -> Result<()> {
+        let hex = secret_key.to_hex();
+        std::fs::write(&path, hex)?;
         Ok(())
     }
 
     /// Deserializes a `Keypair` from file at a given path.
     ///
     /// A utility to help callers working with keypairs avoid using serde or bincode directly.
-    pub fn deserialize_keypair(&self, path: impl AsRef<Path>) -> Result<Keypair> {
-        deserialize_keypair(path)
+    pub fn deserialize_bls_key(&self, path: impl AsRef<Path>) -> Result<BlsSecretKey> {
+        deserialize_bls_key(path)
     }
 }
 
@@ -74,10 +77,9 @@ impl Safe {
 ///
 /// This exists as an independent function in addition to being a function of the safe client
 /// because some deserialization needs to be performed in the CLI before it has access to a client.
-pub fn deserialize_keypair(path: impl AsRef<Path>) -> Result<Keypair> {
-    let deserialized = std::fs::read(path)?;
-    let keypair: Keypair = sn_interface::types::utils::deserialise(&deserialized)?;
-    Ok(keypair)
+pub fn deserialize_bls_key(path: impl AsRef<Path>) -> Result<BlsSecretKey> {
+    let hex = std::fs::read_to_string(path)?;
+    Ok(BlsSecretKey::from_hex(&hex)?)
 }
 
 #[cfg(test)]
@@ -86,6 +88,7 @@ mod tests {
     use sn_interface::types::Keypair;
 
     use assert_fs::prelude::*;
+    use bls::SecretKey as BlsSecretKey;
     use color_eyre::{eyre::eyre, Result};
     use predicates::prelude::*;
     use xor_name::XorName;
@@ -114,14 +117,14 @@ mod tests {
         let tmp_dir = assert_fs::TempDir::new()?;
         let serialized_keypair_file = tmp_dir.child("serialized_keypair");
 
-        let (keypair, _) = safe.new_keypair_with_pk_url()?;
-        let _ = safe.serialize_keypair(&keypair, serialized_keypair_file.path())?;
+        let sk = BlsSecretKey::random();
+        let _ = safe.serialize_bls_key(&sk, serialized_keypair_file.path())?;
 
         serialized_keypair_file.assert(predicate::path::is_file());
 
-        let encoded = std::fs::read(serialized_keypair_file.path())?;
-        let keypair2: Keypair = sn_interface::types::utils::deserialise(&encoded)?;
-        assert_eq!(keypair, keypair2);
+        let sk_hex = std::fs::read_to_string(serialized_keypair_file.path())?;
+        let sk2 = BlsSecretKey::from_hex(&sk_hex)?;
+        assert_eq!(sk, sk2);
         Ok(())
     }
 
@@ -130,11 +133,12 @@ mod tests {
         let safe = Safe::dry_runner(None);
         let tmp_dir = assert_fs::TempDir::new()?;
         let serialized_keypair_file = tmp_dir.child("serialized_keypair");
-        let (keypair, _) = safe.new_keypair_with_pk_url()?;
-        let _ = safe.serialize_keypair(&keypair, serialized_keypair_file.path())?;
 
-        let keypair2 = safe.deserialize_keypair(serialized_keypair_file.path())?;
-        assert_eq!(keypair, keypair2);
+        let sk = BlsSecretKey::random();
+        let _ = safe.serialize_bls_key(&sk, serialized_keypair_file.path())?;
+
+        let sk2 = safe.deserialize_bls_key(serialized_keypair_file.path())?;
+        assert_eq!(sk, sk2);
         Ok(())
     }
 }

--- a/sn_api/src/errors.rs
+++ b/sn_api/src/errors.rs
@@ -12,6 +12,7 @@ use super::{
     safeurl::{Error as UrlError, SafeUrl, XorUrl},
 };
 
+use bls::Error as BlsError;
 use sn_client::Error as ClientError;
 use sn_dbc::Error as DbcError;
 use sn_interface::types::Error as InterfaceError;
@@ -136,4 +137,6 @@ pub enum Error {
     /// NotImplementedError
     #[error("NotImplementedError: {0}")]
     NotImplementedError(String),
+    #[error("BlsError: {0}")]
+    BlsError(#[from] BlsError),
 }

--- a/sn_api/src/errors.rs
+++ b/sn_api/src/errors.rs
@@ -131,9 +131,12 @@ pub enum Error {
     /// DbcReissueError
     #[error("DbcReissueError: {0}")]
     DbcReissueError(String),
-    /// DbcReissueError
+    /// DbcDepositError
     #[error("DbcDepositError: {0}")]
     DbcDepositError(String),
+    /// DbcDepositError
+    #[error("The secret key does not match the public key for this owned DBC")]
+    DbcDepositInvalidSecretKey(),
     /// NotImplementedError
     #[error("NotImplementedError: {0}")]
     NotImplementedError(String),

--- a/sn_api/src/errors.rs
+++ b/sn_api/src/errors.rs
@@ -130,6 +130,9 @@ pub enum Error {
     /// DbcReissueError
     #[error("DbcReissueError: {0}")]
     DbcReissueError(String),
+    /// DbcReissueError
+    #[error("DbcDepositError: {0}")]
+    DbcDepositError(String),
     /// NotImplementedError
     #[error("NotImplementedError: {0}")]
     NotImplementedError(String),

--- a/sn_api/src/errors.rs
+++ b/sn_api/src/errors.rs
@@ -136,7 +136,7 @@ pub enum Error {
     DbcDepositError(String),
     /// DbcDepositError
     #[error("The secret key does not match the public key for this owned DBC")]
-    DbcDepositInvalidSecretKey(),
+    DbcDepositInvalidSecretKey,
     /// NotImplementedError
     #[error("NotImplementedError: {0}")]
     NotImplementedError(String),

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -101,7 +101,7 @@ pub async fn run() -> Result<()> {
             let mut launcher = Box::new(SnLaunchToolNetworkLauncher::default());
             node_commander(cmd, &mut get_config().await?, &mut launcher).await
         }
-        SubCommands::Keys(cmd) => key_commander(cmd, output_fmt, &safe, &get_config().await?).await,
+        SubCommands::Keys(cmd) => key_commander(cmd, output_fmt, &get_config().await?).await,
         SubCommands::Xorurl {
             cmd,
             location,

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -153,7 +153,9 @@ pub async fn run() -> Result<()> {
                 SubCommands::Dog(cmd) => dog_commander(cmd, output_fmt, &safe).await,
                 SubCommands::Files(cmd) => files_commander(cmd, output_fmt, &safe).await,
                 SubCommands::Nrs(cmd) => nrs_commander(cmd, output_fmt, &safe).await,
-                SubCommands::Wallet(cmd) => wallet_commander(cmd, output_fmt, &safe).await,
+                SubCommands::Wallet(cmd) => {
+                    wallet_commander(cmd, output_fmt, &safe, &get_config().await?).await
+                }
                 _ => Err(eyre!("Unknown safe subcommand")),
             }
         }

--- a/sn_cli/src/operations/auth_and_connect.rs
+++ b/sn_cli/src/operations/auth_and_connect.rs
@@ -59,7 +59,7 @@ pub async fn authorise_cli(
 pub async fn connect(safe: &mut Safe, config: &Config, timeout: Duration) -> Result<()> {
     debug!("Connecting...");
 
-    let app_keypair = if let Ok((_, keypair)) = read_credentials(safe, config) {
+    let app_keypair = if let Ok((_, keypair)) = read_credentials(config) {
         keypair
     } else {
         None
@@ -113,9 +113,9 @@ pub fn create_credentials_file(config: &Config) -> Result<(File, PathBuf)> {
     Ok((file, file_path))
 }
 
-pub fn read_credentials(safe: &Safe, config: &Config) -> Result<(PathBuf, Option<Keypair>)> {
+pub fn read_credentials(config: &Config) -> Result<(PathBuf, Option<Keypair>)> {
     let (_, path) = get_credentials_file_path(config)?;
-    let keypair = match safe.deserialize_bls_key(&path) {
+    let keypair = match Safe::deserialize_bls_key(&path) {
         Ok(sk) => Some(Keypair::bls_from_hex(&sk.to_hex())?),
         Err(e) => {
             debug!("Unable to read credentials from {}: {}", path.display(), e);

--- a/sn_cli/src/operations/auth_and_connect.rs
+++ b/sn_cli/src/operations/auth_and_connect.rs
@@ -115,8 +115,8 @@ pub fn create_credentials_file(config: &Config) -> Result<(File, PathBuf)> {
 
 pub fn read_credentials(safe: &Safe, config: &Config) -> Result<(PathBuf, Option<Keypair>)> {
     let (_, path) = get_credentials_file_path(config)?;
-    let keypair = match safe.deserialize_keypair(&path) {
-        Ok(kp) => Some(kp),
+    let keypair = match safe.deserialize_bls_key(&path) {
+        Ok(sk) => Some(Keypair::bls_from_hex(&sk.to_hex())?),
         Err(e) => {
             debug!("Unable to read credentials from {}: {}", path.display(), e);
             None

--- a/sn_cli/src/operations/config.rs
+++ b/sn_cli/src/operations/config.rs
@@ -9,8 +9,7 @@
 use color_eyre::{eyre::bail, eyre::eyre, eyre::WrapErr, Help, Report, Result};
 use comfy_table::Table;
 use serde::{Deserialize, Serialize};
-use sn_api::keys::deserialize_bls_key;
-use sn_api::{NodeConfig, PublicKey};
+use sn_api::{NodeConfig, PublicKey, Safe};
 use sn_dbc::Owner;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -366,7 +365,7 @@ impl Config {
 
     async fn get_dbc_owner(dbc_sk_path: &Path) -> Result<Option<Owner>> {
         if dbc_sk_path.exists() {
-            let sk = deserialize_bls_key(dbc_sk_path)?;
+            let sk = Safe::deserialize_bls_key(dbc_sk_path)?;
             return Ok(Some(Owner::from(sk)));
         }
         Ok(None)
@@ -473,8 +472,7 @@ mod constructor {
         let node_config_file = tmp_dir.child(".safe/node/node_connection_info.config");
         let dbc_owner_sk_file = cli_config_dir.child("credentials");
         let sk = SecretKey::random();
-        let safe = Safe::dry_runner(None);
-        safe.serialize_bls_key(&sk, dbc_owner_sk_file.path())?;
+        Safe::serialize_bls_key(&sk, dbc_owner_sk_file.path())?;
 
         let config = Config::new(
             PathBuf::from(cli_config_file.path()),

--- a/sn_cli/src/subcommands/dog.rs
+++ b/sn_cli/src/subcommands/dog.rs
@@ -120,7 +120,7 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
                     );
                 }
                 SafeData::SafeKey { .. } => {
-                    unimplemented!("The SafeKey data type is not supported at the moment");
+                    println!("The SafeKey data type is not supported at the moment");
                 }
                 SafeData::Multimap {
                     xorurl,

--- a/sn_cli/src/subcommands/dog.rs
+++ b/sn_cli/src/subcommands/dog.rs
@@ -119,16 +119,8 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
                         media_type.clone().unwrap_or_else(|| "Unknown".to_string())
                     );
                 }
-                SafeData::SafeKey {
-                    xorurl,
-                    xorname,
-                    resolved_from,
-                } => {
-                    println!("Resolved from: {}", resolved_from);
-                    println!("= SafeKey =");
-                    println!("XOR-URL: {}", xorurl);
-                    println!("XOR name: 0x{}", xorname_to_hex(xorname));
-                    println!("Native data type: SafeKey");
+                SafeData::SafeKey { .. } => {
+                    unimplemented!("The SafeKey data type is not supported at the moment");
                 }
                 SafeData::Multimap {
                     xorurl,

--- a/sn_cli/src/subcommands/keys.rs
+++ b/sn_cli/src/subcommands/keys.rs
@@ -11,7 +11,7 @@ use crate::operations::auth_and_connect::{get_credentials_file_path, read_creden
 use crate::operations::config::Config;
 use bls::SecretKey;
 use color_eyre::{eyre::WrapErr, Result};
-use sn_api::{resolver::SafeUrl, Keypair, Safe, XorName};
+use sn_api::Safe;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -42,15 +42,15 @@ pub async fn key_commander(
         KeysSubCommands::Show { show_sk } => {
             match read_credentials(safe, config)? {
                 (file_path, Some(keypair)) => {
-                    let xorname = XorName::from(keypair.public_key());
-                    let xorurl = SafeUrl::from_safekey(xorname)?.encode(safe.xorurl_base);
                     let (pk_hex, sk_hex) = keypair.to_hex()?;
-
-                    println!("Current CLI's SafeKey found at {}:", file_path.display());
-                    println!("XOR-URL: {}", xorurl);
-                    println!("Public Key: {}", pk_hex);
-                    if show_sk {
-                        println!("Secret Key: {}", sk_hex);
+                    if output_fmt == OutputFmt::Pretty {
+                        println!("CLI credentials located at {}", file_path.display());
+                        println!("Public Key: {}", pk_hex);
+                        if show_sk {
+                            println!("Secret Key: {}", sk_hex);
+                        }
+                    } else {
+                        println!("{}", serialise_output(&(pk_hex, sk_hex), output_fmt));
                     }
                 }
                 (file_path, None) => println!("No SafeKey found at {}", file_path.display()),

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -120,7 +120,7 @@ pub async fn wallet_commander(
                 sn_dbc::Dbc::from_hex(dbc_hex.trim())?
             };
             let the_name = safe
-                .wallet_deposit(&wallet_url, name.as_deref(), &dbc)
+                .wallet_deposit(&wallet_url, name.as_deref(), &dbc, None)
                 .await?;
 
             if OutputFmt::Pretty == output_fmt {

--- a/sn_cli/tests/cli_cat.rs
+++ b/sn_cli/tests/cli_cat.rs
@@ -12,9 +12,9 @@ use color_eyre::{eyre::eyre, Result};
 use predicates::prelude::*;
 use sn_api::resolver::{ContentType, DataType, SafeUrl};
 use sn_cmd_test_utilities::util::{
-    create_and_get_keys, get_random_nrs_string, parse_files_container_output,
-    parse_files_put_or_sync_output, parse_nrs_register_output, parse_wallet_create_output,
-    safe_cmd, safe_cmd_stderr, safe_cmd_stdout, safeurl_from, test_symlinks_are_valid, upload_path,
+    get_random_nrs_string, parse_files_container_output, parse_files_put_or_sync_output,
+    parse_nrs_register_output, parse_wallet_create_output, safe_cmd, safe_cmd_stderr,
+    safe_cmd_stdout, safeurl_from, test_symlinks_are_valid, upload_path,
     upload_test_symlinks_folder, CLI, DBC_WITH_12_230_000_000,
 };
 use std::path::{Path, PathBuf};
@@ -298,14 +298,6 @@ fn calling_safe_cat_nrsurl_with_immutable_content() -> Result<()> {
         .assert()
         .stdout(predicate::str::contains("exists"));
 
-    Ok(())
-}
-
-#[test]
-fn calling_safe_cat_safekey() -> Result<()> {
-    let (safekey_xorurl, _sk) = create_and_get_keys()?;
-    let cat_output = safe_cmd_stdout(["cat", &safekey_xorurl], Some(0))?;
-    assert_eq!(cat_output, "No content to show since the URL targets a SafeKey. Use the 'dog' command to obtain additional information about the targeted SafeKey.");
     Ok(())
 }
 

--- a/sn_cli/tests/cli_dog.rs
+++ b/sn_cli/tests/cli_dog.rs
@@ -12,8 +12,8 @@ use color_eyre::{eyre::eyre, Result};
 use predicates::prelude::*;
 use sn_api::resolver::{SafeData, SafeUrl};
 use sn_cmd_test_utilities::util::{
-    create_and_get_keys, get_random_nrs_string, parse_files_put_or_sync_output,
-    parse_wallet_create_output, safe_cmd, safe_cmd_stdout, upload_path,
+    get_random_nrs_string, parse_files_put_or_sync_output, parse_wallet_create_output, safe_cmd,
+    safe_cmd_stdout, upload_path,
 };
 use std::path::PathBuf;
 
@@ -112,25 +112,6 @@ fn calling_safe_dog_files_container_nrsurl_yaml() -> Result<()> {
         Ok(())
     } else {
         panic!("Content retrieved was unexpected: {:?}", content);
-    }
-}
-
-#[test]
-fn calling_safe_dog_safekey_nrsurl() -> Result<()> {
-    let (safekey_xorurl, _sk) = create_and_get_keys()?;
-
-    let nrsurl = get_random_nrs_string();
-    safe_cmd(["nrs", "register", &nrsurl, "-l", &safekey_xorurl], Some(0))?;
-    let dog_output = safe_cmd_stdout(["dog", &nrsurl, "--json"], Some(0))?;
-    let (url, mut content): (String, Vec<SafeData>) =
-        serde_json::from_str(&dog_output).expect("Failed to parse output of `safe dog` on file");
-    assert_eq!(url, format!("safe://{}", nrsurl));
-
-    if let Some(SafeData::SafeKey { resolved_from, .. }) = content.pop() {
-        assert_eq!(resolved_from, safekey_xorurl);
-        Ok(())
-    } else {
-        Err(eyre!("Content retrieved was unexpected: {:?}", content))
     }
 }
 

--- a/sn_cli/tests/cli_keys.rs
+++ b/sn_cli/tests/cli_keys.rs
@@ -12,7 +12,7 @@ use sn_cmd_test_utilities::util::{parse_keys_create_output, safe_cmd_stdout};
 #[test]
 fn keys_create_should_output_public_and_secret_key() -> Result<()> {
     let output = safe_cmd_stdout(["keys", "create"], Some(0))?;
-    let lines: Vec<&str> = output.split("\n").collect();
+    let lines: Vec<&str> = output.split('\n').collect();
     let (_, pk_hex) = lines[0]
         .split_once(':')
         .ok_or_else(|| eyre!("the output should contain a public key in hex"))?;
@@ -44,13 +44,13 @@ fn keys_create_with_json_output_should_output_keys_and_url() -> Result<()> {
 #[test]
 fn keys_show_should_output_public_key() -> Result<()> {
     let output = safe_cmd_stdout(["keys", "show"], Some(0))?;
-    let lines: Vec<&str> = output.split("\n").collect();
+    let lines: Vec<&str> = output.split('\n').collect();
     let (_, pk_hex) = lines[1]
         .split_once(':')
         .ok_or_else(|| eyre!("the output should contain a public key in hex"))?;
     let pk_hex = pk_hex.trim();
 
-    match bls::PublicKey::from_hex(&pk_hex) {
+    match bls::PublicKey::from_hex(pk_hex) {
         Ok(_) => Ok(()),
         Err(e) => Err(eyre!(e)),
     }
@@ -59,7 +59,7 @@ fn keys_show_should_output_public_key() -> Result<()> {
 #[test]
 fn keys_show_with_show_sk_should_output_public_and_secret_key() -> Result<()> {
     let output = safe_cmd_stdout(["keys", "show", "--show-sk"], Some(0))?;
-    let lines: Vec<&str> = output.split("\n").collect();
+    let lines: Vec<&str> = output.split('\n').collect();
     let (_, pk_hex) = lines[1]
         .split_once(':')
         .ok_or_else(|| eyre!("the output should contain a public key in hex"))?;
@@ -69,8 +69,8 @@ fn keys_show_with_show_sk_should_output_public_and_secret_key() -> Result<()> {
     let pk_hex = pk_hex.trim();
     let sk_hex = sk_hex.trim();
 
-    let _ = bls::PublicKey::from_hex(&pk_hex)?;
-    let sk = bls::SecretKey::from_hex(&sk_hex)?;
+    let _ = bls::PublicKey::from_hex(pk_hex)?;
+    let sk = bls::SecretKey::from_hex(sk_hex)?;
     assert_eq!(pk_hex, sk.public_key().to_hex());
     Ok(())
 }

--- a/sn_cli/tests/cli_keys.rs
+++ b/sn_cli/tests/cli_keys.rs
@@ -6,106 +6,82 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use assert_cmd::prelude::*;
 use color_eyre::{eyre::eyre, Result};
-use predicates::prelude::*;
-use sn_api::SafeUrl;
-use sn_cmd_test_utilities::util::{parse_keys_create_output, safe_cmd_stdout, CLI, SAFE_PROTOCOL};
-use std::process::Command;
-
-const PRETTY_KEYS_CREATION_RESPONSE: &str = "New SafeKey created:";
+use sn_cmd_test_utilities::util::{parse_keys_create_output, safe_cmd_stdout};
 
 #[test]
-fn calling_safe_keys_create_pretty() -> Result<()> {
-    let mut cmd = Command::cargo_bin(CLI).map_err(|e| eyre!(e.to_string()))?;
-    cmd.args(&vec!["keys", "create"])
-        .assert()
-        .stdout(predicate::str::contains(PRETTY_KEYS_CREATION_RESPONSE))
-        .stdout(predicate::str::contains(SAFE_PROTOCOL).from_utf8())
-        .success();
-    Ok(())
-}
-
-#[test]
-fn keys_create_with_json_should_output_keys_and_url() -> Result<()> {
-    let pk_cmd_result = safe_cmd_stdout(["keys", "create", "--json"], Some(0))?;
-    let (_, (pk_hex, sk_hex)): (SafeUrl, (String, String)) =
-        parse_keys_create_output(&pk_cmd_result)?;
-    // You could write these using `assert!(result.is_ok())` but the problem is you don't get the
-    // failure message, so we do it in this more verbose fashion. We don't actually care what the
-    // parsed values are, just that the outputs from the command get parsed correctly.
-    match bls::PublicKey::from_hex(&pk_hex.trim()) {
-        Ok(_) => {}
-        Err(e) => {
-            return Err(eyre!(e));
-        }
-    }
-    match bls::SecretKey::from_hex(&sk_hex.trim()) {
-        Ok(_) => {}
-        Err(e) => {
-            return Err(eyre!(e));
-        }
-    }
-    Ok(())
-}
-
-#[test]
-fn keys_show_should_output_url_and_public_key() -> Result<()> {
-    let output = safe_cmd_stdout(["keys", "show", "--json"], Some(0))?;
+fn keys_create_should_output_public_and_secret_key() -> Result<()> {
+    let output = safe_cmd_stdout(["keys", "create"], Some(0))?;
     let lines: Vec<&str> = output.split("\n").collect();
-    let (_, url) = lines[1]
-        .split_once(':')
-        .ok_or_else(|| eyre!("the output should contain a URL"))?;
-    let (_, pk_hex) = lines[2]
+    let (_, pk_hex) = lines[0]
         .split_once(':')
         .ok_or_else(|| eyre!("the output should contain a public key in hex"))?;
-
-    match SafeUrl::from_url(url.trim()) {
-        Ok(_) => {}
-        Err(e) => {
-            return Err(eyre!(e));
-        }
-    }
-    match bls::PublicKey::from_hex(&pk_hex.trim()) {
-        Ok(_) => {}
-        Err(e) => {
-            return Err(eyre!(e));
-        }
-    }
-    Ok(())
-}
-
-#[test]
-fn keys_show_should_output_url_public_key_and_secret_key() -> Result<()> {
-    let output = safe_cmd_stdout(["keys", "show", "--show-sk", "--json"], Some(0))?;
-    let lines: Vec<&str> = output.split("\n").collect();
-    let (_, url) = lines[1]
-        .split_once(':')
-        .ok_or_else(|| eyre!("the output should contain a URL"))?;
-    let (_, pk_hex) = lines[2]
-        .split_once(':')
-        .ok_or_else(|| eyre!("the output should contain a public key in hex"))?;
-    let (_, sk_hex) = lines[3]
+    let (_, sk_hex) = lines[1]
         .split_once(':')
         .ok_or_else(|| eyre!("the output should contain a secret key in hex"))?;
+    let pk_hex = pk_hex.trim();
+    let sk_hex = sk_hex.trim();
 
-    match SafeUrl::from_url(url.trim()) {
-        Ok(_) => {}
-        Err(e) => {
-            return Err(eyre!(e));
-        }
+    // Test the key strings are parsable, then make sure they are an actual pair, since it would be
+    // possible for the CLI to print out strings from different pairs.
+    let _ = bls::PublicKey::from_hex(pk_hex)?;
+    let sk = bls::SecretKey::from_hex(sk_hex)?;
+    assert_eq!(pk_hex, sk.public_key().to_hex());
+
+    Ok(())
+}
+
+#[test]
+fn keys_create_with_json_output_should_output_keys_and_url() -> Result<()> {
+    let output = safe_cmd_stdout(["keys", "create", "--json"], Some(0))?;
+    let (pk_hex, sk_hex) = parse_keys_create_output(&output)?;
+    let _ = bls::PublicKey::from_hex(&pk_hex)?;
+    let sk = bls::SecretKey::from_hex(&sk_hex)?;
+    assert_eq!(pk_hex, sk.public_key().to_hex());
+    Ok(())
+}
+
+#[test]
+fn keys_show_should_output_public_key() -> Result<()> {
+    let output = safe_cmd_stdout(["keys", "show"], Some(0))?;
+    let lines: Vec<&str> = output.split("\n").collect();
+    let (_, pk_hex) = lines[1]
+        .split_once(':')
+        .ok_or_else(|| eyre!("the output should contain a public key in hex"))?;
+    let pk_hex = pk_hex.trim();
+
+    match bls::PublicKey::from_hex(&pk_hex) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(eyre!(e)),
     }
-    match bls::PublicKey::from_hex(&pk_hex.trim()) {
-        Ok(_) => {}
-        Err(e) => {
-            return Err(eyre!(e));
-        }
-    }
-    match bls::SecretKey::from_hex(&sk_hex.trim()) {
-        Ok(_) => {}
-        Err(e) => {
-            return Err(eyre!(e));
-        }
-    }
+}
+
+#[test]
+fn keys_show_with_show_sk_should_output_public_and_secret_key() -> Result<()> {
+    let output = safe_cmd_stdout(["keys", "show", "--show-sk"], Some(0))?;
+    let lines: Vec<&str> = output.split("\n").collect();
+    let (_, pk_hex) = lines[1]
+        .split_once(':')
+        .ok_or_else(|| eyre!("the output should contain a public key in hex"))?;
+    let (_, sk_hex) = lines[2]
+        .split_once(':')
+        .ok_or_else(|| eyre!("the output should contain a secret key in hex"))?;
+    let pk_hex = pk_hex.trim();
+    let sk_hex = sk_hex.trim();
+
+    let _ = bls::PublicKey::from_hex(&pk_hex)?;
+    let sk = bls::SecretKey::from_hex(&sk_hex)?;
+    assert_eq!(pk_hex, sk.public_key().to_hex());
+    Ok(())
+}
+
+#[test]
+fn keys_show_with_json_output_should_output_public_and_secret_key() -> Result<()> {
+    let output = safe_cmd_stdout(["keys", "show", "--json"], Some(0))?;
+    let (pk_hex, sk_hex) = parse_keys_create_output(&output)?;
+
+    let _ = bls::PublicKey::from_hex(&pk_hex)?;
+    let sk = bls::SecretKey::from_hex(&sk_hex)?;
+    assert_eq!(pk_hex, sk.public_key().to_hex());
     Ok(())
 }

--- a/sn_cli/tests/cli_keys.rs
+++ b/sn_cli/tests/cli_keys.rs
@@ -50,10 +50,8 @@ fn keys_show_should_output_public_key() -> Result<()> {
         .ok_or_else(|| eyre!("the output should contain a public key in hex"))?;
     let pk_hex = pk_hex.trim();
 
-    match bls::PublicKey::from_hex(pk_hex) {
-        Ok(_) => Ok(()),
-        Err(e) => Err(eyre!(e)),
-    }
+    let _ = bls::PublicKey::from_hex(pk_hex)?;
+    Ok(())
 }
 
 #[test]

--- a/sn_cli/tests/cli_keys.rs
+++ b/sn_cli/tests/cli_keys.rs
@@ -9,7 +9,7 @@
 use assert_cmd::prelude::*;
 use color_eyre::{eyre::eyre, Result};
 use predicates::prelude::*;
-use sn_api::{PublicKey, SafeUrl};
+use sn_api::SafeUrl;
 use sn_cmd_test_utilities::util::{parse_keys_create_output, safe_cmd_stdout, CLI, SAFE_PROTOCOL};
 use std::process::Command;
 
@@ -27,12 +27,85 @@ fn calling_safe_keys_create_pretty() -> Result<()> {
 }
 
 #[test]
-fn calling_safe_keys_create() -> Result<()> {
+fn keys_create_with_json_should_output_keys_and_url() -> Result<()> {
     let pk_cmd_result = safe_cmd_stdout(["keys", "create", "--json"], Some(0))?;
-    let (_, (pk_hex, _)): (SafeUrl, (String, String)) = parse_keys_create_output(&pk_cmd_result)?;
-    let result = PublicKey::bls_from_hex(&pk_hex);
-    // At the moment there is a problem parsing a BLS SecretKey from hex, so for now we'll just
-    // parse the public one.
-    assert!(result.is_ok());
+    let (_, (pk_hex, sk_hex)): (SafeUrl, (String, String)) =
+        parse_keys_create_output(&pk_cmd_result)?;
+    // You could write these using `assert!(result.is_ok())` but the problem is you don't get the
+    // failure message, so we do it in this more verbose fashion. We don't actually care what the
+    // parsed values are, just that the outputs from the command get parsed correctly.
+    match bls::PublicKey::from_hex(&pk_hex.trim()) {
+        Ok(_) => {}
+        Err(e) => {
+            return Err(eyre!(e));
+        }
+    }
+    match bls::SecretKey::from_hex(&sk_hex.trim()) {
+        Ok(_) => {}
+        Err(e) => {
+            return Err(eyre!(e));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn keys_show_should_output_url_and_public_key() -> Result<()> {
+    let output = safe_cmd_stdout(["keys", "show", "--json"], Some(0))?;
+    let lines: Vec<&str> = output.split("\n").collect();
+    let (_, url) = lines[1]
+        .split_once(':')
+        .ok_or_else(|| eyre!("the output should contain a URL"))?;
+    let (_, pk_hex) = lines[2]
+        .split_once(':')
+        .ok_or_else(|| eyre!("the output should contain a public key in hex"))?;
+
+    match SafeUrl::from_url(url.trim()) {
+        Ok(_) => {}
+        Err(e) => {
+            return Err(eyre!(e));
+        }
+    }
+    match bls::PublicKey::from_hex(&pk_hex.trim()) {
+        Ok(_) => {}
+        Err(e) => {
+            return Err(eyre!(e));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn keys_show_should_output_url_public_key_and_secret_key() -> Result<()> {
+    let output = safe_cmd_stdout(["keys", "show", "--show-sk", "--json"], Some(0))?;
+    let lines: Vec<&str> = output.split("\n").collect();
+    let (_, url) = lines[1]
+        .split_once(':')
+        .ok_or_else(|| eyre!("the output should contain a URL"))?;
+    let (_, pk_hex) = lines[2]
+        .split_once(':')
+        .ok_or_else(|| eyre!("the output should contain a public key in hex"))?;
+    let (_, sk_hex) = lines[3]
+        .split_once(':')
+        .ok_or_else(|| eyre!("the output should contain a secret key in hex"))?;
+
+    match SafeUrl::from_url(url.trim()) {
+        Ok(_) => {}
+        Err(e) => {
+            return Err(eyre!(e));
+        }
+    }
+    match bls::PublicKey::from_hex(&pk_hex.trim()) {
+        Ok(_) => {}
+        Err(e) => {
+            return Err(eyre!(e));
+        }
+    }
+    match bls::SecretKey::from_hex(&sk_hex.trim()) {
+        Ok(_) => {}
+        Err(e) => {
+            return Err(eyre!(e));
+        }
+    }
     Ok(())
 }

--- a/sn_cli/tests/cli_wallet.rs
+++ b/sn_cli/tests/cli_wallet.rs
@@ -8,10 +8,11 @@
 
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
-use color_eyre::Result;
+use color_eyre::{eyre::eyre, Result};
 use predicates::prelude::*;
 use sn_cmd_test_utilities::util::{
-    parse_wallet_create_output, safe_cmd, safe_cmd_stdout, DBC_WITH_12_230_000_000,
+    parse_keys_create_output, parse_wallet_create_output, safe_cmd, safe_cmd_stdout,
+    DBC_WITH_12_230_000_000,
 };
 
 #[test]
@@ -25,7 +26,7 @@ fn wallet_create_should_create_a_wallet() -> Result<()> {
 }
 
 #[test]
-fn wallet_deposit_should_deposit_a_dbc() -> Result<()> {
+fn wallet_deposit_should_deposit_a_bearer_dbc() -> Result<()> {
     let json_output = safe_cmd_stdout(["wallet", "create", "--json"], Some(0))?;
     let wallet_xorurl = parse_wallet_create_output(&json_output)?;
 
@@ -176,6 +177,262 @@ fn wallet_deposit_should_fail_with_suggestion_when_path_is_directory() -> Result
     Ok(())
 }
 
+/// Deposit an owned DBC that uses the secret key that's configured for use with the CLI.
+/// Therefore, this test requires the generation of those credentials in advance. We should
+/// probably refactor the CLI test suite so that each test case that requires credentials creates
+/// its own new keypair, but we don't have that infrastructure available at the moment.
+#[test]
+fn wallet_deposit_should_deposit_an_owned_dbc_with_configured_secret_key() -> Result<()> {
+    let keys_show_output = safe_cmd_stdout(["keys", "show", "--json"], Some(0))?;
+    let (pk_hex, _) = parse_keys_create_output(&keys_show_output)?;
+    let wallet_create_output = safe_cmd_stdout(["wallet", "create", "--json"], Some(0))?;
+    let wallet_xorurl = parse_wallet_create_output(&wallet_create_output)?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            DBC_WITH_12_230_000_000,
+            &wallet_xorurl,
+        ],
+        Some(0),
+    )?;
+
+    let reissue_output = safe_cmd_stdout(
+        [
+            "wallet",
+            "reissue",
+            "7.15",
+            "--from",
+            &wallet_xorurl,
+            "--public-key",
+            &pk_hex,
+            "--json",
+        ],
+        Some(0),
+    )?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            &reissue_output,
+            &wallet_xorurl,
+        ],
+        Some(0),
+    )?
+    .assert()
+    .stdout(format!(
+        "Spendable DBC deposited with name '{}' in wallet located at \"{}\"\n",
+        "my-first-dbc", wallet_xorurl
+    ))
+    .success();
+    Ok(())
+}
+
+#[test]
+fn wallet_deposit_should_deposit_an_owned_dbc_with_secret_key_arg() -> Result<()> {
+    let json_output = safe_cmd_stdout(["wallet", "create", "--json"], Some(0))?;
+    let wallet_xorurl = parse_wallet_create_output(&json_output)?;
+    let pk_hex = "8664d6e363117516a6816ad62a0960fdef274c784934e208a7134594888e2454\
+                  f3ed300ba87c1783c79cb671edcf4d95";
+    let sk_hex = "20d58316dc97d533a798dafa08ac46811219e532ee8ba419e9be2ebe7a1e1f24";
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            DBC_WITH_12_230_000_000,
+            &wallet_xorurl,
+        ],
+        Some(0),
+    )?;
+
+    let reissue_output = safe_cmd_stdout(
+        [
+            "wallet",
+            "reissue",
+            "7.15",
+            "--from",
+            &wallet_xorurl,
+            "--public-key",
+            pk_hex,
+            "--json",
+        ],
+        Some(0),
+    )?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            &reissue_output,
+            "--secret-key",
+            sk_hex,
+            &wallet_xorurl,
+        ],
+        Some(0),
+    )?
+    .assert()
+    .stdout(format!(
+        "Spendable DBC deposited with name '{}' in wallet located at \"{}\"\n",
+        "my-first-dbc", wallet_xorurl
+    ))
+    .success();
+    Ok(())
+}
+
+/// This test is a special case that requires the deletion of the credentials file at
+/// ~/.safe/cli/credentials. The scenario is, we are trying to deposit a DBC, but a secret key
+/// hasn't been supplied and there aren't any credentials are available for the CLI to try.
+///
+/// Some of the remaining tests in the CLI test suite require the existence of the generated
+/// credentials, so at the end of this test, we will generate a new set. The best solution would
+/// probably be for each test case that requires credentials to generate its own keypair, but at
+/// the moment we don't have that infrastructure.
+#[test]
+fn wallet_deposit_owned_dbc_with_no_secret_key_or_credentials_should_fail_with_suggestion(
+) -> Result<()> {
+    let pk_hex = bls::SecretKey::random().public_key().to_hex();
+    let wallet_create_output = safe_cmd_stdout(["wallet", "create", "--json"], Some(0))?;
+    let wallet_xorurl = parse_wallet_create_output(&wallet_create_output)?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            DBC_WITH_12_230_000_000,
+            &wallet_xorurl,
+        ],
+        Some(0),
+    )?;
+
+    let reissue_output = safe_cmd_stdout(
+        [
+            "wallet",
+            "reissue",
+            "7.15",
+            "--from",
+            &wallet_xorurl,
+            "--public-key",
+            &pk_hex,
+            "--json",
+        ],
+        Some(0),
+    )?;
+
+    // In a real world scenario, there would have been some long period of time between the reissue
+    // and depositing the DBC. In that period of time, the credentials file would have been
+    // deleted, most likely by accident, but it could have been intentional.
+    let home_path =
+        dirs_next::home_dir().ok_or_else(|| eyre!("Couldn't find user's home directory"))?;
+    std::fs::remove_file(home_path.join(".safe/cli/credentials"))?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            &reissue_output,
+            &wallet_xorurl,
+        ],
+        Some(1),
+    )?
+    .assert()
+    .stderr(predicate::str::contains(
+        "This is an owned DBC. To deposit, it requires a secret key.",
+    ))
+    .stderr(predicate::str::contains(
+        "A secret key was not supplied and there were no credentials configured for use with safe.",
+    ))
+    .stderr(predicate::str::contains(
+        "Please run the command again using the --secret-key argument to specify the key.",
+    ))
+    .failure();
+
+    safe_cmd(["keys", "create", "--for-cli"], Some(0))?;
+    Ok(())
+}
+
+#[test]
+fn wallet_deposit_owned_dbc_with_secret_key_that_does_not_match_should_fail_with_suggestion(
+) -> Result<()> {
+    let sk = bls::SecretKey::random();
+    let sk2 = bls::SecretKey::random();
+    let pk_hex = sk.public_key().to_hex();
+    let wallet_create_output = safe_cmd_stdout(["wallet", "create", "--json"], Some(0))?;
+    let wallet_xorurl = parse_wallet_create_output(&wallet_create_output)?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            DBC_WITH_12_230_000_000,
+            &wallet_xorurl,
+        ],
+        Some(0),
+    )?;
+
+    let reissue_output = safe_cmd_stdout(
+        [
+            "wallet",
+            "reissue",
+            "7.15",
+            "--from",
+            &wallet_xorurl,
+            "--public-key",
+            &pk_hex,
+            "--json",
+        ],
+        Some(0),
+    )?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            &reissue_output,
+            "--secret-key",
+            &sk2.to_hex(),
+            &wallet_xorurl,
+        ],
+        Some(1),
+    )?
+    .assert()
+    .stderr(predicate::str::contains(
+        "The supplied secret key did not match the public key for this DBC.",
+    ))
+    .stderr(predicate::str::contains(
+        "Please run the command again with the correct key for the --secret-key argument.",
+    ))
+    .failure();
+
+    Ok(())
+}
+
 #[test]
 fn wallet_balance_should_report_the_balance_of_a_wallet() -> Result<()> {
     let json_output = safe_cmd_stdout(["wallet", "create", "--json"], Some(0))?;
@@ -279,6 +536,152 @@ fn wallet_reissue_should_reissue_an_owned_dbc_from_a_deposited_dbc() -> Result<(
         pk_hex
     )))
     .success();
+
+    Ok(())
+}
+
+#[test]
+fn wallet_reissue_with_owned_arg_should_reissue_with_configured_public_key() -> Result<()> {
+    let keys_show_output = safe_cmd_stdout(["keys", "show", "--json"], Some(0))?;
+    let (pk_hex, _) = parse_keys_create_output(&keys_show_output)?;
+    let wallet_create_output = safe_cmd_stdout(["wallet", "create", "--json"], Some(0))?;
+    let wallet_xorurl = parse_wallet_create_output(&wallet_create_output)?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            DBC_WITH_12_230_000_000,
+            &wallet_xorurl,
+        ],
+        Some(0),
+    )?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "reissue",
+            "7.15",
+            "--from",
+            &wallet_xorurl,
+            "--owned",
+        ],
+        Some(0),
+    )?
+    .assert()
+    .stdout(predicate::str::contains(
+        "Reissued DBC with 7.15 safecoins.",
+    ))
+    .stdout(predicate::str::contains(format!(
+        "This DBC is owned by public key {}",
+        pk_hex
+    )))
+    .success();
+
+    Ok(())
+}
+
+/// This test is a special case that requires the deletion of the credentials file at
+/// ~/.safe/cli/credentials. The scenario is, we are trying to reissue an owned DBC using the
+/// public key with the credentials configured for the CLI, but there are no credentials at the
+/// point of reissue.
+///
+/// Some of the remaining tests in the CLI test suite require the existence of the generated
+/// credentials, so at the end of this test, we will generate a new set. The best solution would
+/// probably be for each test case that requires credentials to generate its own keypair, but at
+/// the moment we don't have that infrastructure.
+#[test]
+fn wallet_reissue_with_owned_arg_should_fail_if_credentials_are_not_configured() -> Result<()> {
+    let wallet_create_output = safe_cmd_stdout(["wallet", "create", "--json"], Some(0))?;
+    let wallet_xorurl = parse_wallet_create_output(&wallet_create_output)?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            DBC_WITH_12_230_000_000,
+            &wallet_xorurl,
+        ],
+        Some(0),
+    )?;
+
+    // In a real world scenario, there would have been some long period of time between the wallet
+    // being created and the reissue. In that period of time, the credentials file would have been
+    // deleted, most likely by accident, but it could have been intentional.
+    let home_path =
+        dirs_next::home_dir().ok_or_else(|| eyre!("Couldn't find user's home directory"))?;
+    std::fs::remove_file(home_path.join(".safe/cli/credentials"))?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "reissue",
+            "7.15",
+            "--from",
+            &wallet_xorurl,
+            "--owned",
+        ],
+        Some(1),
+    )?
+    .assert()
+    .stderr(predicate::str::contains(
+        "The --owned argument requires credentials to be configured for safe.",
+    ))
+    .stderr(predicate::str::contains(
+        "Run the 'keys create --for-cli' command to generate a credentials then run this command again.",
+    ))
+    .failure();
+
+    safe_cmd(["keys", "create", "--for-cli"], Some(0))?;
+    Ok(())
+}
+
+#[test]
+fn wallet_reissue_with_owned_and_public_key_args_should_fail_with_suggestion() -> Result<()> {
+    let wallet_create_output = safe_cmd_stdout(["wallet", "create", "--json"], Some(0))?;
+    let wallet_xorurl = parse_wallet_create_output(&wallet_create_output)?;
+    let sk = bls::SecretKey::random();
+
+    safe_cmd(
+        [
+            "wallet",
+            "deposit",
+            "--name",
+            "my-first-dbc",
+            "--dbc",
+            DBC_WITH_12_230_000_000,
+            &wallet_xorurl,
+        ],
+        Some(0),
+    )?;
+
+    safe_cmd(
+        [
+            "wallet",
+            "reissue",
+            "7.15",
+            "--from",
+            &wallet_xorurl,
+            "--owned",
+            "--public-key",
+            &sk.public_key().to_hex(),
+        ],
+        Some(1),
+    )?
+    .assert()
+    .stderr(predicate::str::contains(
+        "The --owned and --public-key arguments are mutually exclusive.",
+    ))
+    .stderr(predicate::str::contains(
+        "Please run the command again and use one or the other, but not both, of these arguments.",
+    ))
+    .failure();
 
     Ok(())
 }

--- a/sn_cli/tests/cli_wallet.rs
+++ b/sn_cli/tests/cli_wallet.rs
@@ -220,7 +220,7 @@ fn wallet_deposit_should_deposit_an_owned_dbc_with_configured_secret_key() -> Re
             "wallet",
             "deposit",
             "--name",
-            "my-first-dbc",
+            "reissued-dbc",
             "--dbc",
             &reissue_output,
             &wallet_xorurl,
@@ -230,7 +230,7 @@ fn wallet_deposit_should_deposit_an_owned_dbc_with_configured_secret_key() -> Re
     .assert()
     .stdout(format!(
         "Spendable DBC deposited with name '{}' in wallet located at \"{}\"\n",
-        "my-first-dbc", wallet_xorurl
+        "reissued-dbc", wallet_xorurl
     ))
     .success();
     Ok(())
@@ -276,7 +276,7 @@ fn wallet_deposit_should_deposit_an_owned_dbc_with_secret_key_arg() -> Result<()
             "wallet",
             "deposit",
             "--name",
-            "my-first-dbc",
+            "reissued-dbc",
             "--dbc",
             &reissue_output,
             "--secret-key",
@@ -288,7 +288,7 @@ fn wallet_deposit_should_deposit_an_owned_dbc_with_secret_key_arg() -> Result<()
     .assert()
     .stdout(format!(
         "Spendable DBC deposited with name '{}' in wallet located at \"{}\"\n",
-        "my-first-dbc", wallet_xorurl
+        "reissued-dbc", wallet_xorurl
     ))
     .success();
     Ok(())
@@ -303,6 +303,7 @@ fn wallet_deposit_should_deposit_an_owned_dbc_with_secret_key_arg() -> Result<()
 /// probably be for each test case that requires credentials to generate its own keypair, but at
 /// the moment we don't have that infrastructure.
 #[test]
+#[ignore = "this test is problematic when running in parallel"]
 fn wallet_deposit_owned_dbc_with_no_secret_key_or_credentials_should_fail_with_suggestion(
 ) -> Result<()> {
     let pk_hex = bls::SecretKey::random().public_key().to_hex();
@@ -348,7 +349,7 @@ fn wallet_deposit_owned_dbc_with_no_secret_key_or_credentials_should_fail_with_s
             "wallet",
             "deposit",
             "--name",
-            "my-first-dbc",
+            "reissued-dbc",
             "--dbc",
             &reissue_output,
             &wallet_xorurl,
@@ -412,7 +413,7 @@ fn wallet_deposit_owned_dbc_with_secret_key_that_does_not_match_should_fail_with
             "wallet",
             "deposit",
             "--name",
-            "my-first-dbc",
+            "reissued-dbc",
             "--dbc",
             &reissue_output,
             "--secret-key",
@@ -594,6 +595,7 @@ fn wallet_reissue_with_owned_arg_should_reissue_with_configured_public_key() -> 
 /// probably be for each test case that requires credentials to generate its own keypair, but at
 /// the moment we don't have that infrastructure.
 #[test]
+#[ignore = "this test is problematic when running in parallel"]
 fn wallet_reissue_with_owned_arg_should_fail_if_credentials_are_not_configured() -> Result<()> {
     let wallet_create_output = safe_cmd_stdout(["wallet", "create", "--json"], Some(0))?;
     let wallet_xorurl = parse_wallet_create_output(&wallet_create_output)?;

--- a/sn_cmd_test_utilities/src/lib.rs
+++ b/sn_cmd_test_utilities/src/lib.rs
@@ -101,15 +101,6 @@ pub mod util {
         }
     }
 
-    pub fn create_and_get_keys() -> Result<(String, String)> {
-        let pk_cmd_result = safe_cmd_stdout(["keys", "create", "--json"], Some(0))?;
-
-        let (xorurl, (_pk, sk)): (SafeUrl, (String, String)) =
-            parse_keys_create_output(&pk_cmd_result)?;
-
-        Ok((xorurl.to_string(), sk))
-    }
-
     pub fn create_nrs_link(name: &str, link: &str) -> Result<SafeUrl> {
         let nrs_creation = safe_cmd_stdout(["nrs", "create", name, "-l", link, "--json"], Some(0))?;
         let (_, nrs_map_xorurl, _change_map) = parse_nrs_register_output(&nrs_creation)?;
@@ -341,7 +332,7 @@ pub mod util {
             .map_err(|_| eyre!("Failed to parse output of `safe dog`: {}", output))
     }
 
-    pub fn parse_keys_create_output(output: &str) -> Result<(SafeUrl, (String, String))> {
+    pub fn parse_keys_create_output(output: &str) -> Result<(String, String)> {
         serde_json::from_str(output)
             .map_err(|_| eyre!("Failed to parse output of `safe keys create`: {}", output))
     }

--- a/sn_interface/src/types/errors.rs
+++ b/sn_interface/src/types/errors.rs
@@ -10,6 +10,7 @@ use super::{register::User, RegisterAddress};
 
 use crate::messaging::data::Error as ErrorMsg;
 
+use bls::Error as BlsError;
 use std::{
     collections::BTreeMap,
     fmt::{self, Debug, Formatter},
@@ -124,6 +125,8 @@ pub enum Error {
     UntrustedSectionAuthProvider(String),
     #[error("Proof chain cannot be trusted: {0}")]
     UntrustedProofChain(String),
+    #[error("BlsError: {0}")]
+    BlsError(#[from] BlsError),
 }
 
 pub fn convert_bincode_error(err: bincode::Error) -> Error {

--- a/sn_interface/src/types/keys/keypair.rs
+++ b/sn_interface/src/types/keys/keypair.rs
@@ -328,19 +328,10 @@ mod tests {
     fn to_hex_should_convert_bls_keypair_to_hex() -> Result<()> {
         let keypair = Keypair::new_bls();
         let (pk_hex, sk_hex) = keypair.to_hex()?;
-
-        match bls::PublicKey::from_hex(&pk_hex) {
-            Ok(_) => {}
-            Err(e) => {
-                return Err(Error::Serialisation(e.to_string()));
-            }
-        }
-        match bls::SecretKey::from_hex(&sk_hex) {
-            Ok(_) => {}
-            Err(e) => {
-                return Err(Error::Serialisation(e.to_string()));
-            }
-        }
+        let _ =
+            bls::PublicKey::from_hex(&pk_hex).map_err(|e| Error::Serialisation(e.to_string()))?;
+        let _ =
+            bls::SecretKey::from_hex(&sk_hex).map_err(|e| Error::Serialisation(e.to_string()))?;
         Ok(())
     }
 


### PR DESCRIPTION
- 554c9d688 **chore: upgrade sn_dbc to 3.3.0**

  This version contains an update for converting an owned DBC to a bearer DBC.

- 23802f8e3 **feat!: extend wallet_deposit for owned dbcs**

  BREAKING CHANGE: the `wallet_deposit` function now provides an `Option<bls::SecretKey>` argument for
  providing a secret key when depositing an owned DBC.

  The owned DBC is changed to a bearer by providing the secret key, and the resulting DBC is then
  stored in the wallet. This means you don't need to provide the secret key at reissue time, where
  there is an issue with mapping input DBCs to secret keys.

  A couple of misc changes:
  * Extra test cases were added here to cover assigning the name to the deposit.
  * More instances of "Wallet" were converted to "wallet", because "wallet" is not a proper noun.

  As an unrelated change, this commit also provides more test coverage for `keys show` command. This
  isn't a hugely important command, but I just wanted to ensure we don't break support for BLS keys.

  These are integration tests because you really need to parse the console output, which you can't do
  with unit tests.

  This should probably have been its own commit, but it was accidentally added via an amend, then the
  API changes were also amended on top, so it was too difficult to break out.

- 67006eb2e **feat!: serialize to bls keys in util functions**

  Utility functions were recently added to the API for serializing to the `Keypair` type. This was
  changed to serialize directly to BLS to make it easier for the CLI to deal directly with BLS keys.
  Soon we will be refactoring the `Keypair` type to have a different use case and things like
  `sn_client` would be refactored to directly work with BLS keys. This is a little step in that
  direction.

  There was a utility function added to `sn_interface` to create a `Keypair` from a hex-based BLS key
  because we still need to use the `Keypair` at this point in time.

- f7940c5cd **feat!: remove use of xorurl with keys command**

  The use of BLS keys means the XorUrl that was displayed to the user will no longer be usable, since
  the BLS key is a 48-byte structure, and not 32 bytes like the Dalek key. We will come back and
  address this issue later, possibly re-introducing the `SafeKey` type in some kind of different form.

  The functionality and corresponding test cases for the `cat` and `dog` command that were working
  with the `SafeKey` data type were removed.

  The test cases for the `keys` commands were elaborated here to check the output of both the pretty
  print and the json formats and to make sure the CLI prints out a matching keypair.

- 69079d698 **feat: extend cli wallet deposit for owned dbcs**

  The CLI is now extended to support the deposit of owned DBCs.

  The `deposit` command will check if the supplied DBC is owned, and if it is, it will check to see if
  the `--secret-key` argument is present and use that. If that argument isn't present, it will attempt
  to use the secret key that's configured for use with the CLI, i.e., the `keys create --for-cli`
  command.

  The `reissue` command was also extended to provide an `--owned` flag, which when used, will reissue
  an owned DBC using the public key configured for use with the CLI. This argument is mutually
  exclusive with the `--public-key` argument, which will reissue the DBC using a specified key.

  So we could offer the user a suggestion when a supplied secret key didn't match, this also involved
  making a little extension to the API, to return a specific type of error. We will need to modify
  `sn_dbc` to return a specific error type for this too, so we can avoid checking the string content
  of the error message, but this will be covered on a separate PR.