### PR TITLE
cleanup unused async methods

### DIFF
--- a/sn_cli/src/operations/config.rs
+++ b/sn_cli/src/operations/config.rs
@@ -104,7 +104,7 @@ impl fmt::Display for NetworkInfo {
 }
 
 impl NetworkInfo {
-    pub async fn matches(&self, genesis_key: &BlsPublicKey) -> bool {
+    pub fn matches(&self, genesis_key: &BlsPublicKey) -> bool {
         match self {
             Self::Local(_, genesis_key_opt) => match genesis_key_opt {
                 Some(gk) => gk == genesis_key,
@@ -181,7 +181,7 @@ impl Config {
         fs::create_dir_all(prefix_maps_dir.as_path()).await?;
         let mut dbc_owner_sk_path = pb.clone();
         dbc_owner_sk_path.push("credentials");
-        let dbc_owner = Config::get_dbc_owner(&dbc_owner_sk_path).await?;
+        let dbc_owner = Config::get_dbc_owner(&dbc_owner_sk_path)?;
 
         let config = Config {
             settings,
@@ -451,7 +451,7 @@ impl Config {
         for (network_name, net_info) in self.networks_iter() {
             let mut current = "";
             if let Ok(prefix_map) = &current_prefix_map {
-                if net_info.matches(&prefix_map.genesis_key()).await {
+                if net_info.matches(&prefix_map.genesis_key()) {
                     current = "*";
                 }
             }
@@ -543,7 +543,7 @@ impl Config {
     /// Private helpers
     ///
 
-    async fn get_dbc_owner(dbc_sk_path: &Path) -> Result<Option<Owner>> {
+    fn get_dbc_owner(dbc_sk_path: &Path) -> Result<Option<Owner>> {
         if dbc_sk_path.exists() {
             let sk = Safe::deserialize_bls_key(dbc_sk_path)?;
             return Ok(Some(Owner::from(sk)));

--- a/sn_cli/src/subcommands/networks.rs
+++ b/sn_cli/src/subcommands/networks.rs
@@ -60,7 +60,7 @@ pub async fn networks_commander(
             let prefix_map = config.read_default_prefix_map().await?;
             let mut matched_network = None;
             for (network_name, network_info) in config.networks_iter() {
-                if network_info.matches(&prefix_map.genesis_key()).await {
+                if network_info.matches(&prefix_map.genesis_key()) {
                     matched_network = Some(network_name);
                     break;
                 }

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -565,15 +565,14 @@ mod tests {
 
         // 3 elders were chosen by the client (should only be 3 as even if client chooses adults, AE should kick in prior to them attempting any of this)
         the_logs
-            .assert_count(LogMarker::DataStoreReceivedAtElder, 3)
-            .await?;
+            .assert_count(LogMarker::DataStoreReceivedAtElder, 3)?;
 
         // 4 adults * reqs from 3 elders storing the chunk
-        the_logs.assert_count(LogMarker::StoringChunk, 12).await?;
+        the_logs.assert_count(LogMarker::StoringChunk, 12)?;
 
         // Here we can see that each write thinks it's new, so there's 12... but we let Sled handle this later.
         // 4 adults storing the chunk * 3 messages, so we'll still see this due to the rapid/ concurrent nature here...
-        the_logs.assert_count(LogMarker::StoredNewChunk, 12).await?;
+        the_logs.assert_count(LogMarker::StoredNewChunk, 12)?;
 
         Ok(())
     }

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -564,8 +564,7 @@ mod tests {
         tokio::time::sleep(delay).await;
 
         // 3 elders were chosen by the client (should only be 3 as even if client chooses adults, AE should kick in prior to them attempting any of this)
-        the_logs
-            .assert_count(LogMarker::DataStoreReceivedAtElder, 3)?;
+        the_logs.assert_count(LogMarker::DataStoreReceivedAtElder, 3)?;
 
         // 4 adults * reqs from 3 elders storing the chunk
         the_logs.assert_count(LogMarker::StoringChunk, 12)?;

--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -344,7 +344,7 @@ mod tests {
         tokio::time::sleep(delay).await;
 
         // All elders should have been written to
-        the_logs.assert_count(LogMarker::RegisterWrite, 7).await?;
+        the_logs.assert_count(LogMarker::RegisterWrite, 7)?;
 
         Ok(())
     }

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -52,7 +52,7 @@ impl Session {
         let endpoint = self.endpoint.clone();
         // TODO: Consider other approach: Keep a session per section!
 
-        let (section_pk, elders) = self.get_cmd_elders(dst_address).await?;
+        let (section_pk, elders) = self.get_cmd_elders(dst_address)?;
 
         let msg_id = MsgId::new();
 
@@ -154,7 +154,7 @@ impl Session {
 
         let dst = query.variant.dst_name();
 
-        let (section_pk, elders) = self.get_query_elders(dst).await?;
+        let (section_pk, elders) = self.get_query_elders(dst)?;
         let elders_len = elders.len();
         let msg_id = MsgId::new();
 
@@ -432,7 +432,7 @@ impl Session {
         Ok(())
     }
 
-    async fn get_query_elders(&self, dst: XorName) -> Result<(bls::PublicKey, Vec<Peer>)> {
+    fn get_query_elders(&self, dst: XorName) -> Result<(bls::PublicKey, Vec<Peer>)> {
         // Get DataSection elders details. Resort to own section if DataSection is not available.
         let sap = self.network.closest_or_opposite(&dst, None);
         let (section_pk, mut elders) = if let Some(sap) = &sap {
@@ -460,7 +460,7 @@ impl Session {
         Ok((section_pk, elders))
     }
 
-    async fn get_cmd_elders(&self, dst_address: XorName) -> Result<(bls::PublicKey, Vec<Peer>)> {
+    fn get_cmd_elders(&self, dst_address: XorName) -> Result<(bls::PublicKey, Vec<Peer>)> {
         let a_close_sap = self.network.closest_or_opposite(&dst_address, None);
 
         // Get DataSection elders details.
@@ -685,7 +685,7 @@ mod tests {
         )?;
 
         let mut rng = rand::thread_rng();
-        let result = session.get_cmd_elders(XorName::random(&mut rng)).await?;
+        let result = session.get_cmd_elders(XorName::random(&mut rng))?;
         assert_eq!(result.0, secret_key_set.public_keys().public_key());
         assert_eq!(result.1.len(), elders_len);
 

--- a/sn_client/src/testnet_grep/mod.rs
+++ b/sn_client/src/testnet_grep/mod.rs
@@ -72,11 +72,7 @@ impl NetworkLogState {
     }
 
     /// assert new log marker counts
-    pub(crate) fn assert_count(
-        &mut self,
-        marker: LogMarker,
-        target_count: usize,
-    ) -> Result<()> {
+    pub(crate) fn assert_count(&mut self, marker: LogMarker, target_count: usize) -> Result<()> {
         let new_messages = self.get_additional_marker_count(marker.clone())?;
 
         if let Some(count) = new_messages {

--- a/sn_client/src/testnet_grep/mod.rs
+++ b/sn_client/src/testnet_grep/mod.rs
@@ -72,7 +72,7 @@ impl NetworkLogState {
     }
 
     /// assert new log marker counts
-    pub(crate) async fn assert_count(
+    pub(crate) fn assert_count(
         &mut self,
         marker: LogMarker,
         target_count: usize,

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -902,11 +902,11 @@ mod knowledge_tests {
 
         let adults = (0..10).map(|_| random_xorname()).collect::<Vec<XorName>>();
 
-        let mut dysfunctional_detection = DysfunctionDetection::new(adults.clone());
+        let mut dysfunctional_detection = DysfunctionDetection::new(adults);
 
         // Add a new adults
         let new_adult = random_xorname();
-        dysfunctional_detection.add_new_node(new_adult).await;
+        dysfunctional_detection.add_new_node(new_adult);
 
         // Add just one knowledge issue...
         for _ in 0..1 {

--- a/sn_dysfunction/src/lib.rs
+++ b/sn_dysfunction/src/lib.rs
@@ -198,7 +198,7 @@ impl DysfunctionDetection {
     }
 
     /// Add a new node to the tracker and recompute closest nodes.
-    pub async fn add_new_node(&mut self, adult: XorName) {
+    pub fn add_new_node(&mut self, adult: XorName) {
         info!("Adding new adult:{adult} to DysfunctionDetection tracker");
         self.adults.push(adult);
     }
@@ -395,10 +395,10 @@ mod tests {
     #[tokio::test]
     async fn add_new_node_should_track_new_node() -> Result<()> {
         let adults = (0..10).map(|_| random_xorname()).collect::<Vec<XorName>>();
-        let mut dysfunctional_detection = DysfunctionDetection::new(adults.clone());
+        let mut dysfunctional_detection = DysfunctionDetection::new(adults);
 
         let new_adult = random_xorname();
-        dysfunctional_detection.add_new_node(new_adult).await;
+        dysfunctional_detection.add_new_node(new_adult);
 
         let current_nodes = dysfunctional_detection.current_nodes();
 

--- a/sn_interface/src/messaging/authority.rs
+++ b/sn_interface/src/messaging/authority.rs
@@ -82,7 +82,7 @@ pub struct SectionAuth {
 
 impl SectionAuth {
     /// Try to construct verified section authority by aggregating a new share.
-    pub async fn try_authorize(
+    pub fn try_authorize(
         aggregator: &mut SignatureAggregator,
         share: BlsShareAuth,
         payload: impl AsRef<[u8]>,

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -127,7 +127,7 @@ async fn main() -> Result<()> {
             let mut network = Network::new();
 
             // Create the genesis node
-            network.create_node(event_tx.clone(), true).await;
+            network.create_node(event_tx.clone(), true);
 
             let mut churn_events = schedule.events();
 
@@ -146,7 +146,7 @@ async fn main() -> Result<()> {
                     event = churn_events.next() => {
                         match event {
                             Some(ChurnEvent::Join) => {
-                                network.create_node(event_tx.clone(), false).await
+                                network.create_node(event_tx.clone(), false)
                             }
                             Some(ChurnEvent::Drop) => {
                                 network.remove_random_node()
@@ -221,7 +221,7 @@ impl Network {
     }
 
     // Create new node and let it join the network.
-    async fn create_node(&mut self, event_tx: Sender<Event>, first: bool) {
+    fn create_node(&mut self, event_tx: Sender<Event>, first: bool) {
         let id = self.new_node_id();
         let _prev = self.nodes.insert(id, Node::Joining);
         self.stats.join_attempts += 1;

--- a/sn_node/src/comm/link.rs
+++ b/sn_node/src/comm/link.rs
@@ -63,7 +63,7 @@ impl Link {
         }
     }
 
-    pub(crate) async fn new_with(
+    pub(crate) fn new_with(
         peer: Peer,
         endpoint: Endpoint,
         listener: MsgListener,
@@ -79,7 +79,7 @@ impl Link {
         &self.peer
     }
 
-    pub(crate) async fn add(&mut self, conn: qp2p::Connection) {
+    pub(crate) fn add(&mut self, conn: qp2p::Connection) {
         self.insert(conn);
     }
 

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -495,8 +495,7 @@ impl Comm {
                 self.our_endpoint.clone(),
                 self.msg_listener.clone(),
                 conn,
-            )
-            .await;
+            );
             let session = PeerSession::new(link);
             let _ = self.sessions.insert(*peer, session);
         }

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -159,7 +159,7 @@ impl PeerSessionWorker {
                     SessionStatus::Ok
                 }
                 SessionCmd::AddConnection(conn) => {
-                    self.link.add(conn).await;
+                    self.link.add(conn);
                     SessionStatus::Ok
                 }
                 SessionCmd::Terminate => SessionStatus::Terminating,

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -101,10 +101,7 @@ impl Node {
     }
 
     /// Returns the SAP of the section matching the name.
-    pub(crate) fn matching_section(
-        &self,
-        name: &XorName,
-    ) -> Result<SectionAuthorityProvider> {
+    pub(crate) fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
         self.network_knowledge
             .section_by_name(name)
             .map_err(Error::from)

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -96,12 +96,12 @@ impl Node {
     }
 
     /// Returns the current BLS public key set
-    pub(crate) async fn public_key_set(&self) -> Result<bls::PublicKeySet> {
+    pub(crate) fn public_key_set(&self) -> Result<bls::PublicKeySet> {
         Ok(self.key_share()?.public_key_set)
     }
 
     /// Returns the SAP of the section matching the name.
-    pub(crate) async fn matching_section(
+    pub(crate) fn matching_section(
         &self,
         name: &XorName,
     ) -> Result<SectionAuthorityProvider> {
@@ -133,7 +133,7 @@ impl Node {
     }
 
     // Send message to peers on the network.
-    pub(crate) async fn send_msg_to_nodes(&self, mut wire_msg: WireMsg) -> Result<Option<Cmd>> {
+    pub(crate) fn send_msg_to_nodes(&self, mut wire_msg: WireMsg) -> Result<Option<Cmd>> {
         let dst_location = wire_msg.dst_location();
         let (targets, dg_size) = delivery_group::delivery_targets(
             dst_location,

--- a/sn_node/src/node/connectivity.rs
+++ b/sn_node/src/node/connectivity.rs
@@ -11,7 +11,7 @@ use std::{collections::BTreeSet, net::SocketAddr};
 use xor_name::XorName;
 
 impl Node {
-    pub(crate) async fn handle_peer_lost(&mut self, addr: &SocketAddr) -> Result<Vec<Cmd>> {
+    pub(crate) fn handle_peer_lost(&mut self, addr: &SocketAddr) -> Result<Vec<Cmd>> {
         let name = if let Some(peer) = self.network_knowledge.find_member_by_addr(addr) {
             debug!("Lost known peer {}", peer);
             peer.name()
@@ -25,7 +25,7 @@ impl Node {
             return Ok(vec![]);
         }
 
-        self.log_comm_issue(name).await?;
+        self.log_comm_issue(name)?;
         let cmds = vec![Cmd::StartConnectivityTest(name)];
         Ok(cmds)
     }

--- a/sn_node/src/node/data/records/mod.rs
+++ b/sn_node/src/node/data/records/mod.rs
@@ -86,9 +86,7 @@ impl Node {
             let error = convert_to_error_msg(Error::NoAdults(self.network_knowledge().prefix()));
 
             debug!("No targets found for {msg_id:?}");
-            return self
-                .send_cmd_error_response(CmdError::Data(error), origin, msg_id)
-                .await;
+            return self.send_cmd_error_response(CmdError::Data(error), origin, msg_id);
         }
 
         let mut op_was_already_underway = false;
@@ -179,11 +177,7 @@ impl Node {
 
     /// Set storage level of a given node.
     /// Returns whether the level changed or not.
-    pub(crate) async fn set_storage_level(
-        &mut self,
-        node_id: &PublicKey,
-        level: StorageLevel,
-    ) -> bool {
+    pub(crate) fn set_storage_level(&mut self, node_id: &PublicKey, level: StorageLevel) -> bool {
         info!("Setting new storage level..");
         let changed = self
             .capacity

--- a/sn_node/src/node/data/records/mod.rs
+++ b/sn_node/src/node/data/records/mod.rs
@@ -170,11 +170,11 @@ impl Node {
     }
 
     /// Adds the new adult to the Capacity and Liveness trackers.
-    pub(crate) async fn add_new_adult_to_trackers(&mut self, adult: XorName) {
+    pub(crate) fn add_new_adult_to_trackers(&mut self, adult: XorName) {
         info!("Adding new Adult: {adult} to trackers");
         self.capacity.add_new_adult(adult);
 
-        self.dysfunction_tracking.add_new_node(adult).await;
+        self.dysfunction_tracking.add_new_node(adult);
     }
 
     /// Set storage level of a given node.

--- a/sn_node/src/node/data/records/mod.rs
+++ b/sn_node/src/node/data/records/mod.rs
@@ -46,7 +46,7 @@ impl Node {
             );
 
             let msg = SystemMsg::NodeCmd(NodeCmd::ReplicateData(vec![data]));
-            self.send_node_msg_to_nodes(msg, targets).await
+            self.send_node_msg_to_nodes(msg, targets)
         } else {
             Err(Error::InvalidState)
         }
@@ -139,7 +139,7 @@ impl Node {
                 correlation_id: msg_id,
             });
 
-            self.send_node_msg_to_nodes(msg, targets).await
+            self.send_node_msg_to_nodes(msg, targets)
         } else {
             // we don't do anything as we're still within data query timeout
             Ok(vec![])
@@ -275,7 +275,7 @@ impl Node {
     // Takes a message for specified targets, and builds internal send cmds
     // for sending to each of the targets.
     // Targets are XorName specified so must be within the section
-    async fn send_node_msg_to_nodes(
+    fn send_node_msg_to_nodes(
         &self,
         msg: SystemMsg,
         targets: BTreeSet<XorName>,
@@ -301,7 +301,7 @@ impl Node {
             wire_msg.set_dst_section_pk(dst_section_pk);
             wire_msg.set_dst_xorname(target);
 
-            cmds.extend(self.send_msg_to_nodes(wire_msg).await?);
+            cmds.extend(self.send_msg_to_nodes(wire_msg)?);
         }
 
         Ok(cmds)

--- a/sn_node/src/node/data/records/mod.rs
+++ b/sn_node/src/node/data/records/mod.rs
@@ -34,10 +34,10 @@ use xor_name::XorName;
 
 impl Node {
     // Locate ideal holders for this data, line up wiremsgs for those to instruct them to store the data
-    pub(crate) async fn replicate_data(&self, data: ReplicatedData) -> Result<Vec<Cmd>> {
+    pub(crate) fn replicate_data(&self, data: ReplicatedData) -> Result<Vec<Cmd>> {
         trace!("{:?}: {:?}", LogMarker::DataStoreReceivedAtElder, data);
         if self.is_elder() {
-            let targets = self.get_adults_who_should_store_data(data.name()).await;
+            let targets = self.get_adults_who_should_store_data(data.name());
 
             info!(
                 "Replicating data {:?} to holders {:?}",
@@ -68,9 +68,7 @@ impl Node {
             operation_id
         );
 
-        let targets = self
-            .get_adults_holding_data_including_full(address.name())
-            .await;
+        let targets = self.get_adults_holding_data_including_full(address.name());
 
         // Query only the nth adult
         let targets = BTreeSet::from_iter(
@@ -150,7 +148,7 @@ impl Node {
         MetadataExchange { adult_levels }
     }
 
-    pub(crate) async fn set_adult_levels(&mut self, adult_levels: MetadataExchange) {
+    pub(crate) fn set_adult_levels(&mut self, adult_levels: MetadataExchange) {
         let MetadataExchange { adult_levels } = adult_levels;
         self.capacity.set_adult_levels(adult_levels)
     }
@@ -191,14 +189,14 @@ impl Node {
         changed
     }
 
-    pub(crate) async fn full_adults(&self) -> BTreeSet<XorName> {
+    pub(crate) fn full_adults(&self) -> BTreeSet<XorName> {
         self.capacity.full_adults()
     }
 
     /// Construct list of adults that hold target data, including full nodes.
     /// List is sorted by distance from `target`.
-    async fn get_adults_holding_data_including_full(&self, target: &XorName) -> BTreeSet<XorName> {
-        let full_adults = self.full_adults().await;
+    fn get_adults_holding_data_including_full(&self, target: &XorName) -> BTreeSet<XorName> {
+        let full_adults = self.full_adults();
         let adults = self.network_knowledge().adults();
 
         let adults_names = adults.iter().map(|p2p_node| p2p_node.name());
@@ -240,8 +238,8 @@ impl Node {
     }
 
     /// Used to fetch the list of holders for given name of data. Excludes full nodes
-    async fn get_adults_who_should_store_data(&self, target: XorName) -> BTreeSet<XorName> {
-        let full_adults = self.full_adults().await;
+    fn get_adults_who_should_store_data(&self, target: XorName) -> BTreeSet<XorName> {
+        let full_adults = self.full_adults();
         // TODO: reuse our_adults_sorted_by_distance_to API when core is merged into upper layer
         let adults = self.network_knowledge().adults();
 

--- a/sn_node/src/node/data/storage/mod.rs
+++ b/sn_node/src/node/data/storage/mod.rs
@@ -107,7 +107,7 @@ impl DataStorage {
     ) -> NodeQueryResponse {
         match query {
             DataQueryVariant::GetChunk(addr) => self.chunks.get(addr).await,
-            DataQueryVariant::Register(read) => self.registers.read(read, requester).await,
+            DataQueryVariant::Register(read) => self.registers.read(read, requester),
             DataQueryVariant::Spentbook(read) => {
                 // TODO: this is temporary till spentbook native data type is implemented,
                 // we read from the Register where we store the spentbook data
@@ -123,7 +123,6 @@ impl DataStorage {
                 match self
                     .registers
                     .read(&RegisterQuery::Get(reg_addr), requester)
-                    .await
                 {
                     NodeQueryResponse::GetRegister((Err(Error::DataNotFound(_)), _)) => {
                         NodeQueryResponse::SpentProofShares((Ok(Vec::new()), spentbook_op_id))
@@ -187,10 +186,10 @@ impl DataStorage {
     pub(crate) async fn remove(&mut self, address: &ReplicatedDataAddress) -> Result<()> {
         match address {
             ReplicatedDataAddress::Chunk(addr) => self.chunks.remove_chunk(addr).await,
-            ReplicatedDataAddress::Register(addr) => self.registers.remove_register(addr).await,
+            ReplicatedDataAddress::Register(addr) => self.registers.remove_register(addr),
             ReplicatedDataAddress::Spentbook(addr) => {
                 let reg_addr = RegisterAddress::new(*addr.name(), SPENTBOOK_TYPE_TAG);
-                self.registers.remove_register(&reg_addr).await
+                self.registers.remove_register(&reg_addr)
             }
         }
     }

--- a/sn_node/src/node/dkg/session.rs
+++ b/sn_node/src/node/dkg/session.rs
@@ -548,7 +548,7 @@ mod tests {
             membership_gen: 0,
         };
 
-        let cmds = voter.start(&node, session_id, section_pk).await?;
+        let cmds = voter.start(&node, session_id, section_pk)?;
         assert_matches!(&cmds[..], &[Cmd::HandleDkgOutcome { .. }]);
 
         Ok(())
@@ -591,11 +591,9 @@ mod tests {
             .collect();
 
         for actor in actors.values_mut() {
-            let cmds = futures::executor::block_on(actor.voter.start(
-                &actor.node,
-                session_id.clone(),
-                section_pk,
-            ))?;
+            let cmds = actor
+                .voter
+                .start(&actor.node, session_id.clone(), section_pk)?;
 
             for cmd in cmds {
                 messages.extend(actor.handle(cmd, &session_id)?)
@@ -621,13 +619,13 @@ mod tests {
 
             let actor = actors.get_mut(&addr).context("Unknown message recipient")?;
 
-            let cmds = futures::executor::block_on(actor.voter.process_msg(
+            let cmds = actor.voter.process_msg(
                 actor.peer(),
                 &actor.node,
                 &session_id,
                 message,
                 section_pk,
-            ))?;
+            )?;
 
             for cmd in cmds {
                 messages.extend(actor.handle(cmd, &session_id)?)

--- a/sn_node/src/node/dkg/voter.rs
+++ b/sn_node/src/node/dkg/voter.rs
@@ -57,7 +57,7 @@ impl Default for DkgVoter {
 
 impl DkgVoter {
     // Starts a new DKG session.
-    pub(crate) async fn start(
+    pub(crate) fn start(
         &self,
         node: &NodeInfo,
         session_id: DkgSessionId,
@@ -158,7 +158,7 @@ impl DkgVoter {
     }
 
     // Handle a received DkgMessage.
-    pub(crate) async fn process_msg(
+    pub(crate) fn process_msg(
         &self,
         sender: Peer,
         node: &NodeInfo,
@@ -219,7 +219,7 @@ impl DkgVoter {
         }
     }
 
-    pub(crate) async fn handle_dkg_history(
+    pub(crate) fn handle_dkg_history(
         &self,
         node: &NodeInfo,
         session_id: &DkgSessionId,

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -101,10 +101,7 @@ impl Node {
                 // having to send this `NodeApproval`.
                 cmds.extend(self.send_node_approval(old_info.clone()));
 
-                cmds.extend(
-                    self.relocate_rejoining_peer(old_info.value, new_age)
-                        .await?,
-                );
+                cmds.extend(self.relocate_rejoining_peer(old_info.value, new_age)?);
 
                 return Ok(cmds);
             }
@@ -148,10 +145,7 @@ impl Node {
         // first things first, inform the node it can join us
         cmds.extend(self.send_node_approval(new_info));
 
-        cmds.extend(
-            self.relocate_peers(churn_id, excluded_from_relocation)
-                .await?,
-        );
+        cmds.extend(self.relocate_peers(churn_id, excluded_from_relocation)?);
 
         let result = self.promote_and_demote_elders_except(&BTreeSet::default())?;
 

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -120,7 +120,7 @@ impl Node {
             return Ok(vec![]);
         }
 
-        self.add_new_adult_to_trackers(new_info.name()).await;
+        self.add_new_adult_to_trackers(new_info.name());
 
         info!("handle Online: {} at {}", new_info.name(), new_info.addr());
 

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -22,7 +22,7 @@ use std::{cmp, collections::BTreeSet};
 // Agreement
 impl Node {
     // Send `NodeApproval` to a joining node which makes it a section member
-    pub(crate) async fn send_node_approval(&self, node_state: SectionAuth<NodeState>) -> Vec<Cmd> {
+    pub(crate) fn send_node_approval(&self, node_state: SectionAuth<NodeState>) -> Vec<Cmd> {
         let peer = *node_state.peer();
         let prefix = self.network_knowledge.prefix();
         info!("Our section with {:?} has approved peer {}.", prefix, peer,);
@@ -56,7 +56,7 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         debug!("{:?} {:?}", LogMarker::ProposalAgreed, proposal);
         match proposal {
-            Proposal::Offline(node_state) => self.handle_offline_agreement(node_state, sig).await,
+            Proposal::Offline(node_state) => self.handle_offline_agreement(node_state, sig),
             Proposal::SectionInfo { sap, generation } => {
                 self.handle_section_info_agreement(sap, sig, generation)
                     .await
@@ -99,7 +99,7 @@ impl Node {
             if new_age >= MIN_ADULT_AGE {
                 // TODO: consider handling the relocation inside the bootstrap phase, to avoid
                 // having to send this `NodeApproval`.
-                cmds.extend(self.send_node_approval(old_info.clone()).await);
+                cmds.extend(self.send_node_approval(old_info.clone()));
 
                 cmds.extend(
                     self.relocate_rejoining_peer(old_info.value, new_age)
@@ -146,7 +146,7 @@ impl Node {
         let excluded_from_relocation = vec![new_info.name()].into_iter().collect();
 
         // first things first, inform the node it can join us
-        cmds.extend(self.send_node_approval(new_info).await);
+        cmds.extend(self.send_node_approval(new_info));
 
         cmds.extend(
             self.relocate_peers(churn_id, excluded_from_relocation)
@@ -170,7 +170,7 @@ impl Node {
     }
 
     #[instrument(skip(self))]
-    async fn handle_offline_agreement(
+    fn handle_offline_agreement(
         &mut self,
         node_state: NodeState,
         sig: KeyedSig,
@@ -181,7 +181,7 @@ impl Node {
             node_state.addr()
         );
 
-        self.propose_membership_change(node_state.to_msg()).await
+        self.propose_membership_change(node_state.to_msg())
     }
 
     #[instrument(skip(self), level = "trace")]
@@ -235,8 +235,7 @@ impl Node {
                 signed_section_auth.prefix()
             );
             return self
-                .propose_handover_consensus(SapCandidate::ElderHandover(signed_section_auth))
-                .await;
+                .propose_handover_consensus(SapCandidate::ElderHandover(signed_section_auth));
         }
 
         // manage pending split SAP candidates
@@ -262,7 +261,6 @@ impl Node {
                 sap1.to_owned(),
                 sap2.to_owned(),
             ))
-            .await
         } else {
             debug!("Waiting for more split handover candidates");
             Ok(vec![])

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -581,7 +581,7 @@ impl Node {
     }
 
     // Generate an AE redirect cmd for the given message
-    pub(crate) async fn ae_redirect_to_our_elders(
+    pub(crate) fn ae_redirect_to_our_elders(
         &self,
         sender: Peer,
         src_location: &SrcLocation,

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -319,10 +319,7 @@ impl Node {
         }
     }
 
-    pub(crate) fn handle_dkg_failure(
-        &mut self,
-        failure_set: DkgFailureSigSet,
-    ) -> Result<Cmd> {
+    pub(crate) fn handle_dkg_failure(&mut self, failure_set: DkgFailureSigSet) -> Result<Cmd> {
         // track those failed participants
         for name in &failure_set.failed_participants {
             self.log_dkg_issue(*name)?;

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -161,7 +161,7 @@ impl Node {
             .await
     }
 
-    pub(crate) async fn handle_dkg_not_ready(
+    pub(crate) fn handle_dkg_not_ready(
         &self,
         sender: Peer,
         message: DkgMessage,
@@ -240,7 +240,7 @@ impl Node {
         }
     }
 
-    pub(crate) async fn handle_dkg_failure_agreement(
+    pub(crate) fn handle_dkg_failure_agreement(
         &mut self,
         sender: &XorName,
         failure_set: &DkgFailureSigSet,
@@ -319,7 +319,7 @@ impl Node {
         }
     }
 
-    pub(crate) async fn handle_dkg_failure(
+    pub(crate) fn handle_dkg_failure(
         &mut self,
         failure_set: DkgFailureSigSet,
     ) -> Result<Cmd> {

--- a/sn_node/src/node/messaging/handover.rs
+++ b/sn_node/src/node/messaging/handover.rs
@@ -24,7 +24,7 @@ use xor_name::{Prefix, XorName};
 
 impl Node {
     /// Make a handover consensus proposal vote for a sap candidate
-    pub(crate) async fn propose_handover_consensus(
+    pub(crate) fn propose_handover_consensus(
         &mut self,
         sap_candidates: SapCandidate,
     ) -> Result<Vec<Cmd>> {
@@ -34,7 +34,7 @@ impl Node {
                 let vote = vs.propose(sap_candidates)?;
                 self.handover_voting = Some(vs);
                 debug!("{}: {:?}", LogMarker::HandoverConsensusTrigger, &vote);
-                Ok(self.broadcast_handover_vote_msg(vote).await)
+                Ok(self.broadcast_handover_vote_msg(vote))
             }
             None => {
                 warn!("Failed to make handover consensus proposal because node is not an Elder");
@@ -44,7 +44,7 @@ impl Node {
     }
 
     /// Broadcast handover Vote message to Elders
-    pub(crate) async fn broadcast_handover_vote_msg(
+    pub(crate) fn broadcast_handover_vote_msg(
         &self,
         signed_vote: SignedVote<SapCandidate>,
     ) -> Vec<Cmd> {
@@ -115,7 +115,7 @@ impl Node {
                     ">>> Handover Vote msg successfully handled, broadcasting our vote: {:?}",
                     signed_vote
                 );
-                Ok(self.broadcast_handover_vote_msg(signed_vote).await)
+                Ok(self.broadcast_handover_vote_msg(signed_vote))
             }
             Ok(VoteResponse::WaitingForMoreVotes) => {
                 trace!(
@@ -162,7 +162,7 @@ impl Node {
         Ok(())
     }
 
-    async fn get_members_at_gen(&self, gen: Generation) -> Result<BTreeMap<XorName, NodeState>> {
+    fn get_members_at_gen(&self, gen: Generation) -> Result<BTreeMap<XorName, NodeState>> {
         if let Some(m) = self.membership.as_ref() {
             Ok(m.section_members(gen)?)
         } else {
@@ -171,17 +171,17 @@ impl Node {
         }
     }
 
-    async fn get_sap_for_prefix(&self, prefix: Prefix) -> Result<SectionAuthorityProvider> {
+    fn get_sap_for_prefix(&self, prefix: Prefix) -> Result<SectionAuthorityProvider> {
         self.network_knowledge
             .prefix_map()
             .get(&prefix)
             .ok_or(Error::FailedToGetSAPforPrefix(prefix))
     }
 
-    async fn check_elder_handover_candidates(&self, sap: &SectionAuthorityProvider) -> Result<()> {
+    fn check_elder_handover_candidates(&self, sap: &SectionAuthorityProvider) -> Result<()> {
         // in regular handover the previous SAP's prefix is the same
-        let previous_gen_sap = self.get_sap_for_prefix(sap.prefix()).await?;
-        let members = self.get_members_at_gen(sap.membership_gen()).await?;
+        let previous_gen_sap = self.get_sap_for_prefix(sap.prefix())?;
+        let members = self.get_members_at_gen(sap.membership_gen())?;
         let received_candidates: BTreeSet<&Peer> = sap.elders().collect();
 
         let expected_peers: BTreeSet<Peer> =
@@ -197,7 +197,7 @@ impl Node {
         Ok(())
     }
 
-    async fn check_section_split_candidates(
+    fn check_section_split_candidates(
         &self,
         sap1: &SectionAuthorityProvider,
         sap2: &SectionAuthorityProvider,
@@ -206,8 +206,8 @@ impl Node {
         // we use gen/prefix from sap1, both SAPs in a split have the same generation
         // and the same ancestor prefix
         let prev_prefix = sap1.prefix().popped();
-        let previous_gen_sap = self.get_sap_for_prefix(prev_prefix).await?;
-        let members = self.get_members_at_gen(sap1.membership_gen()).await?;
+        let previous_gen_sap = self.get_sap_for_prefix(prev_prefix)?;
+        let members = self.get_members_at_gen(sap1.membership_gen())?;
         let dummy_chain_len = 0;
         let dummy_gen = 0;
 
@@ -240,7 +240,7 @@ impl Node {
         }
     }
 
-    async fn check_sap_candidate_prefix(&self, sap_candidate: &SapCandidate) -> Result<()> {
+    fn check_sap_candidate_prefix(&self, sap_candidate: &SapCandidate) -> Result<()> {
         let section_prefix = self.network_knowledge.prefix();
         match sap_candidate {
             SapCandidate::ElderHandover(single_sap) => {
@@ -273,35 +273,32 @@ impl Node {
     /// Checks if the elder candidates in the SAP match the oldest elders in the corresponding
     /// membership generation this SAP was proposed at
     /// Also checks the SAP signature
-    async fn check_sap_candidate(
+    fn check_sap_candidate(
         &self,
         sap_candidate: &SapCandidate,
         gen: Generation,
     ) -> Result<()> {
-        self.check_sap_candidate_prefix(sap_candidate).await?;
+        self.check_sap_candidate_prefix(sap_candidate)?;
         match sap_candidate {
             SapCandidate::ElderHandover(authed_sap) => {
                 self.check_sap_sig(authed_sap, gen)?;
                 self.check_elder_handover_candidates(&authed_sap.value)
-                    .await
             }
             SapCandidate::SectionSplit(authed_sap1, authed_sap2) => {
                 self.check_sap_sig(authed_sap1, gen)?;
                 self.check_sap_sig(authed_sap2, gen)?;
                 self.check_section_split_candidates(&authed_sap1.value, &authed_sap2.value)
-                    .await
             }
         }
     }
 
-    async fn check_signed_vote_saps(&self, signed_vote: &SignedVote<SapCandidate>) -> Result<()> {
+    fn check_signed_vote_saps(&self, signed_vote: &SignedVote<SapCandidate>) -> Result<()> {
         let sap_candidates = signed_vote.proposals();
         let gen = signed_vote.vote.gen;
-        let checks: Vec<_> = sap_candidates
-            .iter()
-            .map(|sap_can| self.check_sap_candidate(sap_can, gen))
-            .collect();
-        let _ = futures::future::try_join_all(checks).await?;
+
+        for sap_can in sap_candidates {
+            let _ = self.check_sap_candidate(&sap_can, gen);
+        }
         Ok(())
     }
 
@@ -310,7 +307,7 @@ impl Node {
         peer: Peer,
         signed_vote: SignedVote<SapCandidate>,
     ) -> Result<Vec<Cmd>> {
-        self.check_signed_vote_saps(&signed_vote).await?;
+        self.check_signed_vote_saps(&signed_vote)?;
 
         match &self.handover_voting {
             Some(handover_state) => {
@@ -384,7 +381,7 @@ impl Node {
         Ok(cmds)
     }
 
-    pub(crate) async fn handle_handover_anti_entropy(
+    pub(crate) fn handle_handover_anti_entropy(
         &self,
         peer: Peer,
         gen: Generation,

--- a/sn_node/src/node/messaging/handover.rs
+++ b/sn_node/src/node/messaging/handover.rs
@@ -273,11 +273,7 @@ impl Node {
     /// Checks if the elder candidates in the SAP match the oldest elders in the corresponding
     /// membership generation this SAP was proposed at
     /// Also checks the SAP signature
-    fn check_sap_candidate(
-        &self,
-        sap_candidate: &SapCandidate,
-        gen: Generation,
-    ) -> Result<()> {
+    fn check_sap_candidate(&self, sap_candidate: &SapCandidate, gen: Generation) -> Result<()> {
         self.check_sap_candidate_prefix(sap_candidate)?;
         match sap_candidate {
             SapCandidate::ElderHandover(authed_sap) => {

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -41,7 +41,7 @@ impl Node {
             }
 
             let node_state = NodeState::joined(peer.name(), peer.addr(), None);
-            return self.propose_membership_change(node_state).await;
+            return self.propose_membership_change(node_state);
         }
 
         let our_section_key = self.network_knowledge.section_key();
@@ -96,7 +96,7 @@ impl Node {
             )?]);
         }
 
-        let (is_age_invalid, expected_age) = self.verify_joining_node_age(&peer).await;
+        let (is_age_invalid, expected_age) = self.verify_joining_node_age(&peer);
 
         trace!(
             "our_prefix {:?} expected_age {:?} is_age_invalid {:?}",
@@ -162,7 +162,7 @@ impl Node {
         Ok(vec![cmd])
     }
 
-    pub(crate) async fn verify_joining_node_age(&self, peer: &Peer) -> (bool, u8) {
+    pub(crate) fn verify_joining_node_age(&self, peer: &Peer) -> (bool, u8) {
         // During the first section, nodes shall use ranged age to avoid too many nodes getting
         // relocated at the same time. After the first section splits, nodes shall only
         // start with an age of MIN_ADULT_AGE
@@ -272,6 +272,5 @@ impl Node {
         };
 
         self.propose_membership_change(join_request.relocate_proof.value)
-            .await
     }
 }

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -156,7 +156,7 @@ impl Node {
             self.send_direct_msg(peer, node_msg, our_section_key)?
         } else {
             // It's reachable, let's then send the proof challenge
-            self.send_resource_proof_challenge(peer).await?
+            self.send_resource_proof_challenge(peer)?
         };
 
         Ok(vec![cmd])

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -63,7 +63,7 @@ impl Node {
         if !our_prefix.matches(&peer.name()) {
             debug!("Redirecting JoinRequest from {peer} - name doesn't match our prefix {our_prefix:?}.");
 
-            let retry_sap = self.matching_section(&peer.name()).await?;
+            let retry_sap = self.matching_section(&peer.name())?;
 
             let node_msg =
                 SystemMsg::JoinResponse(Box::new(JoinResponse::Redirect(retry_sap.to_msg())));

--- a/sn_node/src/node/messaging/left.rs
+++ b/sn_node/src/node/messaging/left.rs
@@ -17,7 +17,7 @@ use sn_interface::{
 use std::collections::BTreeSet;
 
 impl Node {
-    pub(crate) async fn handle_node_left(
+    pub(crate) fn handle_node_left(
         &mut self,
         node_state: NodeState,
         sig: KeyedSig,
@@ -59,7 +59,7 @@ impl Node {
         }
 
         let churn_id = ChurnId(signature.to_bytes().to_vec());
-        cmds.extend(self.relocate_peers(churn_id, BTreeSet::default()).await?);
+        cmds.extend(self.relocate_peers(churn_id, BTreeSet::default())?);
 
         let result = self.promote_and_demote_elders_except(&BTreeSet::default())?;
         if result.is_empty() {

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -18,10 +18,7 @@ use std::{collections::BTreeSet, vec};
 
 // Message handling
 impl Node {
-    pub(crate) fn propose_membership_change(
-        &mut self,
-        node_state: NodeState,
-    ) -> Result<Vec<Cmd>> {
+    pub(crate) fn propose_membership_change(&mut self, node_state: NodeState) -> Result<Vec<Cmd>> {
         info!(
             "Proposing membership change: {} - {:?}",
             node_state.name, node_state.state

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -18,7 +18,7 @@ use std::{collections::BTreeSet, vec};
 
 // Message handling
 impl Node {
-    pub(crate) async fn propose_membership_change(
+    pub(crate) fn propose_membership_change(
         &mut self,
         node_state: NodeState,
     ) -> Result<Vec<Cmd>> {

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -134,7 +134,7 @@ impl Node {
 
                                     if known_elders.contains(&sender.name()) {
                                         // we track a dysfunction against our elder here
-                                        self.log_knowledge_issue(sender.name()).await?;
+                                        self.log_knowledge_issue(sender.name())?;
                                     }
 
                                     // short circuit and send those AE responses

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -185,9 +185,7 @@ impl Node {
 
                 if self.is_not_elder() {
                     trace!("Redirecting from adult to section elders");
-                    cmds.push(
-                        self.ae_redirect_to_our_elders(sender, &src_location, &wire_msg)?,
-                    );
+                    cmds.push(self.ae_redirect_to_our_elders(sender, &src_location, &wire_msg)?);
                     return Ok(cmds);
                 }
 

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -186,8 +186,7 @@ impl Node {
                 if self.is_not_elder() {
                     trace!("Redirecting from adult to section elders");
                     cmds.push(
-                        self.ae_redirect_to_our_elders(sender, &src_location, &wire_msg)
-                            .await?,
+                        self.ae_redirect_to_our_elders(sender, &src_location, &wire_msg)?,
                     );
                     return Ok(cmds);
                 }

--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -25,7 +25,7 @@ use xor_name::XorName;
 
 // Relocation
 impl Node {
-    pub(crate) async fn relocate_peers(
+    pub(crate) fn relocate_peers(
         &mut self,
         churn_id: ChurnId,
         excluded: BTreeSet<XorName>,
@@ -58,7 +58,7 @@ impl Node {
         Ok(cmds)
     }
 
-    pub(crate) async fn relocate_rejoining_peer(
+    pub(crate) fn relocate_rejoining_peer(
         &mut self,
         node_state: NodeState,
         age: u8,

--- a/sn_node/src/node/messaging/resource_proof.rs
+++ b/sn_node/src/node/messaging/resource_proof.rs
@@ -44,7 +44,7 @@ impl Node {
             .validate_all(&response.nonce, &response.data, response.solution)
     }
 
-    pub(crate) async fn send_resource_proof_challenge(&self, peer: Peer) -> Result<Cmd> {
+    pub(crate) fn send_resource_proof_challenge(&self, peer: Peer) -> Result<Cmd> {
         let nonce: [u8; 32] = rand::random();
         let serialized =
             bincode::serialize(&(peer.name(), &nonce)).map_err(|_| Error::InvalidMessage)?;

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -34,7 +34,7 @@ use xor_name::XorName;
 
 impl Node {
     /// Forms a `CmdError` msg to send back to the client
-    pub(crate) async fn send_cmd_error_response(
+    pub(crate) fn send_cmd_error_response(
         &self,
         error: CmdError,
         target: Peer,
@@ -44,19 +44,19 @@ impl Node {
             error,
             correlation_id: msg_id,
         };
-        self.send_cmd_response(target, the_error_msg).await
+        self.send_cmd_response(target, the_error_msg)
     }
 
     /// Forms a `CmdAck` msg to send back to the client
-    pub(crate) async fn send_cmd_ack(&self, target: Peer, msg_id: MsgId) -> Result<Vec<Cmd>> {
+    pub(crate) fn send_cmd_ack(&self, target: Peer, msg_id: MsgId) -> Result<Vec<Cmd>> {
         let the_ack_msg = ServiceMsg::CmdAck {
             correlation_id: msg_id,
         };
-        self.send_cmd_response(target, the_ack_msg).await
+        self.send_cmd_response(target, the_ack_msg)
     }
 
     /// Forms a cmd to send a cmd response error/ack to the client
-    async fn send_cmd_response(&self, target: Peer, msg: ServiceMsg) -> Result<Vec<Cmd>> {
+    fn send_cmd_response(&self, target: Peer, msg: ServiceMsg) -> Result<Vec<Cmd>> {
         let dst = DstLocation::EndUser(EndUser(target.name()));
 
         let (auth_kind, payload) = self.ed_sign_client_msg(&msg)?;
@@ -230,14 +230,11 @@ impl Node {
                 spent_transactions,
             })) => {
                 // Generate and sign spent proof share
-                if let Some(spent_proof_share) = self
-                    .gen_spent_proof_share(&key_image, &tx, &spent_proofs, &spent_transactions)
-                    .await?
+                if let Some(spent_proof_share) =
+                    self.gen_spent_proof_share(&key_image, &tx, &spent_proofs, &spent_transactions)?
                 {
                     // Store spent proof share to adults
-                    let reg_cmd = self
-                        .gen_register_cmd(&key_image, &spent_proof_share)
-                        .await?;
+                    let reg_cmd = self.gen_register_cmd(&key_image, &spent_proof_share)?;
                     ReplicatedData::SpentbookWrite(reg_cmd)
                 } else {
                     return Ok(vec![]);
@@ -268,9 +265,9 @@ impl Node {
                 expected: data_copy_count() as u8,
                 found: cmds.len() as u8,
             });
-            return self.send_cmd_error_response(error, origin, msg_id).await;
+            return self.send_cmd_error_response(error, origin, msg_id);
         }
-        cmds.extend(self.send_cmd_ack(origin, msg_id).await?);
+        cmds.extend(self.send_cmd_ack(origin, msg_id)?);
         Ok(cmds)
     }
 
@@ -302,7 +299,7 @@ impl Node {
     }
 
     // Private helper to generate spent proof share
-    async fn gen_spent_proof_share(
+    fn gen_spent_proof_share(
         &self,
         key_image: &KeyImage,
         tx: &RingCtTransaction,
@@ -424,7 +421,7 @@ impl Node {
 
     // Private helper to generate the RegisterCmd to write the SpentProofShare
     // as an entry in the Spentbook (Register).
-    async fn gen_register_cmd(
+    fn gen_register_cmd(
         &self,
         key_image: &KeyImage,
         spent_proof_share: &SpentProofShare,

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -256,7 +256,7 @@ impl Node {
         };
 
         // build the replication cmds
-        let mut cmds = self.replicate_data(data).await?;
+        let mut cmds = self.replicate_data(data)?;
         // make sure the expected replication factor is achieved
         if data_copy_count() > cmds.len() {
             error!("InsufficientAdults for storing data reliably");

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -168,7 +168,6 @@ impl Node {
         // We assume to be aggregated if it contains a BLS Share sig as authority.
         match self
             .aggregate_msg_and_stop(&mut msg_authority, payload)
-            .await
         {
             Ok(false) => {
                 self.handle_valid_msg(msg_id, msg_authority, msg, sender, known_keys, comm)
@@ -761,7 +760,7 @@ impl Node {
     // Convert the provided NodeMsgAuthority to be a `Section` message
     // authority on successful accumulation. Also return 'true' if
     // current message shall not be processed any further.
-    async fn aggregate_msg_and_stop(
+    fn aggregate_msg_and_stop(
         &mut self,
         msg_authority: &mut NodeMsgAuthority,
         payload: Bytes,
@@ -777,7 +776,6 @@ impl Node {
             bls_share_auth.clone().into_inner(),
             &payload,
         )
-        .await
         {
             Ok(section_auth) => {
                 info!("Successfully aggregated message");

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -166,9 +166,7 @@ impl Node {
         trace!("{:?}", LogMarker::SystemMsgToBeHandled);
 
         // We assume to be aggregated if it contains a BLS Share sig as authority.
-        match self
-            .aggregate_msg_and_stop(&mut msg_authority, payload)
-        {
+        match self.aggregate_msg_and_stop(&mut msg_authority, payload) {
             Ok(false) => {
                 self.handle_valid_msg(msg_id, msg_authority, msg, sender, known_keys, comm)
                     .await
@@ -487,14 +485,12 @@ impl Node {
             SystemMsg::DkgNotReady {
                 message,
                 session_id,
-            } => {
-                self.handle_dkg_not_ready(
-                    sender,
-                    message,
-                    session_id,
-                    self.network_knowledge.section_key(),
-                )
-            }
+            } => self.handle_dkg_not_ready(
+                sender,
+                message,
+                session_id,
+                self.network_knowledge.section_key(),
+            ),
             SystemMsg::DkgRetry {
                 message_history,
                 message,
@@ -774,8 +770,7 @@ impl Node {
             &mut self.message_aggregator,
             bls_share_auth.clone().into_inner(),
             &payload,
-        )
-        {
+        ) {
             Ok(section_auth) => {
                 info!("Successfully aggregated message");
                 *msg_authority = NodeMsgAuthority::Section(section_auth);

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -448,7 +448,7 @@ impl Node {
             }
             SystemMsg::DkgStart(session_id) => {
                 trace!("Handling msg: Dkg-Start {:?} from {}", session_id, sender);
-                self.log_dkg_session(&sender.name()).await;
+                self.log_dkg_session(&sender.name());
                 let our_name = self.info().name();
                 if !session_id.contains_elder(our_name) {
                     return Ok(vec![]);

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -500,7 +500,7 @@ impl Node {
                     .await
             }
             SystemMsg::NodeCmd(NodeCmd::RecordStorageLevel { node_id, level, .. }) => {
-                let changed = self.set_storage_level(&node_id, level).await;
+                let changed = self.set_storage_level(&node_id, level);
                 if changed && level.value() == MIN_LEVEL_WHEN_FULL {
                     // ..then we accept a new node in place of the full node
                     self.joins_allowed = true;
@@ -525,8 +525,7 @@ impl Node {
                 if self.is_elder() {
                     if full {
                         let changed = self
-                            .set_storage_level(&node_id, StorageLevel::from(StorageLevel::MAX)?)
-                            .await;
+                            .set_storage_level(&node_id, StorageLevel::from(StorageLevel::MAX)?);
                         if changed {
                             // ..then we accept a new node in place of the full node
                             self.joins_allowed = true;
@@ -560,7 +559,7 @@ impl Node {
                         {
                             Ok(level_report) => {
                                 info!("Storage level report: {:?}", level_report);
-                                cmds.extend(self.record_storage_level_if_any(level_report).await);
+                                cmds.extend(self.record_storage_level_if_any(level_report));
                             }
                             Err(DbError::NotEnoughSpace) => {
                                 // db full
@@ -728,7 +727,7 @@ impl Node {
         }
     }
 
-    async fn record_storage_level_if_any(&self, level: Option<StorageLevel>) -> Vec<Cmd> {
+    fn record_storage_level_if_any(&self, level: Option<StorageLevel>) -> Vec<Cmd> {
         let mut cmds = vec![];
         if let Some(level) = level {
             info!("Storage has now passed {} % used.", 10 * level.value());

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -388,10 +388,10 @@ impl Node {
             }
             SystemMsg::DkgFailureAgreement(sig_set) => {
                 trace!("Handling msg: Dkg-FailureAgreement from {}", sender);
-                self.handle_dkg_failure_agreement(&src_name, &sig_set).await
+                self.handle_dkg_failure_agreement(&src_name, &sig_set)
             }
             SystemMsg::HandoverVotes(votes) => self.handle_handover_msg(sender, votes).await,
-            SystemMsg::HandoverAE(gen) => self.handle_handover_anti_entropy(sender, gen).await,
+            SystemMsg::HandoverAE(gen) => self.handle_handover_anti_entropy(sender, gen),
             SystemMsg::JoinRequest(join_request) => {
                 trace!("Handling msg: JoinRequest from {}", sender);
                 self.handle_join_request(sender, *join_request, comm).await
@@ -494,7 +494,6 @@ impl Node {
                     session_id,
                     self.network_knowledge.section_key(),
                 )
-                .await
             }
             SystemMsg::DkgRetry {
                 message_history,

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -329,14 +329,14 @@ mod core {
         }
 
         /// returns names that are relatively dysfunctional
-        pub(crate) async fn get_dysfunctional_node_names(&mut self) -> Result<BTreeSet<XorName>> {
+        pub(crate) fn get_dysfunctional_node_names(&mut self) -> Result<BTreeSet<XorName>> {
             self.dysfunction_tracking
                 .get_nodes_beyond_severity(DysfunctionSeverity::Dysfunctional)
                 .map_err(Error::from)
         }
 
         /// Log a communication problem
-        pub(crate) async fn log_comm_issue(&mut self, name: XorName) -> Result<()> {
+        pub(crate) fn log_comm_issue(&mut self, name: XorName) -> Result<()> {
             trace!("Logging comms issue in dysfunction");
             self.dysfunction_tracking
                 .track_issue(name, IssueType::Communication)
@@ -344,7 +344,7 @@ mod core {
         }
 
         /// Log a knowledge issue
-        pub(crate) async fn log_knowledge_issue(&mut self, name: XorName) -> Result<()> {
+        pub(crate) fn log_knowledge_issue(&mut self, name: XorName) -> Result<()> {
             trace!("Logging Knowledge issue in dysfunction");
             self.dysfunction_tracking
                 .track_issue(name, IssueType::Knowledge)
@@ -360,7 +360,7 @@ mod core {
         }
 
         /// Log a dkg session as responded to
-        pub(crate) async fn log_dkg_session(&mut self, name: &XorName) {
+        pub(crate) fn log_dkg_session(&mut self, name: &XorName) {
             trace!("Logging Dkg session as responded to in dysfunction");
             self.dysfunction_tracking.dkg_ack_fulfilled(name);
         }

--- a/sn_node/src/node/node_api/dispatcher.rs
+++ b/sn_node/src/node/node_api/dispatcher.rs
@@ -67,7 +67,7 @@ impl Dispatcher {
                 let wire_msg = WireMsg::single_src(&node.info(), dst, msg, src_section_pk)?;
 
                 let mut cmds = vec![];
-                cmds.extend(node.send_msg_to_nodes(wire_msg).await?);
+                cmds.extend(node.send_msg_to_nodes(wire_msg)?);
 
                 Ok(cmds)
             }

--- a/sn_node/src/node/node_api/dispatcher.rs
+++ b/sn_node/src/node/node_api/dispatcher.rs
@@ -101,7 +101,6 @@ impl Dispatcher {
                 let mut node = self.node.write().await;
 
                 node.handle_node_left(auth.value.into_state(), auth.sig)
-                    .await
             }
             Cmd::HandleNewEldersAgreement { proposal, sig } => match proposal {
                 Proposal::NewElders(section_auth) => {

--- a/sn_node/src/node/node_api/dispatcher.rs
+++ b/sn_node/src/node/node_api/dispatcher.rs
@@ -132,7 +132,7 @@ impl Dispatcher {
             Cmd::HandleDkgFailure(signeds) => {
                 let mut node = self.node.write().await;
 
-                node.handle_dkg_failure(signeds).await.map(|cmd| vec![cmd])
+                node.handle_dkg_failure(signeds).map(|cmd| vec![cmd])
             }
             Cmd::SendMsg {
                 recipients,

--- a/sn_node/src/node/node_api/dispatcher.rs
+++ b/sn_node/src/node/node_api/dispatcher.rs
@@ -117,7 +117,7 @@ impl Dispatcher {
             Cmd::HandlePeerLost(peer) => {
                 let mut node = self.node.write().await;
 
-                node.handle_peer_lost(&peer.addr()).await
+                node.handle_peer_lost(&peer.addr())
             }
             Cmd::HandleDkgOutcome {
                 section_auth,
@@ -198,7 +198,7 @@ impl Dispatcher {
                     if self.comm.is_reachable(&member_info.addr()).await.is_err() {
                         let mut node = self.node.write().await;
 
-                        node.log_comm_issue(member_info.name()).await?
+                        node.log_comm_issue(member_info.name())?
                     }
                 }
                 Ok(vec![])

--- a/sn_node/src/node/node_api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/node_api/flow_ctrl/mod.rs
@@ -332,8 +332,7 @@ impl FlowCtrl {
             loop {
                 let _instant = interval.tick().await;
 
-                let dysfunctional_nodes =
-                    self.node.write().await.get_dysfunctional_node_names();
+                let dysfunctional_nodes = self.node.write().await.get_dysfunctional_node_names();
                 let unresponsive_nodes = match dysfunctional_nodes {
                     Ok(nodes) => nodes,
                     Err(error) => {

--- a/sn_node/src/node/node_api/flow_ctrl/mod.rs
+++ b/sn_node/src/node/node_api/flow_ctrl/mod.rs
@@ -333,7 +333,7 @@ impl FlowCtrl {
                 let _instant = interval.tick().await;
 
                 let dysfunctional_nodes =
-                    self.node.write().await.get_dysfunctional_node_names().await;
+                    self.node.write().await.get_dysfunctional_node_names();
                 let unresponsive_nodes = match dysfunctional_nodes {
                     Ok(nodes) => nodes,
                     Err(error) => {

--- a/sn_node/src/node/node_api/mod.rs
+++ b/sn_node/src/node/node_api/mod.rs
@@ -334,7 +334,7 @@ impl NodeApi {
 
     /// Returns the info about the section matching the name.
     pub async fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
-        self.node.read().await.matching_section(name).await
+        self.node.read().await.matching_section(name)
     }
 
     /// Builds a `WireMsg` signed by this Node
@@ -361,7 +361,7 @@ impl NodeApi {
             wire_msg.msg_id()
         );
 
-        let cmds = self.node.read().await.send_msg_to_nodes(wire_msg).await?;
+        let cmds = self.node.read().await.send_msg_to_nodes(wire_msg)?;
 
         if let Some(cmd) = cmds {
             self.flow_ctrl.fire_and_forget(cmd).await?;
@@ -373,6 +373,6 @@ impl NodeApi {
     /// Returns the current BLS public key set if this node has one, or
     /// `Error::MissingSecretKeyShare` otherwise.
     pub async fn public_key_set(&self) -> Result<bls::PublicKeySet> {
-        self.node.read().await.public_key_set().await
+        self.node.read().await.public_key_set()
     }
 }


### PR DESCRIPTION
Used nightly clippy to apply latest `unused_async` lint, which also detects unused async in methods. This wasn't previously the case when I used it to clean up only regular functions. There are still some tests that have unneeded `async` with `tokio::test`, but clippy doesn't seem to pick up on them.

I have tried to clean up in pieces to make sure there are no unexpected side-effects. Only in `handover.rs` in function `check_signed_vote_saps` I changed something into a loop.

- fix(async): cleanup unused async
- fix(async): removed unused async at dysfunction
- fix(async): unused async remove and up-chain
- fix(async): unused async in sn_client
- fix(async): unused async in comm/node methods
- fix(async): more async removal from node/mod.rs
- fix(async): node messaging unused async removal
- chore(fmt): formatting with cargo fmt
- fix(async): more node messaging async removal
- fix(async): unused async in node/dkg etc
- fix(async): unused async in CLI

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
