### PR TITLE
refactor(move-comm-out-of-node): remove NodeInfo in Node struct

### DIFF
--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -53,7 +53,7 @@ impl Dispatcher {
             Cmd::SignOutgoingSystemMsg { msg, dst } => {
                 let src_section_pk = self.node.network_knowledge().section_key().await;
                 let wire_msg =
-                    WireMsg::single_src(&*self.node.info.read().await, dst, msg, src_section_pk)?;
+                    WireMsg::single_src(&self.node.info().await, dst, msg, src_section_pk)?;
 
                 let mut cmds = vec![];
                 cmds.extend(self.node.send_msg_to_nodes(wire_msg).await?);

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -231,7 +231,7 @@ impl FlowCtrl {
                     {
                         // get info for the WireMsg
                         let src_section_pk = node.network_knowledge().section_key().await;
-                        let our_info = &*node.info.read().await;
+                        let our_info = node.info().await;
 
                         let mut recipients = vec![];
 
@@ -258,7 +258,7 @@ impl FlowCtrl {
                         let system_msg =
                             SystemMsg::NodeCmd(NodeCmd::ReplicateData(vec![data_to_send]));
                         let wire_msg =
-                            WireMsg::single_src(our_info, dst, system_msg, src_section_pk)?;
+                            WireMsg::single_src(&our_info, dst, system_msg, src_section_pk)?;
 
                         debug!(
                             "{:?} to: {:?} w/ {:?} ",
@@ -425,7 +425,7 @@ async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Rece
 
                 let span = {
                     let node = &ctrl.node;
-                    trace_span!("handle_message", name = %node.info.read().await.name(), ?sender, msg_id = ?wire_msg.msg_id())
+                    trace_span!("handle_message", name = %node.info().await.name(), ?sender, msg_id = ?wire_msg.msg_id())
                 };
                 let _span_guard = span.enter();
 

--- a/sn_node/src/node/api/tests/mod.rs
+++ b/sn_node/src/node/api/tests/mod.rs
@@ -85,7 +85,7 @@ async fn receive_join_request_without_resource_proof_response() -> Result<()> {
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let node = Node::new(
                 create_comm().await?,
-                node,
+                node.keypair.clone(),
                 section,
                 Some(section_key_share),
                 event_channel::new(TEST_EVENT_CHANNEL_SIZE).0,
@@ -170,7 +170,7 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let node = Node::new(
                 create_comm().await?,
-                node,
+                node.keypair.clone(),
                 section,
                 Some(section_key_share),
                 event_channel::new(TEST_EVENT_CHANNEL_SIZE).0,
@@ -188,7 +188,7 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
 
             let nonce: [u8; 32] = rand::random();
             let serialized = bincode::serialize(&(new_node.name(), nonce))?;
-            let nonce_signature = ed25519::sign(&serialized, &node.info.read().await.keypair);
+            let nonce_signature = ed25519::sign(&serialized, &node.info().await.keypair);
 
             let rp = ResourceProof::new(RESOURCE_PROOF_DATA_SIZE, RESOURCE_PROOF_DIFFICULTY);
             let data = rp.create_proof_data(&nonce);
@@ -262,7 +262,7 @@ async fn membership_churn_starts_on_join_request_from_relocated_node() -> Result
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let node = Node::new(
                 create_comm().await?,
-                node,
+                node.keypair.clone(),
                 section,
                 Some(section_key_share),
                 event_channel::new(TEST_EVENT_CHANNEL_SIZE).0,
@@ -349,7 +349,7 @@ async fn handle_agreement_on_online() -> Result<()> {
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let node = Node::new(
                 create_comm().await?,
-                node,
+                node.keypair.clone(),
                 section,
                 Some(section_key_share),
                 event_sender,
@@ -424,7 +424,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let node = Node::new(
                 create_comm().await?,
-                node,
+                node.keypair.clone(),
                 section,
                 Some(section_key_share),
                 event_channel::new(TEST_EVENT_CHANNEL_SIZE).0,
@@ -599,7 +599,7 @@ async fn handle_agreement_on_online_of_rejoined_node(phase: NetworkPhase, age: u
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let node = Node::new(
                 create_comm().await?,
-                info,
+                info.keypair.clone(),
                 section,
                 Some(section_key_share),
                 event_sender,
@@ -675,7 +675,7 @@ async fn handle_agreement_on_offline_of_non_elder() -> Result<()> {
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let node = Node::new(
                 create_comm().await?,
-                node,
+                node.keypair.clone(),
                 section,
                 Some(section_key_share),
                 event_sender,
@@ -737,7 +737,7 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
             let node = nodes.remove(0);
             let node = Node::new(
                 create_comm().await?,
-                node,
+                node.keypair.clone(),
                 section,
                 Some(section_key_share),
                 event_sender,
@@ -812,7 +812,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let node = Node::new(
                 create_comm().await?,
-                node,
+                node.keypair.clone(),
                 network_knowledge,
                 Some(section_key_share),
                 event_sender,
@@ -934,7 +934,7 @@ async fn untrusted_ae_msg_errors() -> Result<()> {
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let node = Node::new(
                 create_comm().await?,
-                info,
+                info.keypair.clone(),
                 our_section.clone(),
                 None,
                 event_sender,
@@ -1024,7 +1024,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
         let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
         let node = Node::new(
             create_comm().await?,
-            node,
+            node.keypair.clone(),
             section,
             Some(section_key_share),
             event_channel::new(TEST_EVENT_CHANNEL_SIZE).0,
@@ -1110,14 +1110,14 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
         let genesis_sk_set = bls::SecretKeySet::random(0, &mut rand::thread_rng());
         let node = Node::first_node(
             comm,
-            info,
+            info.keypair.clone(),
             event_sender,
             UsedSpace::new(max_capacity),
             root_storage_dir,
             genesis_sk_set,
         )
         .await?;
-        let info = node.info.read().await.clone();
+        let info = node.info().await;
         let section_pk = node.network_knowledge().section_key().await;
         let dispatcher = Dispatcher::new(Arc::new(node));
 
@@ -1239,7 +1239,7 @@ async fn handle_elders_update() -> Result<()> {
         let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
         let node = Node::new(
             create_comm().await?,
-            info,
+            info.keypair.clone(),
             section0.clone(),
             Some(section_key_share),
             event_sender,
@@ -1381,7 +1381,7 @@ async fn handle_demote_during_split() -> Result<()> {
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let node = Node::new(
                 create_comm().await?,
-                info,
+                info.keypair.clone(),
                 section,
                 Some(section_key_share),
                 event_sender,

--- a/sn_node/src/node/core/comm/peer_session.rs
+++ b/sn_node/src/node/core/comm/peer_session.rs
@@ -37,7 +37,7 @@ pub(crate) struct PeerSession {
     sent: MsgThroughput,
     attempted: MsgThroughput,
     peer_desired_rate: Arc<RwLock<f64>>, // msgs per s
-    disconnnected: Arc<RwLock<bool>>,
+    disconnected: Arc<RwLock<bool>>,
 }
 
 impl PeerSession {
@@ -48,7 +48,7 @@ impl PeerSession {
             sent: MsgThroughput::default(),
             attempted: MsgThroughput::default(),
             peer_desired_rate: Arc::new(RwLock::new(DEFAULT_DESIRED_RATE)),
-            disconnnected: Arc::new(RwLock::new(false)),
+            disconnected: Arc::new(RwLock::new(false)),
         };
 
         let session_clone = session.clone();
@@ -124,14 +124,14 @@ impl PeerSession {
     // NB that clones could still exist, however they would be in the disconnected state
     // if only accessing via session map (as intended)
     pub(crate) async fn disconnect(self) {
-        *self.disconnnected.write().await = true;
+        *self.disconnected.write().await = true;
         self.msg_queue.write().await.clear();
         self.link.disconnect().await;
     }
 
     // could be accessed via a clone
     async fn disconnected(&self) -> bool {
-        *self.disconnnected.read().await
+        *self.disconnected.read().await
     }
 
     #[instrument(skip_all)]

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -285,19 +285,15 @@ impl Node {
         // we create a dummy/random dst location,
         // we will set it correctly for each msg and target
         let section_pk = self.network_knowledge().section_key().await;
-        let our_name = self.info.read().await.name();
+        let our_name = self.info().await.name();
         let dummy_dst_location = DstLocation::Node {
             name: our_name,
             section_pk,
         };
 
         // separate this into form_wire_msg based on agg
-        let wire_msg = WireMsg::single_src(
-            &self.info.read().await.clone(),
-            dummy_dst_location,
-            msg,
-            section_pk,
-        )?;
+        let wire_msg =
+            WireMsg::single_src(&self.info().await, dummy_dst_location, msg, section_pk)?;
 
         let mut cmds = vec![];
 

--- a/sn_node/src/node/core/messaging/handling/agreement.rs
+++ b/sn_node/src/node/core/messaging/handling/agreement.rs
@@ -266,7 +266,7 @@ impl Node {
 
         info!("New SAP agreed for:{}", *signed_section_auth);
 
-        let our_name = self.info.read().await.name();
+        let our_name = self.info().await.name();
 
         // Let's update our network knowledge, including our
         // section SAP and chain if the new SAP's prefix matches our name

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -38,7 +38,7 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         let snapshot = self.state_snapshot().await;
 
-        let our_name = self.info.read().await.name();
+        let our_name = self.info().await.name();
         let signed_sap = SectionAuth {
             value: section_auth.clone(),
             sig: section_signed.clone(),
@@ -208,11 +208,11 @@ impl Node {
             value: section_auth.clone(),
             sig: section_signed.clone(),
         };
-        let our_name = self.info.read().await.name();
+        let our_name = self.info().await.name();
         let our_section_prefix = self.network_knowledge.prefix().await;
         let equal_prefix = section_auth.prefix() == our_section_prefix;
         let is_extension_prefix = section_auth.prefix().is_extension_of(&our_section_prefix);
-        let our_peer_info = self.info.read().await.peer();
+        let our_peer_info = self.info().await.peer();
 
         // Update our network knowledge
         let there_was_an_update = self
@@ -328,7 +328,7 @@ impl Node {
                         bounced_msg,
                     };
                     let wire_msg = WireMsg::single_src(
-                        &self.info.read().await.clone(),
+                        &self.info().await.clone(),
                         src_location.to_dst(),
                         ae_msg,
                         self.network_knowledge.section_key().await,
@@ -421,7 +421,7 @@ impl Node {
         };
 
         let wire_msg = WireMsg::single_src(
-            &self.info.read().await.clone(),
+            &self.info().await.clone(),
             src_location.to_dst(),
             ae_msg,
             self.network_knowledge.section_key().await,
@@ -453,7 +453,7 @@ impl Node {
         };
 
         let wire_msg = WireMsg::single_src(
-            &self.info.read().await.clone(),
+            &self.info().await.clone(),
             src_location.to_dst(),
             ae_msg,
             self.network_knowledge.section_key().await,
@@ -512,7 +512,7 @@ mod tests {
                     &our_prefix,
                     env.node.network_knowledge().section_key().await,
                 )?;
-                let sender = env.node.info.read().await.peer();
+                let sender = env.node.info().await.peer();
                 let dst_name = our_prefix.substituted_in(xor_name::rand::random());
                 let dst_section_key = env.node.network_knowledge().section_key().await;
 
@@ -593,7 +593,7 @@ mod tests {
             let other_pk = other_sk.public_key();
 
             let (msg, src_location) = env.create_msg(&env.other_sap.prefix(), other_pk)?;
-            let sender = env.node.info.read().await.peer();
+            let sender = env.node.info().await.peer();
 
             // since it's not aware of the other prefix, it will redirect to self
             let dst_section_key = other_pk;
@@ -629,7 +629,7 @@ mod tests {
                         env.other_sap.clone(),
                         &env.proof_chain,
                         None,
-                        &env.node.info.read().await.name(),
+                        &env.node.info().await.name(),
                         &env.node.section_keys_provider
                     )
                     .await?
@@ -679,7 +679,7 @@ mod tests {
                 &our_prefix,
                 env.node.network_knowledge().section_key().await,
             )?;
-            let sender = env.node.info.read().await.peer();
+            let sender = env.node.info().await.peer();
             let dst_name = our_prefix.substituted_in(xor_name::rand::random());
             let dst_section_key = env.node.network_knowledge().genesis_key();
 
@@ -725,7 +725,7 @@ mod tests {
            &our_prefix,
            env.node.network_knowledge().section_key().await,
        )?;
-       let sender = env.node.info.read().await.peer();
+       let sender = env.node.info().await.peer();
        let dst_name = our_prefix.substituted_in(xor_name::rand::random());
 
        let bogus_env = Env::new().await?;
@@ -784,7 +784,7 @@ mod tests {
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let mut node = Node::first_node(
                 create_comm().await?,
-                info.clone(),
+                info.keypair.clone(),
                 event_channel::new(1).0,
                 UsedSpace::new(max_capacity),
                 root_storage_dir,

--- a/sn_node/src/node/core/messaging/handling/dkg.rs
+++ b/sn_node/src/node/core/messaging/handling/dkg.rs
@@ -69,7 +69,7 @@ impl Node {
         let cmds = self
             .dkg_voter
             .start(
-                &self.info.read().await.clone(),
+                &self.info().await,
                 session_id,
                 self.network_knowledge().section_key().await,
             )
@@ -97,7 +97,7 @@ impl Node {
         self.dkg_voter
             .process_msg(
                 sender,
-                &self.info.read().await.clone(),
+                &self.info().await,
                 &session_id,
                 message,
                 self.network_knowledge().section_key().await,
@@ -119,7 +119,7 @@ impl Node {
             session_id,
         };
         let wire_msg = WireMsg::single_src(
-            &self.info.read().await.clone(),
+            &self.info().await,
             DstLocation::Node {
                 name: sender.name(),
                 section_pk,
@@ -153,7 +153,7 @@ impl Node {
         let mut cmds = self
             .dkg_voter
             .handle_dkg_history(
-                &self.info.read().await.clone(),
+                &self.info().await,
                 session_id,
                 message_history,
                 sender.name(),
@@ -163,13 +163,7 @@ impl Node {
 
         cmds.extend(
             self.dkg_voter
-                .process_msg(
-                    sender,
-                    &self.info.read().await.clone(),
-                    session_id,
-                    message,
-                    section_key,
-                )
+                .process_msg(sender, &self.info().await, session_id, message, section_key)
                 .await?,
         );
         Ok(cmds)

--- a/sn_node/src/node/core/messaging/handling/relocation.rs
+++ b/sn_node/src/node/core/messaging/handling/relocation.rs
@@ -109,7 +109,7 @@ impl Node {
                 return Ok(None);
             };
 
-        let node = self.info.read().await.clone();
+        let node = self.info().await;
         if dst_xorname != node.name() {
             // This `Relocate` message is not for us - it's most likely a duplicate of a previous
             // message that we already handled.

--- a/sn_node/src/node/core/messaging/handling/resource_proof.rs
+++ b/sn_node/src/node/core/messaging/handling/resource_proof.rs
@@ -34,10 +34,9 @@ impl Node {
         };
 
         if self
-            .info
+            .keypair
             .read()
             .await
-            .keypair
             .public
             .verify(&serialized, &response.nonce_signature)
             .is_err()
@@ -57,7 +56,7 @@ impl Node {
             data_size: RESOURCE_PROOF_DATA_SIZE,
             difficulty: RESOURCE_PROOF_DIFFICULTY,
             nonce,
-            nonce_signature: ed25519::sign(&serialized, &self.info.read().await.keypair),
+            nonce_signature: ed25519::sign(&serialized, &*self.keypair.read().await),
         }));
 
         trace!("{}", LogMarker::SendResourceProofChallenge);

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -179,7 +179,7 @@ impl Node {
                 let spent_proof_share = self.gen_spent_proof_share(&key_image, &tx).await?;
 
                 // use own keypair for generating the register command
-                let own_keypair = Keypair::Ed25519(self.info.read().await.keypair.clone());
+                let own_keypair = Keypair::Ed25519(self.keypair.read().await.clone());
 
                 // store spent proof share to adults
                 let reg_cmd = gen_register_cmd(&key_image, &spent_proof_share, own_keypair)?;

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -94,7 +94,7 @@ impl Node {
         let adults_names = adults.iter().map(|p2p_node| p2p_node.name()).collect_vec();
 
         let elders = self.network_knowledge.elders().await;
-        let my_name = self.info.read().await.name();
+        let my_name = self.info().await.name();
 
         // find data targets that are not us.
         let mut target_member_names = adults_names

--- a/sn_node/src/node/core/messaging/sending/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/sending/anti_entropy.rs
@@ -23,7 +23,7 @@ use xor_name::Prefix;
 impl Node {
     /// Send `AntiEntropyUpdate` message to all nodes in our own section.
     pub(crate) async fn send_ae_update_to_our_section(&self) -> Vec<Cmd> {
-        let our_name = self.info.read().await.name();
+        let our_name = self.info().await.name();
         let nodes: Vec<_> = self
             .network_knowledge
             .section_members()

--- a/sn_node/src/node/core/messaging/sending/proposal.rs
+++ b/sn_node/src/node/core/messaging/sending/proposal.rs
@@ -84,7 +84,7 @@ impl Node {
         // Carry out a substitution to prevent the dst_location becomes other section.
         let section_key = self.network_knowledge.section_key().await;
         let wire_msg = WireMsg::single_src(
-            &self.info.read().await.clone(),
+            &self.info().await,
             DstLocation::Section {
                 name: self.network_knowledge.prefix().await.name(),
                 section_pk: section_key,
@@ -99,7 +99,7 @@ impl Node {
         let msg_id = wire_msg.msg_id();
 
         let mut cmds = vec![];
-        let our_name = self.info.read().await.name();
+        let our_name = self.info().await.name();
         // handle ourselves if we should
         for peer in recipients.clone() {
             if peer.name() == our_name {

--- a/sn_node/src/node/core/messaging/sending/services.rs
+++ b/sn_node/src/node/core/messaging/sending/services.rs
@@ -62,7 +62,7 @@ impl Node {
         &self,
         client_msg: &ServiceMsg,
     ) -> Result<(AuthKind, Bytes)> {
-        let keypair = self.info.read().await.keypair.clone();
+        let keypair = self.keypair.read().await.clone();
         let payload = WireMsg::serialize_msg_payload(client_msg)?;
         let signature = keypair.sign(&payload);
 

--- a/sn_node/src/node/core/messaging/sending/system.rs
+++ b/sn_node/src/node/core/messaging/sending/system.rs
@@ -42,7 +42,7 @@ impl Node {
         section_pk: BlsPublicKey,
     ) -> Result<Cmd> {
         trace!("{}", LogMarker::SendDirectToNodes);
-        let our_node = self.info.read().await.clone();
+        let our_node = self.info().await;
         let our_section_key = self.network_knowledge.section_key().await;
 
         let wire_msg = WireMsg::single_src(
@@ -95,7 +95,7 @@ impl Node {
 
         trace!("Send {:?} to {:?}", wire_msg, recipients);
 
-        let our_name = self.info.read().await.name();
+        let our_name = self.info().await.name();
         for recipient in recipients.into_iter() {
             if recipient.name() == our_name {
                 match wire_msg.auth_kind() {


### PR DESCRIPTION
NodeInfo store a copy of our current socket address, 

Throughout our code we have to ask Comm for our current address and
replace the copy in NodeInfo with the address from Comm.

This opens up a potential point of inconsistency if  we forget to update NodeInfo somewhere.

Next changes will hopefully remove more of our reliance on Comm inside
of Node and we can start to move Comm out of Node.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
