### PR TITLE
Address lints from clippy update

### DIFF
--- a/sn_api/src/app/keys.rs
+++ b/sn_api/src/app/keys.rs
@@ -103,7 +103,7 @@ mod tests {
         let serialized_keypair_file = tmp_dir.child("serialized_keypair");
 
         let sk = BlsSecretKey::random();
-        let _ = Safe::serialize_bls_key(&sk, serialized_keypair_file.path())?;
+        Safe::serialize_bls_key(&sk, serialized_keypair_file.path())?;
 
         serialized_keypair_file.assert(predicate::path::is_file());
 
@@ -119,7 +119,7 @@ mod tests {
         let serialized_keypair_file = tmp_dir.child("serialized_keypair");
 
         let sk = BlsSecretKey::random();
-        let _ = Safe::serialize_bls_key(&sk, serialized_keypair_file.path())?;
+        Safe::serialize_bls_key(&sk, serialized_keypair_file.path())?;
 
         let sk2 = Safe::deserialize_bls_key(serialized_keypair_file.path())?;
         assert_eq!(sk, sk2);

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -202,7 +202,7 @@ impl Client {
 
         for res in respones {
             // fail with any issue here
-            let _ = res?;
+            res?;
         }
 
         Ok(head_address)
@@ -507,7 +507,7 @@ mod tests {
         let results = join_all(tasks).await;
 
         for res in results {
-            let _ok = res??;
+            res??;
         }
 
         // TODO: we need to use the node log analysis to check the mem usage across nodes does not exceed X

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -936,7 +936,7 @@ mod knowledge_tests {
 
         // Add a new adults
         let new_adult = random_xorname();
-        let _ = dysfunctional_detection.add_new_node(new_adult).await;
+        dysfunctional_detection.add_new_node(new_adult).await;
 
         // Add just one knowledge issue...
         for _ in 0..1 {

--- a/sn_dysfunction/src/lib.rs
+++ b/sn_dysfunction/src/lib.rs
@@ -306,7 +306,7 @@ mod tests {
         let dysfunctional_detection = DysfunctionDetection::new(adults.clone());
         let nodes_to_retain = adults[5..10].iter().cloned().collect::<BTreeSet<XorName>>();
 
-        let _ = dysfunctional_detection
+        dysfunctional_detection
             .retain_members_only(nodes_to_retain.clone())
             .await;
 
@@ -356,7 +356,7 @@ mod tests {
 
         let nodes_to_retain = adults[5..10].iter().cloned().collect::<BTreeSet<XorName>>();
 
-        let _ = dysfunctional_detection
+        dysfunctional_detection
             .retain_members_only(nodes_to_retain.clone())
             .await;
 
@@ -439,7 +439,7 @@ mod tests {
         let dysfunctional_detection = DysfunctionDetection::new(adults.clone());
 
         let new_adult = random_xorname();
-        let _ = dysfunctional_detection.add_new_node(new_adult).await;
+        dysfunctional_detection.add_new_node(new_adult).await;
 
         let current_nodes = dysfunctional_detection.current_nodes().await;
 

--- a/sn_interface/src/network_knowledge/utils/mod.rs
+++ b/sn_interface/src/network_knowledge/utils/mod.rs
@@ -46,8 +46,7 @@ pub async fn compare_and_write_prefix_map_to_disk(prefix_map: &NetworkPrefixMap)
         .await
         .map_err(|e| Error::FileHandling(e.to_string()))?;
 
-    let _ = file
-        .write_all(&serialized)
+    file.write_all(&serialized)
         .await
         .map_err(|e| Error::FileHandling(e.to_string()))?;
 

--- a/sn_interface/src/types/connections/link.rs
+++ b/sn_interface/src/types/connections/link.rs
@@ -88,7 +88,7 @@ impl Link {
     /// This is due to the fact that we do never leak the qp2p::Connection outside of this struct,
     /// since that struct is cloneable and uses Arc internally.
     pub async fn disconnect(self) {
-        let _ = self.queue.write().await.clear();
+        self.queue.write().await.clear();
         let mut guard = self.connections.write().await;
         for (_, item) in guard.iter() {
             item.conn

--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -223,7 +223,7 @@ pub struct FileRotateAppender {
     writer: FileRotate<AppendCount>,
 }
 
-impl<'a> FileRotateAppender {
+impl FileRotateAppender {
     /// Create default `FileRotateAppender`
     pub fn new(directory: impl AsRef<Path>, file_name_prefix: impl AsRef<Path>) -> Self {
         let log_directory = directory.as_ref().to_str().unwrap();

--- a/sn_node/src/comm/link.rs
+++ b/sn_node/src/comm/link.rs
@@ -88,7 +88,7 @@ impl Link {
     /// This is due to the fact that we do never leak the qp2p::Connection outside of this struct,
     /// since that struct is cloneable and uses Arc internally.
     pub(crate) fn disconnect(&mut self) {
-        let _ = self.queue.clear();
+        self.queue.clear();
         for item in self.connections.values() {
             item.conn
                 .close(Some("We disconnected from peer.".to_string()));

--- a/sn_node/src/node/api/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/api/flow_ctrl/cmd_ctrl.rs
@@ -87,7 +87,7 @@ impl CmdCtrl {
         let mut results = vec![];
 
         for cmd in cmds {
-            let _ = results.push(self.push(cmd).await);
+            results.push(self.push(cmd).await);
         }
 
         results

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -168,7 +168,7 @@ impl Node {
         self.capacity.retain_members_only(&members).await;
 
         // stop tracking liveness of absent holders
-        let _ = self.dysfunction_tracking.retain_members_only(members).await;
+        self.dysfunction_tracking.retain_members_only(members).await;
 
         Ok(())
     }
@@ -178,7 +178,7 @@ impl Node {
         info!("Adding new Adult: {adult} to trackers");
         self.capacity.add_new_adult(adult).await;
 
-        let _ = self.dysfunction_tracking.add_new_node(adult).await;
+        self.dysfunction_tracking.add_new_node(adult).await;
     }
 
     /// Set storage level of a given node.

--- a/sn_node/src/node/core/data/storage/registers.rs
+++ b/sn_node/src/node/core/data/storage/registers.rs
@@ -272,7 +272,7 @@ impl RegisterStorage {
                     );
                     continue;
                 }
-                let _ = self.apply(replicated_cmd).await?;
+                self.apply(replicated_cmd).await?;
             }
         }
 
@@ -328,7 +328,7 @@ impl RegisterStorage {
                 }
 
                 // insert the op to the event log
-                let _ = store.append(cmd)?;
+                store.append(cmd)?;
                 self.used_space.increase(required_space);
 
                 Ok(())
@@ -763,7 +763,7 @@ mod test {
 
         // create register
         let (cmd, authority) = create_register()?;
-        let _ = store.write(cmd.clone()).await?;
+        store.write(cmd.clone()).await?;
 
         // get register
 
@@ -798,7 +798,7 @@ mod test {
 
         // create register
         let (cmd, authority) = create_register()?;
-        let _ = store.write(cmd.clone()).await?;
+        store.write(cmd.clone()).await?;
 
         // export db
         // get all data in db
@@ -808,7 +808,7 @@ mod test {
         // create new db and update it with the data from first db
         let new_store = new_store()?;
 
-        let _ = new_store.update(for_update).await?;
+        new_store.update(for_update).await?;
         let address = cmd.dst_address();
         // assert the same tests hold as for the first db
 
@@ -844,7 +844,7 @@ mod test {
 
         // create register
         let (cmd, authority) = create_register()?;
-        let _ = store.write(cmd.clone()).await?;
+        store.write(cmd.clone()).await?;
 
         let hash = EntryHash(rand::thread_rng().gen::<[u8; 32]>());
 
@@ -873,7 +873,7 @@ mod test {
 
         // create register
         let (cmd, authority) = create_register()?;
-        let _ = store.write(cmd.clone()).await?;
+        store.write(cmd.clone()).await?;
 
         let (user, _) = random_user();
 

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -58,7 +58,7 @@ impl Node {
 
             if holder_adult_list.contains(&sender.name()) {
                 debug!("Our requester should hold: {:?}", data);
-                let _existed = data_for_sender.push(data);
+                data_for_sender.push(data);
             }
         }
 


### PR DESCRIPTION
seems like two new lints came in that affects us:

1. let bindings for unit return values.
2. favoring `write!(str, ..)` over `str.push_str(&format!(..)`