### PR TITLE
chore(misc): remove unused asyncs (clippy)

### DIFF
--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -101,7 +101,7 @@ pub async fn run() -> Result<()> {
             let mut launcher = Box::new(SnLaunchToolNetworkLauncher::default());
             node_commander(cmd, &mut get_config().await?, &mut launcher).await
         }
-        SubCommands::Keys(cmd) => key_commander(cmd, output_fmt, &get_config().await?).await,
+        SubCommands::Keys(cmd) => key_commander(cmd, output_fmt, &get_config().await?),
         SubCommands::Xorurl {
             cmd,
             location,
@@ -109,7 +109,7 @@ pub async fn run() -> Result<()> {
             follow_links,
         } => {
             if let Some(cmd) = cmd {
-                xorurl_commander(cmd, output_fmt, safe.xorurl_base).await
+                xorurl_commander(cmd, output_fmt, safe.xorurl_base)
             } else {
                 xorurl_of_files(
                     location,

--- a/sn_cli/src/subcommands/files_get.rs
+++ b/sn_cli/src/subcommands/files_get.rs
@@ -523,8 +523,7 @@ async fn files_map_get_files(
                 Path::new(&denormalize_slashes(details.getattr("symlink_target")?)),
                 &abspath,
                 details.getattr("symlink_target_type")?,
-            )
-            .await?;
+            )?;
             continue;
         }
 
@@ -553,7 +552,7 @@ async fn files_map_get_files(
 }
 
 #[cfg(unix)]
-async fn create_symlink_worker(
+fn create_symlink_worker(
     target: &Path,
     link: &Path,
     _target_type: &str,
@@ -571,7 +570,7 @@ async fn create_symlink_worker(
 }
 
 #[cfg(windows)]
-async fn create_symlink_worker(
+fn create_symlink_worker(
     target: &Path,
     link: &Path,
     target_type: &str,
@@ -590,14 +589,14 @@ async fn create_symlink_worker(
     )
 }
 
-async fn create_symlink(target: &Path, link: &Path, target_type: &str) -> ApiResult<()> {
+fn create_symlink(target: &Path, link: &Path, target_type: &str) -> ApiResult<()> {
     info!(
         "creating symlink: {} --> {}",
         link.display(),
         target.display()
     );
 
-    let result = create_symlink_worker(target, link, target_type).await;
+    let result = create_symlink_worker(target, link, target_type);
     match result {
         Ok(_) => {}
         Err((msg, os_err)) => {

--- a/sn_cli/src/subcommands/keys.rs
+++ b/sn_cli/src/subcommands/keys.rs
@@ -32,11 +32,7 @@ pub enum KeysSubCommands {
     },
 }
 
-pub async fn key_commander(
-    cmd: KeysSubCommands,
-    output_fmt: OutputFmt,
-    config: &Config,
-) -> Result<()> {
+pub fn key_commander(cmd: KeysSubCommands, output_fmt: OutputFmt, config: &Config) -> Result<()> {
     match cmd {
         KeysSubCommands::Show { show_sk } => {
             match read_credentials(config)? {
@@ -110,8 +106,7 @@ mod create_command {
             KeysSubCommands::Create { for_cli: false },
             OutputFmt::Pretty,
             &config,
-        )
-        .await;
+        );
 
         assert!(result.is_ok());
         credentials_file.assert(predicate::path::missing());
@@ -134,8 +129,7 @@ mod create_command {
             KeysSubCommands::Create { for_cli: true },
             OutputFmt::Pretty,
             &config,
-        )
-        .await;
+        );
 
         assert!(result.is_ok());
         credentials_file.assert(predicate::path::is_file());

--- a/sn_cli/src/subcommands/xorurl.rs
+++ b/sn_cli/src/subcommands/xorurl.rs
@@ -30,7 +30,7 @@ pub enum XorurlSubCommands {
     },
 }
 
-pub async fn xorurl_commander(
+pub fn xorurl_commander(
     cmd: XorurlSubCommands,
     output_fmt: OutputFmt,
     xorurl_base: XorUrlBase,

--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -369,8 +369,7 @@ mod tests {
         init_logger();
         let dbc_owner = get_dbc_owner_from_secret_key_hex(
             "81ebce8339cb2a6e5cbf8b748215ba928acff7f92557b3acfb09a5b25e920d20",
-        )
-        .await?;
+        )?;
 
         let client = create_test_client_with(None, Some(dbc_owner.clone()), None, true).await?;
         assert_eq!(dbc_owner, client.dbc_owner());

--- a/sn_client/src/utils/test_utils/test_client.rs
+++ b/sn_client/src/utils/test_utils/test_client.rs
@@ -62,7 +62,7 @@ pub async fn create_test_client_with(
 /// then be used as the basis for an `Owner`.
 ///
 /// The conversion method was copied from the `mint-repl` example in `sn_dbc`.
-pub async fn get_dbc_owner_from_secret_key_hex(secret_key_hex: &str) -> Result<Owner> {
+pub fn get_dbc_owner_from_secret_key_hex(secret_key_hex: &str) -> Result<Owner> {
     let mut decoded_bytes = hex::decode(secret_key_hex).map_err(|e| eyre!(e))?;
     decoded_bytes.reverse(); // convert from big endian to little endian
     let sk: SecretKey = bincode::deserialize(&decoded_bytes).map_err(|e| eyre!(e))?;

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -51,7 +51,7 @@ impl Dispatcher {
                 Ok(vec![])
             }
             Cmd::SignOutgoingSystemMsg { msg, dst } => {
-                let src_section_pk = self.node.network_knowledge().section_key().await;
+                let src_section_pk = self.node.network_knowledge().section_key();
                 let wire_msg =
                     WireMsg::single_src(&self.node.info().await, dst, msg, src_section_pk)?;
 
@@ -154,12 +154,7 @@ impl Dispatcher {
                     .await?,
             ]),
             Cmd::TestConnectivity(name) => {
-                if let Some(member_info) = self
-                    .node
-                    .network_knowledge()
-                    .get_section_member(&name)
-                    .await
-                {
+                if let Some(member_info) = self.node.network_knowledge().get_section_member(&name) {
                     if self
                         .node
                         .comm

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -119,7 +119,7 @@ impl FlowCtrl {
 
                 // Send a probe message if we are an elder
                 let node = &self.node;
-                if node.is_elder().await && !node.network_knowledge().prefix().await.is_empty() {
+                if node.is_elder().await && !node.network_knowledge().prefix().is_empty() {
                     match node.generate_probe_msg().await {
                         Ok(cmd) => {
                             info!("Sending probe msg");
@@ -145,7 +145,7 @@ impl FlowCtrl {
 
                 // Send a probe message to an elder
                 let node = &self.node;
-                if !node.network_knowledge().prefix().await.is_empty() {
+                if !node.network_knowledge().prefix().is_empty() {
                     match node.generate_section_probe_msg().await {
                         Ok(cmd) => {
                             info!("Sending section probe msg");
@@ -230,7 +230,7 @@ impl FlowCtrl {
                         node.pending_data_to_replicate_to_peers.remove(&address)
                     {
                         // get info for the WireMsg
-                        let src_section_pk = node.network_knowledge().section_key().await;
+                        let src_section_pk = node.network_knowledge().section_key();
                         let our_info = node.info().await;
 
                         let mut recipients = vec![];
@@ -354,11 +354,11 @@ impl FlowCtrl {
                 let _ = interval.tick().await;
 
                 let node = &self.node;
-                let our_info = node.info.read().await;
+                let our_info = node.info().await;
                 let our_name = our_info.name();
 
-                let members = node.network_knowledge().section_members().await;
-                let section_pk = node.network_knowledge().section_key().await;
+                let members = node.network_knowledge().section_members();
+                let section_pk = node.network_knowledge().section_key();
 
                 if let Some(load_report) = node.comm.tolerated_msgs_per_s().await {
                     trace!("New BackPressure report to disseminate: {:?}", load_report);

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -175,10 +175,10 @@ impl NodeApi {
             let network_knowledge = node.network_knowledge();
 
             let elders = Elders {
-                prefix: network_knowledge.prefix().await,
-                key: network_knowledge.section_key().await,
+                prefix: network_knowledge.prefix(),
+                key: network_knowledge.section_key(),
                 remaining: BTreeSet::new(),
-                added: network_knowledge.authority_provider().await.names(),
+                added: network_knowledge.authority_provider().names(),
                 removed: BTreeSet::new(),
             };
 
@@ -303,7 +303,7 @@ impl NodeApi {
 
     /// Prefix of our section
     pub async fn our_prefix(&self) -> Prefix {
-        self.node.network_knowledge().prefix().await
+        self.node.network_knowledge().prefix()
     }
 
     /// Returns whether the node is Elder.
@@ -313,12 +313,12 @@ impl NodeApi {
 
     /// Returns the information of all the current section elders.
     pub async fn our_elders(&self) -> Vec<Peer> {
-        self.node.network_knowledge().elders().await
+        self.node.network_knowledge().elders()
     }
 
     /// Returns the information of all the current section adults.
     pub async fn our_adults(&self) -> Vec<Peer> {
-        self.node.network_knowledge().adults().await
+        self.node.network_knowledge().adults()
     }
 
     /// Returns the info about the section matching the name.

--- a/sn_node/src/node/api/tests/mod.rs
+++ b/sn_node/src/node/api/tests/mod.rs
@@ -697,7 +697,6 @@ async fn handle_agreement_on_offline_of_non_elder() -> Result<()> {
             assert!(!node
                 .network_knowledge()
                 .section_members()
-                .await
                 .contains(&node_state));
             Result::<()>::Ok(())
         })
@@ -727,7 +726,6 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
 
             let remove_node_state = section
                 .get_section_member(&remove_peer.name())
-                .await
                 .expect("member not found")
                 .leave()?;
 
@@ -1118,7 +1116,7 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
         )
         .await?;
         let info = node.info().await;
-        let section_pk = node.network_knowledge().section_key().await;
+        let section_pk = node.network_knowledge().section_key();
         let dispatcher = Dispatcher::new(Arc::new(node));
 
         let dst_location = match dst {

--- a/sn_node/src/node/core/api.rs
+++ b/sn_node/src/node/core/api.rs
@@ -79,9 +79,7 @@ impl Node {
 
     /// Is this node an elder?
     pub(crate) async fn is_elder(&self) -> bool {
-        self.network_knowledge
-            .is_elder(&self.info().await.name())
-            .await
+        self.network_knowledge.is_elder(&self.info().await.name())
     }
 
     pub(crate) async fn is_not_elder(&self) -> bool {
@@ -111,7 +109,7 @@ impl Node {
     /// Returns our key share in the current BLS group if this node is a member of one, or
     /// `Error::MissingSecretKeyShare` otherwise.
     pub(crate) async fn key_share(&self) -> Result<SectionKeyShare> {
-        let section_key = self.network_knowledge.section_key().await;
+        let section_key = self.network_knowledge.section_key();
         self.section_keys_provider
             .key_share(&section_key)
             .await
@@ -130,7 +128,7 @@ impl Node {
         self.dkg_voter.handle_timeout(
             &self.info().await,
             token,
-            self.network_knowledge().section_key().await,
+            self.network_knowledge().section_key(),
         )
     }
 
@@ -141,8 +139,7 @@ impl Node {
             dst_location,
             &self.info().await.name(),
             &self.network_knowledge,
-        )
-        .await?;
+        )?;
 
         let target_name = dst_location.name();
 
@@ -151,7 +148,7 @@ impl Node {
         if self.is_elder().await
             && targets.len() > 1
             && dst_location.is_to_node()
-            && self.network_knowledge.prefix().await.matches(&target_name)
+            && self.network_knowledge.prefix().matches(&target_name)
         {
             // This actually means being an elder, but we don't know the member yet. Which most likely
             // happens during the join process that a node's name is changed.

--- a/sn_node/src/node/core/bootstrap/join.rs
+++ b/sn_node/src/node/core/bootstrap/join.rs
@@ -636,8 +636,8 @@ mod tests {
         // Drive both tasks to completion concurrently (but on the same thread).
         let ((node, section), _) = future::try_join(bootstrap, others).await?;
 
-        assert_eq!(section.authority_provider().await, section_auth);
-        assert_eq!(section.section_key().await, section_key);
+        assert_eq!(section.authority_provider(), section_auth);
+        assert_eq!(section.section_key(), section_key);
         assert_eq!(node.age(), node_age);
 
         Ok(())

--- a/sn_node/src/node/core/connectivity.rs
+++ b/sn_node/src/node/core/connectivity.rs
@@ -16,7 +16,7 @@ use xor_name::XorName;
 
 impl Node {
     pub(crate) async fn handle_peer_lost(&self, addr: &SocketAddr) -> Result<Vec<Cmd>> {
-        let name = if let Some(peer) = self.network_knowledge.find_member_by_addr(addr).await {
+        let name = if let Some(peer) = self.network_knowledge.find_member_by_addr(addr) {
             debug!("Lost known peer {}", peer);
             peer.name()
         } else {
@@ -43,14 +43,13 @@ impl Node {
         let elders: Vec<_> = self
             .network_knowledge
             .authority_provider()
-            .await
             .elders()
             .filter(|peer| !names.contains(&peer.name()))
             .cloned()
             .collect();
         let mut result: Vec<Cmd> = Vec::new();
         for name in names.iter() {
-            if let Some(info) = self.network_knowledge.get_section_member(name).await {
+            if let Some(info) = self.network_knowledge.get_section_member(name) {
                 let info = info.leave()?;
                 if let Ok(cmds) = self
                     .send_proposal(elders.clone(), Proposal::Offline(info))

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -85,8 +85,7 @@ impl Node {
         );
 
         if targets.is_empty() {
-            let error =
-                convert_to_error_msg(Error::NoAdults(self.network_knowledge().prefix().await));
+            let error = convert_to_error_msg(Error::NoAdults(self.network_knowledge().prefix()));
 
             debug!("No targets found for {msg_id:?}");
             return self
@@ -207,7 +206,7 @@ impl Node {
     /// List is sorted by distance from `target`.
     async fn get_adults_holding_data_including_full(&self, target: &XorName) -> BTreeSet<XorName> {
         let full_adults = self.full_adults().await;
-        let adults = self.network_knowledge().adults().await;
+        let adults = self.network_knowledge().adults();
 
         let adults_names = adults.iter().map(|p2p_node| p2p_node.name());
 
@@ -251,7 +250,7 @@ impl Node {
     async fn get_adults_who_should_store_data(&self, target: XorName) -> BTreeSet<XorName> {
         let full_adults = self.full_adults().await;
         // TODO: reuse our_adults_sorted_by_distance_to API when core is merged into upper layer
-        let adults = self.network_knowledge().adults().await;
+        let adults = self.network_knowledge().adults();
 
         trace!("Total adults known about: {:?}", adults.len());
 
@@ -284,7 +283,7 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         // we create a dummy/random dst location,
         // we will set it correctly for each msg and target
-        let section_pk = self.network_knowledge().section_key().await;
+        let section_pk = self.network_knowledge().section_key();
         let our_name = self.info().await.name();
         let dummy_dst_location = DstLocation::Node {
             name: our_name,

--- a/sn_node/src/node/core/messaging/handling/agreement.rs
+++ b/sn_node/src/node/core/messaging/handling/agreement.rs
@@ -59,7 +59,6 @@ impl Node {
         if let Some(old_info) = self
             .network_knowledge
             .is_either_member_or_archived(&new_info.name())
-            .await
         {
             // This node is rejoin with same name.
             if old_info.state() != MembershipState::Left {
@@ -113,7 +112,7 @@ impl Node {
         self.log_section_stats().await;
 
         // Do not disable node joins in first section.
-        let our_prefix = self.network_knowledge.prefix().await;
+        let our_prefix = self.network_knowledge.prefix();
         if !our_prefix.is_empty() {
             // ..otherwise, switch off joins_allowed on a node joining.
             // TODO: fix racing issues here? https://github.com/maidsafe/safe_network/issues/890
@@ -172,10 +171,10 @@ impl Node {
         generation: Generation,
     ) -> Result<Vec<Cmd>> {
         // check if section matches our prefix
-        let equal_prefix = section_auth.prefix() == self.network_knowledge.prefix().await;
+        let equal_prefix = section_auth.prefix() == self.network_knowledge.prefix();
         let is_extension_prefix = section_auth
             .prefix()
-            .is_extension_of(&self.network_knowledge.prefix().await);
+            .is_extension_of(&self.network_knowledge.prefix());
         if !equal_prefix && !is_extension_prefix {
             // Other section. We shouln't be receiving or updating a SAP for
             // a remote section here, that is done with a AE msg response.
@@ -226,7 +225,7 @@ impl Node {
             .write()
             .await
             .process(
-                &self.network_knowledge.prefix().await,
+                &self.network_knowledge.prefix(),
                 signed_section_auth.clone(),
                 sig.clone(),
                 generation,

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -209,7 +209,7 @@ impl Node {
             sig: section_signed.clone(),
         };
         let our_name = self.info().await.name();
-        let our_section_prefix = self.network_knowledge.prefix().await;
+        let our_section_prefix = self.network_knowledge.prefix();
         let equal_prefix = section_auth.prefix() == our_section_prefix;
         let is_extension_prefix = section_auth.prefix().is_extension_of(&our_section_prefix);
         let our_peer_info = self.info().await.peer();
@@ -304,10 +304,10 @@ impl Node {
     ) -> Result<Option<Cmd>> {
         // Check if the message has reached the correct section,
         // if not, we'll need to respond with AE
-        let our_prefix = self.network_knowledge.prefix().await;
+        let our_prefix = self.network_knowledge.prefix();
 
         // Let's try to find a section closer to the destination, if it's not for us.
-        if !self.network_knowledge.prefix().await.matches(&dst_name) {
+        if !self.network_knowledge.prefix().matches(&dst_name) {
             debug!(
                 "AE: prefix not matching. We are: {:?}, they sent to: {:?}",
                 our_prefix, dst_name
@@ -328,10 +328,10 @@ impl Node {
                         bounced_msg,
                     };
                     let wire_msg = WireMsg::single_src(
-                        &self.info().await.clone(),
+                        &self.info().await,
                         src_location.to_dst(),
                         ae_msg,
-                        self.network_knowledge.section_key().await,
+                        self.network_knowledge.section_key(),
                     )?;
                     trace!("{}", LogMarker::AeSendRedirect);
 
@@ -356,14 +356,14 @@ impl Node {
             }
         }
 
-        let section_key = self.network_knowledge.section_key().await;
+        let section_key = self.network_knowledge.section_key();
         trace!(
             "Performing AE checks, provided pk was: {:?} ours is: {:?}",
             dst_section_key,
             section_key
         );
 
-        if dst_section_key == &self.network_knowledge.section_key().await {
+        if dst_section_key == &self.network_knowledge.section_key() {
             // Destination section key matches our current section key
             return Ok(None);
         }
@@ -376,10 +376,7 @@ impl Node {
             Ok(proof_chain) => {
                 info!("Anti-Entropy: sender's ({}) knowledge of our SAP is outdated, bounce msg for AE-Retry with up to date SAP info.", sender);
 
-                let signed_sap = self
-                    .network_knowledge
-                    .section_signed_authority_provider()
-                    .await;
+                let signed_sap = self.network_knowledge.section_signed_authority_provider();
 
                 trace!(
                     "Sending AE-Retry with: proofchain last key: {:?} and  section key: {:?}",
@@ -404,10 +401,7 @@ impl Node {
 
                 let proof_chain = self.network_knowledge.section_chain().await;
 
-                let signed_sap = self
-                    .network_knowledge
-                    .section_signed_authority_provider()
-                    .await;
+                let signed_sap = self.network_knowledge.section_signed_authority_provider();
 
                 trace!("{}", LogMarker::AeSendRetryDstPkFail);
 
@@ -421,10 +415,10 @@ impl Node {
         };
 
         let wire_msg = WireMsg::single_src(
-            &self.info().await.clone(),
+            &self.info().await,
             src_location.to_dst(),
             ae_msg,
-            self.network_knowledge.section_key().await,
+            self.network_knowledge.section_key(),
         )?;
 
         Ok(Some(Cmd::SendMsg {
@@ -440,10 +434,7 @@ impl Node {
         src_location: &SrcLocation,
         original_wire_msg: &WireMsg,
     ) -> Result<Cmd> {
-        let signed_sap = self
-            .network_knowledge
-            .section_signed_authority_provider()
-            .await;
+        let signed_sap = self.network_knowledge.section_signed_authority_provider();
 
         let ae_msg = SystemMsg::AntiEntropyRedirect {
             section_auth: signed_sap.value.to_msg(),
@@ -453,10 +444,10 @@ impl Node {
         };
 
         let wire_msg = WireMsg::single_src(
-            &self.info().await.clone(),
+            &self.info().await,
             src_location.to_dst(),
             ae_msg,
-            self.network_knowledge.section_key().await,
+            self.network_knowledge.section_key(),
         )?;
 
         trace!("{} in ae_redirect", LogMarker::AeSendRedirect);
@@ -507,14 +498,12 @@ mod tests {
         local
             .run_until(async move {
                 let env = Env::new().await?;
-                let our_prefix = env.node.network_knowledge().prefix().await;
-                let (msg, src_location) = env.create_msg(
-                    &our_prefix,
-                    env.node.network_knowledge().section_key().await,
-                )?;
+                let our_prefix = env.node.network_knowledge().prefix();
+                let (msg, src_location) =
+                    env.create_msg(&our_prefix, env.node.network_knowledge().section_key())?;
                 let sender = env.node.info().await.peer();
                 let dst_name = our_prefix.substituted_in(xor_name::rand::random());
-                let dst_section_key = env.node.network_knowledge().section_key().await;
+                let dst_section_key = env.node.network_knowledge().section_key();
 
                 let cmd = env
                     .node
@@ -617,7 +606,7 @@ mod tests {
 
             assert_matches!(msg_type, MsgType::System{ msg, .. } => {
                 assert_matches!(msg, SystemMsg::AntiEntropyRedirect { section_auth, .. } => {
-                    assert_eq!(section_auth, env.node.network_knowledge().authority_provider().await.to_msg());
+                    assert_eq!(section_auth, env.node.network_knowledge().authority_provider().to_msg());
                 });
             });
 
@@ -673,11 +662,11 @@ mod tests {
 
 
             let env = Env::new().await?;
-            let our_prefix = env.node.network_knowledge().prefix().await;
+            let our_prefix = env.node.network_knowledge().prefix();
 
             let (msg, src_location) = env.create_msg(
                 &our_prefix,
-                env.node.network_knowledge().section_key().await,
+                env.node.network_knowledge().section_key(),
             )?;
             let sender = env.node.info().await.peer();
             let dst_name = our_prefix.substituted_in(xor_name::rand::random());
@@ -702,7 +691,7 @@ mod tests {
 
             assert_matches!(msg_type, MsgType::System{ msg, .. } => {
                 assert_matches!(msg, SystemMsg::AntiEntropyRetry { ref section_auth, ref proof_chain, .. } => {
-                    assert_eq!(section_auth, &env.node.network_knowledge().authority_provider().await.to_msg());
+                    assert_eq!(section_auth, &env.node.network_knowledge().authority_provider().to_msg());
                     assert_eq!(proof_chain, &env.node.section_chain().await);
                 });
             });
@@ -719,11 +708,11 @@ mod tests {
         local.run_until(async move {
 
        let env = Env::new().await?;
-       let our_prefix = env.node.network_knowledge().prefix().await;
+       let our_prefix = env.node.network_knowledge().prefix();
 
        let (msg, src_location) = env.create_msg(
            &our_prefix,
-           env.node.network_knowledge().section_key().await,
+           env.node.network_knowledge().section_key(),
        )?;
        let sender = env.node.info().await.peer();
        let dst_name = our_prefix.substituted_in(xor_name::rand::random());
@@ -750,7 +739,7 @@ mod tests {
 
        assert_matches!(msg_type, MsgType::System{ msg, .. } => {
            assert_matches!(msg, SystemMsg::AntiEntropyRetry { ref section_auth, ref proof_chain, .. } => {
-               assert_eq!(*section_auth, env.node.network_knowledge().authority_provider().await.to_msg());
+               assert_eq!(*section_auth, env.node.network_knowledge().authority_provider().to_msg());
                assert_eq!(*proof_chain, env.node.section_chain().await);
            });
        });

--- a/sn_node/src/node/core/messaging/handling/handover.rs
+++ b/sn_node/src/node/core/messaging/handling/handover.rs
@@ -166,7 +166,7 @@ impl Node {
     }
 
     async fn check_sap_candidate_prefix(&self, sap_candidate: &SapCandidate) -> Result<()> {
-        let section_prefix = self.network_knowledge.prefix().await;
+        let section_prefix = self.network_knowledge.prefix();
         match sap_candidate {
             SapCandidate::ElderHandover(single_sap) => {
                 // single handover, must be same prefix
@@ -284,9 +284,9 @@ impl Node {
                 Err(Error::RequestHandoverAntiEntropy(gen)) => {
                     // We hit an error while processing this vote, perhaps we are missing information.
                     // We'll send a handover AE request to see if they can help us catch up.
-                    let sap = self.network_knowledge.authority_provider().await;
+                    let sap = self.network_knowledge.authority_provider();
                     let dst_section_pk = sap.section_key();
-                    let section_name = self.network_knowledge.prefix().await.name();
+                    let section_name = self.network_knowledge.prefix().name();
                     let msg = SystemMsg::HandoverAE(gen);
                     let cmd = self
                         .send_direct_msg_to_nodes(vec![peer], msg, section_name, dst_section_pk)
@@ -326,7 +326,7 @@ impl Node {
                         self.send_direct_msg(
                             peer,
                             SystemMsg::HandoverVotes(catchup_votes),
-                            self.network_knowledge.section_key().await,
+                            self.network_knowledge.section_key(),
                         )
                         .await?,
                     ]

--- a/sn_node/src/node/core/messaging/handling/join.rs
+++ b/sn_node/src/node/core/messaging/handling/join.rs
@@ -55,7 +55,7 @@ impl Node {
             return self.propose_membership_change(node_state).await;
         }
 
-        let our_section_key = self.network_knowledge.section_key().await;
+        let our_section_key = self.network_knowledge.section_key();
         let section_key_matches = join_request.section_key == our_section_key;
 
         // Ignore `JoinRequest` if we are not elder, unless the join request
@@ -70,7 +70,7 @@ impl Node {
             return Ok(vec![]);
         }
 
-        let our_prefix = self.network_knowledge.prefix().await;
+        let our_prefix = self.network_knowledge.prefix();
         if !our_prefix.matches(&peer.name()) {
             debug!("Redirecting JoinRequest from {peer} - name doesn't match our prefix {our_prefix:?}.");
 
@@ -134,10 +134,7 @@ impl Node {
             }
 
             let proof_chain = self.network_knowledge.section_chain().await;
-            let signed_sap = self
-                .network_knowledge
-                .section_signed_authority_provider()
-                .await;
+            let signed_sap = self.network_knowledge.section_signed_authority_provider();
 
             let node_msg = SystemMsg::JoinResponse(Box::new(JoinResponse::Retry {
                 section_auth: signed_sap.value.to_msg(),
@@ -176,12 +173,12 @@ impl Node {
         // During the first section, nodes shall use ranged age to avoid too many nodes getting
         // relocated at the same time. After the first section splits, nodes shall only
         // start with an age of MIN_ADULT_AGE
-        let current_section_size = self.network_knowledge.section_size().await;
-        let our_prefix = self.network_knowledge.prefix().await;
+        let current_section_size = self.network_knowledge.section_size();
+        let our_prefix = self.network_knowledge.prefix();
 
         // Prefix will be empty for first section
         if our_prefix.is_empty() {
-            let elders = self.network_knowledge.elders().await;
+            let elders = self.network_knowledge.elders();
             // Forces the joining node to be younger than the youngest elder in genesis section
             // avoiding unnecessary churn.
 
@@ -215,9 +212,9 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         debug!("Received JoinAsRelocatedRequest {join_request:?} from {peer}",);
 
-        let our_prefix = self.network_knowledge.prefix().await;
+        let our_prefix = self.network_knowledge.prefix();
         if !our_prefix.matches(&peer.name())
-            || join_request.section_key != self.network_knowledge.section_key().await
+            || join_request.section_key != self.network_knowledge.section_key()
         {
             debug!(
                 "JoinAsRelocatedRequest from {peer} - name doesn't match our prefix {our_prefix:?}."
@@ -225,14 +222,14 @@ impl Node {
 
             let node_msg =
                 SystemMsg::JoinAsRelocatedResponse(Box::new(JoinAsRelocatedResponse::Retry(
-                    self.network_knowledge.authority_provider().await.to_msg(),
+                    self.network_knowledge.authority_provider().to_msg(),
                 )));
 
             trace!("{} b", LogMarker::SendJoinAsRelocatedResponse);
 
             trace!("Sending {node_msg:?} to {peer}");
             return Ok(vec![
-                self.send_direct_msg(peer, node_msg, self.network_knowledge.section_key().await)
+                self.send_direct_msg(peer, node_msg, self.network_knowledge.section_key())
                     .await?,
             ]);
         }
@@ -273,7 +270,7 @@ impl Node {
 
             trace!("Sending {:?} to {}", node_msg, peer);
             return Ok(vec![
-                self.send_direct_msg(peer, node_msg, self.network_knowledge.section_key().await)
+                self.send_direct_msg(peer, node_msg, self.network_knowledge.section_key())
                     .await?,
             ]);
         };

--- a/sn_node/src/node/core/messaging/handling/left.rs
+++ b/sn_node/src/node/core/messaging/handling/left.rs
@@ -73,9 +73,9 @@ impl Node {
             .await?;
         if result.is_empty() {
             // Send AE-Update to Adults of our section
-            let our_adults = self.network_knowledge.adults().await;
-            let our_prefix = self.network_knowledge.prefix().await;
-            let our_section_pk = self.network_knowledge.section_key().await;
+            let our_adults = self.network_knowledge.adults();
+            let our_prefix = self.network_knowledge.prefix();
+            let our_section_pk = self.network_knowledge.section_key();
             cmds.extend(
                 self.send_ae_update_to_nodes(our_adults, &our_prefix, our_section_pk)
                     .await,
@@ -87,7 +87,6 @@ impl Node {
         self.liveness_retain_only(
             self.network_knowledge
                 .adults()
-                .await
                 .iter()
                 .map(|peer| peer.name())
                 .collect(),

--- a/sn_node/src/node/core/messaging/handling/membership.rs
+++ b/sn_node/src/node/core/messaging/handling/membership.rs
@@ -30,7 +30,7 @@ impl Node {
             "Proposing membership change: {} - {:?}",
             node_state.name, node_state.state
         );
-        let prefix = self.network_knowledge.prefix().await;
+        let prefix = self.network_knowledge.prefix();
         if let Some(membership) = self.membership.write().await.as_mut() {
             let membership_vote = match membership.propose(node_state, &prefix) {
                 Ok(vote) => vote,
@@ -78,7 +78,7 @@ impl Node {
             "{:?} {signed_votes:?} from {peer}",
             LogMarker::MembershipVotesBeingHandled
         );
-        let prefix = self.network_knowledge.prefix().await;
+        let prefix = self.network_knowledge.prefix();
 
         let mut cmds = vec![];
 
@@ -100,7 +100,7 @@ impl Node {
                         debug!("Membership - We are behind the voter, requesting AE");
                         // We hit an error while processing this vote, perhaps we are missing information.
                         // We'll send a membership AE request to see if they can help us catch up.
-                        let sap = self.network_knowledge.authority_provider().await;
+                        let sap = self.network_knowledge.authority_provider();
                         let dst_section_pk = sap.section_key();
                         let section_name = prefix.name();
                         let msg = SystemMsg::MembershipAE(membership.generation());
@@ -177,7 +177,7 @@ impl Node {
                         self.send_direct_msg(
                             peer,
                             SystemMsg::MembershipVotes(catchup_votes),
-                            self.network_knowledge.section_key().await,
+                            self.network_knowledge.section_key(),
                         )
                         .await?,
                     ]

--- a/sn_node/src/node/core/messaging/handling/mod.rs
+++ b/sn_node/src/node/core/messaging/handling/mod.rs
@@ -144,7 +144,7 @@ impl Node {
                                     .await?
                                 {
                                     // we want to log issues with an elder who is out of sync here...
-                                    let knowledge = self.network_knowledge.elders().await;
+                                    let knowledge = self.network_knowledge.elders();
                                     let mut known_elders = knowledge.iter().map(|peer| peer.name());
 
                                     if known_elders.contains(&sender.name()) {
@@ -495,7 +495,7 @@ impl Node {
             SystemMsg::JoinAsRelocatedRequest(join_request) => {
                 trace!("Handling msg: JoinAsRelocatedRequest from {}", sender);
                 if self.is_not_elder().await
-                    && join_request.section_key == self.network_knowledge.section_key().await
+                    && join_request.section_key == self.network_knowledge.section_key()
                 {
                     return Ok(vec![]);
                 }
@@ -592,7 +592,7 @@ impl Node {
                     sender,
                     message,
                     session_id,
-                    self.network_knowledge.section_key().await,
+                    self.network_knowledge.section_key(),
                 )
                 .await
             }
@@ -653,7 +653,7 @@ impl Node {
                 } else {
                     let mut cmds = vec![];
 
-                    let section_pk = PublicKey::Bls(self.network_knowledge.section_key().await);
+                    let section_pk = PublicKey::Bls(self.network_knowledge.section_key());
                     let own_keypair = Keypair::Ed25519(self.keypair.read().await.clone());
 
                     for data in data_collection {
@@ -772,7 +772,7 @@ impl Node {
                         message_cache,
                         message,
                     };
-                    let section_pk = self.network_knowledge.section_key().await;
+                    let section_pk = self.network_knowledge.section_key();
                     let wire_msg = WireMsg::single_src(
                         &self.info().await,
                         DstLocation::Node {
@@ -803,7 +803,7 @@ impl Node {
                 let payload =
                     WireMsg::serialize_msg_payload(&SystemMsg::DkgStart(session_id.clone()))?;
                 let auth = section_auth.clone().into_inner();
-                if self.network_knowledge.section_key().await == auth.sig.public_key {
+                if self.network_knowledge.section_key() == auth.sig.public_key {
                     if let Err(err) = AuthorityProof::verify(auth, payload) {
                         error!("Error verifying signature for DkgSessionInfo: {:?}", err);
                         return Ok(cmds);
@@ -853,7 +853,7 @@ impl Node {
 
             let dst = DstLocation::Section {
                 name: node_xorname,
-                section_pk: self.network_knowledge.section_key().await,
+                section_pk: self.network_knowledge.section_key(),
             };
 
             cmds.push(Cmd::SignOutgoingSystemMsg { msg, dst });

--- a/sn_node/src/node/core/messaging/handling/proposals.rs
+++ b/sn_node/src/node/core/messaging/handling/proposals.rs
@@ -33,10 +33,10 @@ pub(crate) async fn handle_proposal(
         let section_auth = sap;
         // TODO: do we want to drop older generations too?
 
-        if section_auth.prefix() == network_knowledge.prefix().await
+        if section_auth.prefix() == network_knowledge.prefix()
             || section_auth
                 .prefix()
-                .is_extension_of(&network_knowledge.prefix().await)
+                .is_extension_of(&network_knowledge.prefix())
         {
             // This `SectionInfo` is proposed by the DKG participants and
             // it's signed by the new key created by the DKG so we don't
@@ -53,7 +53,7 @@ pub(crate) async fn handle_proposal(
     } else {
         // Proposal from other section shall be ignored.
         // TODO: check this is for our prefix , or a child prefix, otherwise just drop it
-        if !network_knowledge.prefix().await.matches(&sender.name()) {
+        if !network_knowledge.prefix().matches(&sender.name()) {
             trace!(
                 "Ignore proposal {:?} from other section, src {}: {:?}",
                 proposal,
@@ -65,7 +65,7 @@ pub(crate) async fn handle_proposal(
 
         // Let's now verify the section key in the msg authority is trusted
         // based on our current knowledge of the network and sections chains.
-        if !network_knowledge.has_chain_key(sig_share_pk).await {
+        if !network_knowledge.has_chain_key(sig_share_pk) {
             warn!(
                 "Dropped Propose msg ({:?}) with untrusted sig share from {}: {:?}",
                 msg_id, sender, proposal

--- a/sn_node/src/node/core/messaging/handling/relocation.rs
+++ b/sn_node/src/node/core/messaging/handling/relocation.rs
@@ -35,24 +35,18 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         // Do not carry out relocations in the first section
         // TODO: consider avoiding relocations in first 16 sections instead.
-        if self.network_knowledge.prefix().await.is_empty() {
+        if self.network_knowledge.prefix().is_empty() {
             return Ok(vec![]);
         }
 
         // Do not carry out relocation when there is not enough elder nodes.
-        if self
-            .network_knowledge
-            .authority_provider()
-            .await
-            .elder_count()
-            < elder_count()
-        {
+        if self.network_knowledge.authority_provider().elder_count() < elder_count() {
             return Ok(vec![]);
         }
 
         let mut cmds = vec![];
         for (node_state, relocate_details) in
-            find_nodes_to_relocate(&self.network_knowledge, &churn_id, excluded).await
+            find_nodes_to_relocate(&self.network_knowledge, &churn_id, excluded)
         {
             debug!(
                 "Relocating {:?} to {} (on churn of {})",
@@ -143,10 +137,7 @@ impl Node {
         {
             sap.addresses()
         } else {
-            self.network_knowledge
-                .authority_provider()
-                .await
-                .addresses()
+            self.network_knowledge.authority_provider().addresses()
         };
         let (joining_as_relocated, cmd) = JoiningAsRelocated::start(
             node,

--- a/sn_node/src/node/core/messaging/handling/resource_proof.rs
+++ b/sn_node/src/node/core/messaging/handling/resource_proof.rs
@@ -60,7 +60,7 @@ impl Node {
         }));
 
         trace!("{}", LogMarker::SendResourceProofChallenge);
-        self.send_direct_msg(peer, response, self.network_knowledge.section_key().await)
+        self.send_direct_msg(peer, response, self.network_knowledge.section_key())
             .await
     }
 }

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -57,7 +57,7 @@ impl Node {
         };
 
         // Setup node authority on this response and send this back to our elders
-        let section_pk = self.network_knowledge().section_key().await;
+        let section_pk = self.network_knowledge().section_key();
         let dst = DstLocation::Node {
             name: requesting_elder,
             section_pk,
@@ -205,7 +205,7 @@ impl Node {
         if data_copy_count() > cmds.len() {
             error!("InsufficientAdults for storing data reliably");
             let error = CmdError::Data(ErrorMsg::InsufficientAdults {
-                prefix: self.network_knowledge().prefix().await,
+                prefix: self.network_knowledge().prefix(),
                 expected: data_copy_count() as u8,
                 found: cmds.len() as u8,
             });
@@ -252,7 +252,7 @@ impl Node {
         // 1- perform all validations on the key image and tx received
         // 2- if everything is ok then sign the spent proof
 
-        let sap = self.network_knowledge.authority_provider().await;
+        let sap = self.network_knowledge.authority_provider();
         let current_section_key = sap.section_key();
         let spentbook_pks = sap.public_key_set();
 

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -41,7 +41,7 @@ impl Node {
             return Ok(vec![]);
         }
 
-        let adults = self.network_knowledge.adults().await;
+        let adults = self.network_knowledge.adults();
         let adults_names = adults.iter().map(|p2p_node| p2p_node.name());
 
         let mut data_for_sender = vec![];
@@ -90,10 +90,10 @@ impl Node {
         let data_i_have = self.data_storage.keys().await?;
         let mut cmds = vec![];
 
-        let adults = self.network_knowledge.adults().await;
+        let adults = self.network_knowledge.adults();
         let adults_names = adults.iter().map(|p2p_node| p2p_node.name()).collect_vec();
 
-        let elders = self.network_knowledge.elders().await;
+        let elders = self.network_knowledge.elders();
         let my_name = self.info().await.name();
 
         // find data targets that are not us.
@@ -115,7 +115,7 @@ impl Node {
             let _existed = target_member_names.insert(elder.name());
         }
 
-        let section_pk = self.network_knowledge.section_key().await;
+        let section_pk = self.network_knowledge.section_key();
 
         for name in target_member_names {
             trace!("Sending our data list to: {:?}", name);

--- a/sn_node/src/node/core/messaging/sending/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/sending/anti_entropy.rs
@@ -27,7 +27,6 @@ impl Node {
         let nodes: Vec<_> = self
             .network_knowledge
             .section_members()
-            .await
             .into_iter()
             .filter(|info| info.name() != our_name)
             .map(|info| *info.peer())
@@ -41,7 +40,7 @@ impl Node {
         // The previous PK which is likely what adults know
         let previous_pk = *self.section_chain().await.prev_key();
 
-        let our_prefix = self.network_knowledge.prefix().await;
+        let our_prefix = self.network_knowledge.prefix();
 
         self.send_ae_update_to_nodes(nodes, &our_prefix, previous_pk)
             .await
@@ -62,7 +61,7 @@ impl Node {
             }
         };
 
-        let our_section_key = self.network_knowledge.section_key().await;
+        let our_section_key = self.network_knowledge.section_key();
         match self
             .send_direct_msg_to_nodes(recipients.clone(), node_msg, prefix.name(), our_section_key)
             .await
@@ -115,7 +114,7 @@ impl Node {
         our_prev_state: &StateSnapshot,
     ) -> Result<Vec<Cmd>> {
         debug!("{}", LogMarker::AeSendUpdateToSiblings);
-        let sibling_prefix = self.network_knowledge.prefix().await.sibling();
+        let sibling_prefix = self.network_knowledge.prefix().sibling();
         if let Some(sibling_sap) = self
             .network_knowledge
             .prefix_map()
@@ -165,10 +164,7 @@ impl Node {
     // Private helper to generate AntiEntropyUpdate message to update
     // a peer abot our SAP, with proof_chain and members list.
     async fn generate_ae_update_msg(&self, dst_section_key: BlsPublicKey) -> Result<SystemMsg> {
-        let signed_sap = self
-            .network_knowledge
-            .section_signed_authority_provider()
-            .await;
+        let signed_sap = self.network_knowledge.section_signed_authority_provider();
 
         let proof_chain = if let Ok(chain) = self
             .network_knowledge
@@ -184,7 +180,6 @@ impl Node {
         let members = self
             .network_knowledge
             .section_signed_members()
-            .await
             .iter()
             .map(|state| state.clone().into_authed_msg())
             .collect();

--- a/sn_node/src/node/core/messaging/sending/approval.rs
+++ b/sn_node/src/node/core/messaging/sending/approval.rs
@@ -18,7 +18,7 @@ impl Node {
     // Send `NodeApproval` to a joining node which makes it a section member
     pub(crate) async fn send_node_approval(&self, node_state: SectionAuth<NodeState>) -> Vec<Cmd> {
         let peer = *node_state.peer();
-        let prefix = self.network_knowledge.prefix().await;
+        let prefix = self.network_knowledge.prefix();
         info!("Our section with {:?} has approved peer {}.", prefix, peer,);
 
         let node_msg = SystemMsg::JoinResponse(Box::new(JoinResponse::Approval {
@@ -26,13 +26,12 @@ impl Node {
             section_auth: self
                 .network_knowledge
                 .section_signed_authority_provider()
-                .await
                 .into_authed_msg(),
             node_state: node_state.into_authed_msg(),
             section_chain: self.network_knowledge.section_chain().await,
         }));
 
-        let dst_section_pk = self.network_knowledge.section_key().await;
+        let dst_section_pk = self.network_knowledge.section_key();
         trace!("{}", LogMarker::SendNodeApproval);
         match self.send_direct_msg(peer, node_msg, dst_section_pk).await {
             Ok(cmd) => vec![cmd],

--- a/sn_node/src/node/core/messaging/sending/dkg_start.rs
+++ b/sn_node/src/node/core/messaging/sending/dkg_start.rs
@@ -34,7 +34,7 @@ impl Node {
 
         let prefix = session_id.prefix;
         let node_msg = SystemMsg::DkgStart(session_id);
-        let section_pk = self.network_knowledge.section_key().await;
+        let section_pk = self.network_knowledge.section_key();
         self.send_msg_for_dst_accumulation(
             prefix.name(),
             DstLocation::Section {
@@ -54,7 +54,7 @@ impl Node {
         node_msg: SystemMsg,
         recipients: Vec<Peer>,
     ) -> Result<Vec<Cmd>> {
-        let section_key = self.network_knowledge.section_key().await;
+        let section_key = self.network_knowledge.section_key();
 
         let key_share = self
             .section_keys_provider

--- a/sn_node/src/node/core/messaging/sending/proposal.rs
+++ b/sn_node/src/node/core/messaging/sending/proposal.rs
@@ -22,11 +22,7 @@ use sn_interface::{
 impl Node {
     /// Send proposal to all our elders.
     pub(crate) async fn propose(&self, proposal: Proposal) -> Result<Vec<Cmd>> {
-        let elders = self
-            .network_knowledge
-            .authority_provider()
-            .await
-            .elders_vec();
+        let elders = self.network_knowledge.authority_provider().elders_vec();
         self.send_proposal(elders, proposal).await
     }
 
@@ -36,7 +32,7 @@ impl Node {
         recipients: Vec<Peer>,
         proposal: Proposal,
     ) -> Result<Vec<Cmd>> {
-        let section_key = self.network_knowledge.section_key().await;
+        let section_key = self.network_knowledge.section_key();
 
         let key_share = self
             .section_keys_provider
@@ -82,11 +78,11 @@ impl Node {
 
         // Name of the section_pk may not matches the section prefix.
         // Carry out a substitution to prevent the dst_location becomes other section.
-        let section_key = self.network_knowledge.section_key().await;
+        let section_key = self.network_knowledge.section_key();
         let wire_msg = WireMsg::single_src(
             &self.info().await,
             DstLocation::Section {
-                name: self.network_knowledge.prefix().await.name(),
+                name: self.network_knowledge.prefix().name(),
                 section_pk: section_key,
             },
             node_msg,

--- a/sn_node/src/node/core/messaging/sending/system.rs
+++ b/sn_node/src/node/core/messaging/sending/system.rs
@@ -43,7 +43,7 @@ impl Node {
     ) -> Result<Cmd> {
         trace!("{}", LogMarker::SendDirectToNodes);
         let our_node = self.info().await;
-        let our_section_key = self.network_knowledge.section_key().await;
+        let our_section_key = self.network_knowledge.section_key();
 
         let wire_msg = WireMsg::single_src(
             &our_node,
@@ -68,13 +68,13 @@ impl Node {
         node_state: SectionAuth<NodeState>,
     ) -> Result<Cmd> {
         let node_msg = SystemMsg::Relocate(node_state.into_authed_msg());
-        let section_pk = self.network_knowledge.section_key().await;
+        let section_pk = self.network_knowledge.section_key();
         self.send_direct_msg(recipient, node_msg, section_pk).await
     }
 
     /// Send a direct (`SystemMsg`) message to all Elders in our section
     pub(crate) async fn send_msg_to_our_elders(&self, node_msg: SystemMsg) -> Result<Cmd> {
-        let sap = self.network_knowledge.authority_provider().await;
+        let sap = self.network_knowledge.authority_provider();
         let dst_section_pk = sap.section_key();
         let section_name = sap.prefix().name();
         let elders = sap.elders_vec();
@@ -122,7 +122,7 @@ impl Node {
         }
 
         if handle {
-            wire_msg.set_dst_section_pk(self.network_knowledge.section_key().await);
+            wire_msg.set_dst_section_pk(self.network_knowledge.section_key());
             wire_msg.set_dst_xorname(our_name);
 
             cmds.push(Cmd::HandleMsg {

--- a/sn_node/src/node/core/relocation.rs
+++ b/sn_node/src/node/core/relocation.rs
@@ -37,7 +37,7 @@ impl Display for ChurnId {
 }
 
 /// Find all nodes to relocate after a churn event and generate the relocation details for them.
-pub(super) async fn find_nodes_to_relocate(
+pub(super) fn find_nodes_to_relocate(
     network_knowledge: &NetworkKnowledge,
     churn_id: &ChurnId,
     excluded: BTreeSet<XorName>,
@@ -45,7 +45,7 @@ pub(super) async fn find_nodes_to_relocate(
     // Find the peers that pass the relocation check and take only the oldest ones to avoid
     // relocating too many nodes at the same time.
     // Capped by criteria that cannot relocate too many node at once.
-    let joined_nodes = network_knowledge.section_members().await;
+    let joined_nodes = network_knowledge.section_members();
 
     if joined_nodes.len() < recommended_section_size() {
         return vec![];
@@ -251,11 +251,8 @@ mod tests {
                 .to_vec(),
         );
 
-        let relocations = futures::executor::block_on(find_nodes_to_relocate(
-            &network_knowledge,
-            &churn_id,
-            BTreeSet::default(),
-        ));
+        let relocations =
+            find_nodes_to_relocate(&network_knowledge, &churn_id, BTreeSet::default());
 
         let relocations: Vec<_> = relocations
             .into_iter()

--- a/sn_node/src/node/logging/log_ctx.rs
+++ b/sn_node/src/node/logging/log_ctx.rs
@@ -21,6 +21,6 @@ impl LogCtx {
     }
 
     pub(crate) async fn prefix(&self) -> Prefix {
-        self.node.network_knowledge().prefix().await
+        self.node.network_knowledge().prefix()
     }
 }


### PR DESCRIPTION
Upon removing async keywords from
sn_interface/src/network_knowledge/mod.rs a lot of removal propagated up
and removed most of it with help of Clippy. Clippy does not yet detect
unnecessary async in methods
(https://github.com/rust-lang/rust-clippy/issues/9024), but will soon.

With the help of a new Clippy lint:
cargo clippy --all-targets --all-features -- -W clippy::unused_async
And automatically fixing code with:
cargo fix --broken-code --allow-dirty --all-targets --all-features

Results mostly from the single thread work of @joshuef in #1253 (and
ongoing efforts).

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
