### PR TITLE
fix: passing the churn test

### DIFF
--- a/sn_cli/src/operations/config.rs
+++ b/sn_cli/src/operations/config.rs
@@ -494,7 +494,7 @@ impl Config {
         Ok(())
     }
 
-    pub async fn write_prefix_map(path: &PathBuf, prefix_map: &NetworkPrefixMap) -> Result<()> {
+    pub async fn write_prefix_map(path: &Path, prefix_map: &NetworkPrefixMap) -> Result<()> {
         let serialized = Self::serialise_prefix_map(prefix_map)?;
         fs::write(path, serialized).await.wrap_err_with(|| {
             format!("Unable to write NetworkPrefixMap to '{}'", path.display())
@@ -503,7 +503,7 @@ impl Config {
         Ok(())
     }
 
-    pub async fn retrieve_local_prefix_map(location: &PathBuf) -> Result<NetworkPrefixMap> {
+    pub async fn retrieve_local_prefix_map(location: &Path) -> Result<NetworkPrefixMap> {
         let bytes = fs::read(location)
             .await
             .wrap_err_with(|| format!("Unable to read NetworkPrefixMap from '{:?}'", location))?;

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -620,6 +620,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "too heavy for CI"]
     async fn store_and_read_40mb() -> Result<()> {
         init_logger();
         let _outer_span = tracing::info_span!("store_and_read_40mb").entered();

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -275,10 +275,9 @@ impl Session {
                         if let Some(entry) = queries.get(&op_id) {
                             let all_senders = entry.value();
                             // Only valid response shall get broadcast to all
-                            for (msg_id, sender) in all_senders {
-                                // TO FIX: change the correlation_id to be the origin msg_id
-                                //         currently it is actually the chunk_name
-                                let res = if response.is_success() || msg_id == &correlation_id {
+                            for (ori_msg_id, sender) in all_senders {
+                                let res = if response.is_success() || ori_msg_id == &correlation_id
+                                {
                                     sender.try_send(response.clone())
                                 } else {
                                     continue;

--- a/sn_interface/src/messaging/msg_id.rs
+++ b/sn_interface/src/messaging/msg_id.rs
@@ -9,7 +9,6 @@
 use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use xor_name::XorName;
 
 /// Constant byte length of `MsgId`.
 pub const MESSAGE_ID_LEN: usize = 32;
@@ -24,11 +23,6 @@ impl MsgId {
     /// Generates a new `MsgId` with random content.
     pub fn new() -> Self {
         Self(rand::random())
-    }
-
-    /// Convert an `XorName` into a `MsgId`
-    pub fn from_xor_name(xor_name: XorName) -> Self {
-        Self(xor_name.0)
     }
 
     fn fmt_bytes(bytes: &[u8; MESSAGE_ID_LEN], f: &mut fmt::Formatter) -> fmt::Result {

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -501,6 +501,7 @@ impl NetworkKnowledge {
                 .collect();
 
             if self.merge_members(peers).await? {
+                there_was_an_update = true;
                 let prefix = self.prefix();
                 info!(
                     "Updated our section's members ({:?}): {:?}",

--- a/sn_node/src/node/api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/api/flow_ctrl/mod.rs
@@ -33,7 +33,7 @@ const MISSING_VOTE_INTERVAL: Duration = Duration::from_secs(15);
 const BACKPRESSURE_INTERVAL: Duration = Duration::from_secs(60);
 const SECTION_PROBE_INTERVAL: Duration = Duration::from_secs(300);
 const LINK_CLEANUP_INTERVAL: Duration = Duration::from_secs(120);
-const DATA_BATCH_INTERVAL: Duration = Duration::from_secs(1);
+const DATA_BATCH_INTERVAL: Duration = Duration::from_millis(50);
 const DYSFUNCTION_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
@@ -209,12 +209,13 @@ impl FlowCtrl {
             let mut interval = tokio::time::interval(DATA_BATCH_INTERVAL);
             interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
+            use rand::seq::IteratorRandom;
+            let mut rng = rand::rngs::OsRng;
+
             loop {
                 trace!("data replication loop");
                 let _ = interval.tick().await;
 
-                use rand::seq::IteratorRandom;
-                let mut rng = rand::rngs::OsRng;
                 let mut this_batch_address = None;
 
                 let (src_section_pk, our_info, data_queued) = {
@@ -258,8 +259,8 @@ impl FlowCtrl {
                             continue;
                         }
 
+                        // TO FIX: destination is incorrect here.
                         let name = recipients[0].name();
-
                         let dst = sn_interface::messaging::DstLocation::Node {
                             name,
                             section_pk: src_section_pk,
@@ -279,8 +280,9 @@ impl FlowCtrl {
                             WireMsg::single_src(&our_info, dst, system_msg, src_section_pk)?;
 
                         debug!(
-                            "{:?} to: {:?} w/ {:?} ",
+                            "{:?} Data {:?} to: {:?} w/ {:?} ",
                             LogMarker::SendingMissingReplicatedData,
+                            address,
                             recipients,
                             wire_msg.msg_id()
                         );

--- a/sn_node/src/node/core/data/records/mod.rs
+++ b/sn_node/src/node/core/data/records/mod.rs
@@ -138,7 +138,7 @@ impl Node {
                 query: query.variant,
                 auth: auth.into_inner(),
                 origin: EndUser(origin.name()),
-                correlation_id: MsgId::from_xor_name(*address.name()),
+                correlation_id: msg_id,
             });
 
             self.send_node_msg_to_nodes(msg, targets).await

--- a/sn_node/src/node/core/messaging/anti_entropy.rs
+++ b/sn_node/src/node/core/messaging/anti_entropy.rs
@@ -216,7 +216,7 @@ impl Node {
             sig: section_signed.clone(),
         };
 
-        let _updated = self
+        let updated = self
             .network_knowledge
             .update_knowledge_if_valid(
                 signed_sap.clone(),
@@ -229,7 +229,11 @@ impl Node {
 
         // always run this, only changes will trigger events
         let mut cmds = self.update_self_for_new_node_state(snapshot).await?;
-        cmds.extend(self.try_reorganize_data()?);
+
+        // Only trigger reorganize data when there is a membership change happens.
+        if updated {
+            cmds.extend(self.try_reorganize_data()?);
+        }
 
         Ok(cmds)
     }

--- a/sn_node/src/node/core/messaging/system_msgs.rs
+++ b/sn_node/src/node/core/messaging/system_msgs.rs
@@ -620,6 +620,10 @@ impl Node {
                         origin,
                         correlation_id,
                     } => {
+                        debug!(
+                            "Handle NodeQuery with msg_id {:?} and correlation_id {:?}",
+                            msg_id, correlation_id,
+                        );
                         // There is no point in verifying a sig from a sender A or B here.
                         // Send back response to the sending elder
                         let sender_xorname = msg_authority.get_auth_xorname();
@@ -640,9 +644,10 @@ impl Node {
                 user,
             } => {
                 debug!(
-                    "{:?}: op_id {:?}, correlation_id: {correlation_id:?}, sender: {sender}",
+                    "{:?}: op_id {:?}, correlation_id: {correlation_id:?}, sender: {sender} origin msg_id: {:?}",
                     LogMarker::ChunkQueryResponseReceviedFromAdult,
-                    response.operation_id()?
+                    response.operation_id()?,
+                    msg_id
                 );
                 let sending_nodes_pk = match msg_authority {
                     NodeMsgAuthority::Node(auth) => PublicKey::from(auth.into_inner().node_ed_pk),

--- a/sn_node/src/node/core/messaging/update_section.rs
+++ b/sn_node/src/node/core/messaging/update_section.rs
@@ -57,7 +57,12 @@ impl Node {
                 .collect();
 
             if holder_adult_list.contains(&sender.name()) {
-                debug!("Our requester should hold: {:?}", data);
+                debug!(
+                    "{:?} batch data {:?} to: {:?} ",
+                    LogMarker::QueuingMissingReplicatedData,
+                    data,
+                    sender
+                );
                 data_for_sender.push(data);
             }
         }
@@ -66,12 +71,6 @@ impl Node {
             trace!("We have no data worth sending");
             return Ok(vec![]);
         }
-
-        debug!(
-            "{:?} batch to: {:?} ",
-            LogMarker::QueuingMissingReplicatedData,
-            sender
-        );
 
         let cmd = Cmd::EnqueueDataForReplication {
             recipient: sender,

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -16,7 +16,8 @@ pub(crate) mod membership;
 
 // Node public API
 mod api;
-pub(crate) mod core;
+/// main functionality of the node
+pub mod core;
 mod dkg;
 pub(crate) mod error;
 mod logging;


### PR DESCRIPTION
This PR contains the work to passing the churn test.
There are mainly two fixes:
1, Only trigger data reorganization when there is membership update.
   Previously, data reorganzation get undertaken whenever there is
   incoming message. Which result in a looping of messaging among
   nodes.
2, Only broadcast result when the QueryResponse is not an error.
   Previously, this will cause the client thinking the whole query
   is failed whenever an error response received.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
