### PR TITLE
feat(msgs): validate w low prio before handling

### DIFF
--- a/sn_node/src/bin/sn_node.rs
+++ b/sn_node/src/bin/sn_node.rs
@@ -391,7 +391,7 @@ async fn run_node(config: Config) -> Result<()> {
         }
     }
 
-    // This just keeps the node going as long as routing goes
+    // This loop keeps the node going
     while let Some(event) = event_stream.next().await {
         trace!("Node event! {}", event);
         if let Event::Membership(MembershipEvent::ChurnJoinMissError) = event {

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -20,13 +20,13 @@ mod service_msgs;
 mod system_msgs;
 mod update_section;
 
-use crate::comm::Comm;
 use crate::node::{node_api::cmds::Cmd, Node, Result, DATA_QUERY_LIMIT};
+
 use sn_interface::{
     messaging::{
         data::ServiceMsg,
         system::{NodeMsgAuthorityUtils, SystemMsg},
-        MsgType, WireMsg,
+        DstLocation, MsgType, NodeMsgAuthority, WireMsg,
     },
     network_knowledge::NetworkKnowledge,
     types::Peer,
@@ -38,131 +38,72 @@ use itertools::Itertools;
 
 // Message handling
 impl Node {
-    #[instrument(skip(self, original_bytes, comm))]
-    pub(crate) async fn handle_msg(
+    #[instrument(skip(self, original_bytes))]
+    pub(crate) async fn validate_msg(
         &mut self,
-        sender: Peer,
+        origin: Peer,
         wire_msg: WireMsg,
-        original_bytes: Option<Bytes>,
-        comm: &Comm,
+        original_bytes: Bytes,
     ) -> Result<Vec<Cmd>> {
-        let mut cmds = vec![];
-
         // Deserialize the payload of the incoming message
         let msg_id = wire_msg.msg_id();
         // payload needed for aggregation
-        let payload = wire_msg.payload.clone();
+        let wire_msg_payload = wire_msg.payload.clone();
 
-        let message_type = match wire_msg.into_msg() {
-            Ok(message_type) => message_type,
+        let msg_type = match wire_msg.into_msg() {
+            Ok(msg_type) => msg_type,
             Err(error) => {
                 error!(
                     "Failed to deserialize message payload ({:?}): {:?}",
                     msg_id, error
                 );
-                return Ok(cmds);
+                return Ok(vec![]);
             }
         };
 
-        match message_type {
+        match msg_type {
             MsgType::System {
                 msg_id,
                 msg_authority,
                 dst_location,
                 msg,
             } => {
-                // Let's now verify the section key in the msg authority is trusted
-                // based on our current knowledge of the network and sections chains.
-                let mut known_keys: Vec<BlsPublicKey> = self
-                    .network_knowledge
-                    .section_chain()
-                    .keys()
-                    .copied()
-                    .collect();
-                known_keys.extend(self.network_knowledge.prefix_map().section_keys());
-                known_keys.push(*self.network_knowledge.genesis_key());
+                // Verify that the section key in the msg authority is trusted
+                let known_keys =
+                    if let Some(known_keys) = self.verify_section_key(&msg_authority, &msg).await {
+                        known_keys
+                    } else {
+                        warn!(
+                            "Untrusted message ({:?}) dropped from {:?}: {:?} ",
+                            msg_id, origin, msg
+                        );
+                        return Ok(vec![]);
+                    };
 
-                if !NetworkKnowledge::verify_node_msg_can_be_trusted(
-                    msg_authority.clone(),
-                    msg.clone(),
-                    &known_keys,
-                ) {
-                    warn!(
-                        "Untrusted message ({:?}) dropped from {:?}: {:?} ",
-                        msg_id, sender, msg
-                    );
-                    return Ok(cmds);
-                }
-
-                // Let's check for entropy before we proceed further
-                // Adult nodes don't need to carry out entropy checking,
-                // however the message shall always be handled.
-                if self.is_elder() {
-                    // For the case of receiving a join request not matching our prefix,
-                    // we just let the join request handler to deal with it later on.
-                    // We also skip AE check on Anti-Entropy messages
-                    //
-                    // TODO: consider changing the join and "join as relocated" flows to
-                    // make use of AntiEntropy retry/redirect responses.
-                    match msg {
-                        SystemMsg::AntiEntropyRetry { .. }
-                        | SystemMsg::AntiEntropyUpdate { .. }
-                        | SystemMsg::AntiEntropyRedirect { .. }
-                        | SystemMsg::JoinRequest(_)
-                        | SystemMsg::JoinAsRelocatedRequest(_) => {
-                            trace!(
-                                "Entropy check skipped for {:?}, handling message directly",
-                                msg_id
-                            );
-                        }
-                        _ => match dst_location.section_pk() {
-                            None => {}
-                            Some(dst_section_pk) => {
-                                let msg_bytes = original_bytes.unwrap_or(wire_msg.serialize()?);
-
-                                if let Some(ae_cmd) = self.check_for_entropy(
-                                    // a cheap clone w/ Bytes
-                                    msg_bytes,
-                                    &msg_authority.src_location(),
-                                    &dst_section_pk,
-                                    dst_location.name(),
-                                    &sender,
-                                )? {
-                                    // we want to log issues with an elder who is out of sync here...
-                                    let knowledge = self.network_knowledge.elders();
-                                    let mut known_elders = knowledge.iter().map(|peer| peer.name());
-
-                                    if known_elders.contains(&sender.name()) {
-                                        // we track a dysfunction against our elder here
-                                        self.log_knowledge_issue(sender.name())?;
-                                    }
-
-                                    // short circuit and send those AE responses
-                                    cmds.push(ae_cmd);
-                                    return Ok(cmds);
-                                }
-
-                                trace!("Entropy check passed. Handling verified msg {:?}", msg_id);
-                            }
-                        },
-                    }
-                }
-
-                let handling_msg_cmds = self
-                    .handle_system_msg(
-                        sender,
-                        msg_id,
-                        msg_authority,
-                        msg,
-                        payload,
-                        known_keys,
-                        comm,
+                // Check for entropy before we proceed further
+                if let Some(ae_cmd) = self
+                    .apply_ae(
+                        &origin,
+                        &msg,
+                        &wire_msg,
+                        &dst_location,
+                        &msg_authority,
+                        original_bytes.clone(), // a cheap clone w/ Bytes
                     )
-                    .await?;
+                    .await?
+                {
+                    // short circuit and send those AE responses
+                    return Ok(vec![ae_cmd]);
+                }
 
-                cmds.extend(handling_msg_cmds);
-
-                Ok(cmds)
+                Ok(vec![Cmd::HandleValidSystemMsg {
+                    origin,
+                    msg_id,
+                    msg,
+                    msg_authority,
+                    known_keys,
+                    wire_msg_payload,
+                }])
             }
             MsgType::Service {
                 msg_id,
@@ -170,12 +111,20 @@ impl Node {
                 dst_location,
                 auth,
             } => {
+                if let DstLocation::EndUser(_) = dst_location {
+                    warn!(
+                        "Service msg has been dropped as its destination location ({:?}) is invalid: {:?}",
+                        dst_location, msg
+                    );
+                    return Ok(vec![]);
+                }
+
                 let dst_name = match msg.dst_address() {
                     Some(name) => name,
                     None => {
                         error!(
-                            "Service msg has been dropped since {:?} is not a valid msg to send from a client {}.",
-                            msg, sender.addr()
+                            "Service msg {:?} from {} has been dropped since there is no dst address.",
+                            msg_id, origin.addr(),
                         );
                         return Ok(vec![]);
                     }
@@ -185,8 +134,11 @@ impl Node {
 
                 if self.is_not_elder() {
                     trace!("Redirecting from adult to section elders");
-                    cmds.push(self.ae_redirect_to_our_elders(sender, &src_location, &wire_msg)?);
-                    return Ok(cmds);
+                    return Ok(vec![self.ae_redirect_to_our_elders(
+                        origin,
+                        &src_location,
+                        &wire_msg,
+                    )?]);
                 }
 
                 // First we check if it's query and we have too many on the go at the moment...
@@ -206,31 +158,124 @@ impl Node {
                     Some(section_pk) => section_pk,
                     None => {
                         warn!("Dropping service message as there is no valid dst section_pk.");
-                        return Ok(cmds);
+                        return Ok(vec![]);
                     }
                 };
 
-                let msg_bytes = original_bytes.unwrap_or(wire_msg.serialize()?);
                 if let Some(cmd) = self.check_for_entropy(
-                    // a cheap clone w/ Bytes
-                    msg_bytes,
+                    original_bytes,
                     &src_location,
                     &received_section_pk,
                     dst_name,
-                    &sender,
+                    &origin,
                 )? {
                     // short circuit and send those AE responses
-                    cmds.push(cmd);
-                    return Ok(cmds);
+                    return Ok(vec![cmd]);
                 }
 
-                cmds.extend(
-                    self.handle_service_msg(msg_id, msg, dst_location, auth, sender)
-                        .await?,
-                );
-
-                Ok(cmds)
+                Ok(vec![Cmd::HandleValidServiceMsg {
+                    msg_id,
+                    msg,
+                    origin,
+                    auth,
+                }])
             }
+        }
+    }
+
+    /// Verifies that the section key in the msg authority is trusted
+    /// based on our current knowledge of the network and sections chains.
+    #[instrument(skip_all)]
+    async fn verify_section_key(
+        &mut self,
+        msg_authority: &NodeMsgAuthority,
+        msg: &SystemMsg,
+    ) -> Option<Vec<BlsPublicKey>> {
+        let mut known_keys: Vec<BlsPublicKey> = self
+            .network_knowledge
+            .section_chain()
+            .keys()
+            .copied()
+            .collect();
+        known_keys.extend(self.network_knowledge.prefix_map().section_keys());
+        known_keys.push(*self.network_knowledge.genesis_key());
+
+        if NetworkKnowledge::verify_node_msg_can_be_trusted(
+            msg_authority.clone(),
+            msg.clone(),
+            &known_keys,
+        ) {
+            Some(known_keys)
+        } else {
+            None
+        }
+    }
+
+    /// Check if the origin needs to be updated on network structure/members.
+    /// Returns an ae cmd if we need to halt msg validation and update the origin instead.
+    #[instrument(skip_all)]
+    async fn apply_ae(
+        &mut self,
+        origin: &Peer,
+        msg: &SystemMsg,
+        wire_msg: &WireMsg,
+        dst_location: &DstLocation,
+        msg_authority: &NodeMsgAuthority,
+        msg_bytes: Bytes,
+    ) -> Result<Option<Cmd>> {
+        // Adult nodes don't need to carry out entropy checking,
+        // however the message shall always be handled.
+        if !self.is_elder() {
+            return Ok(None);
+        }
+        // For the case of receiving a join request not matching our prefix,
+        // we just let the join request handler to deal with it later on.
+        // We also skip AE check on Anti-Entropy messages
+        //
+        // TODO: consider changing the join and "join as relocated" flows to
+        // make use of AntiEntropy retry/redirect responses.
+        match msg {
+            SystemMsg::AntiEntropyRetry { .. }
+            | SystemMsg::AntiEntropyUpdate { .. }
+            | SystemMsg::AntiEntropyRedirect { .. }
+            | SystemMsg::JoinRequest(_)
+            | SystemMsg::JoinAsRelocatedRequest(_) => {
+                trace!(
+                    "Entropy check skipped for {:?}, handling message directly",
+                    wire_msg.msg_id()
+                );
+                Ok(None)
+            }
+            _ => match dst_location.section_pk() {
+                None => Ok(None),
+                Some(dst_section_pk) => {
+                    if let Some(ae_cmd) = self.check_for_entropy(
+                        msg_bytes,
+                        &msg_authority.src_location(),
+                        &dst_section_pk,
+                        dst_location.name(),
+                        origin,
+                    )? {
+                        // we want to log issues with an elder who is out of sync here...
+                        let knowledge = self.network_knowledge.elders();
+                        let mut known_elders = knowledge.iter().map(|peer| peer.name());
+
+                        if known_elders.contains(&origin.name()) {
+                            // we track a dysfunction against our elder here
+                            self.log_knowledge_issue(origin.name())?;
+                        }
+
+                        return Ok(Some(ae_cmd));
+                    }
+
+                    trace!(
+                        "Entropy check passed. Handling verified msg {:?}",
+                        wire_msg.msg_id()
+                    );
+
+                    Ok(None)
+                }
+            },
         }
     }
 }

--- a/sn_node/src/node/node_api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/node_api/flow_ctrl/mod.rs
@@ -468,10 +468,10 @@ async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Rece
                     wire_msg
                 };
 
-                let cmd = Cmd::HandleMsg {
-                    sender,
+                let cmd = Cmd::ValidateMsg {
+                    origin: sender,
                     wire_msg,
-                    original_bytes: Some(original_bytes),
+                    original_bytes,
                 };
 
                 let _res = ctrl.cmd_ctrl.push(cmd).await;

--- a/sn_node/src/node/node_api/tests/mod.rs
+++ b/sn_node/src/node/node_api/tests/mod.rs
@@ -114,11 +114,13 @@ async fn receive_join_request_without_resource_proof_response() -> Result<()> {
                 section_key,
             )?;
 
+            let original_bytes = wire_msg.serialize()?;
+
             let mut cmds = dispatcher
-                .process_cmd(Cmd::HandleMsg {
-                    sender: new_node.peer(),
+                .process_cmd(Cmd::ValidateMsg {
+                    origin: new_node.peer(),
                     wire_msg,
-                    original_bytes: None,
+                    original_bytes,
                 })
                 .await?
                 .into_iter();
@@ -214,11 +216,13 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
                 section_key,
             )?;
 
+            let original_bytes = wire_msg.serialize()?;
+
             let _ = dispatcher
-                .process_cmd(Cmd::HandleMsg {
-                    sender: new_node.peer(),
+                .process_cmd(Cmd::ValidateMsg {
+                    origin: new_node.peer(),
                     wire_msg,
-                    original_bytes: None,
+                    original_bytes,
                 })
                 .await?;
 
@@ -310,11 +314,13 @@ async fn membership_churn_starts_on_join_request_from_relocated_node() -> Result
                 section_key,
             )?;
 
+            let original_bytes = wire_msg.serialize()?;
+
             let _ = dispatcher
-                .process_cmd(Cmd::HandleMsg {
-                    sender: relocated_node.peer(),
+                .process_cmd(Cmd::ValidateMsg {
+                    origin: relocated_node.peer(),
                     wire_msg,
-                    original_bytes: None,
+                    original_bytes,
                 })
                 .await?;
 
@@ -877,11 +883,13 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
 
             let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
+            let original_bytes = wire_msg.serialize()?;
+
             let _cmds = dispatcher
-                .process_cmd(Cmd::HandleMsg {
-                    sender: old_node.peer(),
+                .process_cmd(Cmd::ValidateMsg {
+                    origin: old_node.peer(),
                     wire_msg,
-                    original_bytes: None,
+                    original_bytes,
                 })
                 .await?;
 
@@ -963,11 +971,13 @@ async fn untrusted_ae_msg_errors() -> Result<()> {
                 bogus_section_pk,
             )?;
 
+            let original_bytes = wire_msg.serialize()?;
+
             let _cmds = dispatcher
-                .process_cmd(Cmd::HandleMsg {
-                    sender: sender.peer(),
+                .process_cmd(Cmd::ValidateMsg {
+                    origin: sender.peer(),
                     wire_msg,
-                    original_bytes: None,
+                    original_bytes,
                 })
                 .await?;
 


### PR DESCRIPTION
Deserializes and validates at lower prio, to cut off an overload attack angle.
After validity of msg has been established, the msg is dealt with according to its type prio.