### PR TITLE
chore: dey clippy drop_ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
+dependencies = [
+ "clap 3.2.8",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3718,6 +3727,8 @@ dependencies = [
  "bytes",
  "cargo-husky",
  "chrono",
+ "clap 3.2.8",
+ "clap_complete",
  "color-eyre",
  "console-subscriber",
  "crdts",
@@ -3758,7 +3769,6 @@ dependencies = [
  "sn_dbc",
  "sn_dysfunction",
  "sn_interface",
- "structopt",
  "strum",
  "strum_macros",
  "sysinfo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,10 +611,49 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -774,7 +813,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.33.4",
  "criterion-plot",
  "csv",
  "futures",
@@ -1590,6 +1629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,6 +2262,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "os_type"
@@ -2946,7 +2997,7 @@ version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297f34e590f33704543f29d3001db82bf89f30cfbbc026a7f16fc92526430b07"
 dependencies = [
- "clap",
+ "clap 2.33.4",
  "rand 0.4.6",
  "termion",
  "tiny-keccak",
@@ -3435,7 +3486,7 @@ dependencies = [
  "sn_api",
  "sn_cmd_test_utilities",
  "sn_dbc",
- "sn_launch_tool",
+ "sn_launch_tool 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt",
  "tokio",
  "tracing",
@@ -3488,7 +3539,7 @@ dependencies = [
  "signature",
  "sn_dbc",
  "sn_interface",
- "sn_launch_tool",
+ "sn_launch_tool 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt",
  "strum",
  "strum_macros",
@@ -3631,6 +3682,18 @@ dependencies = [
 [[package]]
 name = "sn_launch_tool"
 version = "0.9.9"
+dependencies = [
+ "clap 3.2.8",
+ "color-eyre",
+ "dirs-next 1.0.2",
+ "eyre",
+ "tracing",
+ "tracing-subscriber 0.3.11",
+]
+
+[[package]]
+name = "sn_launch_tool"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0ee2674871b9ee1025f46e144a0a37e1d240f054a05db5eed7ffcb4278f0f1"
 dependencies = [
@@ -3738,12 +3801,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.33.4",
  "lazy_static",
  "structopt-derive",
 ]
@@ -3754,7 +3823,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3773,7 +3842,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3902,12 +3971,12 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 name = "testnet"
 version = "0.1.0"
 dependencies = [
+ "clap 3.2.8",
  "color-eyre",
  "console-subscriber",
  "dirs-next 2.0.0",
  "eyre",
- "sn_launch_tool",
- "structopt",
+ "sn_launch_tool 0.9.9",
  "tokio",
  "tracing",
  "tracing-core",
@@ -3922,6 +3991,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,7 +3497,7 @@ dependencies = [
  "sn_api",
  "sn_cmd_test_utilities",
  "sn_dbc",
- "sn_launch_tool 0.9.9",
+ "sn_launch_tool",
  "tokio",
  "tracing",
  "tracing-subscriber 0.2.25",
@@ -3517,6 +3517,7 @@ dependencies = [
  "blsttc",
  "bytes",
  "cargo-husky",
+ "clap 3.2.8",
  "console-subscriber",
  "crdts",
  "criterion",
@@ -3549,8 +3550,7 @@ dependencies = [
  "signature",
  "sn_dbc",
  "sn_interface",
- "sn_launch_tool 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt",
+ "sn_launch_tool",
  "strum",
  "strum_macros",
  "tempfile",
@@ -3702,20 +3702,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sn_launch_tool"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0ee2674871b9ee1025f46e144a0a37e1d240f054a05db5eed7ffcb4278f0f1"
-dependencies = [
- "color-eyre",
- "dirs-next 1.0.2",
- "eyre",
- "structopt",
- "tracing",
- "tracing-subscriber 0.3.11",
-]
-
-[[package]]
 name = "sn_node"
 version = "0.64.0"
 dependencies = [
@@ -3816,30 +3802,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.33.4",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "strum"
@@ -3987,7 +3949,7 @@ dependencies = [
  "console-subscriber",
  "dirs-next 2.0.0",
  "eyre",
- "sn_launch_tool 0.9.9",
+ "sn_launch_tool",
  "tokio",
  "tracing",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,11 +1970,11 @@ dependencies = [
 name = "log_cmds_inspector"
 version = "0.1.0"
 dependencies = [
+ "clap 3.2.8",
  "console-subscriber",
  "eyre",
  "grep",
  "sn_interface",
- "structopt",
  "strum",
  "strum_macros",
  "walkdir",
@@ -3467,6 +3467,8 @@ dependencies = [
  "blsttc",
  "bytes",
  "chrono",
+ "clap 3.2.8",
+ "clap_complete",
  "color-eyre",
  "comfy-table",
  "console 0.14.1",
@@ -3495,8 +3497,7 @@ dependencies = [
  "sn_api",
  "sn_cmd_test_utilities",
  "sn_dbc",
- "sn_launch_tool 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt",
+ "sn_launch_tool 0.9.9",
  "tokio",
  "tracing",
  "tracing-subscriber 0.2.25",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,7 +3691,9 @@ dependencies = [
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.9.9"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8527acfd201cfddc6a03e9dee59c1cc80e97e41e4f3e42fa325d57f3704174b9"
 dependencies = [
  "clap 3.2.8",
  "color-eyre",

--- a/log_cmds_inspector/Cargo.toml
+++ b/log_cmds_inspector/Cargo.toml
@@ -24,7 +24,7 @@ name="log_cmds_inspector"
 console-subscriber = { version = "~0.1.3", optional = true }
 eyre = "~0.6.5"
 grep="~0.2.8"
-structopt = "~0.3.17"
+clap = { version = "3.0.0", features = ["derive", "env"] }
 strum = "~0.23.0"
 strum_macros = "~0.23.1"
 walkdir = "2"

--- a/log_cmds_inspector/bin.rs
+++ b/log_cmds_inspector/bin.rs
@@ -8,6 +8,7 @@
 
 use sn_interface::types::log_markers::LogMarker;
 
+use clap::{AppSettings::ColoredHelp, Parser, Subcommand};
 use eyre::{bail, Error, Result};
 use grep::{matcher::Matcher, regex::RegexMatcher, searcher::sinks::UTF8, searcher::Searcher};
 use std::{
@@ -15,25 +16,24 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-use structopt::{clap::AppSettings::ColoredHelp, StructOpt};
 use strum::IntoEnumIterator;
 use walkdir::WalkDir;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 /// Inspect Safe Network local testnet logs
-#[structopt(global_settings(&[ColoredHelp]))]
+#[clap(global_settings(&[ColoredHelp]), version)]
 struct CmdArgs {
     /// sub cmds
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: Option<SubCmds>,
     /// Path to the testnet logs folder, e.g. ~/.safe/node/local-test-network
     pub logs_path: PathBuf,
     /// Show stats per node? (this is slower)
-    #[structopt(short)]
+    #[clap(short)]
     pub nodes: bool,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 enum SubCmds {
     /// Generate a report of cmds and corresponding sub-cmds
     // TODO: make the cmd-id optional, to report all cmds
@@ -52,7 +52,7 @@ enum SubCmds {
 }
 
 fn main() -> Result<()> {
-    let args = CmdArgs::from_args();
+    let args = CmdArgs::parse();
     let report = inspect_log_files(&args)?;
 
     println!();

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -39,8 +39,7 @@ reqwest = { version = "~0.11", default-features = false, features = [ "rustls-tl
 rmp-serde = "1.0.0"
 sn_api = { path = "../sn_api", version = "^0.66.0", default-features=false, features = ["app", "authd_client"] }
 sn_dbc = { version = "6.0.0", features = ["serdes"] }
-sn_launch_tool = { path = "../../sn_launch_tool" }
-# sn_launch_tool = "~0.9.9"
+sn_launch_tool = "~0.10.0"
 serde = "1.0.123"
 serde_json = "1.0.62"
 serde_yaml = "~0.8"

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -39,11 +39,13 @@ reqwest = { version = "~0.11", default-features = false, features = [ "rustls-tl
 rmp-serde = "1.0.0"
 sn_api = { path = "../sn_api", version = "^0.66.0", default-features=false, features = ["app", "authd_client"] }
 sn_dbc = { version = "6.0.0", features = ["serdes"] }
-sn_launch_tool = "~0.9.9"
+sn_launch_tool = { path = "../../sn_launch_tool" }
+# sn_launch_tool = "~0.9.9"
 serde = "1.0.123"
 serde_json = "1.0.62"
 serde_yaml = "~0.8"
-structopt = "~0.3"
+clap = { version = "3.0.0", features = ["derive", "env"] }
+clap_complete = { version = "3.0.0" }
 tokio = { version = "1.6.0", features = ["macros"] }
 tracing = "~0.1.26"
 tracing-subscriber = "~0.2.15"

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -25,36 +25,36 @@ use crate::{
         OutputFmt, SubCommands,
     },
 };
+use clap::{AppSettings::ColoredHelp, Parser};
 use color_eyre::{eyre::eyre, Result};
 use sn_api::{Safe, XorUrlBase};
 use std::env;
 use std::path::PathBuf;
 use std::time::Duration;
-use structopt::{clap::AppSettings::ColoredHelp, StructOpt};
 use tracing::debug;
 
 use sn_api::SN_PREFIX_MAP_DIR;
 const DEFAULT_OPERATION_TIMEOUT_SECS: u64 = 120; // 2mins
 const SN_CLI_QUERY_TIMEOUT: &str = "SN_CLI_QUERY_TIMEOUT";
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::StructOpt, Debug)]
 /// Interact with the Safe Network
-#[structopt(global_settings(&[ColoredHelp]))]
+#[clap(global_settings(&[ColoredHelp]), version)]
 pub struct CmdArgs {
     /// subcommands
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: SubCommands,
     /// Output data serialisation: [json, jsoncompact, yaml]
-    #[structopt(short = "o", long = "output", global(true))]
+    #[clap(short = 'o', long = "output", global(true))]
     output_fmt: Option<OutputFmt>,
     /// Sets JSON as output serialisation format (alias of '--output json')
-    #[structopt(long = "json", global(true))]
+    #[clap(long = "json", global(true))]
     output_json: bool,
     // /// Increase output verbosity. (More logs!)
-    // #[structopt(short = "v", long = "verbose", global(true))]
+    // #[clap(short = 'v', long = "verbose", global(true))]
     // verbose: bool,
     /// Dry run of command. No data will be written. No coins spent
-    #[structopt(short = "n", long = "dry-run", global(true))]
+    #[clap(short = 'n', long = "dry-run", global(true))]
     dry: bool,
     /// Base encoding to be used for XOR-URLs generated. Currently supported: base32z (default), base32 and base64
     #[structopt(long = "xorurl", global(true))]

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -57,7 +57,7 @@ pub struct CmdArgs {
     #[clap(short = 'n', long = "dry-run", global(true))]
     dry: bool,
     /// Base encoding to be used for XOR-URLs generated. Currently supported: base32z (default), base32 and base64
-    #[structopt(long = "xorurl", global(true))]
+    #[clap(long = "xorurl", global(true))]
     xorurl_base: Option<XorUrlBase>,
 }
 

--- a/sn_cli/src/operations/config.rs
+++ b/sn_cli/src/operations/config.rs
@@ -8,6 +8,7 @@
 
 use bls::PublicKey as BlsPublicKey;
 use bytes::Bytes;
+use clap::Parser;
 use color_eyre::{eyre::bail, eyre::eyre, eyre::WrapErr, Help, Report, Result};
 use comfy_table::Table;
 use reqwest::StatusCode;
@@ -22,7 +23,6 @@ use std::{
     thread,
     time::Duration,
 };
-use structopt::StructOpt;
 use tokio::fs;
 use tracing::debug;
 use url::Url;

--- a/sn_cli/src/subcommands/cat.rs
+++ b/sn_cli/src/subcommands/cat.rs
@@ -12,22 +12,22 @@ use super::{
     },
     OutputFmt,
 };
+use clap::Args;
 use color_eyre::{eyre::WrapErr, Result};
 use comfy_table::Table;
 use sn_api::{resolver::SafeData, ContentType, Safe, SafeUrl};
 use std::io::{self, Write};
-use structopt::StructOpt;
 use tokio::time::{sleep, Duration};
 use tracing::{debug, trace};
 
 const MAX_RETRY_ATTEMPTS: usize = 5;
 
-#[derive(StructOpt, Debug)]
+#[derive(Args, Debug)]
 pub struct CatCommands {
     /// The safe:// location to retrieve
     location: Option<String>,
     /// Renders file output as hex
-    #[structopt(short = "x", long = "hexdump")]
+    #[clap(short = 'x', long = "hexdump")]
     hexdump: bool,
 }
 

--- a/sn_cli/src/subcommands/config.rs
+++ b/sn_cli/src/subcommands/config.rs
@@ -7,35 +7,35 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::operations::config::{Config, NetworkInfo};
+use clap::Subcommand;
 use color_eyre::Result;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tracing::debug;
 use url::Url;
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum ConfigSubCommands {
-    #[structopt(name = "add")]
+    #[clap(name = "add", subcommand)]
     /// Add a config setting
     Add(SettingAddCmd),
-    #[structopt(name = "remove")]
+    #[clap(name = "remove", subcommand)]
     /// Remove a config setting
     Remove(SettingRemoveCmd),
-    #[structopt(name = "clear")]
+    #[clap(name = "clear")]
     /// Remove all config settings and network maps
     Clear,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum SettingAddCmd {
-    #[structopt(name = "network")]
+    #[clap(name = "network")]
     Network {
         /// Network name
         network_name: String,
         /// Local path or a remote URL to fetch the network map from
         prefix_location: String,
     },
-    // #[structopt(name = "contact")]
+    // #[clap(name = "contact")]
     // Contact {
     //    /// Contact friendly name
     //    name: String,
@@ -44,14 +44,14 @@ pub enum SettingAddCmd {
     // },
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum SettingRemoveCmd {
-    #[structopt(name = "network")]
+    #[clap(name = "network")]
     Network {
         /// Network to remove
         network_name: String,
     },
-    // #[structopt(name = "contact")]
+    // #[clap(name = "contact")]
     // Contact {
     //    /// Name of the contact to remove
     //    name: String,

--- a/sn_cli/src/subcommands/dog.rs
+++ b/sn_cli/src/subcommands/dog.rs
@@ -12,15 +12,15 @@ use super::{
     },
     OutputFmt,
 };
+use clap::Args;
 use color_eyre::Result;
 use sn_api::{
     resolver::{ContentType, SafeData},
     Safe, SafeUrl,
 };
-use structopt::StructOpt;
 use tracing::debug;
 
-#[derive(StructOpt, Debug)]
+#[derive(Args, Debug)]
 pub struct DogCommands {
     /// The safe:// location to inspect
     location: Option<String>,

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -16,6 +16,7 @@ use super::{
 };
 use ansi_term::Colour;
 use bytes::Bytes;
+use clap::Subcommand;
 use color_eyre::{eyre::bail, eyre::eyre, Result};
 use comfy_table::Table;
 use serde::Serialize;
@@ -29,7 +30,6 @@ use std::{
     collections::{BTreeMap, HashMap},
     path::{Component, Path, PathBuf},
 };
-use structopt::StructOpt;
 use tracing::debug;
 
 type FileDetails = BTreeMap<String, String>;
@@ -95,9 +95,9 @@ impl FileTreeNode {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum FilesSubCommands {
-    #[structopt(name = "put")]
+    #[clap(name = "put")]
     /// Put a file or folder's files onto the SAFE Network
     Put {
         /// The source file/folder local path
@@ -105,10 +105,10 @@ pub enum FilesSubCommands {
         /// The destination path (in the FilesContainer) for the uploaded files and folders (default is '/')
         dst: Option<PathBuf>,
         /// Recursively upload folders and files found in the source location
-        #[structopt(short = "r", long = "recursive")]
+        #[clap(short = 'r', long = "recursive")]
         recursive: bool,
         /// Follow symlinks
-        #[structopt(short = "l", long = "follow-links")]
+        #[clap(short = 'l', long = "follow-links")]
         follow_links: bool,
     },
     /// Get a file or folder from the SAFE Network
@@ -118,16 +118,16 @@ pub enum FilesSubCommands {
         /// The local destination path for the retrieved files and folders (default is '.')
         dst: Option<String>,
         /// How to handle pre-existing files.
-        #[structopt(short = "e", long = "exists", possible_values = &["ask", "preserve", "overwrite"], default_value="ask")]
+        #[clap(short = 'e', long = "exists", possible_values = &["ask", "preserve", "overwrite"], default_value="ask")]
         exists: FileExistsAction,
         /// How to display progress.
-        #[structopt(short = "i", long = "progress", possible_values = &["text", "none"], default_value="text")]
+        #[clap(short = 'i', long = "progress", possible_values = &["text", "none"], default_value="text")]
         progress: ProgressIndicator,
         /// Preserves modification times, access times, and modes from the original file
-        #[structopt(short = "p", long = "preserve")]
+        #[clap(short = 'p', long = "preserve")]
         preserve: bool,
     },
-    #[structopt(name = "sync")]
+    #[clap(name = "sync")]
     /// Sync files to the SAFE Network
     Sync {
         /// The source location
@@ -135,66 +135,66 @@ pub enum FilesSubCommands {
         /// The target FilesContainer to sync up source files with, optionally including the destination path (default is '/')
         target: Option<String>,
         /// Recursively sync folders and files found in the source location
-        #[structopt(short = "r", long = "recursive")]
+        #[clap(short = 'r', long = "recursive")]
         recursive: bool,
         /// Follow symlinks
-        #[structopt(short = "l", long = "follow-links")]
+        #[clap(short = 'l', long = "follow-links")]
         follow_links: bool,
         /// Delete files found at the target FilesContainer that are not in the source location. This is only allowed when --recursive is passed as well
-        #[structopt(short = "d", long = "delete")]
+        #[clap(short = 'd', long = "delete")]
         delete: bool,
         /// Automatically update the NRS name to link to the new version of the FilesContainer. This is only allowed if an NRS URL was provided, and if the NRS name is currently linked to a specific version of the FilesContainer
-        #[structopt(short = "u", long = "update-nrs")]
+        #[clap(short = 'u', long = "update-nrs")]
         update_nrs: bool,
     },
-    #[structopt(name = "add")]
+    #[clap(name = "add")]
     /// Add a file to an existing FilesContainer on the network
     Add {
         /// The source file location.  Specify '-' to read from stdin
-        #[structopt(
+        #[clap(
             parse(from_str = parse_stdin_arg),
             requires_if("", "target"),
             requires_if("-", "target")
         )]
         location: String,
         /// The target FilesContainer to add the source file to, optionally including the destination path (default is '/') and new file name
-        #[structopt(parse(from_str = parse_stdin_arg))]
+        #[clap(parse(from_str = parse_stdin_arg))]
         target: Option<String>,
         /// Automatically update the NRS name to link to the new version of the FilesContainer. This is only allowed if an NRS URL was provided, and if the NRS name is currently linked to a specific version of the FilesContainer
-        #[structopt(short = "u", long = "update-nrs")]
+        #[clap(short = 'u', long = "update-nrs")]
         update_nrs: bool,
         /// Overwrite the file on the FilesContainer if there already exists a file with the same name
-        #[structopt(short = "f", long = "force")]
+        #[clap(short = 'f', long = "force")]
         force: bool,
         /// Follow symlinks
-        #[structopt(short = "l", long = "follow-links")]
+        #[clap(short = 'l', long = "follow-links")]
         follow_links: bool,
     },
-    #[structopt(name = "rm")]
+    #[clap(name = "rm")]
     /// Remove a file from an existing FilesContainer on the network
     Rm {
         /// The full URL of the file to remove from its FilesContainer
         target: String,
         /// Automatically update the NRS name to link to the new version of the FilesContainer. This is only allowed if an NRS URL was provided, and if the NRS name is currently linked to a specific version of the FilesContainer
-        #[structopt(short = "u", long = "update-nrs")]
+        #[clap(short = 'u', long = "update-nrs")]
         update_nrs: bool,
         /// Recursively remove files found in the target path
-        #[structopt(short = "r", long = "recursive")]
+        #[clap(short = 'r', long = "recursive")]
         recursive: bool,
     },
-    #[structopt(name = "ls")]
+    #[clap(name = "ls")]
     /// List files found in an existing FilesContainer on the network
     Ls {
         /// The target FilesContainer to list files from, optionally including a path (default is '/')
         target: Option<String>,
     },
-    #[structopt(name = "tree")]
+    #[clap(name = "tree")]
     /// Recursively list files found in an existing FilesContainer on the network
     Tree {
         /// The target FilesContainer to list files from, optionally including a path (default is '/')
         target: Option<String>,
         /// Include file details
-        #[structopt(short = "d", long = "details")]
+        #[clap(short = 'd', long = "details")]
         details: bool,
     },
 }

--- a/sn_cli/src/subcommands/keys.rs
+++ b/sn_cli/src/subcommands/keys.rs
@@ -10,24 +10,24 @@ use super::{helpers::serialise_output, OutputFmt};
 use crate::operations::auth_and_connect::{get_credentials_file_path, read_credentials};
 use crate::operations::config::Config;
 use bls::SecretKey;
+use clap::Subcommand;
 use color_eyre::{eyre::WrapErr, Result};
 use sn_api::Safe;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum KeysSubCommands {
     /// Show information about a SafeKey. By default it will show the one owned by CLI (if found).
     Show {
         /// Set this flag to show the secret key
-        #[structopt(long = "show-sk")]
+        #[clap(long = "show-sk")]
         show_sk: bool,
     },
-    #[structopt(name = "create")]
+    #[clap(name = "create")]
     /// Create a new SafeKey in BLS format.
     Create {
         /// Set this flag to output the generated keypair to file at ~/.safe/cli/credentials. The
         /// CLI will then sign all commands using this keypair.
-        #[structopt(long = "for-cli")]
+        #[clap(long = "for-cli")]
         for_cli: bool,
     },
 }

--- a/sn_cli/src/subcommands/mod.rs
+++ b/sn_cli/src/subcommands/mod.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use clap::{AppSettings, Subcommand};
+
 pub mod cat;
 pub mod config;
 pub mod dog;
@@ -21,8 +23,6 @@ pub mod setup;
 pub mod update;
 pub mod wallet;
 pub mod xorurl;
-
-use structopt::{clap::AppSettings, StructOpt};
 
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum OutputFmt {
@@ -49,113 +49,81 @@ impl std::str::FromStr for OutputFmt {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum SubCommands {
-    #[structopt(
+    #[clap(
         name = "config",
-        no_version,
-        global_settings(&[AppSettings::DisableVersion]),
+        global_settings(&[AppSettings::DisableVersion])
     )]
     /// CLI config settings
     Config {
         /// subcommands
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: Option<config::ConfigSubCommands>,
     },
-    #[structopt(
+    #[clap(
         name = "networks",
-        no_version,
         global_settings(&[AppSettings::DisableVersion]),
     )]
     /// Switch between SAFE networks
     Networks {
         /// subcommands
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: Option<networks::NetworksSubCommands>,
     },
-    #[structopt(
+    #[clap(
         name = "cat",
-        no_version,
         global_settings(&[AppSettings::DisableVersion]),
     )]
     /// Read data on the SAFE Network
     Cat(cat::CatCommands),
-    #[structopt(
+    #[clap(
         name = "dog",
-        no_version,
         global_settings(&[AppSettings::DisableVersion]),
     )]
     /// Inspect data on the SAFE Network providing only metadata information about the content
     Dog(dog::DogCommands),
-    #[structopt(
-        name = "files",
-        no_version,
-        global_settings(&[AppSettings::DisableVersion]),
-    )]
+    #[clap(name = "files", subcommand, global_settings(&[AppSettings::DisableVersion]))]
     /// Manage files on the SAFE Network
     Files(files::FilesSubCommands),
-    #[structopt(
-        name = "setup",
-        no_version,
-        global_settings(&[AppSettings::DisableVersion]),
-    )]
+    #[clap(name = "setup", subcommand, global_settings(&[AppSettings::DisableVersion]))]
     /// Perform setup tasks
     Setup(setup::SetupSubCommands),
-    #[structopt(
-        name = "nrs",
-        no_version,
-        global_settings(&[AppSettings::DisableVersion]),
-    )]
+    #[clap(name = "nrs", subcommand, global_settings(&[AppSettings::DisableVersion]))]
     /// Manage public names on the SAFE Network
     Nrs(nrs::NrsSubCommands),
-    #[structopt(
-        name = "keys",
-        no_version,
-        global_settings(&[AppSettings::DisableVersion]),
-    )]
+    #[clap(name = "keys", subcommand, global_settings(&[AppSettings::DisableVersion]))]
     /// Manage keys on the SAFE Network
     Keys(keys::KeysSubCommands),
-    #[structopt(
-        name = "wallet",
-        no_version,
-        global_settings(&[AppSettings::DisableVersion]),
-    )]
+    #[clap(name = "wallet", subcommand, global_settings(&[AppSettings::DisableVersion]))]
     /// Manage wallets on the SAFE Network
     Wallet(wallet::WalletSubCommands),
     /// Obtain the XOR-URL of data without uploading it to the network, or decode XOR-URLs
     Xorurl {
         /// subcommands
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: Option<xorurl::XorurlSubCommands>,
         /// The source file/folder local path
         location: Option<String>,
         /// Recursively crawl folders and files found in the location
-        #[structopt(short = "r", long = "recursive")]
+        #[clap(short = 'r', long = "recursive")]
         recursive: bool,
         /// Follow symlinks
-        #[structopt(short = "l", long = "follow-links")]
+        #[clap(short = 'l', long = "follow-links")]
         follow_links: bool,
     },
-    #[structopt(
-        name = "update",
-        no_version,
-        global_settings(&[AppSettings::DisableVersion]),
-    )]
+    #[clap(name = "update", global_settings(&[AppSettings::DisableVersion]))]
     /// Update the application to the latest available version
     Update {
         /// Remove prompt to confirm the update.
-        #[structopt(short = "y", long = "no-confirm")]
+        #[clap(short = 'y', long = "no-confirm")]
         no_confirm: bool,
     },
-    #[structopt(
-        name = "node",
-        no_version,
-        global_settings(&[AppSettings::DisableVersion]),
-    )]
+    #[clap(name = "node", global_settings(&[AppSettings::DisableVersion]))]
     /// Commands to manage Safe Network Nodes
     Node {
         /// subcommands
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: Option<node::NodeSubCommands>,
     },
 }

--- a/sn_cli/src/subcommands/networks.rs
+++ b/sn_cli/src/subcommands/networks.rs
@@ -7,24 +7,24 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::operations::config::{Config, NetworkInfo};
+use clap::Subcommand;
 use color_eyre::Result;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tracing::debug;
 use url::Url;
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum NetworksSubCommands {
-    #[structopt(name = "switch")]
+    #[clap(name = "switch")]
     /// Switch to a different SAFE network
     Switch {
         /// Network to switch to
         network_name: String,
     },
-    #[structopt(name = "check")]
+    #[clap(name = "check")]
     /// Check where the default hardlink points and try to match it to the networks in the CLI config
     Check {},
-    #[structopt(name = "add")]
+    #[clap(name = "add")]
     /// Add a network to the CLI config using an existing network map
     Add {
         /// Network name. If network_name already exists, then it's updated with the new network map
@@ -32,7 +32,7 @@ pub enum NetworksSubCommands {
         /// Local path or a remote URL to fetch the network map from
         prefix_location: String,
     },
-    #[structopt(name = "remove")]
+    #[clap(name = "remove")]
     /// Remove a network from the CLI config
     Remove {
         /// Network to remove

--- a/sn_cli/src/subcommands/node.rs
+++ b/sn_cli/src/subcommands/node.rs
@@ -10,48 +10,48 @@ use crate::operations::{
     config::{Config, NetworkInfo, NetworkLauncher},
     node::*,
 };
+use clap::Subcommand;
 use color_eyre::{eyre::eyre, Result};
 use std::{net::SocketAddr, path::PathBuf};
-use structopt::StructOpt;
 
 use sn_api::DEFAULT_PREFIX_HARDLINK_NAME;
 
 const NODES_DATA_DIR_NAME: &str = "baby-fleming-nodes";
 const LOCAL_NODE_DIR_NAME: &str = "local-node";
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum NodeSubCommands {
     /// Gets the version of `sn_node` binary
     BinVersion {
-        #[structopt(long = "node-path", env = "SN_NODE_PATH")]
+        #[clap(long = "node-path", env = "SN_NODE_PATH")]
         node_path: Option<PathBuf>,
     },
-    #[structopt(name = "install")]
+    #[clap(name = "install")]
     /// Install an sn_node binary
     Install {
         /// Optional destination directory path for the installation. The SN_NODE_PATH environment
         /// variable can also be used to supply this path. If this argument is not used, the
         /// binary will be installed at ~/.safe/node/sn_node, or the equivalent user directory
         /// path on Windows.
-        #[structopt(long = "node-path", env = "SN_NODE_PATH")]
+        #[clap(long = "node-path", env = "SN_NODE_PATH")]
         node_path: Option<PathBuf>,
         /// Specify the version of sn_node to install. If not supplied, the latest version will be
         /// installed. Note: just the version number should be supplied, with no 'v' prefix.
-        #[structopt(short = "v", long)]
+        #[clap(short = 'v', long)]
         version: Option<String>,
     },
-    #[structopt(name = "join")]
+    #[clap(name = "join")]
     /// Join an existing network
     Join {
         /// The name of a network from the `networks` command list. Use this argument to join one
         /// of those networks.
-        #[structopt(long = "network-name")]
+        #[clap(long = "network-name")]
         network_name: String,
         /// Path of the directory where sn_node is located (default is ~/.safe/node/). The SN_NODE_PATH env var can also be used to set the path
-        #[structopt(long = "node-dir-path", env = "SN_NODE_PATH")]
+        #[clap(long = "node-dir-path", env = "SN_NODE_PATH")]
         node_dir_path: Option<PathBuf>,
         /// Verbosity level for nodes logs
-        #[structopt(short = "y", parse(from_occurrences))]
+        #[clap(short = 'y', parse(from_occurrences))]
         verbosity: u8,
         /// Local address to be used for the node.
         ///
@@ -65,7 +65,7 @@ pub enum NodeSubCommands {
         /// case, you can setup 'manual' port forwarding on your router, then use this option to set
         /// the address where local packets are being forwarded to. For example, --local-addr
         /// 192.168.1.50:12000.
-        #[structopt(short = "a", long)]
+        #[clap(short = 'a', long)]
         local_addr: Option<SocketAddr>,
         /// External address of the node, to use when writing connection info.
         ///
@@ -76,14 +76,14 @@ pub enum NodeSubCommands {
         /// request was rejected because the other nodes were unable to reach your node. In this
         /// case, you can setup 'manual' port forwarding on your router, then use this option to set
         /// the public IP address of your router. For example, --public-addr 79.71.42.39:12000.
-        #[structopt(short = "p", long)]
+        #[clap(short = 'p', long)]
         public_addr: Option<SocketAddr>,
         /// Delete all data from a previous node running on the same PC
-        #[structopt(long = "clear-data")]
+        #[clap(long = "clear-data")]
         clear_data: bool,
         /// Set this flag if you're connecting to a network where all the nodes are running
         /// locally. This will launch the node and skip any port forwarding.
-        #[structopt(short = "l", long)]
+        #[clap(short = 'l', long)]
         local: bool,
         /// Use this flag to skip the automated, software-based port forwarding on the node binary.
         ///
@@ -91,38 +91,38 @@ pub enum NodeSubCommands {
         /// request was rejected because the other nodes were unable to reach your node. In this
         /// case, you can setup 'manual' port forwarding on your router, then use this option to set
         /// disable the software-based port forwarding in the node binary.
-        #[structopt(long)]
+        #[clap(long)]
         skip_auto_port_forwarding: bool,
     },
-    #[structopt(name = "run-baby-fleming")]
+    #[clap(name = "run-baby-fleming")]
     /// Run nodes to form a local single-section Safe network
     Run {
         /// Path of the directory where sn_node is located (default is ~/.safe/node/). The SN_NODE_PATH env var can also be used to set the path
-        #[structopt(long = "node-dir-path", env = "SN_NODE_PATH")]
+        #[clap(long = "node-dir-path", env = "SN_NODE_PATH")]
         node_dir_path: Option<PathBuf>,
         /// Interval in seconds between launching each of the nodes
-        #[structopt(short = "i", long, default_value = "1")]
+        #[clap(short = 'i', long, default_value = "1")]
         interval: u64,
         /// Number of nodes to be launched
-        #[structopt(long = "nodes", default_value = "11")]
+        #[clap(long = "nodes", default_value = "11")]
         num_of_nodes: u8,
         /// IP to be used to launch the local nodes.
-        #[structopt(long = "ip")]
+        #[clap(long = "ip")]
         ip: Option<String>,
     },
     /// Shutdown all running nodes processes
-    #[structopt(name = "killall")]
+    #[clap(name = "killall")]
     Killall {
         /// Path of the sn_node executable used to launch the processes with (default ~/.safe/node/sn_node). The SN_NODE_PATH env var can be also used to set this path
-        #[structopt(long = "node-path", env = "SN_NODE_PATH")]
+        #[clap(long = "node-path", env = "SN_NODE_PATH")]
         node_path: Option<PathBuf>,
     },
-    #[structopt(name = "update")]
+    #[clap(name = "update")]
     /// Update to latest sn_node released version
     Update {
-        #[structopt(long = "node-path")]
+        #[clap(long = "node-path")]
         /// Path of the sn_node executable to update (default ~/.safe/node/). The SN_NODE_PATH env var can be also used to set the path
-        #[structopt(long = "node-path", env = "SN_NODE_PATH")]
+        #[clap(long = "node-path", env = "SN_NODE_PATH")]
         node_path: Option<PathBuf>,
     },
 }

--- a/sn_cli/src/subcommands/nrs.rs
+++ b/sn_cli/src/subcommands/nrs.rs
@@ -12,15 +12,15 @@ use super::{
     helpers::{get_from_arg_or_stdin, get_target_url, serialise_output},
     OutputFmt,
 };
+use clap::Subcommand;
 use color_eyre::{eyre::eyre, Help, Result};
 use comfy_table::Table;
 use sn_api::Error::{InvalidInput, NetDataError, NrsNameAlreadyExists, UnversionedContentError};
 use sn_api::{Safe, SafeUrl};
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum NrsSubCommands {
-    #[structopt(name = "add")]
+    #[clap(name = "add")]
     /// Add a subname to a registered NRS name and link it to some content, or update an existing
     /// subname with a new link.
     Add {
@@ -32,27 +32,27 @@ pub enum NrsSubCommands {
         /// wrapped in double quotes on bash based systems. A link must be provided for a subname.
         /// If you don't provide it with this argument, you will be prompted to provide it
         /// interactively.
-        #[structopt(short = "l", long = "link")]
+        #[clap(short = 'l', long = "link")]
         link: Option<String>,
         /// Set this flag to register the topname if it hasn't already been registered.
-        #[structopt(short = "y", long = "register-top-name")]
+        #[clap(short = 'y', long = "register-top-name")]
         register_top_name: bool,
         /// Set this flag to register this link as default for the topname when no subname is
         /// specified.
-        #[structopt(long = "default")]
+        #[clap(long = "default")]
         default: bool,
     },
-    #[structopt(name = "register")]
+    #[clap(name = "register")]
     /// Register a new top name in Safe NRS
     Register {
         /// The name of the new topname to register
         name: String,
         /// Optional safe:// URL to link the topname to. Usually a FilesContainer for a website.
         /// This should be wrapped in double quotes on bash based systems.
-        #[structopt(short = "l", long = "link")]
+        #[clap(short = 'l', long = "link")]
         link: Option<String>,
     },
-    #[structopt(name = "remove")]
+    #[clap(name = "remove")]
     /// Remove a subname from an NRS name
     Remove {
         /// The name to remove

--- a/sn_cli/src/subcommands/safe_id.rs
+++ b/sn_cli/src/subcommands/safe_id.rs
@@ -6,46 +6,46 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use structopt::StructOpt;
+use clap::Subcommand;
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum SafeIdSubCommands {
-    #[structopt(name = "create")]
+    #[clap(name = "create")]
     /// Create a new SafeId
     Create {
         /// The SafeId name
-        #[structopt(long = "name")]
+        #[clap(long = "name")]
         name: String,
         /// The SafeId surname
-        #[structopt(long = "surname")]
+        #[clap(long = "surname")]
         surname: String,
         /// The SafeId email
-        #[structopt(long = "email")]
+        #[clap(long = "email")]
         email: String,
         /// The SafeId website
-        #[structopt(long = "website")]
+        #[clap(long = "website")]
         website: String,
         /// The SafeId wallet
-        #[structopt(long = "wallet")]
+        #[clap(long = "wallet")]
         wallet: String,
     },
-    #[structopt(name = "update")]
+    #[clap(name = "update")]
     /// Manage files on the network
     Update {
         /// The SafeId name
-        #[structopt(long = "name")]
+        #[clap(long = "name")]
         name: String,
         /// The SafeId surname
-        #[structopt(long = "surname")]
+        #[clap(long = "surname")]
         surname: String,
         /// The SafeId email
-        #[structopt(long = "email")]
+        #[clap(long = "email")]
         email: String,
         /// The SafeId website
-        #[structopt(long = "website")]
+        #[clap(long = "website")]
         website: String,
         /// The SafeId wallet
-        #[structopt(long = "wallet")]
+        #[clap(long = "wallet")]
         wallet: String,
     },
 }

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -12,24 +12,24 @@ use super::{
 };
 use crate::operations::config::Config;
 use bls::{PublicKey, SecretKey};
+use clap::Subcommand;
 use color_eyre::{eyre::eyre, Help, Result};
 use sn_api::{Error, Safe};
 use sn_dbc::Dbc;
 use std::path::Path;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum WalletSubCommands {
-    #[structopt(name = "create")]
+    #[clap(name = "create")]
     /// Create a new wallet
     Create {},
-    #[structopt(name = "balance")]
+    #[clap(name = "balance")]
     /// Query a wallet's balance
     Balance {
         /// The URL of wallet to query
         target: Option<String>,
     },
-    #[structopt(name = "deposit")]
+    #[clap(name = "deposit")]
     /// Deposit a spendable DBC in a wallet. If the DBC is not bearer, we will try to deposit using
     /// the secret key configured for use with safe. If you wish to use a different key, use the
     /// --secret-key argument.
@@ -37,34 +37,34 @@ pub enum WalletSubCommands {
         /// The URL of the wallet for the deposit
         wallet_url: String,
         /// The name to give this spendable DBC
-        #[structopt(long = "name")]
+        #[clap(long = "name")]
         name: Option<String>,
         /// A path to a file containing hex encoded DBC data, or you can supply the data directly.
         /// Depending on the shell or OS in use, due to the length of the data string, supplying
         /// directly may not work.
-        #[structopt(long = "dbc")]
+        #[clap(long = "dbc")]
         dbc: Option<String>,
-        #[structopt(long = "secret-key")]
+        #[clap(long = "secret-key")]
         /// Use this argument to specify a secret key for an owned DBC. It should be a hex-encoded
         /// BLS key.
         secret_key_hex: Option<String>,
     },
-    #[structopt(name = "reissue")]
+    #[clap(name = "reissue")]
     /// Reissue a DBC from a wallet to a SafeKey.
     Reissue {
         /// The amount to reissue
         amount: String,
         /// The URL of wallet to reissue from
-        #[structopt(long = "from")]
+        #[clap(long = "from")]
         from: String,
         /// To reissue the DBC to a particular owner, provide their public key. This should be a
         /// hex-encoded BLS key. Otherwise the DBC will be reissued as bearer, meaning anyone can
         /// spend it. This argument and the --owned argument are mutually exclusive.
-        #[structopt(long = "public-key")]
+        #[clap(long = "public-key")]
         public_key_hex: Option<String>,
         /// Set this flag to reissue as an owned DBC, using the public key configured for use with
         /// safe. This argument and the --public-key argument are mutually exclusive.
-        #[structopt(long = "owned")]
+        #[clap(long = "owned")]
         owned: bool,
     },
 }

--- a/sn_cli/src/subcommands/xorurl.rs
+++ b/sn_cli/src/subcommands/xorurl.rs
@@ -10,14 +10,14 @@ use super::{
     helpers::{gen_processed_files_table, get_from_arg_or_stdin, serialise_output, xorname_to_hex},
     OutputFmt,
 };
+use clap::Subcommand;
 use color_eyre::{eyre::eyre, Result};
 use sn_api::{files::FilesMapChange, PublicKey, Safe, SafeUrl, XorName, XorUrlBase};
-use structopt::StructOpt;
 
 // Defines subcommands of 'xorurl'
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum XorurlSubCommands {
-    #[structopt(name = "decode")]
+    #[clap(name = "decode")]
     /// Decode a XOR-URL extracting all the information encoded it in
     Decode {
         /// The XOR-URL to decode

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -67,7 +67,7 @@ serde_json = "1.0.53"
 signature = "1.1.10"
 sn_dbc = { version = "6.0.0", features = ["serdes"] }
 sn_interface = { path = "../sn_interface", version = "^0.8.0" }
-structopt = "~0.3.17"
+clap = { version = "3.0.0", features = ["derive", "env"] }
 strum = "~0.23.0"
 strum_macros = "~0.23.1"
 tempfile = "3.2.0"
@@ -91,7 +91,8 @@ grep="~0.2.8"
 proptest = "1.0.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rand_xorshift = "~0.2.0"
-sn_launch_tool = "~0.9.9"
+sn_launch_tool = { path = "../../sn_launch_tool" }
+# sn_launch_tool = "~0.9.9"
 termcolor="1.1.2"
 tokio-util = { version = "~0.6.7", features = ["time"] }
 walkdir = "2"

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -91,8 +91,7 @@ grep="~0.2.8"
 proptest = "1.0.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rand_xorshift = "~0.2.0"
-sn_launch_tool = { path = "../../sn_launch_tool" }
-# sn_launch_tool = "~0.9.9"
+sn_launch_tool = "~0.10.0"
 termcolor="1.1.2"
 tokio-util = { version = "~0.6.7", features = ["time"] }
 walkdir = "2"

--- a/sn_client/examples/churn.rs
+++ b/sn_client/examples/churn.rs
@@ -13,13 +13,13 @@ use sn_client::{Client, ClientConfig};
 use sn_interface::types::utils::random_bytes;
 use sn_launch_tool::Launch;
 
+use clap::Parser;
 use dirs_next::home_dir;
 use eyre::{eyre, Context, Result};
 use std::{
     path::PathBuf,
     process::{Command, Stdio},
 };
-use structopt::StructOpt;
 use tiny_keccak::{Hasher, Sha3};
 use tokio::fs::create_dir_all;
 use tokio::time::{sleep, Duration};

--- a/sn_client/examples/network_split.rs
+++ b/sn_client/examples/network_split.rs
@@ -13,13 +13,13 @@ use sn_client::{Client, ClientConfig};
 use sn_interface::types::utils::random_bytes;
 use sn_launch_tool::Launch;
 
+use clap::Parser;
 use dirs_next::home_dir;
 use eyre::{eyre, Context, Result};
 use std::{
     path::PathBuf,
     process::{Command, Stdio},
 };
-use structopt::StructOpt;
 use tiny_keccak::{Hasher, Sha3};
 use tokio::fs::create_dir_all;
 use tokio::time::{sleep, Duration};

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -121,9 +121,9 @@ impl Session {
         let mut received_ack = 0;
         let mut received_err = 0;
         let mut attempts = 0;
-        let interval = Duration::from_millis(1000);
+        let interval = Duration::from_millis(50);
         let expected_cmd_ack_wait_attempts =
-            std::cmp::max(10, self.cmd_ack_wait.as_millis() / interval.as_millis());
+            std::cmp::max(200, self.cmd_ack_wait.as_millis() / interval.as_millis());
         loop {
             match receiver.try_recv() {
                 Ok((src, None)) => {

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -71,7 +71,7 @@ impl DysfunctionDetection {
         let mut op_scores = BTreeMap::new();
         let mut dkg_scores = BTreeMap::new();
 
-        let adults = self.adults.iter().copied().collect::<Vec<XorName>>();
+        let adults = self.adults.to_vec();
         for node in adults.iter() {
             let _ = dkg_scores.insert(
                 *node,
@@ -110,7 +110,7 @@ impl DysfunctionDetection {
     ) -> f32 {
         let node_count = self.get_node_issue_count(node, issue_type);
         let mut other_node_counts = Vec::new();
-        for adult in adults.clone() {
+        for adult in adults {
             if adult == *node {
                 continue;
             }

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -65,34 +65,25 @@ impl DysfunctionDetection {
     ///
     /// These scores can then be used to highlight nodes that have a higher score than some
     /// particular ratio.
-    pub async fn calculate_scores(&self) -> ScoreResults {
+    pub fn calculate_scores(&self) -> ScoreResults {
         let mut communication_scores = BTreeMap::new();
         let mut knowledge_scores = BTreeMap::new();
         let mut op_scores = BTreeMap::new();
         let mut dkg_scores = BTreeMap::new();
 
-        let adults = self
-            .adults
-            .read()
-            .await
-            .iter()
-            .copied()
-            .collect::<Vec<XorName>>();
+        let adults = self.adults.iter().copied().collect::<Vec<XorName>>();
         for node in adults.iter() {
             let _ = dkg_scores.insert(
                 *node,
-                self.calculate_node_score(node, adults.clone(), &IssueType::Dkg)
-                    .await,
+                self.calculate_node_score(node, adults.clone(), &IssueType::Dkg),
             );
             let _ = communication_scores.insert(
                 *node,
-                self.calculate_node_score(node, adults.clone(), &IssueType::Communication)
-                    .await,
+                self.calculate_node_score(node, adults.clone(), &IssueType::Communication),
             );
             let _ = knowledge_scores.insert(
                 *node,
-                self.calculate_node_score(node, adults.clone(), &IssueType::Knowledge)
-                    .await,
+                self.calculate_node_score(node, adults.clone(), &IssueType::Knowledge),
             );
             let _ = op_scores.insert(
                 *node,
@@ -100,8 +91,7 @@ impl DysfunctionDetection {
                     node,
                     adults.clone(),
                     &IssueType::PendingRequestOperation(None),
-                )
-                .await,
+                ),
             );
         }
         ScoreResults {
@@ -112,19 +102,19 @@ impl DysfunctionDetection {
         }
     }
 
-    async fn calculate_node_score(
+    fn calculate_node_score(
         &self,
         node: &XorName,
         adults: Vec<XorName>,
         issue_type: &IssueType,
     ) -> f32 {
-        let node_count = self.get_node_issue_count(node, issue_type).await;
+        let node_count = self.get_node_issue_count(node, issue_type);
         let mut other_node_counts = Vec::new();
         for adult in adults.clone() {
             if adult == *node {
                 continue;
             }
-            other_node_counts.push(self.get_node_issue_count(&adult, issue_type).await as f32);
+            other_node_counts.push(self.get_node_issue_count(&adult, issue_type) as f32);
         }
         let average = get_mean_of(&other_node_counts).unwrap_or(1.0);
         let score = node_count.checked_sub(average as usize).unwrap_or(1) as f32;
@@ -135,35 +125,35 @@ impl DysfunctionDetection {
         }
     }
 
-    async fn get_node_issue_count(&self, node: &XorName, issue_type: &IssueType) -> usize {
+    fn get_node_issue_count(&self, node: &XorName, issue_type: &IssueType) -> usize {
         match issue_type {
             IssueType::Communication => {
-                let count = if let Some(entry) = self.communication_issues.get(node) {
-                    entry.value().read().await.len()
+                let count = if let Some(issues) = self.communication_issues.get(node) {
+                    issues.len()
                 } else {
                     1
                 };
                 count
             }
             IssueType::Dkg => {
-                let count = if let Some(entry) = self.dkg_issues.get(node) {
-                    entry.value().read().await.len()
+                let count = if let Some(issues) = self.dkg_issues.get(node) {
+                    issues.len()
                 } else {
                     1
                 };
                 count
             }
             IssueType::Knowledge => {
-                let count = if let Some(entry) = self.knowledge_issues.get(node) {
-                    entry.value().read().await.len()
+                let count = if let Some(issues) = self.knowledge_issues.get(node) {
+                    issues.len()
                 } else {
                     1
                 };
                 count
             }
             IssueType::PendingRequestOperation(_) => {
-                let count = if let Some(entry) = self.unfulfilled_ops.get(node) {
-                    entry.value().read().await.len()
+                let count = if let Some(issues) = self.unfulfilled_ops.get(node) {
+                    issues.len()
                 } else {
                     1
                 };
@@ -173,9 +163,9 @@ impl DysfunctionDetection {
     }
 
     /// get scores mapped by name, to score and z-score, which is std dev's from the mean
-    async fn get_weighted_scores(&self) -> BTreeMap<XorName, Option<f32>> {
+    fn get_weighted_scores(&self) -> BTreeMap<XorName, Option<f32>> {
         trace!("Getting weighted scores");
-        let scores = self.calculate_scores().await;
+        let scores = self.calculate_scores();
         let ops_scores = scores.op_scores;
         let conn_scores = scores.communication_scores;
         let dkg_scores = scores.dkg_scores;
@@ -239,19 +229,16 @@ impl DysfunctionDetection {
         final_scores
     }
 
-    async fn cleanup_time_sensistive_checks(&self) -> Result<()> {
-        for node in self.communication_issues.iter() {
-            let mut issues = node.value().write().await;
+    fn cleanup_time_sensistive_checks(&mut self) -> Result<()> {
+        for (_name, issues) in self.communication_issues.iter_mut() {
             issues.retain(|time| time.elapsed() < RECENT_ISSUE_DURATION);
         }
 
-        for node in self.knowledge_issues.iter() {
-            let mut issues = node.value().write().await;
+        for (_name, issues) in self.knowledge_issues.iter_mut() {
             issues.retain(|time| time.elapsed() < RECENT_ISSUE_DURATION);
         }
 
-        for node in self.dkg_issues.iter() {
-            let mut issues = node.value().write().await;
+        for (_name, issues) in self.dkg_issues.iter_mut() {
             issues.retain(|time| time.elapsed() < RECENT_ISSUE_DURATION);
         }
 
@@ -262,15 +249,15 @@ impl DysfunctionDetection {
     /// TODO: order these to act upon _most_ dysfunctional first
     /// (the nodes must all `ProposeOffline` over a dysfunctional node and then _immediately_ vote it off. So any other membershipn changes in flight could block this.
     /// thus, we need to be callling this function often until nodes are removed.)
-    pub async fn get_nodes_beyond_severity(
-        &self,
+    pub fn get_nodes_beyond_severity(
+        &mut self,
         severity: DysfunctionSeverity,
     ) -> Result<BTreeSet<XorName>> {
-        self.cleanup_time_sensistive_checks().await?;
+        self.cleanup_time_sensistive_checks()?;
 
         let mut dysfunctional_nodes = BTreeSet::new();
 
-        let final_scores = self.get_weighted_scores().await;
+        let final_scores = self.get_weighted_scores();
 
         for (name, node_zscore) in final_scores {
             if let Some(z) = node_zscore {
@@ -480,15 +467,14 @@ mod tests {
         {
             Runtime::new().unwrap().block_on(async {
                 let adults = (0..adult_count).map(|_| random_xorname()).collect::<Vec<XorName>>();
-                let dysfunctional_detection = DysfunctionDetection::new(adults.clone());
+                let mut dysfunctional_detection = DysfunctionDetection::new(adults.clone());
                 for _ in 0..5 {
                     let _ = dysfunctional_detection.track_issue(
-                        adults[0], issue_type.clone()).await;
+                        adults[0], issue_type.clone());
                 }
 
                 let score_results = dysfunctional_detection
-                    .calculate_scores()
-                    .await;
+                    .calculate_scores();
                 match issue_type {
                     IssueType::Dkg => {
                         assert_eq!(score_results.dkg_scores.len(), adult_count);
@@ -512,15 +498,14 @@ mod tests {
         {
             Runtime::new().unwrap().block_on(async {
                 let adults = (0..adult_count).map(|_| random_xorname()).collect::<Vec<XorName>>();
-                let dysfunctional_detection = DysfunctionDetection::new(adults.clone());
+                let mut dysfunctional_detection = DysfunctionDetection::new(adults.clone());
                 for _ in 0..issue_count {
                     let _ = dysfunctional_detection.track_issue(
-                        adults[0], issue_type.clone()).await;
+                        adults[0], issue_type.clone());
                 }
 
                 let score_results = dysfunctional_detection
-                    .calculate_scores()
-                    .await;
+                    .calculate_scores();
                 let scores = match issue_type {
                     IssueType::Dkg => {
                         score_results.dkg_scores
@@ -588,7 +573,7 @@ mod tests {
                     // add dysf to our all_nodes
                     let all_node_names = nodes.clone().iter().map(|(name, _)| *name).collect::<Vec<XorName>>();
 
-                    let dysfunctional_detection = DysfunctionDetection::new(all_node_names);
+                    let mut dysfunctional_detection = DysfunctionDetection::new(all_node_names);
 
                     // Now we loop through each issue/msg
                     for (issue, issue_location, fail_test ) in issues {
@@ -603,15 +588,14 @@ mod tests {
 
                             if msg_failed {
                                 let _ = dysfunctional_detection.track_issue(
-                                    node, issue.clone()).await;
+                                    node, issue.clone());
                             }
 
                         }
                     }
                     // now we can see what we have...
                     let dysfunctional_nodes_found = match dysfunctional_detection
-                        .get_nodes_beyond_severity( DysfunctionSeverity::Dysfunctional)
-                        .await {
+                        .get_nodes_beyond_severity( DysfunctionSeverity::Dysfunctional) {
                             Ok(nodes) => nodes,
                             Err(error) => bail!("Failed getting dysfunctional nodes from DysfunctionDetector: {error}")
                         };
@@ -682,7 +666,7 @@ mod tests {
                 // add dysf to our all_nodes
                 let all_node_names = nodes.clone().iter().map(|(name, _)| *name).collect::<Vec<XorName>>();
 
-                let dysfunctional_detection = DysfunctionDetection::new(all_node_names);
+                let mut dysfunctional_detection = DysfunctionDetection::new(all_node_names);
 
                 // Now we loop through each issue/msg
                 for (issue, issue_location, fail_test ) in issues {
@@ -698,15 +682,14 @@ mod tests {
 
                         if msg_failed {
                             let _ = dysfunctional_detection.track_issue(
-                                node, issue.clone()).await;
+                                node, issue.clone());
                         }
 
                     }
                 }
                 // now we can see what we have...
                 let dysfunctional_nodes_found = match dysfunctional_detection
-                    .get_nodes_beyond_severity( DysfunctionSeverity::Dysfunctional)
-                    .await {
+                    .get_nodes_beyond_severity( DysfunctionSeverity::Dysfunctional) {
                         Ok(nodes) => nodes,
                         Err(error) => bail!("Failed getting dysfunctional nodes from DysfunctionDetector: {error}")
                     };
@@ -744,17 +727,16 @@ mod tests {
         {
             Runtime::new().unwrap().block_on(async {
                 let adults = (0..adult_count).map(|_| random_xorname()).collect::<Vec<XorName>>();
-                let dysfunctional_detection = DysfunctionDetection::new(adults.clone());
+                let mut dysfunctional_detection = DysfunctionDetection::new(adults.clone());
                 for adult in adults.iter() {
                     for _ in 0..issue_count {
                         let _ = dysfunctional_detection.track_issue(
-                            *adult, issue_type.clone()).await;
+                            *adult, issue_type.clone());
                     }
                 }
 
                 let score_results = dysfunctional_detection
-                    .calculate_scores()
-                    .await;
+                    .calculate_scores();
                 let scores = match issue_type {
                     IssueType::Communication => {
                         score_results.communication_scores
@@ -795,29 +777,25 @@ mod ops_tests {
     #[tokio::test]
     async fn op_dysfunction_no_variance_is_okay() -> Result<()> {
         let adults = (0..10).map(|_| random_xorname()).collect::<Vec<XorName>>();
-        let dysfunctional_detection = DysfunctionDetection::new(adults.clone());
+        let mut dysfunctional_detection = DysfunctionDetection::new(adults.clone());
         for adult in &adults {
             for _ in 0..NORMAL_OPERATIONS_ISSUES {
-                let _ = dysfunctional_detection
-                    .track_issue(
-                        *adult,
-                        IssueType::PendingRequestOperation(get_random_operation_id()),
-                    )
-                    .await;
+                let _ = dysfunctional_detection.track_issue(
+                    *adult,
+                    IssueType::PendingRequestOperation(get_random_operation_id()),
+                );
             }
         }
 
         assert_eq!(
             dysfunctional_detection
-                .get_nodes_beyond_severity(DysfunctionSeverity::Dysfunctional)
-                .await?
+                .get_nodes_beyond_severity(DysfunctionSeverity::Dysfunctional)?
                 .len(),
             0
         );
         assert_eq!(
             dysfunctional_detection
-                .get_nodes_beyond_severity(DysfunctionSeverity::Suspicious)
-                .await?
+                .get_nodes_beyond_severity(DysfunctionSeverity::Suspicious)?
                 .len(),
             0
         );
@@ -843,28 +821,24 @@ mod comm_tests {
     async fn conn_dys_is_tolerant_of_norms() -> Result<()> {
         let adults = (0..10).map(|_| random_xorname()).collect::<Vec<XorName>>();
 
-        let dysfunctional_detection = DysfunctionDetection::new(adults.clone());
+        let mut dysfunctional_detection = DysfunctionDetection::new(adults.clone());
 
         for adult in &adults {
             for _ in 0..NORMAL_CONNECTION_PROBLEM_COUNT {
-                dysfunctional_detection
-                    .track_issue(*adult, IssueType::Communication)
-                    .await?;
+                dysfunctional_detection.track_issue(*adult, IssueType::Communication)?;
             }
         }
 
         assert_eq!(
             dysfunctional_detection
-                .get_nodes_beyond_severity(DysfunctionSeverity::Dysfunctional)
-                .await?
+                .get_nodes_beyond_severity(DysfunctionSeverity::Dysfunctional)?
                 .len(),
             0,
             "no nodes are dysfunctional"
         );
         assert_eq!(
             dysfunctional_detection
-                .get_nodes_beyond_severity(DysfunctionSeverity::Suspicious)
-                .await?
+                .get_nodes_beyond_severity(DysfunctionSeverity::Suspicious)?
                 .len(),
             0,
             "no nodes are suspect"
@@ -892,14 +866,12 @@ mod knowledge_tests {
     async fn knowledge_dys_is_tolerant_of_norms() -> Result<()> {
         let adults = (0..10).map(|_| random_xorname()).collect::<Vec<XorName>>();
 
-        let dysfunctional_detection = DysfunctionDetection::new(adults.clone());
+        let mut dysfunctional_detection = DysfunctionDetection::new(adults.clone());
 
         // Write data NORMAL_KNOWLEDGE_ISSUES times to the 10 adults
         for adult in &adults {
             for _ in 0..NORMAL_KNOWLEDGE_ISSUES {
-                dysfunctional_detection
-                    .track_issue(*adult, IssueType::Knowledge)
-                    .await?;
+                dysfunctional_detection.track_issue(*adult, IssueType::Knowledge)?;
             }
         }
 
@@ -907,16 +879,14 @@ mod knowledge_tests {
         // This is because all of them are within the tolerance ratio of each other
         assert_eq!(
             dysfunctional_detection
-                .get_nodes_beyond_severity(DysfunctionSeverity::Dysfunctional)
-                .await?
+                .get_nodes_beyond_severity(DysfunctionSeverity::Dysfunctional)?
                 .len(),
             0,
             "no nodes are dysfunctional"
         );
         assert_eq!(
             dysfunctional_detection
-                .get_nodes_beyond_severity(DysfunctionSeverity::Suspicious)
-                .await?
+                .get_nodes_beyond_severity(DysfunctionSeverity::Suspicious)?
                 .len(),
             0,
             "no nodes are suspect"
@@ -932,7 +902,7 @@ mod knowledge_tests {
 
         let adults = (0..10).map(|_| random_xorname()).collect::<Vec<XorName>>();
 
-        let dysfunctional_detection = DysfunctionDetection::new(adults.clone());
+        let mut dysfunctional_detection = DysfunctionDetection::new(adults.clone());
 
         // Add a new adults
         let new_adult = random_xorname();
@@ -940,22 +910,18 @@ mod knowledge_tests {
 
         // Add just one knowledge issue...
         for _ in 0..1 {
-            dysfunctional_detection
-                .track_issue(new_adult, IssueType::Knowledge)
-                .await?;
+            dysfunctional_detection.track_issue(new_adult, IssueType::Knowledge)?;
         }
 
-        let sus = dysfunctional_detection
-            .get_nodes_beyond_severity(DysfunctionSeverity::Suspicious)
-            .await?;
+        let sus =
+            dysfunctional_detection.get_nodes_beyond_severity(DysfunctionSeverity::Suspicious)?;
 
         // Assert that the new adult is not detected as suspect.
         assert!(!sus.contains(&new_adult), "our adult should not be sus");
         assert_eq!(sus.len(), 0, "no node is sus");
 
         let dysfunctional_nodes = dysfunctional_detection
-            .get_nodes_beyond_severity(DysfunctionSeverity::Dysfunctional)
-            .await?;
+            .get_nodes_beyond_severity(DysfunctionSeverity::Dysfunctional)?;
 
         // Assert that the new adult is not dysfuncitonal
         assert!(

--- a/sn_dysfunction/src/lib.rs
+++ b/sn_dysfunction/src/lib.rs
@@ -187,14 +187,14 @@ impl DysfunctionDetection {
     /// If there are no unfulfilled operations tracked, an empty list will be returned.
     pub fn get_unfulfilled_ops(&self, adult: XorName) -> Vec<OperationId> {
         if let Some(val) = self.unfulfilled_ops.get(&adult) {
-            return val.iter().copied().collect::<Vec<OperationId>>();
+            return val.to_vec();
         }
         Vec::new()
     }
 
     /// List all current tracked nodes
     pub fn current_nodes(&self) -> Vec<XorName> {
-        self.adults.iter().copied().collect::<Vec<XorName>>()
+        self.adults.to_vec()
     }
 
     /// Add a new node to the tracker and recompute closest nodes.

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -73,7 +73,8 @@ serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
 sled = "~0.34.6"
-structopt = "~0.3.17"
+clap = { version = "3.0.0", features = ["derive"] }
+clap_complete = { version = "3.0.0" }
 strum = "~0.23.0"
 strum_macros = "~0.23.1"
 sysinfo = "~0.23.2"

--- a/sn_node/benches/data_storage.rs
+++ b/sn_node/benches/data_storage.rs
@@ -132,7 +132,7 @@ fn bench_data_storage_reads(c: &mut Criterion) -> Result<()> {
     //         println!("finished {size} writes");
 
     //         b.to_async(&runtime).iter(|| async {
-    //             match storage.keys().await {
+    //             match storage.keys() {
     //                 Ok(_) => {
     //                     let random_filename: String = thread_rng()
     //                         .sample_iter(&Alphanumeric)
@@ -169,7 +169,7 @@ fn bench_data_storage_reads(c: &mut Criterion) -> Result<()> {
             println!("finished {size} writes");
 
             b.to_async(&runtime).iter(|| async {
-                match &storage.keys().await {
+                match &storage.keys() {
                     Ok(_keys) => {
                         let random_filename: String = thread_rng()
                             .sample_iter(&Alphanumeric)

--- a/sn_node/examples/config_handling.rs
+++ b/sn_node/examples/config_handling.rs
@@ -6,18 +6,18 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use clap::Parser;
 use eyre::Result;
 use sn_node::node::Config;
 use std::time::Duration;
-use structopt::StructOpt;
 use tokio::{fs::remove_file, io};
 
 // This example is to demonstrate how the node configuration is constructed
 // The node will attempt to read a cached config file from disk
 // The node will then overwrite the config using the provided command line args
 
-// Note: This is essentially a test, but, when using test filtering, StructOpt
-// tries to parse the filter as an argument passed resulting in a `UnmatchedArgument` error.
+// Note: This is essentially a test, but, when using test filtering, Clap tries to
+// parse the filter as an argument passed resulting in a `UnmatchedArgument` error.
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/sn_node/examples/routing_minimal.rs
+++ b/sn_node/examples/routing_minimal.rs
@@ -38,6 +38,7 @@ use sn_node::node::{
     MessagingEvent, NodeApi,
 };
 
+use clap::Parser;
 use eyre::Result;
 use futures::future::join_all;
 use std::{
@@ -46,16 +47,15 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     time::Duration,
 };
-use structopt::StructOpt;
 use tokio::task::JoinHandle;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
 /// Minimal example node.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::StructOpt)]
 struct Options {
     /// Whether this is the first node ("genesis node") of the network. Only one node can be first.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     first: bool,
     /// IP address to bind to. Default is localhost which is fine when spawning example nodes
     /// on a single machine. If one wants to run nodes on multiple machines, an address that is
@@ -66,26 +66,26 @@ struct Options {
     ///
     /// If starting multiple nodes (see --count), then this option applies only to the first one.
     /// The rest are started as regular nodes.
-    #[structopt(short, long, value_name = "IP")]
+    #[clap(short, long, value_name = "IP")]
     ip: Option<IpAddr>,
     /// Port to listen to. If omitted, a randomly assigned port is used.
     ///
     /// If starting multiple nodes (see --count), then this is used as base port and the actual
     /// port of `n-th` node is calculated as `port + n` (if available)
-    #[structopt(short, long, value_name = "PORT")]
+    #[clap(short, long, value_name = "PORT")]
     port: Option<u16>,
     /// Number of nodes to start. Each node is started in its own thread. Default is to start just
     /// one node.
-    #[structopt(
+    #[clap(
         short,
         long,
-        default_value,
+        default_value_t,
         value_name = "COUNT",
         hide_default_value = true
     )]
     count: usize,
     /// Enable verbose output. Can be specified multiple times for increased verbosity.
-    #[structopt(short, parse(from_occurrences))]
+    #[clap(short, parse(from_occurrences))]
     verbosity: u8,
 }
 

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -18,6 +18,7 @@ use sn_node::node::{
 };
 
 use bls::PublicKey;
+use clap::Parser;
 use eyre::{eyre, Context, Error, Result};
 use futures::{
     future,
@@ -35,7 +36,6 @@ use std::{
     io::BufWriter,
     time::{Duration, Instant},
 };
-use structopt::StructOpt;
 use tokio::{
     sync::mpsc::{self, Sender},
     time,
@@ -52,17 +52,17 @@ const MIN_PRINT_DELAY: Duration = Duration::from_millis(500);
 const PROBE_WINDOW: Duration = Duration::from_secs(60);
 
 /// Stress test for sn-routing.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::StructOpt)]
 struct Options {
     /// Enable logging. Takes path to a file to log to or "-" to log to stdout. If omitted, logging
     /// is disabled.
-    #[structopt(short, long, name = "PATH")]
+    #[clap(short, long, name = "PATH")]
     log: Option<String>,
     /// How many probe messages to send per second.
     ///
     /// Probe messages are used to determine network health. The higher the percentage of
     /// successfully delivered probe messages, the healthier the network is.
-    #[structopt(short, long, default_value = "1")]
+    #[clap(short, long, default_value = "1")]
     probe_frequency: f64,
     /// Churn schedule: DURATION1 JOINS1 DROPS1 DURATION2 JOINS2 DROPS2, ...
     ///

--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -51,8 +51,8 @@ use tracing_subscriber::filter::EnvFilter;
 
 #[cfg(not(feature = "tokio-console"))]
 const MODULE_NAME: &str = "sn_node";
-const JOIN_TIMEOUT_SEC: u64 = 10;
-const BOOTSTRAP_RETRY_TIME_SEC: u64 = 10;
+const JOIN_TIMEOUT_SEC: u64 = 30;
+const BOOTSTRAP_RETRY_TIME_SEC: u64 = 15;
 
 fn main() -> Result<()> {
     color_eyre::install()?;

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -141,8 +141,7 @@ impl Comm {
                     peers_to_cleanup.push(*peer);
                 }
 
-                dysfunction
-                    .track_issue(peer.name(), sn_dysfunction::IssueType::Communication)?;
+                dysfunction.track_issue(peer.name(), sn_dysfunction::IssueType::Communication)?;
             }
         }
 

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -125,7 +125,7 @@ impl Comm {
     pub(crate) async fn cleanup_peers(
         &self,
         retain_peers: Vec<Peer>,
-        dysfunction: DysfunctionDetection,
+        mut dysfunction: DysfunctionDetection,
     ) -> Result<()> {
         let mut peers_to_cleanup = vec![];
         for entry in self.sessions.iter() {
@@ -142,8 +142,7 @@ impl Comm {
                 }
 
                 dysfunction
-                    .track_issue(peer.name(), sn_dysfunction::IssueType::Communication)
-                    .await?;
+                    .track_issue(peer.name(), sn_dysfunction::IssueType::Communication)?;
             }
         }
 

--- a/sn_node/src/dbs/lru_cache.rs
+++ b/sn_node/src/dbs/lru_cache.rs
@@ -6,13 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use dashmap::DashMap;
 use priority_queue::PriorityQueue;
-use std::sync::{
-    atomic::{AtomicU16, Ordering},
-    Arc,
-};
-use tokio::sync::RwLock;
+use std::{collections::BTreeMap, ops::Sub};
 use xor_name::XorName;
 
 type Priority = u16;
@@ -26,25 +21,25 @@ type Priority = u16;
 ///
 /// At an insert of a new value, when the cache is full, the priority queue will simply be popped, and the least
 /// recently used value will have the largest number, so it will be at the top of the queue.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct LruCache<T> {
-    data: DashMap<XorName, Arc<T>>,
-    queue: Arc<RwLock<PriorityQueue<XorName, Priority>>>,
+    data: BTreeMap<XorName, T>,
+    queue: PriorityQueue<XorName, Priority>,
     size: u16,
-    start: Arc<AtomicU16>,
+    start: u16,
 }
 
 impl<T> LruCache<T> {
     pub(crate) fn new(size: u16) -> Self {
         Self {
-            data: DashMap::new(),
-            queue: Arc::new(RwLock::new(PriorityQueue::new())),
+            data: BTreeMap::new(),
+            queue: PriorityQueue::new(),
             size,
-            start: Arc::new(AtomicU16::new(u16::MAX)),
+            start: u16::MAX,
         }
     }
 
-    pub(crate) async fn insert(&self, key: &XorName, val: Arc<T>) {
+    pub(crate) fn insert(&mut self, key: &XorName, val: T) {
         if self.data.contains_key(key) {
             return;
         }
@@ -54,58 +49,55 @@ impl<T> LruCache<T> {
             let mut prio = self.priority();
             if prio == 0 {
                 // empty the cache when we overflow
-                self.queue.write().await.clear();
+                self.queue.clear();
                 self.data.clear();
-                prio = self.start.fetch_sub(1, Ordering::SeqCst)
+                prio = self.start.sub(1)
             }
 
-            let _ = self.queue.write().await.push(*key, prio);
+            let _ = self.queue.push(*key, prio);
         }
 
-        let len = { self.queue.read().await.len() as u16 };
+        let len = { self.queue.len() as u16 };
         if len > self.size {
-            let mut write = self.queue.write().await;
-            if let Some((evicted, _)) = write.pop() {
+            if let Some((evicted, _)) = self.queue.pop() {
                 let _ = self.data.remove(&evicted);
             }
         }
     }
 
-    pub(crate) async fn get(&self, key: &XorName) -> Option<Arc<T>> {
+    pub(crate) fn get(&mut self, key: &XorName) -> Option<&T> {
         let exists = {
-            let read_only = self.queue.read().await;
+            let read_only = &self.queue;
             read_only.get(key).is_some()
         };
         if exists {
             let mut prio = self.priority();
             if prio == 0 {
                 // empty the cache when we overflow
-                self.queue.write().await.clear();
+                self.queue.clear();
                 self.data.clear();
-                prio = self.start.fetch_sub(1, Ordering::SeqCst)
+                prio = self.start.sub(1)
             }
 
-            let _ = self.queue.write().await.change_priority(key, prio);
+            let _ = self.queue.change_priority(key, prio);
         }
-        self.data.get(key).as_deref().cloned()
+        self.data.get(key)
     }
 
-    pub(crate) async fn remove(&self, key: &XorName) {
-        let _ = self.queue.write().await.remove(key);
+    pub(crate) fn remove(&mut self, key: &XorName) {
+        let _ = self.queue.remove(key);
         let _ = self.data.remove(key);
     }
 
     /// returns current priority
     fn priority(&self) -> Priority {
-        self.start.fetch_sub(1, Ordering::SeqCst)
+        self.start.sub(1)
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::LruCache;
-
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_basic() {
@@ -114,11 +106,11 @@ mod test {
         let key_1 = &xor_name::rand::random();
         let key_2 = &xor_name::rand::random();
         let key_3 = &xor_name::rand::random();
-        cache.insert(key_1, Arc::new("Strawberries")).await;
-        cache.insert(key_2, Arc::new("Bananas")).await;
-        cache.insert(key_3, Arc::new("Peaches")).await;
+        cache.insert(key_1, "Strawberries");
+        cache.insert(key_2, "Bananas");
+        cache.insert(key_3, "Peaches");
 
-        let result_string = format!("{:?}", cache.get(key_2).await);
+        let result_string = format!("{:?}", cache.get(key_2));
         let expected_string = format!("{:?}", Some("Bananas"));
 
         assert_eq!(result_string, expected_string);
@@ -132,12 +124,12 @@ mod test {
         let key_2 = &xor_name::rand::random();
         let key_3 = &xor_name::rand::random();
         let key_4 = &xor_name::rand::random();
-        cache.insert(key_1, Arc::new("Strawberries")).await;
-        cache.insert(key_2, Arc::new("Bananas")).await;
-        cache.insert(key_3, Arc::new("Peaches")).await;
-        cache.insert(key_4, Arc::new("Blueberries")).await;
+        cache.insert(key_1, "Strawberries");
+        cache.insert(key_2, "Bananas");
+        cache.insert(key_3, "Peaches");
+        cache.insert(key_4, "Blueberries");
 
-        let result_string = format!("{:?}", cache.get(key_1).await);
+        let result_string = format!("{:?}", cache.get(key_1));
         let expected_string = format!("{:?}", None::<String>);
 
         assert_eq!(result_string, expected_string);
@@ -150,18 +142,18 @@ mod test {
         let key_1 = &xor_name::rand::random();
         let key_2 = &xor_name::rand::random();
         let key_3 = &xor_name::rand::random();
-        cache.insert(key_1, Arc::new("Strawberries")).await;
-        cache.insert(key_2, Arc::new("Bananas")).await;
-        cache.insert(key_3, Arc::new("Peaches")).await;
+        cache.insert(key_1, "Strawberries");
+        cache.insert(key_2, "Bananas");
+        cache.insert(key_3, "Peaches");
 
-        let result_string = format!("{:?}", cache.get(key_2).await);
+        let result_string = format!("{:?}", cache.get(key_2));
         let expected_string = format!("{:?}", Some("Bananas"));
 
         assert_eq!(result_string, expected_string);
 
-        cache.remove(key_2).await;
+        cache.remove(key_2);
 
-        let result_string = format!("{:?}", cache.get(key_2).await);
+        let result_string = format!("{:?}", cache.get(key_2));
         let expected_string = format!("{:?}", None::<String>);
 
         assert_eq!(result_string, expected_string);

--- a/sn_node/src/dbs/lru_cache.rs
+++ b/sn_node/src/dbs/lru_cache.rs
@@ -101,7 +101,7 @@ mod test {
 
     #[tokio::test]
     async fn test_basic() {
-        let cache = LruCache::new(3);
+        let mut cache = LruCache::new(3);
 
         let key_1 = &xor_name::rand::random();
         let key_2 = &xor_name::rand::random();
@@ -118,7 +118,7 @@ mod test {
 
     #[tokio::test]
     async fn test_lru() {
-        let cache = LruCache::new(3);
+        let mut cache = LruCache::new(3);
 
         let key_1 = &xor_name::rand::random();
         let key_2 = &xor_name::rand::random();
@@ -137,7 +137,7 @@ mod test {
 
     #[tokio::test]
     async fn test_remove() {
-        let cache = LruCache::new(3);
+        let mut cache = LruCache::new(3);
 
         let key_1 = &xor_name::rand::random();
         let key_2 = &xor_name::rand::random();

--- a/sn_node/src/dbs/mod.rs
+++ b/sn_node/src/dbs/mod.rs
@@ -10,14 +10,12 @@ mod chunk_store;
 mod encoding;
 mod errors;
 mod event_store;
-mod lru_cache;
 mod used_space;
 
 pub(crate) use chunk_store::ChunkStore;
 pub(crate) use encoding::{deserialise, serialise};
 pub(crate) use errors::{convert_to_error_msg, Error, Result};
 pub(crate) use event_store::EventStore;
-pub(crate) use lru_cache::LruCache;
 use std::path::Path;
 pub use used_space::UsedSpace;
 

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -35,7 +35,8 @@
     unused_import_braces,
     unused_qualifications,
     unused_results,
-    clippy::unicode_not_nfc
+    clippy::unicode_not_nfc,
+    clippy::drop_ref
 )]
 
 #[macro_use]

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -150,6 +150,7 @@ impl Dispatcher {
             } => {
                 // we should queue this
                 for data in data_batch {
+                    trace!("data being enqueued for replication {}", data);
                     let node = self.node.write().await;
                     if let Some(mut data_entry) =
                         node.pending_data_to_replicate_to_peers.get_mut(&data)

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -155,16 +155,14 @@ impl Dispatcher {
                     if let Some(mut data_entry) =
                         node.pending_data_to_replicate_to_peers.get_mut(&data)
                     {
-                        let peer_set = data_entry.value_mut();
                         debug!("data already queued, adding peer");
-                        let _existed = peer_set.insert(recipient);
+                        let _existed = peers_set.insert(recipient);
                     } else {
-                        // let queue = DashSet::new();
-                        let mut peer_set = BTreeSet::new();
-                        let _existed = peer_set.insert(recipient);
+                        let mut peers_set = BTreeSet::new();
+                        let _existed = peers_set.insert(recipient);
                         let _existed = node
                             .pending_data_to_replicate_to_peers
-                            .insert(data, peer_set);
+                            .insert(data, peers_set);
                     };
                 }
                 Ok(vec![])

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -204,7 +204,7 @@ impl Dispatcher {
 
                 if let Some(member_info) = node_state {
                     if self.comm.is_reachable(&member_info.addr()).await.is_err() {
-                        let node = self.node.write().await;
+                        let mut node = self.node.write().await;
 
                         node.log_comm_issue(member_info.name()).await?
                     }

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -69,7 +69,7 @@ impl Dispatcher {
                 let node = self.node.read().await;
 
                 let src_section_pk = node.network_knowledge().section_key();
-                let wire_msg = WireMsg::single_src(&node.info().await, dst, msg, src_section_pk)?;
+                let wire_msg = WireMsg::single_src(&node.info(), dst, msg, src_section_pk)?;
 
                 let mut cmds = vec![];
                 cmds.extend(node.send_msg_to_nodes(wire_msg).await?);
@@ -89,7 +89,7 @@ impl Dispatcher {
             Cmd::HandleDkgTimeout(token) => {
                 let node = self.node.read().await;
 
-                node.handle_dkg_timeout(token).await
+                node.handle_dkg_timeout(token)
             }
             Cmd::HandleAgreement { proposal, sig } => {
                 let mut node = self.node.write().await;

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -150,10 +150,9 @@ impl Dispatcher {
             } => {
                 // we should queue this
                 for data in data_batch {
-                    trace!("data being enqueued for replication {}", data);
-                    let node = self.node.write().await;
-                    if let Some(mut data_entry) =
-                        node.pending_data_to_replicate_to_peers.get_mut(&data)
+                    trace!("data being enqueued for replication {:?}", data);
+                    let mut node = self.node.write().await;
+                    if let Some(peers_set) = node.pending_data_to_replicate_to_peers.get_mut(&data)
                     {
                         debug!("data already queued, adding peer");
                         let _existed = peers_set.insert(recipient);

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -24,13 +24,13 @@ use tokio::{sync::watch, sync::RwLock, time};
 
 // Cmd Dispatcher.
 pub(crate) struct Dispatcher {
-    node: Arc<Node>,
+    node: Arc<RwLock<Node>>,
     comm: Comm,
     dkg_timeout: Arc<DkgTimeout>,
 }
 
 impl Dispatcher {
-    pub(super) fn new(node: Arc<Node>, comm: Comm) -> Self {
+    pub(super) fn new(node: Arc<RwLock<Node>>, comm: Comm) -> Self {
         let (cancel_timer_tx, cancel_timer_rx) = watch::channel(false);
         let dkg_timeout = Arc::new(DkgTimeout {
             cancel_timer_tx,
@@ -44,7 +44,7 @@ impl Dispatcher {
         }
     }
 
-    pub(crate) fn node(&self) -> Arc<Node> {
+    pub(crate) fn node(&self) -> Arc<RwLock<Node>> {
         self.node.clone()
     }
 
@@ -58,19 +58,21 @@ impl Dispatcher {
     pub(crate) async fn process_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
         match cmd {
             Cmd::CleanupPeerLinks => {
-                let elders = self.node.network_knowledge.elders();
+                let node = self.node.read().await;
+                let elders = node.network_knowledge.elders();
                 self.comm
-                    .cleanup_peers(elders, self.node.dysfunction_tracking.clone())
+                    .cleanup_peers(elders, node.dysfunction_tracking.clone())
                     .await?;
                 Ok(vec![])
             }
             Cmd::SignOutgoingSystemMsg { msg, dst } => {
-                let src_section_pk = self.node.network_knowledge().section_key();
-                let wire_msg =
-                    WireMsg::single_src(&self.node.info().await, dst, msg, src_section_pk)?;
+                let node = self.node.read().await;
+
+                let src_section_pk = node.network_knowledge().section_key();
+                let wire_msg = WireMsg::single_src(&node.info().await, dst, msg, src_section_pk)?;
 
                 let mut cmds = vec![];
-                cmds.extend(self.node.send_msg_to_nodes(wire_msg).await?);
+                cmds.extend(node.send_msg_to_nodes(wire_msg).await?);
 
                 Ok(cmds)
             }
@@ -79,50 +81,64 @@ impl Dispatcher {
                 wire_msg,
                 original_bytes,
             } => {
-                self.node
-                    .handle_msg(sender, wire_msg, original_bytes, &self.comm)
+                let mut node = self.node.write().await;
+
+                node.handle_msg(sender, wire_msg, original_bytes, &self.comm)
                     .await
             }
-            Cmd::HandleDkgTimeout(token) => self.node.handle_dkg_timeout(token).await,
+            Cmd::HandleDkgTimeout(token) => {
+                let node = self.node.read().await;
+
+                node.handle_dkg_timeout(token).await
+            }
             Cmd::HandleAgreement { proposal, sig } => {
-                self.node.handle_general_agreements(proposal, sig).await
+                let mut node = self.node.write().await;
+
+                node.handle_general_agreements(proposal, sig).await
             }
             Cmd::HandleNewNodeOnline(auth) => {
-                self.node
-                    .handle_online_agreement(auth.value.into_state(), auth.sig)
+                let mut node = self.node.write().await;
+
+                node.handle_online_agreement(auth.value.into_state(), auth.sig)
                     .await
             }
             Cmd::HandleNodeLeft(auth) => {
-                self.node
-                    .handle_node_left(auth.value.into_state(), auth.sig)
+                let mut node = self.node.write().await;
+
+                node.handle_node_left(auth.value.into_state(), auth.sig)
                     .await
             }
             Cmd::HandleNewEldersAgreement { proposal, sig } => match proposal {
                 Proposal::NewElders(section_auth) => {
-                    self.node
-                        .handle_new_elders_agreement(section_auth, sig)
-                        .await
+                    let mut node = self.node.write().await;
+
+                    node.handle_new_elders_agreement(section_auth, sig).await
                 }
                 _ => {
                     error!("Other agreement messages should be handled in `HandleAgreement`, which is non-blocking ");
                     Ok(vec![])
                 }
             },
-            Cmd::HandlePeerLost(peer) => self.node.handle_peer_lost(&peer.addr()).await,
+            Cmd::HandlePeerLost(peer) => {
+                let node = self.node.write().await;
+
+                node.handle_peer_lost(&peer.addr()).await
+            }
             Cmd::HandleDkgOutcome {
                 section_auth,
                 outcome,
                 generation,
             } => {
-                self.node
-                    .handle_dkg_outcome(section_auth, outcome, generation)
+                let mut node = self.node.write().await;
+
+                node.handle_dkg_outcome(section_auth, outcome, generation)
                     .await
             }
-            Cmd::HandleDkgFailure(signeds) => self
-                .node
-                .handle_dkg_failure(signeds)
-                .await
-                .map(|cmd| vec![cmd]),
+            Cmd::HandleDkgFailure(signeds) => {
+                let node = self.node.read().await;
+
+                node.handle_dkg_failure(signeds).await.map(|cmd| vec![cmd])
+            }
             Cmd::SendMsg {
                 recipients,
                 wire_msg,
@@ -134,21 +150,21 @@ impl Dispatcher {
             } => {
                 // we should queue this
                 for data in data_batch {
-                    if let Some(data_entry) =
-                        self.node.pending_data_to_replicate_to_peers.get_mut(&data)
+                    let node = self.node.write().await;
+                    if let Some(mut data_entry) =
+                        node.pending_data_to_replicate_to_peers.get_mut(&data)
                     {
-                        let peer_set = data_entry.value();
+                        let peer_set = data_entry.value_mut();
                         debug!("data already queued, adding peer");
-                        let _existed = peer_set.write().await.insert(recipient);
+                        let _existed = peer_set.insert(recipient);
                     } else {
                         // let queue = DashSet::new();
                         let mut peer_set = BTreeSet::new();
                         let _existed = peer_set.insert(recipient);
-                        let _existed = self
-                            .node
+                        let _existed = node
                             .pending_data_to_replicate_to_peers
-                            .insert(data, Arc::new(RwLock::new(peer_set)));
-                    }
+                            .insert(data, peer_set);
+                    };
                 }
                 Ok(vec![])
             }
@@ -165,16 +181,32 @@ impl Dispatcher {
                 .await
                 .into_iter()
                 .collect()),
-            Cmd::ProposeOffline(names) => self.node.cast_offline_proposals(&names).await,
-            Cmd::StartConnectivityTest(name) => Ok(vec![
-                self.node
-                    .send_msg_to_our_elders(SystemMsg::StartConnectivityTest(name))
-                    .await?,
-            ]),
+            Cmd::ProposeOffline(names) => {
+                let node = self.node.read().await;
+
+                node.cast_offline_proposals(&names).await
+            }
+            Cmd::StartConnectivityTest(name) => {
+                let node = self.node.read().await;
+
+                Ok(vec![
+                    node.send_msg_to_our_elders(SystemMsg::StartConnectivityTest(name))
+                        .await?,
+                ])
+            }
             Cmd::TestConnectivity(name) => {
-                if let Some(member_info) = self.node.network_knowledge().get_section_member(&name) {
+                let node_state = self
+                    .node
+                    .read()
+                    .await
+                    .network_knowledge()
+                    .get_section_member(&name);
+
+                if let Some(member_info) = node_state {
                     if self.comm.is_reachable(&member_info.addr()).await.is_err() {
-                        self.node.log_comm_issue(member_info.name()).await?
+                        let node = self.node.write().await;
+
+                        node.log_comm_issue(member_info.name()).await?
                     }
                 }
                 Ok(vec![])

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -120,7 +120,7 @@ impl Dispatcher {
                 }
             },
             Cmd::HandlePeerLost(peer) => {
-                let node = self.node.write().await;
+                let node = self.node.read().await;
 
                 node.handle_peer_lost(&peer.addr()).await
             }

--- a/sn_node/src/node/api/dispatcher.rs
+++ b/sn_node/src/node/api/dispatcher.rs
@@ -120,7 +120,7 @@ impl Dispatcher {
                 }
             },
             Cmd::HandlePeerLost(peer) => {
-                let node = self.node.read().await;
+                let mut node = self.node.write().await;
 
                 node.handle_peer_lost(&peer.addr()).await
             }
@@ -135,7 +135,7 @@ impl Dispatcher {
                     .await
             }
             Cmd::HandleDkgFailure(signeds) => {
-                let node = self.node.read().await;
+                let mut node = self.node.write().await;
 
                 node.handle_dkg_failure(signeds).await.map(|cmd| vec![cmd])
             }

--- a/sn_node/src/node/api/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/api/flow_ctrl/cmd_ctrl.rs
@@ -78,7 +78,7 @@ impl CmdCtrl {
         session
     }
 
-    pub(crate) fn node(&self) -> Arc<crate::node::core::Node> {
+    pub(crate) fn node(&self) -> Arc<RwLock<crate::node::core::Node>> {
         self.dispatcher.node()
     }
 

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -318,7 +318,7 @@ impl FlowCtrl {
                 let _instant = interval.tick().await;
 
                 let dysfunctional_nodes =
-                    self.node.read().await.get_dysfunctional_node_names().await;
+                    self.node.write().await.get_dysfunctional_node_names().await;
                 let unresponsive_nodes = match dysfunctional_nodes {
                     Ok(nodes) => nodes,
                     Err(error) => {

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -210,6 +210,7 @@ impl FlowCtrl {
             interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
             loop {
+                trace!("data replication loop");
                 let _ = interval.tick().await;
 
                 use rand::seq::IteratorRandom;
@@ -217,6 +218,7 @@ impl FlowCtrl {
                 let mut this_batch_address = None;
                 let node = &self.node;
 
+                trace!("about to query pending data to replx");
                 // choose a data to replicate at random
                 if let Some(data_queued) = node
                     .read()
@@ -228,7 +230,9 @@ impl FlowCtrl {
                     this_batch_address = Some(*data_queued.key());
                 }
 
+                trace!("queried");
                 if let Some(address) = this_batch_address {
+                    trace!("data found to send out");
                     if let Some((data_address, data_recipients)) = node
                         .read()
                         .await
@@ -284,6 +288,8 @@ impl FlowCtrl {
                             error!("Error in data replication loop: {:?}", e);
                         }
                     }
+                } else {
+                    trace!("no data to be sending");
                 }
             }
         });

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -22,7 +22,7 @@ use sn_interface::{
 
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use tokio::{
-    sync::mpsc,
+    sync::{mpsc, RwLock},
     task::{self, JoinHandle},
     time::MissedTickBehavior,
 };
@@ -38,7 +38,7 @@ const DYSFUNCTION_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub(crate) struct FlowCtrl {
-    node: Arc<Node>,
+    node: Arc<RwLock<Node>>,
     cmd_ctrl: CmdCtrl,
 }
 
@@ -114,8 +114,10 @@ impl FlowCtrl {
 
                 // Send a probe message if we are an elder
                 let node = &self.node;
-                if node.is_elder().await && !node.network_knowledge().prefix().is_empty() {
-                    match node.generate_probe_msg().await {
+                if node.read().await.is_elder().await
+                    && !node.read().await.network_knowledge().prefix().is_empty()
+                {
+                    match node.read().await.generate_probe_msg().await {
                         Ok(cmd) => {
                             info!("Sending probe msg");
                             if let Err(e) = self.cmd_ctrl.push(cmd).await {
@@ -140,8 +142,8 @@ impl FlowCtrl {
 
                 // Send a probe message to an elder
                 let node = &self.node;
-                if !node.network_knowledge().prefix().is_empty() {
-                    match node.generate_section_probe_msg().await {
+                if !node.read().await.network_knowledge().prefix().is_empty() {
+                    match node.read().await.generate_section_probe_msg().await {
                         Ok(cmd) => {
                             info!("Sending section probe msg");
                             if let Err(e) = self.cmd_ctrl.push(cmd).await {
@@ -166,21 +168,26 @@ impl FlowCtrl {
             loop {
                 let _instant = interval.tick().await;
 
-                if !dispatcher.node.is_elder().await {
+                if !dispatcher.node.read().await.is_elder().await {
                     continue;
                 }
                 trace!("looping vote check in elder");
+                let node = dispatcher.node.read().await;
+                let membership = &node.membership;
 
-                let membership = dispatcher.node.membership.read().await;
-
-                if let Some(membership) = &*membership {
+                if let Some(membership) = &membership {
                     let last_received_vote_time = membership.last_received_vote_time();
 
                     if let Some(time) = last_received_vote_time {
                         // we want to resend the prev vote
                         if time.elapsed() >= MISSING_VOTE_INTERVAL {
                             debug!("Vote consensus appears stalled...");
-                            let cmds = self.node.resend_our_last_vote_to_elders().await?;
+                            let cmds = self
+                                .node
+                                .read()
+                                .await
+                                .resend_our_last_vote_to_elders()
+                                .await?;
 
                             trace!("Vote resending cmds: {:?}", cmds.len());
                             for cmd in cmds {
@@ -213,6 +220,8 @@ impl FlowCtrl {
 
                 // choose a data to replicate at random
                 if let Some(data_queued) = node
+                    .read()
+                    .await
                     .pending_data_to_replicate_to_peers
                     .iter()
                     .choose(&mut rng)
@@ -221,16 +230,19 @@ impl FlowCtrl {
                 }
 
                 if let Some(address) = this_batch_address {
-                    if let Some((data_address, data_recipients)) =
-                        node.pending_data_to_replicate_to_peers.remove(&address)
+                    if let Some((data_address, data_recipients)) = node
+                        .read()
+                        .await
+                        .pending_data_to_replicate_to_peers
+                        .remove(&address)
                     {
                         // get info for the WireMsg
-                        let src_section_pk = node.network_knowledge().section_key();
-                        let our_info = node.info().await;
+                        let src_section_pk = node.read().await.network_knowledge().section_key();
+                        let our_info = node.read().await.info().await;
 
                         let mut recipients = vec![];
 
-                        for peer in data_recipients.read().await.iter() {
+                        for peer in data_recipients.iter() {
                             recipients.push(*peer);
                         }
 
@@ -246,6 +258,8 @@ impl FlowCtrl {
                         };
 
                         let data_to_send = node
+                            .read()
+                            .await
                             .data_storage
                             .get_from_local_store(&data_address)
                             .await?;
@@ -306,13 +320,14 @@ impl FlowCtrl {
 
                 let node = &self.node;
 
-                let unresponsive_nodes = match node.get_dysfunctional_node_names().await {
-                    Ok(nodes) => nodes,
-                    Err(error) => {
-                        error!("Error getting dysfunctional nodes: {error}");
-                        BTreeSet::default()
-                    }
-                };
+                let unresponsive_nodes =
+                    match node.read().await.get_dysfunctional_node_names().await {
+                        Ok(nodes) => nodes,
+                        Err(error) => {
+                            error!("Error getting dysfunctional nodes: {error}");
+                            BTreeSet::default()
+                        }
+                    };
 
                 if !unresponsive_nodes.is_empty() {
                     debug!("{:?} : {unresponsive_nodes:?}", LogMarker::ProposeOffline);
@@ -422,7 +437,7 @@ async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Rece
 
                 let span = {
                     let node = &ctrl.node;
-                    trace_span!("handle_message", name = %node.info().await.name(), ?sender, msg_id = ?wire_msg.msg_id())
+                    trace_span!("handle_message", name = %node.read().await.info().await.name(), ?sender, msg_id = ?wire_msg.msg_id())
                 };
                 let _span_guard = span.enter();
 

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -257,7 +257,7 @@ impl FlowCtrl {
                         };
 
                         let data_to_send = node
-                            .read()
+                            .write()
                             .await
                             .data_storage
                             .get_from_local_store(&data_address)

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -114,7 +114,7 @@ impl FlowCtrl {
 
                 // Send a probe message if we are an elder
                 let node = &self.node;
-                if node.read().await.is_elder().await
+                if node.read().await.is_elder()
                     && !node.read().await.network_knowledge().prefix().is_empty()
                 {
                     match node.read().await.generate_probe_msg().await {
@@ -168,7 +168,7 @@ impl FlowCtrl {
             loop {
                 let _instant = interval.tick().await;
 
-                if !dispatcher.node.read().await.is_elder().await {
+                if !dispatcher.node.read().await.is_elder() {
                     continue;
                 }
                 trace!("looping vote check in elder");
@@ -238,7 +238,7 @@ impl FlowCtrl {
                     {
                         // get info for the WireMsg
                         let src_section_pk = node.read().await.network_knowledge().section_key();
-                        let our_info = node.read().await.info().await;
+                        let our_info = node.read().await.info();
 
                         let mut recipients = vec![];
 
@@ -363,8 +363,8 @@ impl FlowCtrl {
             loop {
                 let _ = interval.tick().await;
 
-                let node = &self.node;
-                let our_info = node.info().await;
+                let node = self.node.read().await;
+                let our_info = node.info();
                 let our_name = our_info.name();
 
                 let members = node.network_knowledge().section_members();
@@ -437,7 +437,7 @@ async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Rece
 
                 let span = {
                     let node = &ctrl.node;
-                    trace_span!("handle_message", name = %node.read().await.info().await.name(), ?sender, msg_id = ?wire_msg.msg_id())
+                    trace_span!("handle_message", name = %node.read().await.info().name(), ?sender, msg_id = ?wire_msg.msg_id())
                 };
                 let _span_guard = span.enter();
 

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -359,7 +359,9 @@ impl NodeApi {
             wire_msg.msg_id()
         );
 
-        if let Some(cmd) = self.node.read().await.send_msg_to_nodes(wire_msg).await? {
+        let cmds = self.node.read().await.send_msg_to_nodes(wire_msg).await?;
+
+        if let Some(cmd) = cmds {
             self.flow_ctrl.fire_and_forget(cmd).await?;
         }
 

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -262,8 +262,8 @@ impl NodeApi {
             )
             .await?;
 
-            info!("{} Joined the network!", node.info().await.name());
-            info!("Our AGE: {}", node.info().await.age());
+            info!("{} Joined the network!", node.info().name());
+            info!("Our AGE: {}", node.info().age());
 
             (node, comm)
         };
@@ -282,7 +282,7 @@ impl NodeApi {
 
     /// Returns the current age of this node.
     pub async fn age(&self) -> u8 {
-        self.node.read().await.info().await.age()
+        self.node.read().await.info().age()
     }
 
     /// Returns the ed25519 public key of this node.
@@ -292,12 +292,12 @@ impl NodeApi {
 
     /// The name of this node.
     pub async fn name(&self) -> XorName {
-        self.node.read().await.info().await.name()
+        self.node.read().await.info().name()
     }
 
     /// Returns connection info of this node.
     pub async fn our_connection_info(&self) -> SocketAddr {
-        self.node.read().await.info().await.addr
+        self.node.read().await.info().addr
     }
 
     /// Returns the Section Signed Chain
@@ -317,7 +317,7 @@ impl NodeApi {
 
     /// Returns whether the node is Elder.
     pub async fn is_elder(&self) -> bool {
-        self.node.read().await.is_elder().await
+        self.node.read().await.is_elder()
     }
 
     /// Returns the information of all the current section elders.
@@ -343,7 +343,7 @@ impl NodeApi {
     ) -> Result<WireMsg> {
         let src_section_pk = *self.section_chain().await.last_key();
         WireMsg::single_src(
-            &self.node.read().await.info().await,
+            &self.node.read().await.info(),
             dst,
             node_msg,
             src_section_pk,

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -50,7 +50,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::{fs, sync::mpsc};
+use tokio::{fs, sync::{mpsc, RwLock} };
 use xor_name::{Prefix, XorName};
 
 // Filename for storing the content of the genesis DBC.
@@ -71,7 +71,7 @@ const GENESIS_DBC_FILENAME: &str = "genesis_dbc";
 /// role, and can be `use sn_interface::messaging::SrcLocation::Node` or `use sn_interface::messaging::SrcLocation::Section`.
 #[allow(missing_debug_implementations)]
 pub struct NodeApi {
-    node: Arc<Node>,
+    node: Arc<RwLock<Node>>,
     flow_ctrl: FlowCtrl,
 }
 
@@ -86,7 +86,7 @@ impl NodeApi {
     pub async fn new(config: &Config, join_timeout: Duration) -> Result<(Self, EventReceiver)> {
         let root_dir_buf = config.root_dir()?;
         let root_dir = root_dir_buf.as_path();
-        tokio::fs::create_dir_all(root_dir).await?;
+        fs::create_dir_all(root_dir).await?;
 
         let _reward_key = match get_reward_pk(root_dir).await? {
             Some(public_key) => TypesPublicKey::Ed25519(public_key),
@@ -104,7 +104,7 @@ impl NodeApi {
             Self::start_node(config, used_space, root_dir, join_timeout).await?;
 
         // Network keypair may have to be changed due to naming criteria or network requirements.
-        let keypair_as_bytes = api.node.keypair.read().await.to_bytes();
+        let keypair_as_bytes = api.node.read().await.keypair.to_bytes();
         store_network_keypair(root_dir, keypair_as_bytes).await?;
 
         let our_pid = std::process::id();
@@ -268,7 +268,7 @@ impl NodeApi {
             (node, comm)
         };
 
-        let node = Arc::new(node);
+        let node = Arc::new(RwLock::new(node));
         let cmd_ctrl = CmdCtrl::new(
             Dispatcher::new(node.clone(), comm),
             monitoring,
@@ -282,57 +282,57 @@ impl NodeApi {
 
     /// Returns the current age of this node.
     pub async fn age(&self) -> u8 {
-        self.node.info().await.age()
+        self.node.read().await.info().await.age()
     }
 
     /// Returns the ed25519 public key of this node.
     pub async fn public_key(&self) -> PublicKey {
-        self.node.keypair.read().await.public
+        self.node.read().await.keypair.public
     }
 
     /// The name of this node.
     pub async fn name(&self) -> XorName {
-        self.node.info().await.name()
+        self.node.read().await.info().await.name()
     }
 
     /// Returns connection info of this node.
     pub async fn our_connection_info(&self) -> SocketAddr {
-        self.node.info().await.addr
+        self.node.read().await.info().await.addr
     }
 
     /// Returns the Section Signed Chain
     pub async fn section_chain(&self) -> SecuredLinkedList {
-        self.node.section_chain().await
+        self.node.read().await.section_chain().await
     }
 
     /// Returns the Section Chain's genesis key
     pub async fn genesis_key(&self) -> bls::PublicKey {
-        *self.node.network_knowledge().genesis_key()
+        *self.node.read().await.network_knowledge().genesis_key()
     }
 
     /// Prefix of our section
     pub async fn our_prefix(&self) -> Prefix {
-        self.node.network_knowledge().prefix()
+        self.node.read().await.network_knowledge().prefix()
     }
 
     /// Returns whether the node is Elder.
     pub async fn is_elder(&self) -> bool {
-        self.node.is_elder().await
+        self.node.read().await.is_elder().await
     }
 
     /// Returns the information of all the current section elders.
     pub async fn our_elders(&self) -> Vec<Peer> {
-        self.node.network_knowledge().elders()
+        self.node.read().await.network_knowledge().elders()
     }
 
     /// Returns the information of all the current section adults.
     pub async fn our_adults(&self) -> Vec<Peer> {
-        self.node.network_knowledge().adults()
+        self.node.read().await.network_knowledge().adults()
     }
 
     /// Returns the info about the section matching the name.
     pub async fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
-        self.node.matching_section(name).await
+        self.node.read().await.matching_section(name).await
     }
 
     /// Builds a `WireMsg` signed by this Node
@@ -342,7 +342,12 @@ impl NodeApi {
         dst: DstLocation,
     ) -> Result<WireMsg> {
         let src_section_pk = *self.section_chain().await.last_key();
-        WireMsg::single_src(&self.node.info().await, dst, node_msg, src_section_pk)
+        WireMsg::single_src(
+            &self.node.read().await.info().await,
+            dst,
+            node_msg,
+            src_section_pk,
+        )
     }
 
     /// Send a message.
@@ -354,7 +359,7 @@ impl NodeApi {
             wire_msg.msg_id()
         );
 
-        if let Some(cmd) = self.node.send_msg_to_nodes(wire_msg).await? {
+        if let Some(cmd) = self.node.read().await.send_msg_to_nodes(wire_msg).await? {
             self.flow_ctrl.fire_and_forget(cmd).await?;
         }
 
@@ -364,6 +369,6 @@ impl NodeApi {
     /// Returns the current BLS public key set if this node has one, or
     /// `Error::MissingSecretKeyShare` otherwise.
     pub async fn public_key_set(&self) -> Result<bls::PublicKeySet> {
-        self.node.public_key_set().await
+        self.node.read().await.public_key_set().await
     }
 }

--- a/sn_node/src/node/api/mod.rs
+++ b/sn_node/src/node/api/mod.rs
@@ -50,7 +50,10 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::{fs, sync::{mpsc, RwLock} };
+use tokio::{
+    fs,
+    sync::{mpsc, RwLock},
+};
 use xor_name::{Prefix, XorName};
 
 // Filename for storing the content of the genesis DBC.

--- a/sn_node/src/node/api/tests/mod.rs
+++ b/sn_node/src/node/api/tests/mod.rs
@@ -60,7 +60,7 @@ use std::{
 };
 use tempfile::tempdir;
 use tokio::{
-    sync::mpsc,
+    sync::{mpsc, RwLock},
     time::{timeout, Duration},
 };
 use xor_name::{Prefix, XorName};
@@ -97,7 +97,7 @@ async fn receive_join_request_without_resource_proof_response() -> Result<()> {
                 root_storage_dir,
             )
             .await?;
-            let dispatcher = Dispatcher::new(Arc::new(node), comm);
+            let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             let new_node_comm = create_comm().await?;
             let new_node = NodeInfo::new(
@@ -183,7 +183,7 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
                 root_storage_dir,
             )
             .await?;
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             let new_node = NodeInfo::new(
@@ -193,7 +193,8 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
 
             let nonce: [u8; 32] = rand::random();
             let serialized = bincode::serialize(&(new_node.name(), nonce))?;
-            let nonce_signature = ed25519::sign(&serialized, &node.info().await.keypair);
+            let nonce_signature =
+                ed25519::sign(&serialized, &node.read().await.info().await.keypair);
 
             let rp = ResourceProof::new(RESOURCE_PROOF_DATA_SIZE, RESOURCE_PROOF_DIFFICULTY);
             let data = rp.create_proof_data(&nonce);
@@ -227,19 +228,18 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
                 .await?;
 
             assert!(node
-                .membership
                 .read()
                 .await
+                .membership
                 .as_ref()
                 .unwrap()
                 .is_churn_in_progress());
             // makes sure that the nonce signature is always valid
             let random_peer = Peer::new(xor_name::rand::random(), gen_addr());
-            assert!(
-                !node
-                    .validate_resource_proof_response(&random_peer.name(), resource_proof_response)
-                    .await
-            );
+            assert!(!node
+                .read()
+                .await
+                .validate_resource_proof_response(&random_peer.name(), resource_proof_response));
             Result::<()>::Ok(())
         })
         .await
@@ -276,7 +276,7 @@ async fn membership_churn_starts_on_join_request_from_relocated_node() -> Result
                 root_storage_dir,
             )
             .await?;
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             let relocated_node = NodeInfo::new(
@@ -324,9 +324,9 @@ async fn membership_churn_starts_on_join_request_from_relocated_node() -> Result
                 .await?;
 
             assert!(node
-                .membership
                 .read()
                 .await
+                .membership
                 .as_ref()
                 .unwrap()
                 .is_churn_in_progress());
@@ -364,7 +364,7 @@ async fn handle_agreement_on_online() -> Result<()> {
                 root_storage_dir,
             )
             .await?;
-            let dispatcher = Dispatcher::new(Arc::new(node), comm);
+            let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             let new_peer = create_peer(MIN_ADULT_AGE);
 
@@ -440,7 +440,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
                 root_storage_dir,
             )
             .await?;
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             // Handle agreement on Online of a peer that is older than the youngest
@@ -451,9 +451,9 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
             let auth = section_signed(sk_set.secret_key(), node_state.to_msg())?;
 
             // Force this node to join
-            node.membership
-                .write()
+            node.read()
                 .await
+                .membership
                 .as_mut()
                 .unwrap()
                 .force_bootstrap(node_state.to_msg());
@@ -616,7 +616,7 @@ async fn handle_agreement_on_online_of_rejoined_node(phase: NetworkPhase, age: u
                 root_storage_dir,
             )
             .await?;
-            let dispatcher = Dispatcher::new(Arc::new(node), comm);
+            let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             // Simulate peer with the same name is rejoin and verify resulted behaviours.
             let status = handle_online_cmd(&peer, &sk_set, &dispatcher, &section_auth).await?;
@@ -693,7 +693,7 @@ async fn handle_agreement_on_offline_of_non_elder() -> Result<()> {
                 root_storage_dir,
             )
             .await?;
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             let node_state = NodeState::left(existing_peer, None);
@@ -705,6 +705,8 @@ async fn handle_agreement_on_offline_of_non_elder() -> Result<()> {
                 .await?;
 
             assert!(!node
+                .read()
+                .await
                 .network_knowledge()
                 .section_members()
                 .contains(&node_state));
@@ -754,7 +756,7 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
                 root_storage_dir,
             )
             .await?;
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             // Handle agreement on the Offline proposal
@@ -768,9 +770,9 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
             // Verify we initiated a membership churn
 
             assert!(node
-                .membership
                 .read()
                 .await
+                .membership
                 .as_ref()
                 .unwrap()
                 .is_churn_in_progress());
@@ -881,7 +883,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
                 .insert(create_section_key_share(&sk_set2, 0))
                 .await;
 
-            let dispatcher = Dispatcher::new(Arc::new(node), comm);
+            let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             let _cmds = dispatcher
                 .process_cmd(Cmd::HandleMsg {
@@ -954,7 +956,7 @@ async fn untrusted_ae_msg_errors() -> Result<()> {
             )
             .await?;
 
-            let node = Arc::new(node);
+            let node = Arc::new(RwLock::new(node));
             let dispatcher = Dispatcher::new(node.clone(), comm);
 
             let sender = gen_info(MIN_ADULT_AGE, None);
@@ -977,9 +979,9 @@ async fn untrusted_ae_msg_errors() -> Result<()> {
                 })
                 .await?;
 
-            assert_eq!(node.network_knowledge().genesis_key(), &pk0);
+            assert_eq!(node.read().await.network_knowledge().genesis_key(), &pk0);
             assert_eq!(
-                node.network_knowledge().prefix_map().all(),
+                node.read().await.network_knowledge().prefix_map().all(),
                 vec![section_signed_our_section_auth.value]
             );
             Result::<()>::Ok(())
@@ -1044,7 +1046,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
             root_storage_dir,
         )
         .await?;
-        let dispatcher = Dispatcher::new(Arc::new(node), comm);
+        let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
         let relocated_peer = match relocated_peer_role {
             RelocatedPeerRole::Elder => *section_auth.elders().nth(1).expect("too few elders"),
@@ -1131,7 +1133,7 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
         .await?;
         let info = node.info().await;
         let section_pk = node.network_knowledge().section_key();
-        let dispatcher = Dispatcher::new(Arc::new(node), comm);
+        let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
         let dst_location = match dst {
             MessageDst::Node => DstLocation::Node {
@@ -1267,7 +1269,7 @@ async fn handle_elders_update() -> Result<()> {
             .insert(create_section_key_share(&sk_set1, 0))
             .await;
 
-        let dispatcher = Dispatcher::new(Arc::new(node), comm);
+        let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
         let cmds = dispatcher
             .process_cmd(Cmd::HandleNewEldersAgreement { proposal, sig })
@@ -1419,7 +1421,7 @@ async fn handle_demote_during_split() -> Result<()> {
                     .await;
             }
 
-            let dispatcher = Dispatcher::new(Arc::new(node), comm);
+            let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             // Create agreement on `OurElder` for both sub-sections
             let create_our_elders_cmd = |signed_sap| -> Result<_> {

--- a/sn_node/src/node/api/tests/mod.rs
+++ b/sn_node/src/node/api/tests/mod.rs
@@ -193,8 +193,7 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
 
             let nonce: [u8; 32] = rand::random();
             let serialized = bincode::serialize(&(new_node.name(), nonce))?;
-            let nonce_signature =
-                ed25519::sign(&serialized, &node.read().await.info().await.keypair);
+            let nonce_signature = ed25519::sign(&serialized, &node.read().await.info().keypair);
 
             let rp = ResourceProof::new(RESOURCE_PROOF_DATA_SIZE, RESOURCE_PROOF_DIFFICULTY);
             let data = rp.create_proof_data(&nonce);
@@ -451,7 +450,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
             let auth = section_signed(sk_set.secret_key(), node_state.to_msg())?;
 
             // Force this node to join
-            node.read()
+            node.write()
                 .await
                 .membership
                 .as_mut()
@@ -1131,7 +1130,7 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
             genesis_sk_set,
         )
         .await?;
-        let info = node.info().await;
+        let info = node.info();
         let section_pk = node.network_knowledge().section_key();
         let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 

--- a/sn_node/src/node/core/api.rs
+++ b/sn_node/src/node/core/api.rs
@@ -69,15 +69,14 @@ impl Node {
     }
 
     pub(crate) async fn relocate(
-        &self,
+        &mut self,
         new_keypair: Arc<Keypair>,
         new_section: NetworkKnowledge,
     ) -> Result<()> {
         // we first try to relocate section info.
         self.network_knowledge.relocated_to(new_section).await?;
 
-        let mut our_keypair = self.keypair.write().await;
-        *our_keypair = new_keypair;
+        self.keypair = new_keypair;
 
         Ok(())
     }

--- a/sn_node/src/node/core/api.rs
+++ b/sn_node/src/node/core/api.rs
@@ -90,12 +90,12 @@ impl Node {
     }
 
     /// Is this node an elder?
-    pub(crate) async fn is_elder(&self) -> bool {
-        self.network_knowledge.is_elder(&self.info().await.name())
+    pub(crate) fn is_elder(&self) -> bool {
+        self.network_knowledge.is_elder(&self.info().name())
     }
 
-    pub(crate) async fn is_not_elder(&self) -> bool {
-        !self.is_elder().await
+    pub(crate) fn is_not_elder(&self) -> bool {
+        !self.is_elder()
     }
 
     /// Returns the current BLS public key set
@@ -131,12 +131,9 @@ impl Node {
     //   ---------------------------------- Mut ------------------------------------------
     // ----------------------------------------------------------------------------------------
 
-    pub(crate) async fn handle_dkg_timeout(&self, token: u64) -> Result<Vec<Cmd>> {
-        self.dkg_voter.handle_timeout(
-            &self.info().await,
-            token,
-            self.network_knowledge().section_key(),
-        )
+    pub(crate) fn handle_dkg_timeout(&self, token: u64) -> Result<Vec<Cmd>> {
+        self.dkg_voter
+            .handle_timeout(&self.info(), token, self.network_knowledge().section_key())
     }
 
     // Send message to peers on the network.
@@ -144,7 +141,7 @@ impl Node {
         let dst_location = wire_msg.dst_location();
         let (targets, dg_size) = delivery_group::delivery_targets(
             dst_location,
-            &self.info().await.name(),
+            &self.info().name(),
             &self.network_knowledge,
         )?;
 
@@ -152,7 +149,7 @@ impl Node {
 
         // To avoid loop: if destination is to Node, targets are multiple, self is an elder,
         //     self section prefix matches the destination name, then don't carry out a relay.
-        if self.is_elder().await
+        if self.is_elder()
             && targets.len() > 1
             && dst_location.is_to_node()
             && self.network_knowledge.prefix().matches(&target_name)

--- a/sn_node/src/node/core/api.rs
+++ b/sn_node/src/node/core/api.rs
@@ -184,7 +184,7 @@ impl Node {
     // excluding the ones in the provided list. And if the outcome list of candidates
     // differs from the current elders, trigger a DKG.
     pub(crate) async fn promote_and_demote_elders_except(
-        &self,
+        &mut self,
         excluded_names: &BTreeSet<XorName>,
     ) -> Result<Vec<Cmd>> {
         debug!("{}", LogMarker::TriggeringPromotionAndDemotion);

--- a/sn_node/src/node/core/connectivity.rs
+++ b/sn_node/src/node/core/connectivity.rs
@@ -15,7 +15,7 @@ use std::{collections::BTreeSet, net::SocketAddr};
 use xor_name::XorName;
 
 impl Node {
-    pub(crate) async fn handle_peer_lost(&self, addr: &SocketAddr) -> Result<Vec<Cmd>> {
+    pub(crate) async fn handle_peer_lost(&mut self, addr: &SocketAddr) -> Result<Vec<Cmd>> {
         let name = if let Some(peer) = self.network_knowledge.find_member_by_addr(addr) {
             debug!("Lost known peer {}", peer);
             peer.name()

--- a/sn_node/src/node/core/connectivity.rs
+++ b/sn_node/src/node/core/connectivity.rs
@@ -24,7 +24,7 @@ impl Node {
             return Ok(vec![]);
         };
 
-        if self.is_not_elder().await {
+        if self.is_not_elder() {
             // Adults cannot complain about connectivity.
             return Ok(vec![]);
         }

--- a/sn_node/src/node/core/data/records/capacity.rs
+++ b/sn_node/src/node/core/data/records/capacity.rs
@@ -10,11 +10,7 @@ use crate::node::{Prefix, XorName};
 use sn_interface::messaging::data::StorageLevel;
 
 use itertools::Itertools;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-};
-use tokio::sync::RwLock;
+use std::collections::{BTreeMap, BTreeSet};
 
 // The number of separate copies of a chunk which should be maintained.
 pub(crate) const MIN_LEVEL_WHEN_FULL: u8 = 9; // considered full when >= 90 %.
@@ -22,63 +18,55 @@ pub(crate) const MIN_LEVEL_WHEN_FULL: u8 = 9; // considered full when >= 90 %.
 /// A util for sharing the
 /// info on data capacity among the
 /// chunk storing nodes in the section.
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub(crate) struct Capacity {
-    adult_levels: Arc<RwLock<BTreeMap<XorName, Arc<RwLock<StorageLevel>>>>>,
+    adult_levels: BTreeMap<XorName, StorageLevel>,
 }
 
 impl Capacity {
     /// Whether the adult is considered full.
     /// This happens when it has reported at least `MIN_LEVEL_WHEN_FULL`.
-    pub(crate) async fn is_full(&self, adult: &XorName) -> Option<bool> {
-        let adult_levels = self.adult_levels.read().await;
-        let level = adult_levels.get(adult)?.read().await.value();
+    pub(crate) fn is_full(&self, adult: &XorName) -> Option<bool> {
+        let level = self.adult_levels.get(adult)?.value();
         Some(level >= MIN_LEVEL_WHEN_FULL)
     }
 
-    pub(super) async fn add_new_adult(&self, adult: XorName) {
+    pub(super) fn add_new_adult(&mut self, adult: XorName) {
         info!("Adding new adult:{adult} to Capacity tracker");
 
-        if let Some(old_entry) = self
-            .adult_levels
-            .write()
-            .await
-            .insert(adult, Arc::new(RwLock::new(StorageLevel::zero())))
-        {
-            let _level = old_entry.read().await.value();
+        if let Some(old_entry) = self.adult_levels.insert(adult, StorageLevel::zero()) {
+            let _level = old_entry.value();
             warn!("Throwing old storage level for Adult {adult}:{_level}");
         }
     }
 
     /// Avg usage by nodes in the section, a value between 0 and 10.
-    pub(super) async fn avg_usage(&self) -> u8 {
+    pub(super) fn avg_usage(&self) -> u8 {
         let mut total = 0_usize;
-        let levels = self.adult_levels.read().await;
         // not sure if necessary, but now we'll be working with an isolated snapshot:
-        let levels = levels.values().collect_vec();
+        let levels = self.adult_levels.values().collect_vec();
         let num_adults = levels.len();
         if num_adults == 0 {
             return 0; // avoid divide by zero
         }
         for v in levels {
-            total += v.read().await.value() as usize;
+            total += v.value() as usize;
         }
         (total / num_adults) as u8
     }
 
     /// Storage levels of nodes in the section.
-    pub(super) async fn levels(&self) -> BTreeMap<XorName, StorageLevel> {
+    pub(super) fn levels(&self) -> BTreeMap<XorName, StorageLevel> {
         let mut map = BTreeMap::new();
-        for (name, level) in self.adult_levels.read().await.iter() {
-            let _prev = map.insert(*name, *level.read().await);
+        for (name, level) in self.adult_levels.iter() {
+            let _prev = map.insert(*name, *level);
         }
         map
     }
 
     /// Nodes and storage levels of nodes matching the prefix.
-    pub(super) async fn levels_matching(&self, prefix: Prefix) -> BTreeMap<XorName, StorageLevel> {
+    pub(super) fn levels_matching(&self, prefix: Prefix) -> BTreeMap<XorName, StorageLevel> {
         self.levels()
-            .await
             .iter()
             .filter(|(name, _)| prefix.matches(name))
             .map(|(name, level)| (*name, *level))
@@ -86,31 +74,30 @@ impl Capacity {
     }
 
     /// Full chunk storing nodes in the section (considered full when at >= `MIN_LEVEL_WHEN_FULL`).
-    pub(super) async fn full_adults(&self) -> BTreeSet<XorName> {
+    pub(super) fn full_adults(&self) -> BTreeSet<XorName> {
         let mut set = BTreeSet::new();
-        for (name, level) in self.adult_levels.read().await.iter() {
-            if level.read().await.value() >= MIN_LEVEL_WHEN_FULL {
+        for (name, level) in self.adult_levels.iter() {
+            if level.value() >= MIN_LEVEL_WHEN_FULL {
                 let _changed = set.insert(*name);
             }
         }
         set
     }
 
-    pub(super) async fn set_adult_levels(&self, levels: BTreeMap<XorName, StorageLevel>) {
+    pub(super) fn set_adult_levels(&mut self, levels: BTreeMap<XorName, StorageLevel>) {
         for (name, level) in levels {
-            let _changed = self.set_adult_level(name, level).await;
+            let _changed = self.set_adult_level(name, level);
         }
     }
 
     /// Returns whether the level changed or not.
-    pub(super) async fn set_adult_level(&self, adult: XorName, new_level: StorageLevel) -> bool {
+    pub(super) fn set_adult_level(&mut self, adult: XorName, new_level: StorageLevel) -> bool {
         {
-            let all_levels = self.adult_levels.read().await;
-            if let Some(level) = all_levels.get(&adult) {
-                let current_level = { level.read().await.value() };
+            if let Some(level) = self.adult_levels.get_mut(&adult) {
+                let current_level = { level.value() };
                 info!("Current level: {}", current_level);
                 if new_level.value() > current_level {
-                    *level.write().await = new_level;
+                    *level = new_level;
                     info!("Old value overwritten.");
                     return true; // value changed
                 }
@@ -120,21 +107,20 @@ impl Capacity {
 
         info!("No current level, aqcuiring top level write lock..");
         // locks to prevent racing
-        let mut all_levels = self.adult_levels.write().await;
         info!("Top level write lock acquired.");
         // checking the value again, if there was a concurrent insert..
-        if let Some(level) = all_levels.get(&adult) {
+        if let Some(level) = self.adult_levels.get_mut(&adult) {
             info!("Oh wait, a value was just recorded..");
-            let current_level = { level.read().await.value() };
+            let current_level = { level.value() };
             info!("Current level: {}", current_level);
             if new_level.value() > current_level {
-                *level.write().await = new_level;
+                *level = new_level;
                 info!("Old value overwritten.");
                 return true; // value changed
             }
             false // no change
         } else {
-            let _level = all_levels.insert(adult, Arc::new(RwLock::new(new_level)));
+            let _level = self.adult_levels.insert(adult, new_level);
             info!("New value inserted.");
             true // value changed
         }
@@ -142,16 +128,16 @@ impl Capacity {
 
     /// Registered holders not present in provided list of members
     /// will be removed from `adult_levels` and no longer tracked for liveness.
-    pub(super) async fn retain_members_only(&self, members: &BTreeSet<XorName>) {
-        let mut adult_levels = self.adult_levels.write().await;
-        let absent_adults: Vec<_> = adult_levels
+    pub(super) fn retain_members_only(&mut self, members: &BTreeSet<XorName>) {
+        let absent_adults: Vec<_> = self
+            .adult_levels
             .iter()
             .filter(|(key, _)| !members.contains(key))
             .map(|(key, _)| *key)
             .collect();
 
         for adult in &absent_adults {
-            let _level = adult_levels.remove(adult);
+            let _level = self.adult_levels.remove(adult);
         }
     }
 }

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -55,7 +55,7 @@ impl Node {
     }
 
     pub(crate) async fn read_data_from_adults(
-        &self,
+        &mut self,
         query: DataQuery,
         msg_id: MsgId,
         auth: AuthorityProof<ServiceAuth>,
@@ -122,8 +122,7 @@ impl Node {
                     .track_issue(
                         *target,
                         IssueType::PendingRequestOperation(Some(operation_id)),
-                    )
-                    .await?;
+                    )?;
             }
 
             trace!(

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -118,11 +118,10 @@ impl Node {
             // ensure we only add a pending request when we're actually sending out requests.
             for target in &targets {
                 trace!("adding pending req for {target:?} in dysfunction tracking");
-                self.dysfunction_tracking
-                    .track_issue(
-                        *target,
-                        IssueType::PendingRequestOperation(Some(operation_id)),
-                    )?;
+                self.dysfunction_tracking.track_issue(
+                    *target,
+                    IssueType::PendingRequestOperation(Some(operation_id)),
+                )?;
             }
 
             trace!(

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -38,7 +38,7 @@ impl Node {
     // Locate ideal holders for this data, line up wiremsgs for those to instruct them to store the data
     pub(crate) async fn replicate_data(&self, data: ReplicatedData) -> Result<Vec<Cmd>> {
         trace!("{:?}: {:?}", LogMarker::DataStoreReceivedAtElder, data);
-        if self.is_elder().await {
+        if self.is_elder() {
             let targets = self.get_adults_who_should_store_data(data.name()).await;
 
             info!(
@@ -284,15 +284,14 @@ impl Node {
         // we create a dummy/random dst location,
         // we will set it correctly for each msg and target
         let section_pk = self.network_knowledge().section_key();
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         let dummy_dst_location = DstLocation::Node {
             name: our_name,
             section_pk,
         };
 
         // separate this into form_wire_msg based on agg
-        let wire_msg =
-            WireMsg::single_src(&self.info().await, dummy_dst_location, msg, section_pk)?;
+        let wire_msg = WireMsg::single_src(&self.info(), dummy_dst_location, msg, section_pk)?;
 
         let mut cmds = vec![];
 

--- a/sn_node/src/node/core/data/storage/mod.rs
+++ b/sn_node/src/node/core/data/storage/mod.rs
@@ -253,7 +253,7 @@ mod tests {
         let used_space = UsedSpace::new(usize::MAX);
 
         // Create instance
-        let storage = DataStorage::new(path, used_space)?;
+        let mut storage = DataStorage::new(path, used_space)?;
 
         // 5mb random data chunk
         let bytes = random_bytes(5 * 1024 * 1024);

--- a/sn_node/src/node/core/data/storage/mod.rs
+++ b/sn_node/src/node/core/data/storage/mod.rs
@@ -29,7 +29,7 @@ use sn_interface::{
 use std::path::Path;
 
 /// Operations on data.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 // exposed as pub due to benches
 pub struct DataStorage {
     chunks: ChunkStorage,
@@ -198,7 +198,7 @@ impl DataStorage {
     }
 
     /// Retrieve all keys/ReplicatedDataAddresses of stored data
-    pub async fn keys(&mut self) -> Result<Vec<ReplicatedDataAddress>> {
+    pub async fn keys(&self) -> Result<Vec<ReplicatedDataAddress>> {
         let chunk_keys = self
             .chunks
             .keys()?
@@ -206,8 +206,7 @@ impl DataStorage {
             .map(ReplicatedDataAddress::Chunk);
         let reg_keys = self
             .registers
-            .keys()
-            .await?
+            .keys()?
             .into_iter()
             .map(ReplicatedDataAddress::Register);
         Ok(reg_keys.chain(chunk_keys).collect())
@@ -338,7 +337,7 @@ mod tests {
         let path = temp_dir.path();
         let used_space = UsedSpace::new(usize::MAX);
         let runtime = Runtime::new()?;
-        let storage = DataStorage::new(path, used_space)?;
+        let mut storage = DataStorage::new(path, used_space)?;
         let owner_pk = PublicKey::Bls(bls::SecretKey::random().public_key());
         let owner_keypair = Keypair::new_ed25519();
         for op in ops.into_iter() {

--- a/sn_node/src/node/core/data/storage/mod.rs
+++ b/sn_node/src/node/core/data/storage/mod.rs
@@ -198,7 +198,7 @@ impl DataStorage {
     }
 
     /// Retrieve all keys/ReplicatedDataAddresses of stored data
-    pub async fn keys(&self) -> Result<Vec<ReplicatedDataAddress>> {
+    pub fn keys(&self) -> Result<Vec<ReplicatedDataAddress>> {
         let chunk_keys = self
             .chunks
             .keys()?

--- a/sn_node/src/node/core/data/storage/mod.rs
+++ b/sn_node/src/node/core/data/storage/mod.rs
@@ -163,7 +163,7 @@ impl DataStorage {
 
     // Read data from local store
     pub(crate) async fn get_from_local_store(
-        &mut self,
+        &self,
         address: &ReplicatedDataAddress,
     ) -> Result<ReplicatedData> {
         match address {
@@ -173,13 +173,11 @@ impl DataStorage {
             ReplicatedDataAddress::Register(addr) => self
                 .registers
                 .get_register_replica(addr)
-                .await
                 .map(ReplicatedData::RegisterLog),
             ReplicatedDataAddress::Spentbook(addr) => {
                 let reg_addr = RegisterAddress::new(*addr.name(), SPENTBOOK_TYPE_TAG);
                 self.registers
                     .get_register_replica(&reg_addr)
-                    .await
                     .map(ReplicatedData::SpentbookLog)
             }
         }

--- a/sn_node/src/node/core/data/storage/registers.rs
+++ b/sn_node/src/node/core/data/storage/registers.rs
@@ -130,8 +130,8 @@ impl RegisterStorage {
     }
 
     /// Used for replication of data to new Adults.
-    pub(crate) async fn get_register_replica(
-        &mut self,
+    pub(crate) fn get_register_replica(
+        &self,
         address: &RegisterAddress,
     ) -> Result<ReplicatedRegisterLog> {
         let key = address.id()?;

--- a/sn_node/src/node/core/messaging/handling/agreement.rs
+++ b/sn_node/src/node/core/messaging/handling/agreement.rs
@@ -263,7 +263,7 @@ impl Node {
 
         info!("New SAP agreed for:{}", *signed_section_auth);
 
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
 
         // Let's update our network knowledge, including our
         // section SAP and chain if the new SAP's prefix matches our name

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -30,7 +30,7 @@ use xor_name::XorName;
 impl Node {
     #[instrument(skip_all)]
     pub(crate) async fn handle_anti_entropy_update_msg(
-        &self,
+        &mut self,
         section_auth: SectionAuthorityProvider,
         section_signed: KeyedSig,
         proof_chain: SecuredLinkedList,
@@ -63,7 +63,7 @@ impl Node {
     }
 
     pub(crate) async fn handle_anti_entropy_retry_msg(
-        &self,
+        &mut self,
         section_auth: SectionAuthorityProvider,
         section_signed: KeyedSig,
         proof_chain: SecuredLinkedList,

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -38,7 +38,7 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         let snapshot = self.state_snapshot().await;
 
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         let signed_sap = SectionAuth {
             value: section_auth.clone(),
             sig: section_signed.clone(),
@@ -208,11 +208,11 @@ impl Node {
             value: section_auth.clone(),
             sig: section_signed.clone(),
         };
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         let our_section_prefix = self.network_knowledge.prefix();
         let equal_prefix = section_auth.prefix() == our_section_prefix;
         let is_extension_prefix = section_auth.prefix().is_extension_of(&our_section_prefix);
-        let our_peer_info = self.info().await.peer();
+        let our_peer_info = self.info().peer();
 
         // Update our network knowledge
         let there_was_an_update = self
@@ -328,7 +328,7 @@ impl Node {
                         bounced_msg,
                     };
                     let wire_msg = WireMsg::single_src(
-                        &self.info().await,
+                        &self.info(),
                         src_location.to_dst(),
                         ae_msg,
                         self.network_knowledge.section_key(),
@@ -415,7 +415,7 @@ impl Node {
         };
 
         let wire_msg = WireMsg::single_src(
-            &self.info().await,
+            &self.info(),
             src_location.to_dst(),
             ae_msg,
             self.network_knowledge.section_key(),
@@ -444,7 +444,7 @@ impl Node {
         };
 
         let wire_msg = WireMsg::single_src(
-            &self.info().await,
+            &self.info(),
             src_location.to_dst(),
             ae_msg,
             self.network_knowledge.section_key(),
@@ -501,7 +501,7 @@ mod tests {
                 let our_prefix = env.node.network_knowledge().prefix();
                 let (msg, src_location) =
                     env.create_msg(&our_prefix, env.node.network_knowledge().section_key())?;
-                let sender = env.node.info().await.peer();
+                let sender = env.node.info().peer();
                 let dst_name = our_prefix.substituted_in(xor_name::rand::random());
                 let dst_section_key = env.node.network_knowledge().section_key();
 
@@ -582,7 +582,7 @@ mod tests {
             let other_pk = other_sk.public_key();
 
             let (msg, src_location) = env.create_msg(&env.other_sap.prefix(), other_pk)?;
-            let sender = env.node.info().await.peer();
+            let sender = env.node.info().peer();
 
             // since it's not aware of the other prefix, it will redirect to self
             let dst_section_key = other_pk;
@@ -618,7 +618,7 @@ mod tests {
                         env.other_sap.clone(),
                         &env.proof_chain,
                         None,
-                        &env.node.info().await.name(),
+                        &env.node.info().name(),
                         &env.node.section_keys_provider
                     )
                     .await?
@@ -668,7 +668,7 @@ mod tests {
                 &our_prefix,
                 env.node.network_knowledge().section_key(),
             )?;
-            let sender = env.node.info().await.peer();
+            let sender = env.node.info().peer();
             let dst_name = our_prefix.substituted_in(xor_name::rand::random());
             let dst_section_key = env.node.network_knowledge().genesis_key();
 
@@ -714,7 +714,7 @@ mod tests {
            &our_prefix,
            env.node.network_knowledge().section_key(),
        )?;
-       let sender = env.node.info().await.peer();
+       let sender = env.node.info().peer();
        let dst_name = our_prefix.substituted_in(xor_name::rand::random());
 
        let bogus_env = Env::new().await?;

--- a/sn_node/src/node/core/messaging/handling/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/handling/anti_entropy.rs
@@ -57,7 +57,7 @@ impl Node {
 
         // always run this, only changes will trigger events
         let mut cmds = self.update_self_for_new_node_state(snapshot).await?;
-        cmds.extend(self.try_reorganize_data().await?);
+        cmds.extend(self.try_reorganize_data()?);
 
         Ok(cmds)
     }

--- a/sn_node/src/node/core/messaging/handling/dkg.rs
+++ b/sn_node/src/node/core/messaging/handling/dkg.rs
@@ -181,7 +181,7 @@ impl Node {
     }
 
     pub(crate) async fn handle_dkg_failure_agreement(
-        &self,
+        &mut self,
         sender: &XorName,
         failure_set: &DkgFailureSigSet,
     ) -> Result<Vec<Cmd>> {
@@ -268,7 +268,7 @@ impl Node {
         }
     }
 
-    pub(crate) async fn handle_dkg_failure(&self, failure_set: DkgFailureSigSet) -> Result<Cmd> {
+    pub(crate) async fn handle_dkg_failure(&mut self, failure_set: DkgFailureSigSet) -> Result<Cmd> {
         // track those failed participants
         for name in &failure_set.failed_participants {
             self.log_dkg_issue(*name).await?;

--- a/sn_node/src/node/core/messaging/handling/dkg.rs
+++ b/sn_node/src/node/core/messaging/handling/dkg.rs
@@ -65,7 +65,7 @@ impl Node {
         let cmds = self
             .dkg_voter
             .start(
-                &self.info().await,
+                &self.info(),
                 session_id,
                 self.network_knowledge().section_key(),
             )
@@ -93,7 +93,7 @@ impl Node {
         self.dkg_voter
             .process_msg(
                 sender,
-                &self.info().await,
+                &self.info(),
                 &session_id,
                 message,
                 self.network_knowledge().section_key(),
@@ -115,7 +115,7 @@ impl Node {
             session_id,
         };
         let wire_msg = WireMsg::single_src(
-            &self.info().await,
+            &self.info(),
             DstLocation::Node {
                 name: sender.name(),
                 section_pk,
@@ -149,7 +149,7 @@ impl Node {
         let mut cmds = self
             .dkg_voter
             .handle_dkg_history(
-                &self.info().await,
+                &self.info(),
                 session_id,
                 message_history,
                 sender.name(),
@@ -159,7 +159,7 @@ impl Node {
 
         cmds.extend(
             self.dkg_voter
-                .process_msg(sender, &self.info().await, session_id, message, section_key)
+                .process_msg(sender, &self.info(), session_id, message, section_key)
                 .await?,
         );
         Ok(cmds)

--- a/sn_node/src/node/core/messaging/handling/dkg.rs
+++ b/sn_node/src/node/core/messaging/handling/dkg.rs
@@ -30,7 +30,7 @@ use std::collections::BTreeSet;
 use xor_name::XorName;
 
 impl Node {
-    pub(crate) async fn handle_dkg_start(&self, session_id: DkgSessionId) -> Result<Vec<Cmd>> {
+    pub(crate) async fn handle_dkg_start(&mut self, session_id: DkgSessionId) -> Result<Vec<Cmd>> {
         let current_generation = self.network_knowledge.chain_len();
         if session_id.section_chain_len < current_generation {
             trace!("Skipping DkgStart for older generation: {:?}", &session_id);
@@ -59,12 +59,9 @@ impl Node {
         }
 
         trace!("Received DkgStart for {:?}", session_id);
-        self.dkg_sessions
-            .write()
-            .await
-            .retain(|_, existing_session_info| {
-                existing_session_info.session_id.section_chain_len >= session_id.section_chain_len
-            });
+        self.dkg_sessions.retain(|_, existing_session_info| {
+            existing_session_info.session_id.section_chain_len >= session_id.section_chain_len
+        });
         let cmds = self
             .dkg_voter
             .start(
@@ -234,7 +231,7 @@ impl Node {
     }
 
     pub(crate) async fn handle_dkg_outcome(
-        &self,
+        &mut self,
         sap: SectionAuthorityProvider,
         key_share: SectionKeyShare,
         generation: Generation,

--- a/sn_node/src/node/core/messaging/handling/dkg.rs
+++ b/sn_node/src/node/core/messaging/handling/dkg.rs
@@ -268,7 +268,10 @@ impl Node {
         }
     }
 
-    pub(crate) async fn handle_dkg_failure(&mut self, failure_set: DkgFailureSigSet) -> Result<Cmd> {
+    pub(crate) async fn handle_dkg_failure(
+        &mut self,
+        failure_set: DkgFailureSigSet,
+    ) -> Result<Cmd> {
         // track those failed participants
         for name in &failure_set.failed_participants {
             self.log_dkg_issue(*name).await?;

--- a/sn_node/src/node/core/messaging/handling/join.rs
+++ b/sn_node/src/node/core/messaging/handling/join.rs
@@ -54,7 +54,7 @@ impl Node {
         // Ignore `JoinRequest` if we are not elder, unless the join request
         // is outdated in which case we'll reply with `JoinResponse::Retry`
         // with the up-to-date info.
-        if self.is_not_elder().await && section_key_matches {
+        if self.is_not_elder() && section_key_matches {
             // Note: We don't bounce this message because the current bounce-resend
             // mechanism wouldn't preserve the original SocketAddr which is needed for
             // properly handling this message.

--- a/sn_node/src/node/core/messaging/handling/join.rs
+++ b/sn_node/src/node/core/messaging/handling/join.rs
@@ -30,7 +30,7 @@ const FIRST_SECTION_MIN_ELDER_AGE: u8 = 90;
 // Message handling
 impl Node {
     pub(crate) async fn handle_join_request(
-        &self,
+        &mut self,
         peer: Peer,
         join_request: JoinRequest,
         comm: &Comm,
@@ -39,10 +39,7 @@ impl Node {
 
         // Require resource signed if joining as a new node.
         if let Some(response) = join_request.resource_proof_response {
-            if !self
-                .validate_resource_proof_response(&peer.name(), response)
-                .await
-            {
+            if !self.validate_resource_proof_response(&peer.name(), response) {
                 debug!("Ignoring JoinRequest from {peer} - invalid resource signed response");
                 return Ok(vec![]);
             }
@@ -83,7 +80,7 @@ impl Node {
             ]);
         }
 
-        if !*self.joins_allowed.read().await {
+        if !self.joins_allowed {
             debug!(
                 "Rejecting JoinRequest from {} - joins currently not allowed.",
                 peer,
@@ -203,7 +200,7 @@ impl Node {
     }
 
     pub(crate) async fn handle_join_as_relocated_request(
-        &self,
+        &mut self,
         peer: Peer,
         join_request: JoinAsRelocatedRequest,
         known_keys: Vec<BlsPublicKey>,

--- a/sn_node/src/node/core/messaging/handling/left.rs
+++ b/sn_node/src/node/core/messaging/handling/left.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeSet;
 
 impl Node {
     pub(crate) async fn handle_node_left(
-        &self,
+        &mut self,
         node_state: NodeState,
         sig: KeyedSig,
     ) -> Result<Vec<Cmd>> {
@@ -92,7 +92,7 @@ impl Node {
                 .collect(),
         )
         .await?;
-        *self.joins_allowed.write().await = true;
+        self.joins_allowed = true;
 
         Ok(cmds)
     }

--- a/sn_node/src/node/core/messaging/handling/mod.rs
+++ b/sn_node/src/node/core/messaging/handling/mod.rs
@@ -710,7 +710,6 @@ impl Node {
                 );
 
                 self.get_missing_data_for_node(sender, known_data_addresses)
-                    .await
             }
             SystemMsg::NodeQuery(node_query) => {
                 match node_query {

--- a/sn_node/src/node/core/messaging/handling/mod.rs
+++ b/sn_node/src/node/core/messaging/handling/mod.rs
@@ -109,7 +109,7 @@ impl Node {
                 // Let's check for entropy before we proceed further
                 // Adult nodes don't need to carry out entropy checking,
                 // however the message shall always be handled.
-                if self.is_elder().await {
+                if self.is_elder() {
                     // For the case of receiving a join request not matching our prefix,
                     // we just let the join request handler to deal with it later on.
                     // We also skip AE check on Anti-Entropy messages
@@ -198,7 +198,7 @@ impl Node {
 
                 let src_location = wire_msg.auth_kind().src();
 
-                if self.is_not_elder().await {
+                if self.is_not_elder() {
                     trace!("Redirecting from adult to section elders");
                     cmds.push(
                         self.ae_redirect_to_our_elders(sender, &src_location, &wire_msg)
@@ -335,7 +335,7 @@ impl Node {
                     sender,
                     msg_id
                 );
-                if self.is_not_elder().await {
+                if self.is_not_elder() {
                     return Ok(vec![]);
                 }
 
@@ -439,7 +439,7 @@ impl Node {
                         if let Some(ref mut joining_as_relocated) = self.relocate_state {
                             let new_node = joining_as_relocated.node.clone();
                             let new_name = new_node.name();
-                            let previous_name = self.info().await.name();
+                            let previous_name = self.info().name();
                             let new_keypair = new_node.keypair.clone();
 
                             info!(
@@ -504,7 +504,7 @@ impl Node {
             }
             SystemMsg::JoinAsRelocatedRequest(join_request) => {
                 trace!("Handling msg: JoinAsRelocatedRequest from {}", sender);
-                if self.is_not_elder().await
+                if self.is_not_elder()
                     && join_request.section_key == self.network_knowledge.section_key()
                 {
                     return Ok(vec![]);
@@ -524,7 +524,7 @@ impl Node {
                 proposal,
                 sig_share,
             } => {
-                if self.is_not_elder().await {
+                if self.is_not_elder() {
                     trace!("Adult handling a Propose msg from {}: {:?}", sender, msg_id);
                 }
 
@@ -556,7 +556,7 @@ impl Node {
             SystemMsg::DkgStart(session_id) => {
                 trace!("Handling msg: Dkg-Start {:?} from {}", session_id, sender);
                 self.log_dkg_session(&sender.name()).await;
-                let our_name = self.info().await.name();
+                let our_name = self.info().name();
                 if !session_id.contains_elder(our_name) {
                     return Ok(vec![]);
                 }
@@ -639,7 +639,7 @@ impl Node {
                     msg_id
                 );
 
-                if self.is_elder().await {
+                if self.is_elder() {
                     if full {
                         let changed = self
                             .set_storage_level(&node_id, StorageLevel::from(StorageLevel::MAX)?)
@@ -657,7 +657,7 @@ impl Node {
             }
             SystemMsg::NodeCmd(NodeCmd::ReplicateData(data_collection)) => {
                 info!("ReplicateData MsgId: {:?}", msg_id);
-                return if self.is_elder().await {
+                return if self.is_elder() {
                     error!("Received unexpected message while Elder");
                     Ok(vec![])
                 } else {
@@ -778,7 +778,7 @@ impl Node {
                     };
                     let section_pk = self.network_knowledge.section_key();
                     let wire_msg = WireMsg::single_src(
-                        &self.info().await,
+                        &self.info(),
                         DstLocation::Node {
                             name: sender.name(),
                             section_pk,

--- a/sn_node/src/node/core/messaging/handling/relocation.rs
+++ b/sn_node/src/node/core/messaging/handling/relocation.rs
@@ -103,7 +103,7 @@ impl Node {
                 return Ok(None);
             };
 
-        let node = self.info().await;
+        let node = self.info();
         if dst_xorname != node.name() {
             // This `Relocate` message is not for us - it's most likely a duplicate of a previous
             // message that we already handled.

--- a/sn_node/src/node/core/messaging/handling/relocation.rs
+++ b/sn_node/src/node/core/messaging/handling/relocation.rs
@@ -85,7 +85,7 @@ impl Node {
     }
 
     pub(crate) async fn handle_relocate(
-        &self,
+        &mut self,
         relocate_proof: SectionAuth<NodeStateMsg>,
     ) -> Result<Option<Cmd>> {
         let (dst_xorname, dst_section_key, new_age) =
@@ -115,7 +115,7 @@ impl Node {
             dst_xorname
         );
 
-        match *self.relocate_state.read().await {
+        match self.relocate_state {
             Some(_) => {
                 trace!("Ignore Relocate - relocation already in progress");
                 return Ok(None);
@@ -149,7 +149,7 @@ impl Node {
             new_age,
         )?;
 
-        *self.relocate_state.write().await = Some(Box::new(joining_as_relocated));
+        self.relocate_state = Some(Box::new(joining_as_relocated));
 
         Ok(Some(cmd))
     }

--- a/sn_node/src/node/core/messaging/handling/resource_proof.rs
+++ b/sn_node/src/node/core/messaging/handling/resource_proof.rs
@@ -22,7 +22,7 @@ use xor_name::XorName;
 
 // Resource signed
 impl Node {
-    pub(crate) async fn validate_resource_proof_response(
+    pub(crate) fn validate_resource_proof_response(
         &self,
         peer_name: &XorName,
         response: ResourceProofResponse,
@@ -35,8 +35,6 @@ impl Node {
 
         if self
             .keypair
-            .read()
-            .await
             .public
             .verify(&serialized, &response.nonce_signature)
             .is_err()
@@ -56,7 +54,7 @@ impl Node {
             data_size: RESOURCE_PROOF_DATA_SIZE,
             difficulty: RESOURCE_PROOF_DIFFICULTY,
             nonce,
-            nonce_signature: ed25519::sign(&serialized, &*self.keypair.read().await),
+            nonce_signature: ed25519::sign(&serialized, &self.keypair),
         }));
 
         trace!("{}", LogMarker::SendResourceProofChallenge);

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -146,7 +146,7 @@ impl Node {
             response: query_response,
             correlation_id,
         };
-        let (auth_kind, payload) = self.ed_sign_client_msg(&msg).await?;
+        let (auth_kind, payload) = self.ed_sign_client_msg(&msg)?;
 
         for peer in waiting_peers.iter() {
             let dst = DstLocation::EndUser(EndUser(peer.name()));

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -73,7 +73,7 @@ impl Node {
     /// Records response in liveness tracking
     /// Forms a response to send to the requester
     pub(crate) async fn handle_data_query_response_at_elder(
-        &self,
+        &mut self,
         correlation_id: MsgId,
         response: NodeQueryResponse,
         user: EndUser,
@@ -109,8 +109,7 @@ impl Node {
 
         let pending_removed = self
             .dysfunction_tracking
-            .request_operation_fulfilled(&node_id, op_id)
-            .await;
+            .request_operation_fulfilled(&node_id, op_id);
 
         if !pending_removed {
             trace!("Ignoring un-expected response");
@@ -164,7 +163,7 @@ impl Node {
 
     /// Handle `ServiceMsgs` received from `EndUser`
     pub(crate) async fn handle_service_msg_received(
-        &self,
+        &mut self,
         msg_id: MsgId,
         msg: ServiceMsg,
         auth: AuthorityProof<ServiceAuth>,
@@ -227,7 +226,7 @@ impl Node {
 
     /// Handle incoming data msgs.
     pub(crate) async fn handle_service_msg(
-        &self,
+        &mut self,
         msg_id: MsgId,
         msg: ServiceMsg,
         dst_location: DstLocation,

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -36,7 +36,7 @@ use xor_name::XorName;
 impl Node {
     /// Handle data query
     pub(crate) async fn handle_data_query_at_adult(
-        &self,
+        &mut self,
         correlation_id: MsgId,
         query: &DataQueryVariant,
         auth: ServiceAuth,

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -123,7 +123,6 @@ impl Node {
                 && self
                     .capacity
                     .is_full(&XorName::from(sending_node_pk))
-                    .await
                     .unwrap_or(false))
         {
             // lets requeue waiting peers in case another adult has the data...

--- a/sn_node/src/node/core/messaging/handling/service_msgs.rs
+++ b/sn_node/src/node/core/messaging/handling/service_msgs.rs
@@ -244,7 +244,7 @@ impl Node {
             return Ok(vec![]);
         }
 
-        if self.is_not_elder().await {
+        if self.is_not_elder() {
             error!("Received unexpected message while Adult: {:?}", msg_id);
             return Ok(vec![]);
         }
@@ -365,7 +365,7 @@ impl Node {
         let _ = permissions.insert(User::Anyone, Permissions::new(true));
 
         // use our own keypair for generating the register command
-        let own_keypair = Keypair::Ed25519(self.info().await.keypair);
+        let own_keypair = Keypair::Ed25519(self.info().keypair);
         let owner = User::Key(own_keypair.public_key());
         let policy = Policy { owner, permissions };
 

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -25,7 +25,7 @@ impl Node {
     /// we have, and send such data to the peer.
     #[instrument(skip(self, data_sender_has))]
     pub(crate) async fn get_missing_data_for_node(
-        &self,
+        &mut self,
         sender: Peer,
         data_sender_has: Vec<ReplicatedDataAddress>,
     ) -> Result<Vec<Cmd>> {
@@ -85,7 +85,7 @@ impl Node {
     /// These nodes should send back anything missing (in batches).
     /// Relevant nodes should be all _prior_ neighbours + _new_ elders.
     #[instrument(skip(self))]
-    pub(crate) async fn ask_for_any_new_data(&self) -> Result<Vec<Cmd>> {
+    pub(crate) async fn ask_for_any_new_data(&mut self) -> Result<Vec<Cmd>> {
         debug!("Querying section for any new data");
         let data_i_have = self.data_storage.keys().await?;
         let mut cmds = vec![];
@@ -132,7 +132,7 @@ impl Node {
 
     /// Will reorganize data if we are an adult,
     /// and there were changes to adults (any added or removed).
-    pub(crate) async fn try_reorganize_data(&self) -> Result<Vec<Cmd>> {
+    pub(crate) async fn try_reorganize_data(&mut self) -> Result<Vec<Cmd>> {
         // as an elder we dont want to get any more data for our name
         // (elders will eventually be caching data in general)
         if self.is_elder() {

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -94,7 +94,7 @@ impl Node {
         let adults_names = adults.iter().map(|p2p_node| p2p_node.name()).collect_vec();
 
         let elders = self.network_knowledge.elders();
-        let my_name = self.info().await.name();
+        let my_name = self.info().name();
 
         // find data targets that are not us.
         let mut target_member_names = adults_names
@@ -135,7 +135,7 @@ impl Node {
     pub(crate) async fn try_reorganize_data(&self) -> Result<Vec<Cmd>> {
         // as an elder we dont want to get any more data for our name
         // (elders will eventually be caching data in general)
-        if self.is_elder().await {
+        if self.is_elder() {
             return Ok(vec![]);
         }
 

--- a/sn_node/src/node/core/messaging/handling/update_section.rs
+++ b/sn_node/src/node/core/messaging/handling/update_section.rs
@@ -24,7 +24,7 @@ impl Node {
     /// Given what data the peer has, we shall calculate what data the peer is missing that
     /// we have, and send such data to the peer.
     #[instrument(skip(self, data_sender_has))]
-    pub(crate) async fn get_missing_data_for_node(
+    pub(crate) fn get_missing_data_for_node(
         &mut self,
         sender: Peer,
         data_sender_has: Vec<ReplicatedDataAddress>,
@@ -33,7 +33,7 @@ impl Node {
         // Collection of data addresses that we do not have
 
         // TODO: can we cache this data stored per churn event?
-        let data_i_have = self.data_storage.keys().await?;
+        let data_i_have = self.data_storage.keys()?;
         trace!("Our data got");
 
         if data_i_have.is_empty() {
@@ -85,9 +85,9 @@ impl Node {
     /// These nodes should send back anything missing (in batches).
     /// Relevant nodes should be all _prior_ neighbours + _new_ elders.
     #[instrument(skip(self))]
-    pub(crate) async fn ask_for_any_new_data(&mut self) -> Result<Vec<Cmd>> {
+    pub(crate) fn ask_for_any_new_data(&mut self) -> Result<Vec<Cmd>> {
         debug!("Querying section for any new data");
-        let data_i_have = self.data_storage.keys().await?;
+        let data_i_have = self.data_storage.keys()?;
         let mut cmds = vec![];
 
         let adults = self.network_knowledge.adults();
@@ -132,7 +132,7 @@ impl Node {
 
     /// Will reorganize data if we are an adult,
     /// and there were changes to adults (any added or removed).
-    pub(crate) async fn try_reorganize_data(&mut self) -> Result<Vec<Cmd>> {
+    pub(crate) fn try_reorganize_data(&mut self) -> Result<Vec<Cmd>> {
         // as an elder we dont want to get any more data for our name
         // (elders will eventually be caching data in general)
         if self.is_elder() {
@@ -141,6 +141,6 @@ impl Node {
 
         trace!("{:?}", LogMarker::DataReorganisationUnderway);
 
-        self.ask_for_any_new_data().await
+        self.ask_for_any_new_data()
     }
 }

--- a/sn_node/src/node/core/messaging/sending/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/sending/anti_entropy.rs
@@ -23,7 +23,7 @@ use xor_name::Prefix;
 impl Node {
     /// Send `AntiEntropyUpdate` message to all nodes in our own section.
     pub(crate) async fn send_ae_update_to_our_section(&self) -> Vec<Cmd> {
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         let nodes: Vec<_> = self
             .network_knowledge
             .section_members()

--- a/sn_node/src/node/core/messaging/sending/handover.rs
+++ b/sn_node/src/node/core/messaging/sending/handover.rs
@@ -20,15 +20,14 @@ use tracing::warn;
 impl Node {
     /// Make a handover consensus proposal vote for a sap candidate
     pub(crate) async fn propose_handover_consensus(
-        &self,
+        &mut self,
         sap_candidates: SapCandidate,
     ) -> Result<Vec<Cmd>> {
-        let mut wlock = self.handover_voting.write().await;
-        match &*wlock {
+        match &self.handover_voting {
             Some(handover_voting_state) => {
                 let mut vs = handover_voting_state.clone();
                 let vote = vs.propose(sap_candidates)?;
-                *wlock = Some(vs);
+                self.handover_voting = Some(vs);
                 debug!("{}: {:?}", LogMarker::HandoverConsensusTrigger, &vote);
                 Ok(self.broadcast_handover_vote_msg(vote).await)
             }

--- a/sn_node/src/node/core/messaging/sending/proposal.rs
+++ b/sn_node/src/node/core/messaging/sending/proposal.rs
@@ -80,7 +80,7 @@ impl Node {
         // Carry out a substitution to prevent the dst_location becomes other section.
         let section_key = self.network_knowledge.section_key();
         let wire_msg = WireMsg::single_src(
-            &self.info().await,
+            &self.info(),
             DstLocation::Section {
                 name: self.network_knowledge.prefix().name(),
                 section_pk: section_key,
@@ -95,7 +95,7 @@ impl Node {
         let msg_id = wire_msg.msg_id();
 
         let mut cmds = vec![];
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         // handle ourselves if we should
         for peer in recipients.clone() {
             if peer.name() == our_name {

--- a/sn_node/src/node/core/messaging/sending/services.rs
+++ b/sn_node/src/node/core/messaging/sending/services.rs
@@ -46,7 +46,7 @@ impl Node {
     async fn send_cmd_response(&self, target: Peer, msg: ServiceMsg) -> Result<Vec<Cmd>> {
         let dst = DstLocation::EndUser(EndUser(target.name()));
 
-        let (auth_kind, payload) = self.ed_sign_client_msg(&msg).await?;
+        let (auth_kind, payload) = self.ed_sign_client_msg(&msg)?;
         let wire_msg = WireMsg::new_msg(MsgId::new(), payload, auth_kind, dst)?;
 
         let cmd = Cmd::SendMsg {
@@ -58,11 +58,8 @@ impl Node {
     }
 
     /// Currently using node's Ed key. May need to use bls key share for concensus purpose.
-    pub(crate) async fn ed_sign_client_msg(
-        &self,
-        client_msg: &ServiceMsg,
-    ) -> Result<(AuthKind, Bytes)> {
-        let keypair = self.keypair.read().await.clone();
+    pub(crate) fn ed_sign_client_msg(&self, client_msg: &ServiceMsg) -> Result<(AuthKind, Bytes)> {
+        let keypair = self.keypair.clone();
         let payload = WireMsg::serialize_msg_payload(client_msg)?;
         let signature = keypair.sign(&payload);
 

--- a/sn_node/src/node/core/messaging/sending/system.rs
+++ b/sn_node/src/node/core/messaging/sending/system.rs
@@ -42,7 +42,7 @@ impl Node {
         section_pk: BlsPublicKey,
     ) -> Result<Cmd> {
         trace!("{}", LogMarker::SendDirectToNodes);
-        let our_node = self.info().await;
+        let our_node = self.info();
         let our_section_key = self.network_knowledge.section_key();
 
         let wire_msg = WireMsg::single_src(
@@ -95,7 +95,7 @@ impl Node {
 
         trace!("Send {:?} to {:?}", wire_msg, recipients);
 
-        let our_name = self.info().await.name();
+        let our_name = self.info().name();
         for recipient in recipients.into_iter() {
             if recipient.name() == our_name {
                 match wire_msg.auth_kind() {

--- a/sn_node/src/node/core/mod.rs
+++ b/sn_node/src/node/core/mod.rs
@@ -58,7 +58,7 @@ use sn_interface::{
 };
 
 use backoff::ExponentialBackoff;
-use dashmap::{DashMap, DashSet};
+use dashmap::DashSet;
 use ed25519_dalek::Keypair;
 use itertools::Itertools;
 use resource_proof::ResourceProof;
@@ -116,7 +116,7 @@ pub(crate) struct Node {
     /// queue up all batch data to be replicated (as a result of churn events atm)
     // TODO: This can probably be reworked into the general per peer msg queue, but as
     // we need to pull data first before we form the WireMsg, we won't do that just now
-    pub(crate) pending_data_to_replicate_to_peers: DashMap<ReplicatedDataAddress, BTreeSet<Peer>>,
+    pub(crate) pending_data_to_replicate_to_peers: BTreeMap<ReplicatedDataAddress, BTreeSet<Peer>>,
     resource_proof: ResourceProof,
     // Network resources
     pub(crate) section_keys_provider: SectionKeysProvider,
@@ -225,7 +225,7 @@ impl Node {
             capacity: Capacity::default(),
             dysfunction_tracking: node_dysfunction_detector,
             pending_data_queries: Cache::with_expiry_duration(DATA_QUERY_TIMEOUT),
-            pending_data_to_replicate_to_peers: DashMap::new(),
+            pending_data_to_replicate_to_peers: BTreeMap::new(),
             ae_backoff_cache: AeBackoffCache::default(),
             membership,
         };

--- a/sn_node/src/node/core/mod.rs
+++ b/sn_node/src/node/core/mod.rs
@@ -69,7 +69,6 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::sync::RwLock;
 use uluru::LRUCache;
 use xor_name::{Prefix, XorName};
 
@@ -106,8 +105,7 @@ pub(crate) struct DkgSessionInfo {
 }
 
 // Store up to 100 in use backoffs
-pub(crate) type AeBackoffCache =
-    Arc<RwLock<LRUCache<(Peer, ExponentialBackoff), BACKOFF_CACHE_LIMIT>>>;
+pub(crate) type AeBackoffCache = LRUCache<(Peer, ExponentialBackoff), BACKOFF_CACHE_LIMIT>;
 
 // Core state + logic of a node.
 pub(crate) struct Node {

--- a/sn_node/src/node/core/mod.rs
+++ b/sn_node/src/node/core/mod.rs
@@ -290,44 +290,40 @@ impl Node {
     }
 
     /// returns names that are relatively dysfunctional
-    pub(crate) async fn get_dysfunctional_node_names(&self) -> Result<BTreeSet<XorName>> {
+    pub(crate) async fn get_dysfunctional_node_names(&mut self) -> Result<BTreeSet<XorName>> {
         self.dysfunction_tracking
             .get_nodes_beyond_severity(DysfunctionSeverity::Dysfunctional)
-            .await
             .map_err(Error::from)
     }
 
     /// Log a communication problem
-    pub(crate) async fn log_comm_issue(&self, name: XorName) -> Result<()> {
+    pub(crate) async fn log_comm_issue(&mut self, name: XorName) -> Result<()> {
         trace!("Logging comms issue in dysfunction");
         self.dysfunction_tracking
             .track_issue(name, IssueType::Communication)
-            .await
             .map_err(Error::from)
     }
 
     /// Log a knowledge issue
-    pub(crate) async fn log_knowledge_issue(&self, name: XorName) -> Result<()> {
+    pub(crate) async fn log_knowledge_issue(&mut self, name: XorName) -> Result<()> {
         trace!("Logging Knowledge issue in dysfunction");
         self.dysfunction_tracking
             .track_issue(name, IssueType::Knowledge)
-            .await
             .map_err(Error::from)
     }
 
     /// Log a dkg issue (ie, an initialised but unfinished dkg round for a given participant)
-    pub(crate) async fn log_dkg_issue(&self, name: XorName) -> Result<()> {
+    pub(crate) async fn log_dkg_issue(&mut self, name: XorName) -> Result<()> {
         trace!("Logging Dkg issue in dysfunction");
         self.dysfunction_tracking
             .track_issue(name, IssueType::Dkg)
-            .await
             .map_err(Error::from)
     }
 
     /// Log a dkg session as responded to
-    pub(crate) async fn log_dkg_session(&self, name: &XorName) {
+    pub(crate) async fn log_dkg_session(&mut self, name: &XorName) {
         trace!("Logging Dkg session as responded to in dysfunction");
-        self.dysfunction_tracking.dkg_ack_fulfilled(name).await;
+        self.dysfunction_tracking.dkg_ack_fulfilled(name);
     }
 
     pub(super) async fn state_snapshot(&self) -> StateSnapshot {
@@ -343,7 +339,7 @@ impl Node {
     /// excluding any member matching a name in the provided `excluded_names` set.
     /// Returns a set of candidate `DkgSessionId`'s.
     pub(super) async fn promote_and_demote_elders(
-        &self,
+        &mut self,
         excluded_names: &BTreeSet<XorName>,
     ) -> Result<Vec<DkgSessionId>> {
         let sap = self.network_knowledge.authority_provider();

--- a/sn_node/src/node/core/mod.rs
+++ b/sn_node/src/node/core/mod.rs
@@ -237,7 +237,7 @@ impl Node {
         Ok(node)
     }
 
-    pub(crate) async fn info(&self) -> NodeInfo {
+    pub(crate) fn info(&self) -> NodeInfo {
         let keypair = self.keypair.clone();
         let addr = self.addr;
         NodeInfo { keypair, addr }
@@ -334,7 +334,7 @@ impl Node {
 
     pub(super) async fn state_snapshot(&self) -> StateSnapshot {
         StateSnapshot {
-            is_elder: self.is_elder().await,
+            is_elder: self.is_elder(),
             section_key: self.network_knowledge.section_key(),
             prefix: self.network_knowledge.prefix(),
             elders: self.network_knowledge().authority_provider().names(),

--- a/sn_node/src/node/logging/log_ctx.rs
+++ b/sn_node/src/node/logging/log_ctx.rs
@@ -9,18 +9,19 @@
 use crate::node::core::Node;
 
 use std::sync::Arc;
+use tokio::sync::RwLock;
 use xor_name::Prefix;
 
 pub(crate) struct LogCtx {
-    node: Arc<Node>,
+    node: Arc<RwLock<Node>>,
 }
 
 impl LogCtx {
-    pub(crate) fn new(node: Arc<Node>) -> Self {
+    pub(crate) fn new(node: Arc<RwLock<Node>>) -> Self {
         Self { node }
     }
 
     pub(crate) async fn prefix(&self) -> Prefix {
-        self.node.network_knowledge().prefix()
+        self.node.read().await.network_knowledge().prefix()
     }
 }

--- a/sn_node/src/node/membership/mod.rs
+++ b/sn_node/src/node/membership/mod.rs
@@ -142,12 +142,14 @@ pub(crate) struct Membership {
 }
 
 impl Membership {
+    #[instrument]
     pub(crate) fn from(
         secret_key: (NodeId, SecretKeyShare),
         elders: PublicKeySet,
         n_elders: usize,
         bootstrap_members: BTreeSet<NodeState>,
     ) -> Self {
+        trace!("Membership - Creating new membership instance");
         Membership {
             consensus: Consensus::from(secret_key, elders, n_elders),
             bootstrap_members,

--- a/testnet/Cargo.toml
+++ b/testnet/Cargo.toml
@@ -28,8 +28,7 @@ console-subscriber = { version = "~0.1.0", optional = true }
 eyre = "~0.6.5"
 clap = { version = "3.0.0", features = ["derive", "env"]}
 dirs-next = "2.0.0"
-# sn_launch_tool = "~0.9.9"
-sn_launch_tool = { path = "../../sn_launch_tool" }
+sn_launch_tool = "~0.10.0"
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = { version = "~0.3.1", features = ["env-filter", "json"] }

--- a/testnet/Cargo.toml
+++ b/testnet/Cargo.toml
@@ -26,9 +26,10 @@ name="testnet"
 color-eyre = "~0.6.0"
 console-subscriber = { version = "~0.1.0", optional = true }
 eyre = "~0.6.5"
-structopt = "~0.3.17"
+clap = { version = "3.0.0", features = ["derive", "env"]}
 dirs-next = "2.0.0"
-sn_launch_tool = "~0.9.9"
+# sn_launch_tool = "~0.9.9"
+sn_launch_tool = { path = "../../sn_launch_tool" }
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = { version = "~0.3.1", features = ["env-filter", "json"] }

--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -27,15 +27,14 @@
     unused_results
 )]
 
+use clap::Parser;
 use dirs_next::home_dir;
 use eyre::{eyre, Result, WrapErr as _};
 use sn_launch_tool::Launch;
 #[cfg(not(target_os = "windows"))]
 use std::process::{Command, Stdio};
 use std::{io, path::PathBuf};
-use structopt::StructOpt;
 use tokio::fs::{create_dir_all, remove_dir_all};
-use tokio::time::{sleep, Duration};
 use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
 
@@ -50,26 +49,26 @@ const NODES_DIR: &str = "local-test-network";
 const DEFAULT_INTERVAL: &str = "10000";
 const DEFAULT_NODE_COUNT: u32 = 30;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "testnet")]
+#[derive(Debug, clap::StructOpt)]
+#[structopt(name = "testnet", version)]
 struct Cmd {
     /// All nodes will be joining existing testnet, none will be started as a genesis node.
-    #[structopt(long = "add")]
+    #[clap(long = "add", value_parser)]
     add_nodes_to_existing_network: bool,
 
     /// Interval in milliseconds between launching each of the nodes.
-    #[structopt(long = "interval", default_value = DEFAULT_INTERVAL)]
+    #[clap(long = "interval", default_value = DEFAULT_INTERVAL)]
     interval: u64,
 
     /// Format logs as JSON.
-    #[structopt(long)]
+    #[clap(long)]
     json_logs: bool,
 
     /// Use flamegraph setup.
     /// NB. This requires cargo flamegraph to be installed
     /// NB. This runs nodes as `sudo`, so any files created will
     /// have to be handled as such (ie, `sudo rm -rf ~/.safe/node/local-test-network`)
-    #[structopt(long)]
+    #[clap(long)]
     flame: bool,
 }
 
@@ -159,16 +158,8 @@ pub async fn run_network() -> Result<()> {
     let arg_node_log_dir = node_log_dir.display().to_string();
     info!("Storing nodes' generated data at {}", arg_node_log_dir);
 
-    let node_count = std::env::var("NODE_COUNT")
-        .map_or_else(
-            |error| match error {
-                std::env::VarError::NotPresent => Ok(DEFAULT_NODE_COUNT),
-                _ => Err(eyre!(error)),
-            },
-            |node_count| Ok(node_count.parse()?),
-        )
-        .wrap_err("Invalid value for NODE_COUNT")?;
-    let node_count_str = node_count.to_string();
+    let node_count_str =
+        std::env::var("NODE_COUNT").unwrap_or_else(|_| DEFAULT_NODE_COUNT.to_string());
 
     // Let's create an args array to pass to the network launcher tool
     let interval_str = args.interval.to_string();
@@ -215,11 +206,6 @@ pub async fn run_network() -> Result<()> {
     // We can now call the tool with the args
     info!("Launching local Safe network...");
     Launch::from_iter_safe(&sn_launch_tool_args)?.run()?;
-
-    // leave a longer interval with more nodes to allow for splits if using split amounts
-    let interval_duration = Duration::from_millis(args.interval * (node_count as u64 / 10));
-
-    sleep(interval_duration).await;
 
     Ok(())
 }

--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -50,7 +50,7 @@ const DEFAULT_INTERVAL: &str = "10000";
 const DEFAULT_NODE_COUNT: u32 = 30;
 
 #[derive(Debug, clap::StructOpt)]
-#[structopt(name = "testnet", version)]
+#[clap(name = "testnet", version)]
 struct Cmd {
     /// All nodes will be joining existing testnet, none will be started as a genesis node.
     #[clap(long = "add", value_parser)]


### PR DESCRIPTION
We've seen missing this wanring can cause confusing deadlocks if we're borrowing
into a write lock, eg.

Better just to deny it at compile time

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
