### PR TITLE
chore(rustfmt): `try!` macro is deprecated

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-use_try_shorthand = true

--- a/sn_client/examples/churn.rs
+++ b/sn_client/examples/churn.rs
@@ -55,7 +55,8 @@ async fn main() -> Result<()> {
         .map_err(|err| {
             eyre!(
                 "Failed to run build command with args '{:?}': {}",
-                args, err
+                args,
+                err
             )
         })?;
 

--- a/sn_client/examples/network_split.rs
+++ b/sn_client/examples/network_split.rs
@@ -53,7 +53,8 @@ async fn main() -> Result<()> {
         .map_err(|err| {
             eyre!(
                 "Failed to run build command with args '{:?}': {}",
-                args, err
+                args,
+                err
             )
         })?;
 

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -451,12 +451,12 @@ mod tests {
             // we use the "issue location" to determine which four nodes to send to
             // this should therefore be reproducible amongst proptest retries/shrinking etc
             nodes
-            .iter()
-            .sorted_by(|lhs, rhs| issue_location.cmp_distance(&lhs.0, &rhs.0))
-            // and we simul-send it to 4 nodes
-            .take(4)
-            .cloned()
-            .collect::<Vec<_>>()
+                .iter()
+                .sorted_by(|lhs, rhs| issue_location.cmp_distance(&lhs.0, &rhs.0))
+                // and we simul-send it to 4 nodes
+                .take(4)
+                .cloned()
+                .collect::<Vec<_>>()
         }
     }
 

--- a/sn_dysfunction/src/lib.rs
+++ b/sn_dysfunction/src/lib.rs
@@ -277,7 +277,8 @@ mod tests {
                 .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
                 .with_target(false)
                 // .event_format(LogFormatter::default())
-                .try_init().unwrap_or_else(|_| println!("Error initializing logger"));
+                .try_init()
+                .unwrap_or_else(|_| println!("Error initializing logger"));
         });
     }
 

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -157,6 +157,7 @@ pub fn init_logger() {
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .with_target(false)
             .event_format(LogFormatter::default())
-            .try_init().unwrap_or_else(|_| println!("Error initializing logger"));
+            .try_init()
+            .unwrap_or_else(|_| println!("Error initializing logger"));
     });
 }

--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -172,18 +172,18 @@ fn init_node_logging(config: Config) -> Result<Option<WorkerGuard>> {
         let non_blocking_builder = tracing_appender::non_blocking::NonBlockingBuilder::default();
 
         let (non_blocking, guard) = non_blocking_builder
-                  // lose lines and keep perf, or exert backpressure?
-                  .lossy(false)
-                  // optionally change buffered lines limit
-                  // .buffered_lines_limit(buffered_lines_limit)
-                  .finish(file_appender);
+            // lose lines and keep perf, or exert backpressure?
+            .lossy(false)
+            // optionally change buffered lines limit
+            // .buffered_lines_limit(buffered_lines_limit)
+            .finish(file_appender);
 
         let builder = tracing_subscriber::fmt()
-              // eg : RUST_LOG=my_crate=info,my_crate::my_mod=debug,[my_span]=trace
-                  .with_env_filter(filter)
-                  .with_thread_names(true)
-                  .with_ansi(false)
-                  .with_writer(non_blocking);
+            // eg : RUST_LOG=my_crate=info,my_crate::my_mod=debug,[my_span]=trace
+            .with_env_filter(filter)
+            .with_thread_names(true)
+            .with_ansi(false)
+            .with_writer(non_blocking);
 
         if config.json_logs {
             builder.json().init();

--- a/sn_node/src/node/core/relocation.rs
+++ b/sn_node/src/node/core/relocation.rs
@@ -59,11 +59,11 @@ pub(super) fn find_nodes_to_relocate(
 
     // Find the peers that pass the relocation check
     let mut candidates: Vec<_> = joined_nodes
-            .into_iter()
-            .filter(|info| check(info.age(), churn_id))
-            // the newly joined node shall not be relocated immediately
-            .filter(|info| !excluded.contains(&info.name()))
-            .collect();
+        .into_iter()
+        .filter(|info| check(info.age(), churn_id))
+        // the newly joined node shall not be relocated immediately
+        .filter(|info| !excluded.contains(&info.name()))
+        .collect();
     // To avoid a node to manipulate its name to gain priority of always being first in XorName,
     // here we sort the nodes by its distance to the churn_id.
     let target_name = XorName::from_content(&churn_id.0);

--- a/sn_node/src/node/membership/mod.rs
+++ b/sn_node/src/node/membership/mod.rs
@@ -300,7 +300,11 @@ impl Membership {
             .iter() // history is a BTreeSet, .iter() is ordered by generation
             .filter(|(gen, _)| **gen > from_gen)
             .map(|(gen, (decision, c))| {
-                Ok(c.build_super_majority_vote(decision.votes.clone(), decision.faults.clone(), *gen)?)
+                Ok(c.build_super_majority_vote(
+                    decision.votes.clone(),
+                    decision.faults.clone(),
+                    *gen,
+                )?)
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -125,8 +125,16 @@ async fn main() -> Result<()> {
                 .stderr(Stdio::inherit())
                 .output()
                 .map_err(Into::into)
-                .and_then(|result| result.status.success().then(|| ()).ok_or_else(|| eyre!("Command exited with error")))
-                .wrap_err_with(|| format!("Failed to run build command with args: {:?}", build_args))?;
+                .and_then(|result| {
+                    result
+                        .status
+                        .success()
+                        .then(|| ())
+                        .ok_or_else(|| eyre!("Command exited with error"))
+                })
+                .wrap_err_with(|| {
+                    format!("Failed to run build command with args: {:?}", build_args)
+                })?;
             info!("sn_node built successfully");
         }
     }


### PR DESCRIPTION
No need for rustfmt to check/replace this, as the compiler will already
warn for this. Deprecated since 1.39.

Removing the option seems to trigger a couple of formatting changes that
rustfmt did not seem to pick on before.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
