### PR TITLE
fix(membership): only process each membership decision once

### DIFF
--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -79,13 +79,10 @@ impl Node {
         for signed_vote in signed_votes {
             let mut vote_broadcast = None;
             if let Some(membership) = self.membership.as_mut() {
-                match membership.handle_signed_vote(signed_vote, &prefix) {
-                    Ok(VoteResponse::Broadcast(response_vote)) => {
-                        vote_broadcast = Some(SystemMsg::MembershipVotes(vec![response_vote]));
-                    }
-                    Ok(VoteResponse::WaitingForMoreVotes) => {
-                        //do nothing
-                    }
+                let (vote_response, decision) = match membership
+                    .handle_signed_vote(signed_vote, &prefix)
+                {
+                    Ok(result) => result,
                     Err(membership::Error::RequestAntiEntropy) => {
                         debug!("Membership - We are behind the voter, requesting AE");
                         // We hit an error while processing this vote, perhaps we are missing information.
@@ -113,31 +110,31 @@ impl Node {
                     }
                 };
 
-                // TODO: We should be able to detect when a *new* decision is made
-                //       As it stands, we will reprocess each decision for any new vote
-                //       we receive, it should be safe to do as `HandleNewNodeOnline`
-                //       should be idempotent.
-                if let Some(decision) = membership.most_recent_decision() {
+                match vote_response {
+                    VoteResponse::Broadcast(response_vote) => {
+                        vote_broadcast = Some(SystemMsg::MembershipVotes(vec![response_vote]));
+                    }
+                    VoteResponse::WaitingForMoreVotes => {
+                        // do nothing
+                    }
+                };
+
+                if let Some(decision) = decision {
                     // process the membership change
                     debug!(
                         "Handling Membership Decision {:?}",
                         BTreeSet::from_iter(decision.proposals.keys())
                     );
-                    for (state, signature) in &decision.proposals {
+                    let public_key = self.network_knowledge.section_key();
+                    for (value, signature) in decision.proposals {
                         let sig = KeyedSig {
-                            public_key: membership.voters_public_key_set().public_key(),
-                            signature: signature.clone(),
+                            public_key,
+                            signature,
                         };
-                        if membership.is_leaving_section(state, prefix) {
-                            cmds.push(Cmd::HandleNodeLeft(SectionAuth {
-                                value: state.clone(),
-                                sig,
-                            }));
+                        if membership.is_leaving_section(&value, prefix) {
+                            cmds.push(Cmd::HandleNodeLeft(SectionAuth { value, sig }));
                         } else {
-                            cmds.push(Cmd::HandleNewNodeOnline(SectionAuth {
-                                value: state.clone(),
-                                sig,
-                            }));
+                            cmds.push(Cmd::HandleNewNodeOnline(SectionAuth { value, sig }));
                         }
                     }
                 }


### PR DESCRIPTION
Previously we were re-processing each membership decision on every new vote that comes in.

This was a hack to simplify the initial membership integration, but it is causing nodes to do a lot of extra work.

This PR massages our decision processing logic so that we only process a decision once when it first happens.