### PR TITLE
chore: warn clippy drop_ref

### DIFF
--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -35,7 +35,8 @@
     unused_import_braces,
     unused_qualifications,
     unused_results,
-    clippy::unicode_not_nfc
+    clippy::unicode_not_nfc,
+    clippy::drop_ref
 )]
 
 #[macro_use]


### PR DESCRIPTION
We've seen missing this wanring can cause confusing deadlocks if we're borrowing
into a write lock, eg.

Better just to deny it at compile time

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
