### PR TITLE
fix(join): do not leave loop running on timeout

### DIFF
--- a/sn_node/examples/routing_minimal.rs
+++ b/sn_node/examples/routing_minimal.rs
@@ -195,9 +195,9 @@ async fn start_node(
         ..Default::default()
     };
 
-    let joining_timeout = Duration::from_secs(3 * 60);
+    let join_timeout = Duration::from_secs(3 * 60);
 
-    let (node, event_receiver) = NodeApi::new(&config, joining_timeout)
+    let (node, event_receiver) = NodeApi::new(&config, join_timeout)
         .await
         .expect("Failed to instantiate a Node");
 

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -650,9 +650,9 @@ async fn add_node(id: u64, mut config: Config, event_sender: Sender<Event>) -> R
     let (_, root_dir) = create_test_max_capacity_and_root_storage()?;
 
     config.root_dir = Some(root_dir);
-    let joining_timeout = Duration::from_secs(3 * 60);
+    let join_timeout = Duration::from_secs(3 * 60);
 
-    let (node, mut event_receiver) = match NodeApi::new(&config, joining_timeout).await {
+    let (node, mut event_receiver) = match NodeApi::new(&config, join_timeout).await {
         Ok(output) => output,
         Err(error) => {
             let _res = event_sender

--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -53,6 +53,7 @@ use tracing_subscriber::filter::EnvFilter;
 
 #[cfg(not(feature = "tokio-console"))]
 const MODULE_NAME: &str = "sn_node";
+const JOIN_TIMEOUT_SEC: u64 = 30;
 const BOOTSTRAP_RETRY_TIME_SEC: u64 = 15;
 
 fn main() -> Result<()> {
@@ -310,9 +311,11 @@ async fn run_node(config: Config) -> Result<()> {
 
     let log = format!("The network is not accepting nodes right now. Retrying after {BOOTSTRAP_RETRY_TIME_SEC} seconds");
 
+    let join_timeout = Duration::from_secs(JOIN_TIMEOUT_SEC);
     let bootstrap_retry_duration = Duration::from_secs(BOOTSTRAP_RETRY_TIME_SEC);
+
     let (node, mut event_stream) = loop {
-        match NodeApi::new(&config, bootstrap_retry_duration).await {
+        match NodeApi::new(&config, join_timeout).await {
             Ok(result) => break result,
             Err(NodeError::CannotConnectEndpoint(qp2p::EndpointError::Upnp(error))) => {
                 return Err(error).suggestion(

--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -53,8 +53,8 @@ use tracing_subscriber::filter::EnvFilter;
 
 #[cfg(not(feature = "tokio-console"))]
 const MODULE_NAME: &str = "sn_node";
-const JOIN_TIMEOUT_SEC: u64 = 30;
-const BOOTSTRAP_RETRY_TIME_SEC: u64 = 15;
+const JOIN_TIMEOUT_SEC: u64 = 10;
+const BOOTSTRAP_RETRY_TIME_SEC: u64 = 10;
 
 fn main() -> Result<()> {
     color_eyre::install()?;

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -69,7 +69,7 @@ impl Dispatcher {
                 let node = self.node.read().await;
 
                 let src_section_pk = node.network_knowledge().section_key();
-                let wire_msg = WireMsg::single_src(&node.info().await, dst, msg, src_section_pk)?;
+                let wire_msg = WireMsg::single_src(&node.info(), dst, msg, src_section_pk)?;
 
                 let mut cmds = vec![];
                 cmds.extend(node.send_msg_to_nodes(wire_msg).await?);
@@ -89,7 +89,7 @@ impl Dispatcher {
             Cmd::HandleDkgTimeout(token) => {
                 let node = self.node.read().await;
 
-                node.handle_dkg_timeout(token).await
+                node.handle_dkg_timeout(token)
             }
             Cmd::HandleAgreement { proposal, sig } => {
                 let mut node = self.node.write().await;

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -24,13 +24,13 @@ use tokio::{sync::watch, sync::RwLock, time};
 
 // Cmd Dispatcher.
 pub(crate) struct Dispatcher {
-    node: Arc<Node>,
+    node: Arc<RwLock<Node>>,
     comm: Comm,
     dkg_timeout: Arc<DkgTimeout>,
 }
 
 impl Dispatcher {
-    pub(super) fn new(node: Arc<Node>, comm: Comm) -> Self {
+    pub(super) fn new(node: Arc<RwLock<Node>>, comm: Comm) -> Self {
         let (cancel_timer_tx, cancel_timer_rx) = watch::channel(false);
         let dkg_timeout = Arc::new(DkgTimeout {
             cancel_timer_tx,
@@ -44,7 +44,7 @@ impl Dispatcher {
         }
     }
 
-    pub(crate) fn node(&self) -> Arc<Node> {
+    pub(crate) fn node(&self) -> Arc<RwLock<Node>> {
         self.node.clone()
     }
 
@@ -58,19 +58,21 @@ impl Dispatcher {
     pub(crate) async fn process_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
         match cmd {
             Cmd::CleanupPeerLinks => {
-                let elders = self.node.network_knowledge.elders();
+                let node = self.node.read().await;
+                let elders = node.network_knowledge.elders();
                 self.comm
-                    .cleanup_peers(elders, self.node.dysfunction_tracking.clone())
+                    .cleanup_peers(elders, node.dysfunction_tracking.clone())
                     .await?;
                 Ok(vec![])
             }
             Cmd::SignOutgoingSystemMsg { msg, dst } => {
-                let src_section_pk = self.node.network_knowledge().section_key();
-                let wire_msg =
-                    WireMsg::single_src(&self.node.info().await, dst, msg, src_section_pk)?;
+                let node = self.node.read().await;
+
+                let src_section_pk = node.network_knowledge().section_key();
+                let wire_msg = WireMsg::single_src(&node.info().await, dst, msg, src_section_pk)?;
 
                 let mut cmds = vec![];
-                cmds.extend(self.node.send_msg_to_nodes(wire_msg).await?);
+                cmds.extend(node.send_msg_to_nodes(wire_msg).await?);
 
                 Ok(cmds)
             }
@@ -79,50 +81,64 @@ impl Dispatcher {
                 wire_msg,
                 original_bytes,
             } => {
-                self.node
-                    .handle_msg(sender, wire_msg, original_bytes, &self.comm)
+                let mut node = self.node.write().await;
+
+                node.handle_msg(sender, wire_msg, original_bytes, &self.comm)
                     .await
             }
-            Cmd::HandleDkgTimeout(token) => self.node.handle_dkg_timeout(token).await,
+            Cmd::HandleDkgTimeout(token) => {
+                let node = self.node.read().await;
+
+                node.handle_dkg_timeout(token).await
+            }
             Cmd::HandleAgreement { proposal, sig } => {
-                self.node.handle_general_agreements(proposal, sig).await
+                let mut node = self.node.write().await;
+
+                node.handle_general_agreements(proposal, sig).await
             }
             Cmd::HandleNewNodeOnline(auth) => {
-                self.node
-                    .handle_online_agreement(auth.value.into_state(), auth.sig)
+                let mut node = self.node.write().await;
+
+                node.handle_online_agreement(auth.value.into_state(), auth.sig)
                     .await
             }
             Cmd::HandleNodeLeft(auth) => {
-                self.node
-                    .handle_node_left(auth.value.into_state(), auth.sig)
+                let mut node = self.node.write().await;
+
+                node.handle_node_left(auth.value.into_state(), auth.sig)
                     .await
             }
             Cmd::HandleNewEldersAgreement { proposal, sig } => match proposal {
                 Proposal::NewElders(section_auth) => {
-                    self.node
-                        .handle_new_elders_agreement(section_auth, sig)
-                        .await
+                    let mut node = self.node.write().await;
+
+                    node.handle_new_elders_agreement(section_auth, sig).await
                 }
                 _ => {
                     error!("Other agreement messages should be handled in `HandleAgreement`, which is non-blocking ");
                     Ok(vec![])
                 }
             },
-            Cmd::HandlePeerLost(peer) => self.node.handle_peer_lost(&peer.addr()).await,
+            Cmd::HandlePeerLost(peer) => {
+                let node = self.node.write().await;
+
+                node.handle_peer_lost(&peer.addr()).await
+            }
             Cmd::HandleDkgOutcome {
                 section_auth,
                 outcome,
                 generation,
             } => {
-                self.node
-                    .handle_dkg_outcome(section_auth, outcome, generation)
+                let mut node = self.node.write().await;
+
+                node.handle_dkg_outcome(section_auth, outcome, generation)
                     .await
             }
-            Cmd::HandleDkgFailure(signeds) => self
-                .node
-                .handle_dkg_failure(signeds)
-                .await
-                .map(|cmd| vec![cmd]),
+            Cmd::HandleDkgFailure(signeds) => {
+                let node = self.node.read().await;
+
+                node.handle_dkg_failure(signeds).await.map(|cmd| vec![cmd])
+            }
             Cmd::SendMsg {
                 recipients,
                 wire_msg,
@@ -134,21 +150,21 @@ impl Dispatcher {
             } => {
                 // we should queue this
                 for data in data_batch {
-                    if let Some(data_entry) =
-                        self.node.pending_data_to_replicate_to_peers.get_mut(&data)
+                    let node = self.node.write().await;
+                    if let Some(mut data_entry) =
+                        node.pending_data_to_replicate_to_peers.get_mut(&data)
                     {
-                        let peer_set = data_entry.value();
+                        let peer_set = data_entry.value_mut();
                         debug!("data already queued, adding peer");
-                        let _existed = peer_set.write().await.insert(recipient);
+                        let _existed = peer_set.insert(recipient);
                     } else {
                         // let queue = DashSet::new();
                         let mut peer_set = BTreeSet::new();
                         let _existed = peer_set.insert(recipient);
-                        let _existed = self
-                            .node
+                        let _existed = node
                             .pending_data_to_replicate_to_peers
-                            .insert(data, Arc::new(RwLock::new(peer_set)));
-                    }
+                            .insert(data, peer_set);
+                    };
                 }
                 Ok(vec![])
             }
@@ -165,16 +181,32 @@ impl Dispatcher {
                 .await
                 .into_iter()
                 .collect()),
-            Cmd::ProposeOffline(names) => self.node.cast_offline_proposals(&names).await,
-            Cmd::StartConnectivityTest(name) => Ok(vec![
-                self.node
-                    .send_msg_to_our_elders(SystemMsg::StartConnectivityTest(name))
-                    .await?,
-            ]),
+            Cmd::ProposeOffline(names) => {
+                let node = self.node.read().await;
+
+                node.cast_offline_proposals(&names).await
+            }
+            Cmd::StartConnectivityTest(name) => {
+                let node = self.node.read().await;
+
+                Ok(vec![
+                    node.send_msg_to_our_elders(SystemMsg::StartConnectivityTest(name))
+                        .await?,
+                ])
+            }
             Cmd::TestConnectivity(name) => {
-                if let Some(member_info) = self.node.network_knowledge().get_section_member(&name) {
+                let node_state = self
+                    .node
+                    .read()
+                    .await
+                    .network_knowledge()
+                    .get_section_member(&name);
+
+                if let Some(member_info) = node_state {
                     if self.comm.is_reachable(&member_info.addr()).await.is_err() {
-                        self.node.log_comm_issue(member_info.name()).await?
+                        let node = self.node.write().await;
+
+                        node.log_comm_issue(member_info.name()).await?
                     }
                 }
                 Ok(vec![])

--- a/sn_node/src/node/api/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/api/flow_ctrl/cmd_ctrl.rs
@@ -78,7 +78,7 @@ impl CmdCtrl {
         session
     }
 
-    pub(crate) fn node(&self) -> Arc<crate::node::core::Node> {
+    pub(crate) fn node(&self) -> Arc<RwLock<crate::node::core::Node>> {
         self.dispatcher.node()
     }
 

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -22,7 +22,7 @@ use sn_interface::{
 
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use tokio::{
-    sync::mpsc,
+    sync::{mpsc, RwLock},
     task::{self, JoinHandle},
     time::MissedTickBehavior,
 };
@@ -38,7 +38,7 @@ const DYSFUNCTION_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub(crate) struct FlowCtrl {
-    node: Arc<Node>,
+    node: Arc<RwLock<Node>>,
     cmd_ctrl: CmdCtrl,
 }
 
@@ -114,8 +114,10 @@ impl FlowCtrl {
 
                 // Send a probe message if we are an elder
                 let node = &self.node;
-                if node.is_elder().await && !node.network_knowledge().prefix().is_empty() {
-                    match node.generate_probe_msg().await {
+                if node.read().await.is_elder().await
+                    && !node.read().await.network_knowledge().prefix().is_empty()
+                {
+                    match node.read().await.generate_probe_msg().await {
                         Ok(cmd) => {
                             info!("Sending probe msg");
                             if let Err(e) = self.cmd_ctrl.push(cmd).await {
@@ -140,8 +142,8 @@ impl FlowCtrl {
 
                 // Send a probe message to an elder
                 let node = &self.node;
-                if !node.network_knowledge().prefix().is_empty() {
-                    match node.generate_section_probe_msg().await {
+                if !node.read().await.network_knowledge().prefix().is_empty() {
+                    match node.read().await.generate_section_probe_msg().await {
                         Ok(cmd) => {
                             info!("Sending section probe msg");
                             if let Err(e) = self.cmd_ctrl.push(cmd).await {
@@ -166,21 +168,26 @@ impl FlowCtrl {
             loop {
                 let _instant = interval.tick().await;
 
-                if !dispatcher.node.is_elder().await {
+                if !dispatcher.node.read().await.is_elder().await {
                     continue;
                 }
                 trace!("looping vote check in elder");
+                let node = dispatcher.node.read().await;
+                let membership = &node.membership;
 
-                let membership = dispatcher.node.membership.read().await;
-
-                if let Some(membership) = &*membership {
+                if let Some(membership) = &membership {
                     let last_received_vote_time = membership.last_received_vote_time();
 
                     if let Some(time) = last_received_vote_time {
                         // we want to resend the prev vote
                         if time.elapsed() >= MISSING_VOTE_INTERVAL {
                             debug!("Vote consensus appears stalled...");
-                            let cmds = self.node.resend_our_last_vote_to_elders().await?;
+                            let cmds = self
+                                .node
+                                .read()
+                                .await
+                                .resend_our_last_vote_to_elders()
+                                .await?;
 
                             trace!("Vote resending cmds: {:?}", cmds.len());
                             for cmd in cmds {
@@ -213,6 +220,8 @@ impl FlowCtrl {
 
                 // choose a data to replicate at random
                 if let Some(data_queued) = node
+                    .read()
+                    .await
                     .pending_data_to_replicate_to_peers
                     .iter()
                     .choose(&mut rng)
@@ -221,16 +230,19 @@ impl FlowCtrl {
                 }
 
                 if let Some(address) = this_batch_address {
-                    if let Some((data_address, data_recipients)) =
-                        node.pending_data_to_replicate_to_peers.remove(&address)
+                    if let Some((data_address, data_recipients)) = node
+                        .read()
+                        .await
+                        .pending_data_to_replicate_to_peers
+                        .remove(&address)
                     {
                         // get info for the WireMsg
-                        let src_section_pk = node.network_knowledge().section_key();
-                        let our_info = node.info().await;
+                        let src_section_pk = node.read().await.network_knowledge().section_key();
+                        let our_info = node.read().await.info().await;
 
                         let mut recipients = vec![];
 
-                        for peer in data_recipients.read().await.iter() {
+                        for peer in data_recipients.iter() {
                             recipients.push(*peer);
                         }
 
@@ -246,6 +258,8 @@ impl FlowCtrl {
                         };
 
                         let data_to_send = node
+                            .read()
+                            .await
                             .data_storage
                             .get_from_local_store(&data_address)
                             .await?;
@@ -306,13 +320,14 @@ impl FlowCtrl {
 
                 let node = &self.node;
 
-                let unresponsive_nodes = match node.get_dysfunctional_node_names().await {
-                    Ok(nodes) => nodes,
-                    Err(error) => {
-                        error!("Error getting dysfunctional nodes: {error}");
-                        BTreeSet::default()
-                    }
-                };
+                let unresponsive_nodes =
+                    match node.read().await.get_dysfunctional_node_names().await {
+                        Ok(nodes) => nodes,
+                        Err(error) => {
+                            error!("Error getting dysfunctional nodes: {error}");
+                            BTreeSet::default()
+                        }
+                    };
 
                 if !unresponsive_nodes.is_empty() {
                     debug!("{:?} : {unresponsive_nodes:?}", LogMarker::ProposeOffline);
@@ -422,7 +437,7 @@ async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Rece
 
                 let span = {
                     let node = &ctrl.node;
-                    trace_span!("handle_message", name = %node.info().await.name(), ?sender, msg_id = ?wire_msg.msg_id())
+                    trace_span!("handle_message", name = %node.read().await.info().await.name(), ?sender, msg_id = ?wire_msg.msg_id())
                 };
                 let _span_guard = span.enter();
 

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -114,7 +114,7 @@ impl FlowCtrl {
 
                 // Send a probe message if we are an elder
                 let node = &self.node;
-                if node.read().await.is_elder().await
+                if node.read().await.is_elder()
                     && !node.read().await.network_knowledge().prefix().is_empty()
                 {
                     match node.read().await.generate_probe_msg().await {
@@ -168,7 +168,7 @@ impl FlowCtrl {
             loop {
                 let _instant = interval.tick().await;
 
-                if !dispatcher.node.read().await.is_elder().await {
+                if !dispatcher.node.read().await.is_elder() {
                     continue;
                 }
                 trace!("looping vote check in elder");
@@ -238,7 +238,7 @@ impl FlowCtrl {
                     {
                         // get info for the WireMsg
                         let src_section_pk = node.read().await.network_knowledge().section_key();
-                        let our_info = node.read().await.info().await;
+                        let our_info = node.read().await.info();
 
                         let mut recipients = vec![];
 
@@ -363,8 +363,8 @@ impl FlowCtrl {
             loop {
                 let _ = interval.tick().await;
 
-                let node = &self.node;
-                let our_info = node.info().await;
+                let node = self.node.read().await;
+                let our_info = node.info();
                 let our_name = our_info.name();
 
                 let members = node.network_knowledge().section_members();
@@ -437,7 +437,7 @@ async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Rece
 
                 let span = {
                     let node = &ctrl.node;
-                    trace_span!("handle_message", name = %node.read().await.info().await.name(), ?sender, msg_id = ?wire_msg.msg_id())
+                    trace_span!("handle_message", name = %node.read().await.info().name(), ?sender, msg_id = ?wire_msg.msg_id())
                 };
                 let _span_guard = span.enter();
 

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -49,7 +49,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, RwLock};
 use xor_name::{Prefix, XorName};
 
 /// Interface for sending and receiving messages to and from other nodes, in the role of a full
@@ -61,7 +61,7 @@ use xor_name::{Prefix, XorName};
 /// role, and can be `use sn_interface::messaging::SrcLocation::Node` or `use sn_interface::messaging::SrcLocation::Section`.
 #[allow(missing_debug_implementations)]
 pub struct NodeApi {
-    node: Arc<Node>,
+    node: Arc<RwLock<Node>>,
     flow_ctrl: FlowCtrl,
 }
 
@@ -98,7 +98,7 @@ impl NodeApi {
         .map_err(|_| Error::JoinTimeout)??;
 
         // Network keypair may have to be changed due to naming criteria or network requirements.
-        let keypair_as_bytes = api.node.keypair.read().await.to_bytes();
+        let keypair_as_bytes = api.node.read().await.keypair.to_bytes();
         store_network_keypair(root_dir, keypair_as_bytes).await?;
 
         let our_pid = std::process::id();
@@ -262,7 +262,7 @@ impl NodeApi {
             (node, comm)
         };
 
-        let node = Arc::new(node);
+        let node = Arc::new(RwLock::new(node));
         let cmd_ctrl = CmdCtrl::new(
             Dispatcher::new(node.clone(), comm),
             monitoring,
@@ -276,57 +276,57 @@ impl NodeApi {
 
     /// Returns the current age of this node.
     pub async fn age(&self) -> u8 {
-        self.node.info().await.age()
+        self.node.read().await.info().await.age()
     }
 
     /// Returns the ed25519 public key of this node.
     pub async fn public_key(&self) -> PublicKey {
-        self.node.keypair.read().await.public
+        self.node.read().await.keypair.public
     }
 
     /// The name of this node.
     pub async fn name(&self) -> XorName {
-        self.node.info().await.name()
+        self.node.read().await.info().await.name()
     }
 
     /// Returns connection info of this node.
     pub async fn our_connection_info(&self) -> SocketAddr {
-        self.node.info().await.addr
+        self.node.read().await.info().await.addr
     }
 
     /// Returns the Section Signed Chain
     pub async fn section_chain(&self) -> SecuredLinkedList {
-        self.node.section_chain().await
+        self.node.read().await.section_chain().await
     }
 
     /// Returns the Section Chain's genesis key
     pub async fn genesis_key(&self) -> bls::PublicKey {
-        *self.node.network_knowledge().genesis_key()
+        *self.node.read().await.network_knowledge().genesis_key()
     }
 
     /// Prefix of our section
     pub async fn our_prefix(&self) -> Prefix {
-        self.node.network_knowledge().prefix()
+        self.node.read().await.network_knowledge().prefix()
     }
 
     /// Returns whether the node is Elder.
     pub async fn is_elder(&self) -> bool {
-        self.node.is_elder().await
+        self.node.read().await.is_elder().await
     }
 
     /// Returns the information of all the current section elders.
     pub async fn our_elders(&self) -> Vec<Peer> {
-        self.node.network_knowledge().elders()
+        self.node.read().await.network_knowledge().elders()
     }
 
     /// Returns the information of all the current section adults.
     pub async fn our_adults(&self) -> Vec<Peer> {
-        self.node.network_knowledge().adults()
+        self.node.read().await.network_knowledge().adults()
     }
 
     /// Returns the info about the section matching the name.
     pub async fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
-        self.node.matching_section(name).await
+        self.node.read().await.matching_section(name).await
     }
 
     /// Builds a WireMsg signed by this Node
@@ -336,7 +336,12 @@ impl NodeApi {
         dst: DstLocation,
     ) -> Result<WireMsg> {
         let src_section_pk = *self.section_chain().await.last_key();
-        WireMsg::single_src(&self.node.info().await, dst, node_msg, src_section_pk)
+        WireMsg::single_src(
+            &self.node.read().await.info().await,
+            dst,
+            node_msg,
+            src_section_pk,
+        )
     }
 
     /// Send a message.
@@ -348,7 +353,7 @@ impl NodeApi {
             wire_msg.msg_id()
         );
 
-        if let Some(cmd) = self.node.send_msg_to_nodes(wire_msg).await? {
+        if let Some(cmd) = self.node.read().await.send_msg_to_nodes(wire_msg).await? {
             self.flow_ctrl.fire_and_forget(cmd).await?;
         }
 
@@ -358,6 +363,6 @@ impl NodeApi {
     /// Returns the current BLS public key set if this node has one, or
     /// `Error::MissingSecretKeyShare` otherwise.
     pub async fn public_key_set(&self) -> Result<bls::PublicKeySet> {
-        self.node.public_key_set().await
+        self.node.read().await.public_key_set().await
     }
 }

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -73,7 +73,7 @@ impl NodeApi {
     ////////////////////////////////////////////////////////////////////////////
 
     /// Initialize a new node.
-    pub async fn new(config: &Config, joining_timeout: Duration) -> Result<(Self, EventReceiver)> {
+    pub async fn new(config: &Config, join_timeout: Duration) -> Result<(Self, EventReceiver)> {
         let root_dir_buf = config.root_dir()?;
         let root_dir = root_dir_buf.as_path();
         tokio::fs::create_dir_all(root_dir).await?;
@@ -90,12 +90,8 @@ impl NodeApi {
 
         let used_space = UsedSpace::new(config.max_capacity());
 
-        let (api, network_events) = tokio::time::timeout(
-            joining_timeout,
-            Self::start_node(config, used_space, root_dir),
-        )
-        .await
-        .map_err(|_| Error::JoinTimeout)??;
+        let (api, network_events) =
+            Self::start_node(config, used_space, root_dir, join_timeout).await?;
 
         // Network keypair may have to be changed due to naming criteria or network requirements.
         let keypair_as_bytes = api.node.read().await.keypair.to_bytes();
@@ -123,14 +119,11 @@ impl NodeApi {
     }
 
     // Private helper to create a new node using the given config and bootstraps it to the network.
-    //
-    // NOTE: It's not guaranteed this function ever returns. This can happen due to messages being
-    // lost in transit during bootstrapping, or other reasons. It's the responsibility of the
-    // caller to handle this case, for example by using a timeout.
     async fn start_node(
         config: &Config,
         used_space: UsedSpace,
         root_storage_dir: &Path,
+        join_timeout: Duration,
     ) -> Result<(Self, EventReceiver)> {
         let (connection_event_tx, mut connection_event_rx) = mpsc::channel(1);
 
@@ -242,6 +235,7 @@ impl NodeApi {
                 &mut connection_event_rx,
                 bootstrap_addr,
                 genesis_key,
+                join_timeout,
             )
             .await?;
 

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -256,8 +256,8 @@ impl NodeApi {
             )
             .await?;
 
-            info!("{} Joined the network!", node.info().await.name());
-            info!("Our AGE: {}", node.info().await.age());
+            info!("{} Joined the network!", node.info().name());
+            info!("Our AGE: {}", node.info().age());
 
             (node, comm)
         };
@@ -276,7 +276,7 @@ impl NodeApi {
 
     /// Returns the current age of this node.
     pub async fn age(&self) -> u8 {
-        self.node.read().await.info().await.age()
+        self.node.read().await.info().age()
     }
 
     /// Returns the ed25519 public key of this node.
@@ -286,12 +286,12 @@ impl NodeApi {
 
     /// The name of this node.
     pub async fn name(&self) -> XorName {
-        self.node.read().await.info().await.name()
+        self.node.read().await.info().name()
     }
 
     /// Returns connection info of this node.
     pub async fn our_connection_info(&self) -> SocketAddr {
-        self.node.read().await.info().await.addr
+        self.node.read().await.info().addr
     }
 
     /// Returns the Section Signed Chain
@@ -311,7 +311,7 @@ impl NodeApi {
 
     /// Returns whether the node is Elder.
     pub async fn is_elder(&self) -> bool {
-        self.node.read().await.is_elder().await
+        self.node.read().await.is_elder()
     }
 
     /// Returns the information of all the current section elders.
@@ -337,7 +337,7 @@ impl NodeApi {
     ) -> Result<WireMsg> {
         let src_section_pk = *self.section_chain().await.last_key();
         WireMsg::single_src(
-            &self.node.read().await.info().await,
+            &self.node.read().await.info(),
             dst,
             node_msg,
             src_section_pk,

--- a/sn_node/src/node/api/tests/mod.rs
+++ b/sn_node/src/node/api/tests/mod.rs
@@ -60,7 +60,7 @@ use std::{
 };
 use tempfile::tempdir;
 use tokio::{
-    sync::mpsc,
+    sync::{mpsc, RwLock},
     time::{timeout, Duration},
 };
 use xor_name::{Prefix, XorName};
@@ -97,7 +97,7 @@ async fn receive_join_request_without_resource_proof_response() -> Result<()> {
                 root_storage_dir,
             )
             .await?;
-            let dispatcher = Dispatcher::new(Arc::new(node), comm);
+            let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             let new_node_comm = create_comm().await?;
             let new_node = NodeInfo::new(
@@ -183,7 +183,7 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
                 root_storage_dir,
             )
             .await?;
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             let new_node = NodeInfo::new(
@@ -193,7 +193,8 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
 
             let nonce: [u8; 32] = rand::random();
             let serialized = bincode::serialize(&(new_node.name(), nonce))?;
-            let nonce_signature = ed25519::sign(&serialized, &node.info().await.keypair);
+            let nonce_signature =
+                ed25519::sign(&serialized, &node.read().await.info().await.keypair);
 
             let rp = ResourceProof::new(RESOURCE_PROOF_DATA_SIZE, RESOURCE_PROOF_DIFFICULTY);
             let data = rp.create_proof_data(&nonce);
@@ -227,19 +228,18 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
                 .await?;
 
             assert!(node
-                .membership
                 .read()
                 .await
+                .membership
                 .as_ref()
                 .unwrap()
                 .is_churn_in_progress());
             // makes sure that the nonce signature is always valid
             let random_peer = Peer::new(xor_name::rand::random(), gen_addr());
-            assert!(
-                !node
-                    .validate_resource_proof_response(&random_peer.name(), resource_proof_response)
-                    .await
-            );
+            assert!(!node
+                .read()
+                .await
+                .validate_resource_proof_response(&random_peer.name(), resource_proof_response));
             Result::<()>::Ok(())
         })
         .await
@@ -276,7 +276,7 @@ async fn membership_churn_starts_on_join_request_from_relocated_node() -> Result
                 root_storage_dir,
             )
             .await?;
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             let relocated_node = NodeInfo::new(
@@ -324,9 +324,9 @@ async fn membership_churn_starts_on_join_request_from_relocated_node() -> Result
                 .await?;
 
             assert!(node
-                .membership
                 .read()
                 .await
+                .membership
                 .as_ref()
                 .unwrap()
                 .is_churn_in_progress());
@@ -364,7 +364,7 @@ async fn handle_agreement_on_online() -> Result<()> {
                 root_storage_dir,
             )
             .await?;
-            let dispatcher = Dispatcher::new(Arc::new(node), comm);
+            let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             let new_peer = create_peer(MIN_ADULT_AGE);
 
@@ -440,7 +440,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
                 root_storage_dir,
             )
             .await?;
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             // Handle agreement on Online of a peer that is older than the youngest
@@ -451,9 +451,9 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
             let auth = section_signed(sk_set.secret_key(), node_state.to_msg())?;
 
             // Force this node to join
-            node.membership
-                .write()
+            node.read()
                 .await
+                .membership
                 .as_mut()
                 .unwrap()
                 .force_bootstrap(node_state.to_msg());
@@ -616,7 +616,7 @@ async fn handle_agreement_on_online_of_rejoined_node(phase: NetworkPhase, age: u
                 root_storage_dir,
             )
             .await?;
-            let dispatcher = Dispatcher::new(Arc::new(node), comm);
+            let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             // Simulate peer with the same name is rejoin and verify resulted behaviours.
             let status = handle_online_cmd(&peer, &sk_set, &dispatcher, &section_auth).await?;
@@ -693,7 +693,7 @@ async fn handle_agreement_on_offline_of_non_elder() -> Result<()> {
                 root_storage_dir,
             )
             .await?;
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             let node_state = NodeState::left(existing_peer, None);
@@ -705,6 +705,8 @@ async fn handle_agreement_on_offline_of_non_elder() -> Result<()> {
                 .await?;
 
             assert!(!node
+                .read()
+                .await
                 .network_knowledge()
                 .section_members()
                 .contains(&node_state));
@@ -754,7 +756,7 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
                 root_storage_dir,
             )
             .await?;
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             // Handle agreement on the Offline proposal
@@ -768,9 +770,9 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
             // Verify we initiated a membership churn
 
             assert!(node
-                .membership
                 .read()
                 .await
+                .membership
                 .as_ref()
                 .unwrap()
                 .is_churn_in_progress());
@@ -881,7 +883,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
                 .insert(create_section_key_share(&sk_set2, 0))
                 .await;
 
-            let dispatcher = Dispatcher::new(Arc::new(node), comm);
+            let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             let _cmds = dispatcher
                 .process_cmd(Cmd::HandleMsg {
@@ -954,7 +956,7 @@ async fn untrusted_ae_msg_errors() -> Result<()> {
             )
             .await?;
 
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             let sender = gen_info(MIN_ADULT_AGE, None);
@@ -977,9 +979,9 @@ async fn untrusted_ae_msg_errors() -> Result<()> {
                 })
                 .await?;
 
-            assert_eq!(node.network_knowledge().genesis_key(), &pk0);
+            assert_eq!(node.read().await.network_knowledge().genesis_key(), &pk0);
             assert_eq!(
-                node.network_knowledge().prefix_map().all(),
+                node.read().await.network_knowledge().prefix_map().all(),
                 vec![section_signed_our_section_auth.value]
             );
             Result::<()>::Ok(())
@@ -1044,7 +1046,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
             root_storage_dir,
         )
         .await?;
-        let dispatcher = Dispatcher::new(Arc::new(node), comm);
+        let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
         let relocated_peer = match relocated_peer_role {
             RelocatedPeerRole::Elder => *section_auth.elders().nth(1).expect("too few elders"),
@@ -1131,7 +1133,7 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
         .await?;
         let info = node.info().await;
         let section_pk = node.network_knowledge().section_key();
-        let dispatcher = Dispatcher::new(Arc::new(node), comm);
+        let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
         let dst_location = match dst {
             MessageDst::Node => DstLocation::Node {
@@ -1267,7 +1269,7 @@ async fn handle_elders_update() -> Result<()> {
             .insert(create_section_key_share(&sk_set1, 0))
             .await;
 
-        let dispatcher = Dispatcher::new(Arc::new(node), comm);
+        let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
         let cmds = dispatcher
             .process_cmd(Cmd::HandleNewEldersAgreement { proposal, sig })
@@ -1419,7 +1421,7 @@ async fn handle_demote_during_split() -> Result<()> {
                     .await;
             }
 
-            let dispatcher = Dispatcher::new(Arc::new(node), comm);
+            let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             // Create agreement on `OurElder` for both sub-sections
             let create_our_elders_cmd = |signed_sap| -> Result<_> {

--- a/sn_node/src/node/api/tests/mod.rs
+++ b/sn_node/src/node/api/tests/mod.rs
@@ -193,8 +193,7 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
 
             let nonce: [u8; 32] = rand::random();
             let serialized = bincode::serialize(&(new_node.name(), nonce))?;
-            let nonce_signature =
-                ed25519::sign(&serialized, &node.read().await.info().await.keypair);
+            let nonce_signature = ed25519::sign(&serialized, &node.read().await.info().keypair);
 
             let rp = ResourceProof::new(RESOURCE_PROOF_DATA_SIZE, RESOURCE_PROOF_DIFFICULTY);
             let data = rp.create_proof_data(&nonce);
@@ -451,7 +450,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
             let auth = section_signed(sk_set.secret_key(), node_state.to_msg())?;
 
             // Force this node to join
-            node.read()
+            node.write()
                 .await
                 .membership
                 .as_mut()
@@ -1131,7 +1130,7 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
             genesis_sk_set,
         )
         .await?;
-        let info = node.info().await;
+        let info = node.info();
         let section_pk = node.network_knowledge().section_key();
         let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 

--- a/sn_node/src/node/core/api.rs
+++ b/sn_node/src/node/core/api.rs
@@ -77,12 +77,12 @@ impl Node {
     }
 
     /// Is this node an elder?
-    pub(crate) async fn is_elder(&self) -> bool {
-        self.network_knowledge.is_elder(&self.info().await.name())
+    pub(crate) fn is_elder(&self) -> bool {
+        self.network_knowledge.is_elder(&self.info().name())
     }
 
-    pub(crate) async fn is_not_elder(&self) -> bool {
-        !self.is_elder().await
+    pub(crate) fn is_not_elder(&self) -> bool {
+        !self.is_elder()
     }
 
     /// Returns the current BLS public key set
@@ -118,12 +118,9 @@ impl Node {
     //   ---------------------------------- Mut ------------------------------------------
     // ----------------------------------------------------------------------------------------
 
-    pub(crate) async fn handle_dkg_timeout(&self, token: u64) -> Result<Vec<Cmd>> {
-        self.dkg_voter.handle_timeout(
-            &self.info().await,
-            token,
-            self.network_knowledge().section_key(),
-        )
+    pub(crate) fn handle_dkg_timeout(&self, token: u64) -> Result<Vec<Cmd>> {
+        self.dkg_voter
+            .handle_timeout(&self.info(), token, self.network_knowledge().section_key())
     }
 
     // Send message to peers on the network.
@@ -131,7 +128,7 @@ impl Node {
         let dst_location = wire_msg.dst_location();
         let (targets, dg_size) = delivery_group::delivery_targets(
             dst_location,
-            &self.info().await.name(),
+            &self.info().name(),
             &self.network_knowledge,
         )?;
 
@@ -139,7 +136,7 @@ impl Node {
 
         // To avoid loop: if destination is to Node, targets are multiple, self is an elder,
         //     self section prefix matches the destination name, then don't carry out a relay.
-        if self.is_elder().await
+        if self.is_elder()
             && targets.len() > 1
             && dst_location.is_to_node()
             && self.network_knowledge.prefix().matches(&target_name)

--- a/sn_node/src/node/core/api.rs
+++ b/sn_node/src/node/core/api.rs
@@ -56,15 +56,14 @@ impl Node {
     }
 
     pub(crate) async fn relocate(
-        &self,
+        &mut self,
         new_keypair: Arc<Keypair>,
         new_section: NetworkKnowledge,
     ) -> Result<()> {
         // we first try to relocate section info.
         self.network_knowledge.relocated_to(new_section).await?;
 
-        let mut our_keypair = self.keypair.write().await;
-        *our_keypair = new_keypair;
+        self.keypair = new_keypair;
 
         Ok(())
     }

--- a/sn_node/src/node/core/connectivity.rs
+++ b/sn_node/src/node/core/connectivity.rs
@@ -24,7 +24,7 @@ impl Node {
             return Ok(vec![]);
         };
 
-        if self.is_not_elder().await {
+        if self.is_not_elder() {
             // Adults cannot complain about connectivity.
             return Ok(vec![]);
         }

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -38,7 +38,7 @@ impl Node {
     // Locate ideal holders for this data, line up wiremsgs for those to instruct them to store the data
     pub(crate) async fn replicate_data(&self, data: ReplicatedData) -> Result<Vec<Cmd>> {
         trace!("{:?}: {:?}", LogMarker::DataStoreReceivedAtElder, data);
-        if self.is_elder().await {
+        if self.is_elder() {
             let targets = self.get_adults_who_should_store_data(data.name()).await;
 
             info!(
@@ -284,15 +284,14 @@ impl Node {
         // we create a dummy/random dst location,
         // we will set it correctly for each msg and target
         let section_pk = self.network_knowledge().section_key();
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         let dummy_dst_location = DstLocation::Node {
             name: our_name,
             section_pk,
         };
 
         // separate this into form_wire_msg based on agg
-        let wire_msg =
-            WireMsg::single_src(&self.info().await, dummy_dst_location, msg, section_pk)?;
+        let wire_msg = WireMsg::single_src(&self.info(), dummy_dst_location, msg, section_pk)?;
 
         let mut cmds = vec![];
 

--- a/sn_node/src/node/core/messaging/handling/agreement.rs
+++ b/sn_node/src/node/core/messaging/handling/agreement.rs
@@ -263,7 +263,7 @@ impl Node {
 
         info!("New SAP agreed for:{}", *signed_section_auth);
 
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
 
         // Let's update our network knowledge, including our
         // section SAP and chain if the new SAP's prefix matches our name

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -30,7 +30,7 @@ use xor_name::XorName;
 impl Node {
     #[instrument(skip_all)]
     pub(crate) async fn handle_anti_entropy_update_msg(
-        &self,
+        &mut self,
         section_auth: SectionAuthorityProvider,
         section_signed: KeyedSig,
         proof_chain: SecuredLinkedList,
@@ -63,7 +63,7 @@ impl Node {
     }
 
     pub(crate) async fn handle_anti_entropy_retry_msg(
-        &self,
+        &mut self,
         section_auth: SectionAuthorityProvider,
         section_signed: KeyedSig,
         proof_chain: SecuredLinkedList,

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -38,7 +38,7 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         let snapshot = self.state_snapshot().await;
 
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         let signed_sap = SectionAuth {
             value: section_auth.clone(),
             sig: section_signed.clone(),
@@ -208,11 +208,11 @@ impl Node {
             value: section_auth.clone(),
             sig: section_signed.clone(),
         };
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         let our_section_prefix = self.network_knowledge.prefix();
         let equal_prefix = section_auth.prefix() == our_section_prefix;
         let is_extension_prefix = section_auth.prefix().is_extension_of(&our_section_prefix);
-        let our_peer_info = self.info().await.peer();
+        let our_peer_info = self.info().peer();
 
         // Update our network knowledge
         let there_was_an_update = self
@@ -328,7 +328,7 @@ impl Node {
                         bounced_msg,
                     };
                     let wire_msg = WireMsg::single_src(
-                        &self.info().await,
+                        &self.info(),
                         src_location.to_dst(),
                         ae_msg,
                         self.network_knowledge.section_key(),
@@ -415,7 +415,7 @@ impl Node {
         };
 
         let wire_msg = WireMsg::single_src(
-            &self.info().await,
+            &self.info(),
             src_location.to_dst(),
             ae_msg,
             self.network_knowledge.section_key(),
@@ -444,7 +444,7 @@ impl Node {
         };
 
         let wire_msg = WireMsg::single_src(
-            &self.info().await,
+            &self.info(),
             src_location.to_dst(),
             ae_msg,
             self.network_knowledge.section_key(),
@@ -501,7 +501,7 @@ mod tests {
                 let our_prefix = env.node.network_knowledge().prefix();
                 let (msg, src_location) =
                     env.create_msg(&our_prefix, env.node.network_knowledge().section_key())?;
-                let sender = env.node.info().await.peer();
+                let sender = env.node.info().peer();
                 let dst_name = our_prefix.substituted_in(xor_name::rand::random());
                 let dst_section_key = env.node.network_knowledge().section_key();
 
@@ -582,7 +582,7 @@ mod tests {
             let other_pk = other_sk.public_key();
 
             let (msg, src_location) = env.create_msg(&env.other_sap.prefix(), other_pk)?;
-            let sender = env.node.info().await.peer();
+            let sender = env.node.info().peer();
 
             // since it's not aware of the other prefix, it will redirect to self
             let dst_section_key = other_pk;
@@ -618,7 +618,7 @@ mod tests {
                         env.other_sap.clone(),
                         &env.proof_chain,
                         None,
-                        &env.node.info().await.name(),
+                        &env.node.info().name(),
                         &env.node.section_keys_provider
                     )
                     .await?
@@ -668,7 +668,7 @@ mod tests {
                 &our_prefix,
                 env.node.network_knowledge().section_key(),
             )?;
-            let sender = env.node.info().await.peer();
+            let sender = env.node.info().peer();
             let dst_name = our_prefix.substituted_in(xor_name::rand::random());
             let dst_section_key = env.node.network_knowledge().genesis_key();
 
@@ -714,7 +714,7 @@ mod tests {
            &our_prefix,
            env.node.network_knowledge().section_key(),
        )?;
-       let sender = env.node.info().await.peer();
+       let sender = env.node.info().peer();
        let dst_name = our_prefix.substituted_in(xor_name::rand::random());
 
        let bogus_env = Env::new().await?;

--- a/sn_node/src/node/core/messaging/handling/dkg.rs
+++ b/sn_node/src/node/core/messaging/handling/dkg.rs
@@ -65,7 +65,7 @@ impl Node {
         let cmds = self
             .dkg_voter
             .start(
-                &self.info().await,
+                &self.info(),
                 session_id,
                 self.network_knowledge().section_key(),
             )
@@ -93,7 +93,7 @@ impl Node {
         self.dkg_voter
             .process_msg(
                 sender,
-                &self.info().await,
+                &self.info(),
                 &session_id,
                 message,
                 self.network_knowledge().section_key(),
@@ -115,7 +115,7 @@ impl Node {
             session_id,
         };
         let wire_msg = WireMsg::single_src(
-            &self.info().await,
+            &self.info(),
             DstLocation::Node {
                 name: sender.name(),
                 section_pk,
@@ -149,7 +149,7 @@ impl Node {
         let mut cmds = self
             .dkg_voter
             .handle_dkg_history(
-                &self.info().await,
+                &self.info(),
                 session_id,
                 message_history,
                 sender.name(),
@@ -159,7 +159,7 @@ impl Node {
 
         cmds.extend(
             self.dkg_voter
-                .process_msg(sender, &self.info().await, session_id, message, section_key)
+                .process_msg(sender, &self.info(), session_id, message, section_key)
                 .await?,
         );
         Ok(cmds)

--- a/sn_node/src/node/core/messaging/handling/dkg.rs
+++ b/sn_node/src/node/core/messaging/handling/dkg.rs
@@ -30,7 +30,7 @@ use std::collections::BTreeSet;
 use xor_name::XorName;
 
 impl Node {
-    pub(crate) async fn handle_dkg_start(&self, session_id: DkgSessionId) -> Result<Vec<Cmd>> {
+    pub(crate) async fn handle_dkg_start(&mut self, session_id: DkgSessionId) -> Result<Vec<Cmd>> {
         let current_generation = self.network_knowledge.chain_len();
         if session_id.section_chain_len < current_generation {
             trace!("Skipping DkgStart for older generation: {:?}", &session_id);
@@ -59,12 +59,9 @@ impl Node {
         }
 
         trace!("Received DkgStart for {:?}", session_id);
-        self.dkg_sessions
-            .write()
-            .await
-            .retain(|_, existing_session_info| {
-                existing_session_info.session_id.section_chain_len >= session_id.section_chain_len
-            });
+        self.dkg_sessions.retain(|_, existing_session_info| {
+            existing_session_info.session_id.section_chain_len >= session_id.section_chain_len
+        });
         let cmds = self
             .dkg_voter
             .start(
@@ -234,7 +231,7 @@ impl Node {
     }
 
     pub(crate) async fn handle_dkg_outcome(
-        &self,
+        &mut self,
         sap: SectionAuthorityProvider,
         key_share: SectionKeyShare,
         generation: Generation,

--- a/sn_node/src/node/core/messaging/handling/join.rs
+++ b/sn_node/src/node/core/messaging/handling/join.rs
@@ -54,7 +54,7 @@ impl Node {
         // Ignore `JoinRequest` if we are not elder, unless the join request
         // is outdated in which case we'll reply with `JoinResponse::Retry`
         // with the up-to-date info.
-        if self.is_not_elder().await && section_key_matches {
+        if self.is_not_elder() && section_key_matches {
             // Note: We don't bounce this message because the current bounce-resend
             // mechanism wouldn't preserve the original SocketAddr which is needed for
             // properly handling this message.

--- a/sn_node/src/node/core/messaging/handling/join.rs
+++ b/sn_node/src/node/core/messaging/handling/join.rs
@@ -30,7 +30,7 @@ const FIRST_SECTION_MIN_ELDER_AGE: u8 = 90;
 // Message handling
 impl Node {
     pub(crate) async fn handle_join_request(
-        &self,
+        &mut self,
         peer: Peer,
         join_request: JoinRequest,
         comm: &Comm,
@@ -39,10 +39,7 @@ impl Node {
 
         // Require resource signed if joining as a new node.
         if let Some(response) = join_request.resource_proof_response {
-            if !self
-                .validate_resource_proof_response(&peer.name(), response)
-                .await
-            {
+            if !self.validate_resource_proof_response(&peer.name(), response) {
                 debug!("Ignoring JoinRequest from {peer} - invalid resource signed response");
                 return Ok(vec![]);
             }
@@ -83,7 +80,7 @@ impl Node {
             ]);
         }
 
-        if !*self.joins_allowed.read().await {
+        if !self.joins_allowed {
             debug!(
                 "Rejecting JoinRequest from {} - joins currently not allowed.",
                 peer,
@@ -203,7 +200,7 @@ impl Node {
     }
 
     pub(crate) async fn handle_join_as_relocated_request(
-        &self,
+        &mut self,
         peer: Peer,
         join_request: JoinAsRelocatedRequest,
         known_keys: Vec<BlsPublicKey>,

--- a/sn_node/src/node/core/messaging/handling/left.rs
+++ b/sn_node/src/node/core/messaging/handling/left.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeSet;
 
 impl Node {
     pub(crate) async fn handle_node_left(
-        &self,
+        &mut self,
         node_state: NodeState,
         sig: KeyedSig,
     ) -> Result<Vec<Cmd>> {
@@ -92,7 +92,7 @@ impl Node {
                 .collect(),
         )
         .await?;
-        *self.joins_allowed.write().await = true;
+        self.joins_allowed = true;
 
         Ok(cmds)
     }

--- a/sn_node/src/node/core/messaging/handling/mod.rs
+++ b/sn_node/src/node/core/messaging/handling/mod.rs
@@ -109,7 +109,7 @@ impl Node {
                 // Let's check for entropy before we proceed further
                 // Adult nodes don't need to carry out entropy checking,
                 // however the message shall always be handled.
-                if self.is_elder().await {
+                if self.is_elder() {
                     // For the case of receiving a join request not matching our prefix,
                     // we just let the join request handler to deal with it later on.
                     // We also skip AE check on Anti-Entropy messages
@@ -198,7 +198,7 @@ impl Node {
 
                 let src_location = wire_msg.auth_kind().src();
 
-                if self.is_not_elder().await {
+                if self.is_not_elder() {
                     trace!("Redirecting from adult to section elders");
                     cmds.push(
                         self.ae_redirect_to_our_elders(sender, &src_location, &wire_msg)
@@ -335,7 +335,7 @@ impl Node {
                     sender,
                     msg_id
                 );
-                if self.is_not_elder().await {
+                if self.is_not_elder() {
                     return Ok(vec![]);
                 }
 
@@ -439,7 +439,7 @@ impl Node {
                         if let Some(ref mut joining_as_relocated) = self.relocate_state {
                             let new_node = joining_as_relocated.node.clone();
                             let new_name = new_node.name();
-                            let previous_name = self.info().await.name();
+                            let previous_name = self.info().name();
                             let new_keypair = new_node.keypair.clone();
 
                             info!(
@@ -504,7 +504,7 @@ impl Node {
             }
             SystemMsg::JoinAsRelocatedRequest(join_request) => {
                 trace!("Handling msg: JoinAsRelocatedRequest from {}", sender);
-                if self.is_not_elder().await
+                if self.is_not_elder()
                     && join_request.section_key == self.network_knowledge.section_key()
                 {
                     return Ok(vec![]);
@@ -524,7 +524,7 @@ impl Node {
                 proposal,
                 sig_share,
             } => {
-                if self.is_not_elder().await {
+                if self.is_not_elder() {
                     trace!("Adult handling a Propose msg from {}: {:?}", sender, msg_id);
                 }
 
@@ -556,7 +556,7 @@ impl Node {
             SystemMsg::DkgStart(session_id) => {
                 trace!("Handling msg: Dkg-Start {:?} from {}", session_id, sender);
                 self.log_dkg_session(&sender.name()).await;
-                let our_name = self.info().await.name();
+                let our_name = self.info().name();
                 if !session_id.contains_elder(our_name) {
                     return Ok(vec![]);
                 }
@@ -639,7 +639,7 @@ impl Node {
                     msg_id
                 );
 
-                if self.is_elder().await {
+                if self.is_elder() {
                     if full {
                         let changed = self
                             .set_storage_level(&node_id, StorageLevel::from(StorageLevel::MAX)?)
@@ -657,7 +657,7 @@ impl Node {
             }
             SystemMsg::NodeCmd(NodeCmd::ReplicateData(data_collection)) => {
                 info!("ReplicateData MsgId: {:?}", msg_id);
-                return if self.is_elder().await {
+                return if self.is_elder() {
                     error!("Received unexpected message while Elder");
                     Ok(vec![])
                 } else {
@@ -778,7 +778,7 @@ impl Node {
                     };
                     let section_pk = self.network_knowledge.section_key();
                     let wire_msg = WireMsg::single_src(
-                        &self.info().await,
+                        &self.info(),
                         DstLocation::Node {
                             name: sender.name(),
                             section_pk,

--- a/sn_node/src/node/core/messaging/handling/relocation.rs
+++ b/sn_node/src/node/core/messaging/handling/relocation.rs
@@ -103,7 +103,7 @@ impl Node {
                 return Ok(None);
             };
 
-        let node = self.info().await;
+        let node = self.info();
         if dst_xorname != node.name() {
             // This `Relocate` message is not for us - it's most likely a duplicate of a previous
             // message that we already handled.

--- a/sn_node/src/node/core/messaging/handling/relocation.rs
+++ b/sn_node/src/node/core/messaging/handling/relocation.rs
@@ -85,7 +85,7 @@ impl Node {
     }
 
     pub(crate) async fn handle_relocate(
-        &self,
+        &mut self,
         relocate_proof: SectionAuth<NodeStateMsg>,
     ) -> Result<Option<Cmd>> {
         let (dst_xorname, dst_section_key, new_age) =
@@ -115,7 +115,7 @@ impl Node {
             dst_xorname
         );
 
-        match *self.relocate_state.read().await {
+        match self.relocate_state {
             Some(_) => {
                 trace!("Ignore Relocate - relocation already in progress");
                 return Ok(None);
@@ -149,7 +149,7 @@ impl Node {
             new_age,
         )?;
 
-        *self.relocate_state.write().await = Some(Box::new(joining_as_relocated));
+        self.relocate_state = Some(Box::new(joining_as_relocated));
 
         Ok(Some(cmd))
     }

--- a/sn_node/src/node/core/messaging/handling/resource_proof.rs
+++ b/sn_node/src/node/core/messaging/handling/resource_proof.rs
@@ -22,7 +22,7 @@ use xor_name::XorName;
 
 // Resource signed
 impl Node {
-    pub(crate) async fn validate_resource_proof_response(
+    pub(crate) fn validate_resource_proof_response(
         &self,
         peer_name: &XorName,
         response: ResourceProofResponse,
@@ -35,8 +35,6 @@ impl Node {
 
         if self
             .keypair
-            .read()
-            .await
             .public
             .verify(&serialized, &response.nonce_signature)
             .is_err()
@@ -56,7 +54,7 @@ impl Node {
             data_size: RESOURCE_PROOF_DATA_SIZE,
             difficulty: RESOURCE_PROOF_DIFFICULTY,
             nonce,
-            nonce_signature: ed25519::sign(&serialized, &*self.keypair.read().await),
+            nonce_signature: ed25519::sign(&serialized, &self.keypair),
         }));
 
         trace!("{}", LogMarker::SendResourceProofChallenge);

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -146,7 +146,7 @@ impl Node {
             response: query_response,
             correlation_id,
         };
-        let (auth_kind, payload) = self.ed_sign_client_msg(&msg).await?;
+        let (auth_kind, payload) = self.ed_sign_client_msg(&msg)?;
 
         for peer in waiting_peers.iter() {
             let dst = DstLocation::EndUser(EndUser(peer.name()));

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -244,7 +244,7 @@ impl Node {
             return Ok(vec![]);
         }
 
-        if self.is_not_elder().await {
+        if self.is_not_elder() {
             error!("Received unexpected message while Adult: {:?}", msg_id);
             return Ok(vec![]);
         }
@@ -365,7 +365,7 @@ impl Node {
         let _ = permissions.insert(User::Anyone, Permissions::new(true));
 
         // use our own keypair for generating the register command
-        let own_keypair = Keypair::Ed25519(self.info().await.keypair);
+        let own_keypair = Keypair::Ed25519(self.info().keypair);
         let owner = User::Key(own_keypair.public_key());
         let policy = Policy { owner, permissions };
 

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -94,7 +94,7 @@ impl Node {
         let adults_names = adults.iter().map(|p2p_node| p2p_node.name()).collect_vec();
 
         let elders = self.network_knowledge.elders();
-        let my_name = self.info().await.name();
+        let my_name = self.info().name();
 
         // find data targets that are not us.
         let mut target_member_names = adults_names
@@ -135,7 +135,7 @@ impl Node {
     pub(crate) async fn try_reorganize_data(&self) -> Result<Vec<Cmd>> {
         // as an elder we dont want to get any more data for our name
         // (elders will eventually be caching data in general)
-        if self.is_elder().await {
+        if self.is_elder() {
             return Ok(vec![]);
         }
 

--- a/sn_node/src/node/core/messaging/sending/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/sending/anti_entropy.rs
@@ -23,7 +23,7 @@ use xor_name::Prefix;
 impl Node {
     /// Send `AntiEntropyUpdate` message to all nodes in our own section.
     pub(crate) async fn send_ae_update_to_our_section(&self) -> Vec<Cmd> {
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         let nodes: Vec<_> = self
             .network_knowledge
             .section_members()

--- a/sn_node/src/node/core/messaging/sending/handover.rs
+++ b/sn_node/src/node/core/messaging/sending/handover.rs
@@ -20,15 +20,14 @@ use tracing::warn;
 impl Node {
     /// Make a handover consensus proposal vote for a sap candidate
     pub(crate) async fn propose_handover_consensus(
-        &self,
+        &mut self,
         sap_candidates: SapCandidate,
     ) -> Result<Vec<Cmd>> {
-        let mut wlock = self.handover_voting.write().await;
-        match &*wlock {
+        match &self.handover_voting {
             Some(handover_voting_state) => {
                 let mut vs = handover_voting_state.clone();
                 let vote = vs.propose(sap_candidates)?;
-                *wlock = Some(vs);
+                self.handover_voting = Some(vs);
                 debug!("{}: {:?}", LogMarker::HandoverConsensusTrigger, &vote);
                 Ok(self.broadcast_handover_vote_msg(vote).await)
             }

--- a/sn_node/src/node/core/messaging/sending/proposal.rs
+++ b/sn_node/src/node/core/messaging/sending/proposal.rs
@@ -80,7 +80,7 @@ impl Node {
         // Carry out a substitution to prevent the dst_location becomes other section.
         let section_key = self.network_knowledge.section_key();
         let wire_msg = WireMsg::single_src(
-            &self.info().await,
+            &self.info(),
             DstLocation::Section {
                 name: self.network_knowledge.prefix().name(),
                 section_pk: section_key,
@@ -95,7 +95,7 @@ impl Node {
         let msg_id = wire_msg.msg_id();
 
         let mut cmds = vec![];
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         // handle ourselves if we should
         for peer in recipients.clone() {
             if peer.name() == our_name {

--- a/sn_node/src/node/core/messaging/sending/services.rs
+++ b/sn_node/src/node/core/messaging/sending/services.rs
@@ -46,7 +46,7 @@ impl Node {
     async fn send_cmd_response(&self, target: Peer, msg: ServiceMsg) -> Result<Vec<Cmd>> {
         let dst = DstLocation::EndUser(EndUser(target.name()));
 
-        let (auth_kind, payload) = self.ed_sign_client_msg(&msg).await?;
+        let (auth_kind, payload) = self.ed_sign_client_msg(&msg)?;
         let wire_msg = WireMsg::new_msg(MsgId::new(), payload, auth_kind, dst)?;
 
         let cmd = Cmd::SendMsg {
@@ -58,11 +58,8 @@ impl Node {
     }
 
     /// Currently using node's Ed key. May need to use bls key share for concensus purpose.
-    pub(crate) async fn ed_sign_client_msg(
-        &self,
-        client_msg: &ServiceMsg,
-    ) -> Result<(AuthKind, Bytes)> {
-        let keypair = self.keypair.read().await.clone();
+    pub(crate) fn ed_sign_client_msg(&self, client_msg: &ServiceMsg) -> Result<(AuthKind, Bytes)> {
+        let keypair = self.keypair.clone();
         let payload = WireMsg::serialize_msg_payload(client_msg)?;
         let signature = keypair.sign(&payload);
 

--- a/sn_node/src/node/core/messaging/sending/system.rs
+++ b/sn_node/src/node/core/messaging/sending/system.rs
@@ -42,7 +42,7 @@ impl Node {
         section_pk: BlsPublicKey,
     ) -> Result<Cmd> {
         trace!("{}", LogMarker::SendDirectToNodes);
-        let our_node = self.info().await;
+        let our_node = self.info();
         let our_section_key = self.network_knowledge.section_key();
 
         let wire_msg = WireMsg::single_src(
@@ -95,7 +95,7 @@ impl Node {
 
         trace!("Send {:?} to {:?}", wire_msg, recipients);
 
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         for recipient in recipients.into_iter() {
             if recipient.name() == our_name {
                 match wire_msg.auth_kind() {

--- a/sn_node/src/node/core/mod.rs
+++ b/sn_node/src/node/core/mod.rs
@@ -231,7 +231,7 @@ impl Node {
         Ok(node)
     }
 
-    pub(crate) async fn info(&self) -> NodeInfo {
+    pub(crate) fn info(&self) -> NodeInfo {
         let keypair = self.keypair.clone();
         let addr = self.addr;
         NodeInfo { keypair, addr }
@@ -328,7 +328,7 @@ impl Node {
 
     pub(super) async fn state_snapshot(&self) -> StateSnapshot {
         StateSnapshot {
-            is_elder: self.is_elder().await,
+            is_elder: self.is_elder(),
             section_key: self.network_knowledge.section_key(),
             prefix: self.network_knowledge.prefix(),
             elders: self.network_knowledge().authority_provider().names(),

--- a/sn_node/src/node/core/mod.rs
+++ b/sn_node/src/node/core/mod.rs
@@ -108,12 +108,11 @@ pub(crate) struct Node {
     addr: SocketAddr, // does this change? if so... when? only at node start atm?
     pub(super) event_sender: EventSender,
     pub(super) data_storage: DataStorage, // Adult only before cache
-    pub(crate) keypair: Arc<RwLock<Arc<Keypair>>>,
+    pub(crate) keypair: Arc<Keypair>,
     /// queue up all batch data to be replicated (as a result of churn events atm)
     // TODO: This can probably be reworked into the general per peer msg queue, but as
     // we need to pull data first before we form the WireMsg, we won't do that just now
-    pub(crate) pending_data_to_replicate_to_peers:
-        Arc<DashMap<ReplicatedDataAddress, Arc<RwLock<BTreeSet<Peer>>>>>,
+    pub(crate) pending_data_to_replicate_to_peers: DashMap<ReplicatedDataAddress, BTreeSet<Peer>>,
     resource_proof: ResourceProof,
     // Network resources
     pub(crate) section_keys_provider: SectionKeysProvider,
@@ -122,19 +121,19 @@ pub(crate) struct Node {
     message_aggregator: SignatureAggregator,
     proposal_aggregator: SignatureAggregator,
     // DKG/Split/Churn modules
-    split_barrier: Arc<RwLock<SplitBarrier>>,
-    dkg_sessions: Arc<RwLock<HashMap<Digest256, DkgSessionInfo>>>,
+    split_barrier: SplitBarrier,
+    dkg_sessions: HashMap<Digest256, DkgSessionInfo>,
     dkg_voter: DkgVoter,
-    relocate_state: Arc<RwLock<Option<Box<JoiningAsRelocated>>>>,
+    relocate_state: Option<Box<JoiningAsRelocated>>,
     // ======================== Elder only ========================
-    pub(crate) membership: Arc<RwLock<Option<Membership>>>,
+    pub(crate) membership: Option<Membership>,
     // Section handover consensus state (Some for Elders, None for others)
-    pub(crate) handover_voting: Arc<RwLock<Option<Handover>>>,
-    joins_allowed: Arc<RwLock<bool>>,
+    pub(crate) handover_voting: Option<Handover>,
+    joins_allowed: bool,
     // Trackers
     capacity: Capacity,
     pub(crate) dysfunction_tracking: DysfunctionDetection,
-    pending_data_queries: Arc<Cache<OperationId, Arc<DashSet<Peer>>>>,
+    pending_data_queries: Cache<OperationId, Arc<DashSet<Peer>>>,
     // Caches
     ae_backoff_cache: AeBackoffCache,
 }
@@ -205,26 +204,26 @@ impl Node {
 
         let node = Self {
             addr,
-            keypair: Arc::new(RwLock::new(keypair)),
+            keypair,
             network_knowledge,
             section_keys_provider,
-            dkg_sessions: Arc::new(RwLock::new(HashMap::default())),
+            dkg_sessions: HashMap::default(),
             proposal_aggregator: SignatureAggregator::default(),
-            split_barrier: Arc::new(RwLock::new(SplitBarrier::new())),
+            split_barrier: SplitBarrier::new(),
             message_aggregator: SignatureAggregator::default(),
             dkg_voter: DkgVoter::default(),
-            relocate_state: Arc::new(RwLock::new(None)),
+            relocate_state: None,
             event_sender,
-            handover_voting: Arc::new(RwLock::new(handover)),
-            joins_allowed: Arc::new(RwLock::new(true)),
+            handover_voting: handover,
+            joins_allowed: true,
             resource_proof: ResourceProof::new(RESOURCE_PROOF_DATA_SIZE, RESOURCE_PROOF_DIFFICULTY),
             data_storage,
             capacity: Capacity::default(),
             dysfunction_tracking: node_dysfunction_detector,
-            pending_data_queries: Arc::new(Cache::with_expiry_duration(DATA_QUERY_TIMEOUT)),
-            pending_data_to_replicate_to_peers: Arc::new(DashMap::new()),
+            pending_data_queries: Cache::with_expiry_duration(DATA_QUERY_TIMEOUT),
+            pending_data_to_replicate_to_peers: DashMap::new(),
             ae_backoff_cache: AeBackoffCache::default(),
-            membership: Arc::new(RwLock::new(membership)),
+            membership,
         };
 
         node.write_prefix_map().await;
@@ -233,7 +232,7 @@ impl Node {
     }
 
     pub(crate) async fn info(&self) -> NodeInfo {
-        let keypair = self.keypair.read().await.clone();
+        let keypair = self.keypair.clone();
         let addr = self.addr;
         NodeInfo { keypair, addr }
     }
@@ -348,20 +347,19 @@ impl Node {
 
         // get current gen and members
         let current_gen;
-        let members: BTreeMap<XorName, NodeState> =
-            if let Some(m) = self.membership.read().await.as_ref() {
-                current_gen = m.generation();
-                m.current_section_members()
-                    .iter()
-                    .filter(|(name, _node_state)| !excluded_names.contains(*name))
-                    .map(|(n, s)| (*n, s.clone()))
-                    .collect()
-            } else {
-                error!(
+        let members: BTreeMap<XorName, NodeState> = if let Some(m) = self.membership.as_ref() {
+            current_gen = m.generation();
+            m.current_section_members()
+                .iter()
+                .filter(|(name, _node_state)| !excluded_names.contains(*name))
+                .map(|(n, s)| (*n, s.clone()))
+                .collect()
+        } else {
+            error!(
                 "attempted to promote and demote elders when we don't have a membership instance"
             );
-                return Ok(vec![]);
-            };
+            return Ok(vec![]);
+        };
 
         // Try splitting
         trace!("{}", LogMarker::SplitAttempt);
@@ -448,15 +446,13 @@ impl Node {
         Ok(res)
     }
 
-    async fn initialize_membership(&self, sap: SectionAuthorityProvider) -> Result<()> {
+    async fn initialize_membership(&mut self, sap: SectionAuthorityProvider) -> Result<()> {
         let key = self
             .section_keys_provider
             .key_share(&self.network_knowledge.section_key())
             .await?;
 
-        let mut membership = self.membership.write().await;
-
-        *membership = Some(Membership::from(
+        self.membership = Some(Membership::from(
             (key.index as u8, key.secret_key_share),
             key.public_key_set,
             sap.elders.len(),
@@ -466,7 +462,7 @@ impl Node {
         Ok(())
     }
 
-    async fn initialize_handover(&self) -> Result<()> {
+    async fn initialize_handover(&mut self) -> Result<()> {
         let key = self
             .section_keys_provider
             .key_share(&self.network_knowledge.section_key())
@@ -474,11 +470,9 @@ impl Node {
         let n_elders = self.network_knowledge.authority_provider().elder_count();
 
         // reset split barrier for
-        let mut split_barrier = self.split_barrier.write().await;
-        *split_barrier = SplitBarrier::new();
+        self.split_barrier = SplitBarrier::new();
 
-        let mut handover_voting = self.handover_voting.write().await;
-        *handover_voting = Some(Handover::from(
+        self.handover_voting = Some(Handover::from(
             (key.index as u8, key.secret_key_share),
             key.public_key_set,
             n_elders,
@@ -487,7 +481,7 @@ impl Node {
         Ok(())
     }
 
-    async fn initialize_elder_state(&self) -> Result<()> {
+    async fn initialize_elder_state(&mut self) -> Result<()> {
         let sap = self
             .network_knowledge
             .section_signed_authority_provider()
@@ -500,7 +494,7 @@ impl Node {
 
     /// Generate cmds and fire events based upon any node state changes.
     pub(super) async fn update_self_for_new_node_state(
-        &self,
+        &mut self,
         old: StateSnapshot,
     ) -> Result<Vec<Cmd>> {
         let mut cmds = vec![];
@@ -545,7 +539,7 @@ impl Node {
                     // Whenever there is an elders change, casting a round of joins_allowed
                     // proposals to sync.
                     cmds.extend(
-                        self.propose(Proposal::JoinsAllowed(*self.joins_allowed.read().await))
+                        self.propose(Proposal::JoinsAllowed(self.joins_allowed))
                             .await?,
                     );
                 }
@@ -554,8 +548,7 @@ impl Node {
                 self.log_section_stats().await;
             } else {
                 // if not elder
-                let mut handover_voting = self.handover_voting.write().await;
-                *handover_voting = None;
+                self.handover_voting = None;
             }
 
             if new.is_elder || old.is_elder {
@@ -671,7 +664,7 @@ impl Node {
     }
 
     pub(super) async fn log_section_stats(&self) {
-        if let Some(m) = self.membership.read().await.as_ref() {
+        if let Some(m) = self.membership.as_ref() {
             let adults = self.network_knowledge.adults().len();
 
             let elders = self.network_knowledge.authority_provider().elder_count();

--- a/sn_node/src/node/logging/log_ctx.rs
+++ b/sn_node/src/node/logging/log_ctx.rs
@@ -9,18 +9,19 @@
 use crate::node::core::Node;
 
 use std::sync::Arc;
+use tokio::sync::RwLock;
 use xor_name::Prefix;
 
 pub(crate) struct LogCtx {
-    node: Arc<Node>,
+    node: Arc<RwLock<Node>>,
 }
 
 impl LogCtx {
-    pub(crate) fn new(node: Arc<Node>) -> Self {
+    pub(crate) fn new(node: Arc<RwLock<Node>>) -> Self {
         Self { node }
     }
 
     pub(crate) async fn prefix(&self) -> Prefix {
-        self.node.network_knowledge().prefix()
+        self.node.read().await.network_knowledge().prefix()
     }
 }


### PR DESCRIPTION
Fixes the case when a node start times out and a new node is started
while the previous one is still looping in some task.

This used to cause `address already in use` errors.

Even though a random address would have solved that,
it's better to ensure that the running node actually is dropped, before
starting a new one.

(NB: Might well be better and cleaner solutions to this, that could be discussed in this PR)