### PR TITLE
chore(client): now we only contact one adult at a time increase retry…

### DIFF
--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -24,7 +24,7 @@ use tracing::{debug, info_span};
 
 // We divide the total query timeout by this number.
 // This also represents the max retries possible, while still staying within the max_timeout.
-const MAX_RETRY_COUNT: f32 = 5.0;
+const MAX_RETRY_COUNT: f32 = 20.0;
 
 impl Client {
     /// Send a Query to the network and await a response.


### PR DESCRIPTION
… count

This should get us more contact with more elders in the same amount of time as previous.
Only returning faster if initial adult query returns

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
