### PR TITLE
feat(node): generate the genesis DBC when launching first node

### DIFF
--- a/sn_api/src/app/wallet.rs
+++ b/sn_api/src/app/wallet.rs
@@ -53,6 +53,7 @@ impl Safe {
         // TODO: check the input DBCs were spent and all other sort of verifications,
         // perhaps all optional, and we may want a separate API to also do these verifications
         // for the user to perform them without depositing the DBC into a wallet.
+
         let dbc_to_deposit = if dbc.is_bearer() {
             if secret_key.is_some() {
                 return Err(Error::DbcDepositError(

--- a/sn_node/src/node/api/tests/mod.rs
+++ b/sn_node/src/node/api/tests/mod.rs
@@ -1120,7 +1120,7 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
         let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
 
         let genesis_sk_set = bls::SecretKeySet::random(0, &mut rand::thread_rng());
-        let node = Node::first_node(
+        let (node, _) = Node::first_node(
             comm.socket_addr(),
             info.keypair.clone(),
             event_sender,

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -771,7 +771,7 @@ mod tests {
             assert_eq!(genesis_pk, *chain.root_key());
 
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
-            let mut node = Node::first_node(
+            let (mut node, _) = Node::first_node(
                 create_comm().await?.socket_addr(),
                 info.keypair.clone(),
                 event_channel::new(1).0,

--- a/sn_node/src/node/core/mod.rs
+++ b/sn_node/src/node/core/mod.rs
@@ -73,6 +73,12 @@ use tokio::sync::RwLock;
 use uluru::LRUCache;
 use xor_name::{Prefix, XorName};
 
+/// Amount of tokens to be owned by the Genesis DBC.
+/// At the inception of the Network a total supply of 4,525,524,120 whole tokens will be created.
+/// Each whole token can be subdivided 10^9 times,
+/// thus creating a total of 4,525,524,120,000,000,000 available units.
+pub const GENESIS_DBC_AMOUNT: u64 = 4_525_524_120 * u64::pow(10, 9);
+
 pub(super) const RESOURCE_PROOF_DATA_SIZE: usize = 128;
 pub(super) const RESOURCE_PROOF_DIFFICULTY: u8 = 10;
 

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -191,6 +191,9 @@ pub enum Error {
     /// Spentbook error
     #[error("Spentbook Error: {0}")]
     SpentbookError(String),
+    /// Error occurred when minting the Genesis DBC.
+    #[error("Genesis DBC error:: {0}")]
+    GenesisDbcError(String),
 }
 
 impl From<qp2p::ClientEndpointError> for Error {

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -32,7 +32,7 @@ pub use self::{
         NodeApi,
     },
     cfg::config_handler::Config,
-    core::DataStorage,
+    core::{DataStorage, GENESIS_DBC_AMOUNT},
     error::{Error, Result},
     test_utils::*,
 };


### PR DESCRIPTION
This is a follow up PR (5th PR) to PR https://github.com/maidsafe/safe_network/pull/1235, PR https://github.com/maidsafe/safe_network/pull/1097, PR https://github.com/maidsafe/safe_network/pull/1105, and PR https://github.com/maidsafe/safe_network/pull/1143.

The Genesis DBC is generated and owned by the genesis PK of the network's section chain, i.e. the very first section key in the chain. 
The first node mints the genesis DBC (as a bearer DBC) and stores it in a file named `genesis_dbc`, located at it's configured root dir, e.g. when using the `sn_launch_tool` the genesis DBC will be stored at `~/.safe/node/local-test-network/sn-node-genesis/genesis_dbc`.

In this implementation the amount owned by the Genesis DBC is set to `4,525,524,120,000,000,000` individual units.
As per current state of discussions (still in progress), at the inception of the Safe network a total supply of 4,525,524,120 whole tokens will be created, each whole token can be subdivided 10^9 times, thus creating a total of 4,525,524,120,000,000,000 available units.

E.g. the following CLI commands deposit the generated genesis DBC into a wallet on Safe, and check its total balance:
```
$ safe wallet create
Wallet created at: "safe://hyryynyizz7zfcmeyeu3ety9mp549nh5r1z7ro9t1ebjib9drcmk15d59fyb6o"

$ safe wallet balance safe://hyryynyizz7zfcmeyeu3ety9mp549nh5r1z7ro9t1ebjib9drcmk15d59fyb6o
Wallet at "safe://hyryynyizz7zfcmeyeu3ety9mp549nh5r1z7ro9t1ebjib9drcmk15d59fyb6o" has a total balance of 0.000000000 safecoins

$ safe wallet deposit safe://hyryynyizz7zfcmeyeu3ety9mp549nh5r1z7ro9t1ebjib9drcmk15d59fyb6o --name genesis --dbc ~/.safe/node/local-test-network/sn-node-genesis/genesis_dbc
Spendable DBC deposited with name 'genesis' in wallet located at "safe://hyryynyizz7zfcmeyeu3ety9mp549nh5r1z7ro9t1ebjib9drcmk15d59fyb6o"

$ safe wallet balance safe://hyryynyizz7zfcmeyeu3ety9mp549nh5r1z7ro9t1ebjib9drcmk15d59fyb6o
Wallet at "safe://hyryynyizz7zfcmeyeu3ety9mp549nh5r1z7ro9t1ebjib9drcmk15d59fyb6o" has a total balance of 4525524120.000000000 safecoins
```