### PR TITLE
feat(membership): join approval has membership decision + remove support for rejoins

### DIFF
--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -642,7 +642,7 @@ mod tests {
         messaging::data::CmdError,
         network_knowledge::{
             prefix_map::NetworkPrefixMap,
-            test_utils::{gen_section_authority_provider, section_signed},
+            test_utils::{random_sap, section_signed},
         },
     };
 
@@ -674,7 +674,7 @@ mod tests {
         let (err_sender, _err_receiver) = channel::<CmdError>(10);
 
         let prefix = prefix("0")?;
-        let (section_auth, _, secret_key_set) = gen_section_authority_provider(prefix, elders_len);
+        let (section_auth, _, secret_key_set) = random_sap(prefix, elders_len);
         let sap0 = section_signed(secret_key_set.secret_key(), section_auth)?;
         let (prefix_map, _genesis_sk, genesis_key) = new_network_prefix_map();
         assert!(prefix_map.insert_without_chain(sap0));

--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -12,6 +12,7 @@ use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Signature;
 use secured_linked_list::SecuredLinkedList;
 use serde::{Deserialize, Serialize};
+use sn_consensus::Decision;
 use std::{collections::VecDeque, net::SocketAddr};
 
 /// Request to join a section
@@ -76,10 +77,10 @@ pub enum JoinResponse {
         genesis_key: BlsPublicKey,
         /// SectionAuthorityProvider Signed by (current section)
         section_auth: SectionAuth<SectionAuthorityProvider>,
-        /// Current node's state
-        node_state: SectionAuth<NodeState>,
         /// Full verifiable section chain
         section_chain: SecuredLinkedList,
+        /// Current node's state
+        decision: Decision<NodeState>,
     },
     /// Join was rejected
     Rejected(JoinRejectionReason),

--- a/sn_interface/src/network_knowledge/errors.rs
+++ b/sn_interface/src/network_knowledge/errors.rs
@@ -46,4 +46,6 @@ pub enum Error {
     NotAMember,
     #[error("Request does not match the section prefix")]
     WrongSection,
+    #[error("Consensus({0:?})")]
+    Consensus(#[from] sn_consensus::Error),
 }

--- a/sn_interface/src/network_knowledge/errors.rs
+++ b/sn_interface/src/network_knowledge/errors.rs
@@ -48,4 +48,7 @@ pub enum Error {
     WrongSection,
     #[error("Consensus({0:?})")]
     Consensus(#[from] sn_consensus::Error),
+
+    #[error("An archived node attempted to rejoin the section")]
+    ArchivedNodeRejoined,
 }

--- a/sn_interface/src/network_knowledge/errors.rs
+++ b/sn_interface/src/network_knowledge/errors.rs
@@ -48,7 +48,6 @@ pub enum Error {
     WrongSection,
     #[error("Consensus({0:?})")]
     Consensus(#[from] sn_consensus::Error),
-
     #[error("An archived node attempted to rejoin the section")]
     ArchivedNodeRejoined,
 }

--- a/sn_interface/src/network_knowledge/node_state.rs
+++ b/sn_interface/src/network_knowledge/node_state.rs
@@ -170,10 +170,7 @@ impl NodeState {
 
     pub fn leave(self) -> Result<Self, Error> {
         // Do not allow switching to `Left` when already relocated,
-        // to avoid rejoining with the same name.
-        if let MembershipState::Relocated(_) = self.state {
-            return Err(Error::InvalidState);
-        }
+        assert_eq!(self.state, MembershipState::Joined);
 
         Ok(Self {
             state: MembershipState::Left,

--- a/sn_interface/src/network_knowledge/prefix_map/mod.rs
+++ b/sn_interface/src/network_knowledge/prefix_map/mod.rs
@@ -446,7 +446,7 @@ impl Eq for NetworkPrefixMap {}
 mod tests {
     use super::*;
     // sn_interface::network_knowledge::test_utils::gen_section_authority_provider
-    use crate::network_knowledge::test_utils::{gen_section_authority_provider, section_signed};
+    use crate::network_knowledge::test_utils::{random_sap, section_signed};
     use eyre::{eyre, Context, Result};
 
     #[test]
@@ -700,7 +700,7 @@ mod tests {
     }
 
     fn gen_section_auth(prefix: Prefix) -> Result<SectionAuth<SectionAuthorityProvider>> {
-        let (section_auth, _, secret_key_set) = gen_section_authority_provider(prefix, 5);
+        let (section_auth, _, secret_key_set) = random_sap(prefix, 5);
         section_signed(secret_key_set.secret_key(), section_auth)
             .context(format!("Failed to generate SAP for prefix {:?}", prefix))
     }

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -317,7 +317,7 @@ pub mod test_utils {
     }
 
     // Generate random `SectionAuthorityProvider` for testing purposes.
-    pub fn gen_section_authority_provider(
+    pub fn random_sap(
         prefix: Prefix,
         count: usize,
     ) -> (SectionAuthorityProvider, Vec<NodeInfo>, SecretKeySet) {

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -273,6 +273,7 @@ pub mod test_utils {
     use crate::network_knowledge::{NodeInfo, MIN_ADULT_AGE};
     use crate::types::SecretKeySet;
     use itertools::Itertools;
+    use sn_consensus::{Ballot, Consensus, Decision, Proposition, Vote, VoteResponse};
     // use ed25519::ed25519;
     use std::{cell::Cell, net::SocketAddr};
     use xor_name::Prefix;
@@ -337,6 +338,42 @@ pub mod test_utils {
             public_key: secret_key.public_key(),
             signature: secret_key.sign(&bytes),
         })
+    }
+
+    pub fn section_decision<P: Proposition>(
+        secret_key_set: &bls::SecretKeySet,
+        proposal: P,
+    ) -> Result<Decision<P>> {
+        let n = secret_key_set.threshold() + 1;
+        let mut nodes = Vec::from_iter((1..=n).into_iter().map(|idx| {
+            let secret = (idx as u8, secret_key_set.secret_key_share(idx));
+            Consensus::from(secret, secret_key_set.public_keys(), n)
+        }));
+
+        let first_vote = nodes[0].sign_vote(Vote {
+            gen: 0,
+            ballot: Ballot::Propose(proposal),
+            faults: Default::default(),
+        })?;
+
+        let mut votes = vec![nodes[0].cast_vote(first_vote)?];
+
+        while let Some(vote) = votes.pop() {
+            for node in nodes.iter_mut() {
+                match node.handle_signed_vote(vote.clone())? {
+                    VoteResponse::WaitingForMoreVotes => (),
+                    VoteResponse::Broadcast(vote) => votes.push(vote),
+                }
+            }
+        }
+
+        // All nodes have agreed to the same proposal
+        assert_eq!(
+            BTreeSet::from_iter(nodes.iter().map(|n| n.decision.clone().unwrap().proposals)).len(),
+            1
+        );
+
+        Ok(nodes[0].decision.clone().unwrap())
     }
 
     // Wrap the given payload in `SectionAuth`

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -566,8 +566,7 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (section_auth, mut nodes, sk_set) =
-            gen_section_authority_provider(Prefix::default(), elder_count());
+        let (section_auth, mut nodes, sk_set) = random_sap(Prefix::default(), elder_count());
         let bootstrap_node = nodes.remove(0);
         let bootstrap_addr = bootstrap_node.addr;
         let sk = sk_set.secret_key();
@@ -682,8 +681,7 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (_, mut nodes, sk_set) =
-            gen_section_authority_provider(Prefix::default(), elder_count());
+        let (_, mut nodes, sk_set) = random_sap(Prefix::default(), elder_count());
         let bootstrap_node = nodes.remove(0);
         let genesis_key = sk_set.secret_key().public_key();
 
@@ -722,8 +720,7 @@ mod tests {
                 .map(|_| (xor_name::rand::random(), gen_addr()))
                 .collect();
 
-            let (new_section_auth, _, new_sk_set) =
-                gen_section_authority_provider(Prefix::default(), elder_count());
+            let (new_section_auth, _, new_sk_set) = random_sap(Prefix::default(), elder_count());
             let new_pk_set = new_sk_set.public_keys();
 
             send_response(
@@ -788,8 +785,7 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (_, mut nodes, sk_set) =
-            gen_section_authority_provider(Prefix::default(), elder_count());
+        let (_, mut nodes, sk_set) = random_sap(Prefix::default(), elder_count());
         let bootstrap_node = nodes.remove(0);
 
         let node = NodeInfo::new(
@@ -814,8 +810,7 @@ mod tests {
             assert_matches!(wire_msg.into_msg(), Ok(MsgType::System { msg, .. }) =>
             assert_matches!(msg, SystemMsg::JoinRequest{..}));
 
-            let (new_section_auth, _, new_sk_set) =
-                gen_section_authority_provider(Prefix::default(), elder_count());
+            let (new_section_auth, _, new_sk_set) = random_sap(Prefix::default(), elder_count());
             let new_pk_set = new_sk_set.public_keys();
 
             send_response(
@@ -880,8 +875,7 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (section_auth, mut nodes, sk_set) =
-            gen_section_authority_provider(Prefix::default(), elder_count());
+        let (section_auth, mut nodes, sk_set) = random_sap(Prefix::default(), elder_count());
         let bootstrap_node = nodes.remove(0);
 
         let node = NodeInfo::new(
@@ -959,7 +953,7 @@ mod tests {
             }
         };
 
-        let (section_auth, _, sk_set) = gen_section_authority_provider(good_prefix, elder_count());
+        let (section_auth, _, sk_set) = random_sap(good_prefix, elder_count());
         let section_key = sk_set.public_keys().public_key();
 
         let state = Joiner::new(
@@ -996,9 +990,7 @@ mod tests {
             send_response(
                 &recv_tx,
                 SystemMsg::JoinResponse(Box::new(JoinResponse::Retry {
-                    section_auth: gen_section_authority_provider(bad_prefix, elder_count())
-                        .0
-                        .to_msg(),
+                    section_auth: random_sap(bad_prefix, elder_count()).0.to_msg(),
                     section_signed: signed_sap.sig.clone(),
                     proof_chain: section_chain.clone(),
                     expected_age: MIN_ADULT_AGE,

--- a/sn_node/src/node/cfg/config_handler.rs
+++ b/sn_node/src/node/cfg/config_handler.rs
@@ -135,12 +135,6 @@ impl Config {
     /// Returns a new `Config` instance.  Tries to read from the default node config file location,
     /// and overrides values with any equivalent cmd line args.
     pub async fn new() -> Result<Self, Error> {
-        // FIXME: Re-enable when we have rejoins working
-        // let mut config = match Self::read_from_file() {
-        //     Ok(Some(config)) => config,
-        //     Ok(None) | Err(_) => Default::default(),
-        // };
-
         let mut config = Config::default();
 
         let cmd_line_args = Config::parse();

--- a/sn_node/src/node/delivery_group.rs
+++ b/sn_node/src/node/delivery_group.rs
@@ -173,7 +173,7 @@ mod tests {
     use sn_interface::{
         network_knowledge::{
             test_utils::section_signed,
-            test_utils::{gen_addr, gen_section_authority_provider},
+            test_utils::{gen_addr, random_sap},
             NodeState, SectionAuthorityProvider, MIN_ADULT_AGE,
         },
         types::keys::ed25519,
@@ -535,8 +535,7 @@ mod tests {
         let prefix0 = Prefix::default().pushed(false);
         let prefix1 = Prefix::default().pushed(true);
 
-        let (section_auth0, _, secret_key_set) =
-            gen_section_authority_provider(prefix0, elder_count());
+        let (section_auth0, _, secret_key_set) = random_sap(prefix0, elder_count());
         let genesis_sk = secret_key_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -553,8 +552,7 @@ mod tests {
             assert!(network_knowledge.update_member(node_state));
         }
 
-        let (section_auth1, _, secret_key_set) =
-            gen_section_authority_provider(prefix1, elder_count());
+        let (section_auth1, _, secret_key_set) = random_sap(prefix1, elder_count());
         let sk1 = secret_key_set.secret_key();
         let pk1 = sk1.public_key();
 
@@ -588,8 +586,7 @@ mod tests {
     fn setup_adult() -> Result<(XorName, NetworkKnowledge)> {
         let prefix0 = Prefix::default().pushed(false);
 
-        let (section_auth, _, secret_key_set) =
-            gen_section_authority_provider(prefix0, elder_count());
+        let (section_auth, _, secret_key_set) = random_sap(prefix0, elder_count());
         let genesis_sk = secret_key_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
         let section_auth = section_signed(genesis_sk, section_auth)?;

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -133,7 +133,7 @@ pub(crate) enum Cmd {
     /// Handle agreement on a proposal.
     HandleAgreement { proposal: Proposal, sig: KeyedSig },
     /// Handle a new Node joining agreement.
-    HandleNewNodeOnline(Decision<NodeState>),
+    HandleJoinDecision(Decision<NodeState>),
     /// Handle a Node leaving agreement.
     HandleNodeLeft(SectionAuth<NodeState>),
     /// Handle agree on elders. This blocks node message processing until complete.
@@ -205,7 +205,7 @@ impl Cmd {
             HandlePeerLost(_) => 9,
             HandleNodeLeft(_) => 9,
             ProposeOffline(_) => 9,
-            HandleNewNodeOnline(_) => 9,
+            HandleJoinDecision(_) => 9,
             EnqueueDataForReplication { .. } => 9,
             CleanupPeerLinks => 9,
 
@@ -255,7 +255,7 @@ impl fmt::Display for Cmd {
             Cmd::HandlePeerLost(peer) => write!(f, "HandlePeerLost({:?})", peer.name()),
             Cmd::HandleAgreement { .. } => write!(f, "HandleAgreement"),
             Cmd::HandleNewEldersAgreement { .. } => write!(f, "HandleNewEldersAgreement"),
-            Cmd::HandleNewNodeOnline(_) => write!(f, "HandleNewNodeOnline"),
+            Cmd::HandleJoinDecision(_) => write!(f, "HandleJoinDecision"),
             Cmd::HandleNodeLeft(_) => write!(f, "HandleNodeLeft"),
             Cmd::HandleDkgOutcome { .. } => write!(f, "HandleDkgOutcome"),
             Cmd::HandleDkgFailure(_) => write!(f, "HandleDkgFailure"),

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -8,6 +8,7 @@
 
 use crate::node::{Proposal, XorName};
 
+use sn_consensus::Decision;
 use sn_interface::{
     messaging::{
         data::ServiceMsg,
@@ -132,7 +133,7 @@ pub(crate) enum Cmd {
     /// Handle agreement on a proposal.
     HandleAgreement { proposal: Proposal, sig: KeyedSig },
     /// Handle a new Node joining agreement.
-    HandleNewNodeOnline(SectionAuth<NodeState>),
+    HandleNewNodeOnline(Decision<NodeState>),
     /// Handle a Node leaving agreement.
     HandleNodeLeft(SectionAuth<NodeState>),
     /// Handle agree on elders. This blocks node message processing until complete.

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -167,10 +167,10 @@ impl Dispatcher {
 
                 node.handle_general_agreements(proposal, sig).await
             }
-            Cmd::HandleNewNodeOnline(decision) => {
+            Cmd::HandleJoinDecision(decision) => {
                 let mut node = self.node.write().await;
 
-                node.handle_online_agreement(decision).await
+                node.handle_join_decision(decision).await
             }
             Cmd::HandleNodeLeft(auth) => {
                 let mut node = self.node.write().await;

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -167,11 +167,10 @@ impl Dispatcher {
 
                 node.handle_general_agreements(proposal, sig).await
             }
-            Cmd::HandleNewNodeOnline(auth) => {
+            Cmd::HandleNewNodeOnline(decision) => {
                 let mut node = self.node.write().await;
 
-                node.handle_online_agreement(auth.value.into_state(), auth.sig)
-                    .await
+                node.handle_online_agreement(decision).await
             }
             Cmd::HandleNodeLeft(auth) => {
                 let mut node = self.node.write().await;

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -72,8 +72,7 @@ async fn receive_join_request_without_resource_proof_response() -> Result<()> {
     local
         .run_until(async move {
             let prefix1 = Prefix::default().pushed(true);
-            let (section_auth, mut nodes, sk_set) =
-                gen_section_authority_provider(prefix1, elder_count());
+            let (section_auth, mut nodes, sk_set) = random_sap(prefix1, elder_count());
 
             let pk_set = sk_set.public_keys();
             let section_key = pk_set.public_key();
@@ -156,8 +155,7 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
     local
         .run_until(async move {
             let prefix1 = Prefix::default().pushed(true);
-            let (section_auth, mut nodes, sk_set) =
-                gen_section_authority_provider(prefix1, elder_count());
+            let (section_auth, mut nodes, sk_set) = random_sap(prefix1, elder_count());
 
             let pk_set = sk_set.public_keys();
             let section_key = pk_set.public_key();
@@ -349,7 +347,7 @@ async fn handle_agreement_on_online() -> Result<()> {
             let prefix = Prefix::default();
 
             let (section_auth, mut nodes, sk_set) =
-                gen_section_authority_provider(prefix, elder_count());
+                random_sap(prefix, elder_count());
             let (section, section_key_share) = create_section(&sk_set, &section_auth)?;
             let node = nodes.remove(0);
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
@@ -588,9 +586,8 @@ async fn handle_agreement_on_online_of_rejoined_node(phase: NetworkPhase, age: u
                 NetworkPhase::Startup => Prefix::default(),
                 NetworkPhase::Regular => "0".parse().unwrap(),
             };
-            let (section_auth, mut node_infos, sk_set) =
-                gen_section_authority_provider(prefix, elder_count());
-            let (section, section_key_share) = create_section(&sk_set, &section_auth)?;
+            let (sap, mut node_infos, sk_set) = random_sap(prefix, elder_count());
+            let (section, section_key_share) = create_section(&sk_set, &sap)?;
 
             // Make a left peer.
             let peer = create_peer(age);
@@ -616,7 +613,7 @@ async fn handle_agreement_on_online_of_rejoined_node(phase: NetworkPhase, age: u
             let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
             // Simulate peer with the same name is rejoin and verify resulted behaviours.
-            let status = handle_online_cmd(&peer, &sk_set, &dispatcher, &section_auth).await?;
+            let status = handle_online_cmd(&peer, &sk_set, &dispatcher, &sap).await?;
 
             // A rejoin node with low age will be rejected.
             if age / 2 < MIN_ADULT_AGE {
@@ -1018,7 +1015,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
             RelocatedPeerRole::Elder => elder_count(),
             RelocatedPeerRole::NonElder => recommended_section_size(),
         };
-        let (section_auth, mut nodes, sk_set) = gen_section_authority_provider(prefix, elder_count());
+        let (section_auth, mut nodes, sk_set) = random_sap(prefix, elder_count());
         let (section, section_key_share) = create_section(&sk_set, &section_auth)?;
 
         let mut adults = section_size - elder_count();
@@ -1525,8 +1522,7 @@ pub(crate) async fn create_comm() -> Result<Comm> {
 
 // Generate random SectionAuthorityProvider and the corresponding Nodes.
 fn create_section_auth() -> (SectionAuthorityProvider, Vec<NodeInfo>, SecretKeySet) {
-    let (section_auth, elders, secret_key_set) =
-        gen_section_authority_provider(Prefix::default(), elder_count());
+    let (section_auth, elders, secret_key_set) = random_sap(Prefix::default(), elder_count());
     (section_auth, elders, secret_key_set)
 }
 

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -620,7 +620,7 @@ async fn handle_join_request_of_rejoined_node() -> Result<()> {
                 .propose_membership_change(node_state.clone())
                 .unwrap();
 
-            // A rejoining node with always be rejected
+            // A rejoining node will always be rejected
             assert!(join_cmds.is_empty()); // no commands signals this membership proposal was dropped.
             assert!(!dispatcher
                 .node()

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -457,7 +457,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
                 .force_bootstrap(node_state.to_msg());
 
             let cmds =
-                run_and_collect_cmds(Cmd::HandleNewNodeOnline(membership_decision), &dispatcher)
+                run_and_collect_cmds(Cmd::HandleJoinDecision(membership_decision), &dispatcher)
                     .await?;
 
             // Verify we sent a `DkgStart` message with the expected participants.
@@ -513,7 +513,7 @@ async fn handle_online_cmd(
     let membership_decision = section_decision(sk_set, node_state.to_msg())?;
 
     let all_cmds =
-        run_and_collect_cmds(Cmd::HandleNewNodeOnline(membership_decision), dispatcher).await?;
+        run_and_collect_cmds(Cmd::HandleJoinDecision(membership_decision), dispatcher).await?;
 
     let mut status = HandleOnlineStatus {
         node_approval_sent: false,
@@ -1055,7 +1055,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
         };
 
         let membership_decision = create_relocation_trigger(&sk_set, relocated_peer.age())?;
-        let cmds = run_and_collect_cmds(Cmd::HandleNewNodeOnline(membership_decision), &dispatcher).await?;
+        let cmds = run_and_collect_cmds(Cmd::HandleJoinDecision(membership_decision), &dispatcher).await?;
 
         let mut offline_relocate_sent = false;
 

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -6,60 +6,16 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::{
-    flow_ctrl::cmds::Cmd, relocation::ChurnId, Event, MembershipEvent, Node, Proposal, Result,
-};
-use bls::Signature;
-use sn_consensus::Decision;
+use crate::node::{flow_ctrl::cmds::Cmd, Node, Proposal, Result};
 use sn_interface::{
-    messaging::system::{
-        JoinResponse, KeyedSig, MembershipState, NodeState as NodeStateMsg, SectionAuth, SystemMsg,
-    },
-    network_knowledge::{
-        NodeState, SapCandidate, SectionAuthUtils, SectionAuthorityProvider, MIN_ADULT_AGE,
-    },
+    messaging::system::{KeyedSig, SectionAuth},
+    network_knowledge::{NodeState, SapCandidate, SectionAuthUtils, SectionAuthorityProvider},
     types::log_markers::LogMarker,
 };
 use std::collections::BTreeSet;
 
 // Agreement
 impl Node {
-    // Send `NodeApproval` to a joining node which makes it a section member
-    pub(crate) fn send_node_approval(&self, decision: Decision<NodeStateMsg>) -> Vec<Cmd> {
-        let peers = Vec::from_iter(
-            decision
-                .proposals
-                .keys()
-                .filter(|n| n.state == MembershipState::Joined)
-                .map(|n| n.peer()),
-        );
-        let prefix = self.network_knowledge.prefix();
-        info!("Section {prefix:?} has approved new peers {peers:?}.");
-
-        let node_msg = SystemMsg::JoinResponse(Box::new(JoinResponse::Approval {
-            genesis_key: *self.network_knowledge.genesis_key(),
-            section_auth: self
-                .network_knowledge
-                .section_signed_authority_provider()
-                .into_authed_msg(),
-            section_chain: self.network_knowledge.section_chain(),
-            decision,
-        }));
-
-        let sap = self.network_knowledge.authority_provider();
-        let dst_section_pk = sap.section_key();
-        let section_name = sap.prefix().name();
-
-        trace!("{}", LogMarker::SendNodeApproval);
-        match self.send_direct_msg_to_nodes(peers.clone(), node_msg, section_name, dst_section_pk) {
-            Ok(cmd) => vec![cmd],
-            Err(err) => {
-                error!("Failed to send join approval to new peers {peers:?}: {err:?}");
-                vec![]
-            }
-        }
-    }
-
     #[instrument(skip(self), level = "trace")]
     pub(crate) async fn handle_general_agreements(
         &mut self,
@@ -79,106 +35,6 @@ impl Node {
                 Ok(vec![])
             }
         }
-    }
-
-    pub(crate) async fn handle_online_agreement(
-        &mut self,
-        decision: Decision<NodeStateMsg>,
-    ) -> Result<Vec<Cmd>> {
-        debug!("{}", LogMarker::AgreementOfOnline);
-        let mut cmds = vec![];
-
-        cmds.extend(self.send_node_approval(decision.clone()));
-        let joining_nodes = Vec::from_iter(
-            decision
-                .proposals
-                .clone()
-                .into_iter()
-                .filter(|(n, _)| n.state == MembershipState::Joined),
-        );
-
-        for (new_info, signature) in joining_nodes.iter().cloned() {
-            cmds.extend(self.handle_joining_node(new_info, signature).await?);
-        }
-
-        self.log_section_stats();
-
-        // Do not disable node joins in first section.
-        let our_prefix = self.network_knowledge.prefix();
-        if !our_prefix.is_empty() {
-            // ..otherwise, switch off joins_allowed on a node joining.
-            // TODO: fix racing issues here? https://github.com/maidsafe/safe_network/issues/890
-            self.joins_allowed = false;
-        }
-
-        if let Some((_, sig)) = joining_nodes.iter().max_by_key(|(_, sig)| sig) {
-            let churn_id = ChurnId(sig.to_bytes().to_vec());
-            let excluded_from_relocation =
-                BTreeSet::from_iter(joining_nodes.iter().map(|(n, _)| n.name));
-
-            cmds.extend(self.relocate_peers(churn_id, excluded_from_relocation)?);
-        }
-
-        let result = self.promote_and_demote_elders_except(&BTreeSet::default())?;
-
-        if result.is_empty() {
-            // Send AE-Update to our section
-            cmds.extend(self.send_ae_update_to_our_section());
-        }
-
-        cmds.extend(result);
-
-        info!("cmds in queue for Accepting node {:?}", cmds);
-
-        self.print_network_stats();
-
-        Ok(cmds)
-    }
-
-    async fn handle_joining_node(
-        &mut self,
-        new_info: NodeStateMsg,
-        signature: Signature,
-    ) -> Result<Vec<Cmd>> {
-        if let Some(old_info) = self
-            .network_knowledge
-            .is_either_member_or_archived(&new_info.name)
-        {
-            // We would approve and relocate it only if half its age is at least MIN_ADULT_AGE
-            let new_age = old_info.age() / 2;
-            if new_age >= MIN_ADULT_AGE {
-                return self.relocate_rejoining_peer(old_info.value, new_age);
-            }
-        }
-
-        let sig = KeyedSig {
-            public_key: self.network_knowledge.section_key(),
-            signature,
-        };
-
-        let new_info = SectionAuth {
-            value: new_info.into_state(),
-            sig,
-        };
-
-        if !self.network_knowledge.update_member(new_info.clone()) {
-            info!("ignore Online: {}", new_info.peer());
-            return Ok(vec![]);
-        }
-
-        self.add_new_adult_to_trackers(new_info.name());
-
-        info!("handle Online: {}", new_info.peer());
-
-        // still used for testing
-        self.send_event(Event::Membership(MembershipEvent::MemberJoined {
-            name: new_info.name(),
-            previous_name: new_info.previous_name(),
-            age: new_info.age(),
-        }))
-        .await;
-
-        Ok(vec![])
     }
 
     #[instrument(skip(self))]

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -630,7 +630,7 @@ mod tests {
             SectionAuth as SectionAuthMsg,
         },
         network_knowledge::{
-            test_utils::{gen_addr, gen_section_authority_provider, section_signed},
+            test_utils::{gen_addr, random_sap, section_signed},
             NetworkKnowledge, NodeInfo, SectionKeyShare, SectionKeysProvider,
         },
         types::keys::ed25519,
@@ -903,8 +903,7 @@ mod tests {
             let prefix1 = Prefix::default().pushed(true);
 
             // generate a SAP for prefix0
-            let (section_auth, mut nodes, secret_key_set) =
-                gen_section_authority_provider(prefix0, elder_count());
+            let (section_auth, mut nodes, secret_key_set) = random_sap(prefix0, elder_count());
             let info = nodes.remove(0);
             let sap_sk = secret_key_set.secret_key();
             let signed_sap = section_signed(sap_sk, section_auth)?;
@@ -943,8 +942,7 @@ mod tests {
             );
 
             // generate other SAP for prefix1
-            let (other_sap, _, secret_key_set) =
-                gen_section_authority_provider(prefix1, elder_count());
+            let (other_sap, _, secret_key_set) = random_sap(prefix1, elder_count());
             let other_sap_sk = secret_key_set.secret_key();
             let other_sap = section_signed(other_sap_sk, other_sap)?;
             // generate a proof chain for this other SAP

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::comm::Comm;
-use crate::node::{flow_ctrl::cmds::Cmd, relocation::RelocateDetailsUtils, Node, Result};
+use crate::node::{flow_ctrl::cmds::Cmd, Node, Result};
 use sn_interface::{
     elder_count,
     messaging::system::{

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -16,7 +16,6 @@ use sn_interface::{
     messaging::system::{
         JoinResponse, KeyedSig, MembershipState, NodeState, SectionAuth, SystemMsg,
     },
-    network_knowledge::MIN_ADULT_AGE,
     types::{log_markers::LogMarker, Peer},
 };
 
@@ -251,17 +250,6 @@ impl Node {
         new_info: NodeState,
         signature: Signature,
     ) -> Result<Vec<Cmd>> {
-        if let Some(old_info) = self
-            .network_knowledge
-            .is_either_member_or_archived(&new_info.name)
-        {
-            // We would approve and relocate it only if half its age is at least MIN_ADULT_AGE
-            let new_age = old_info.age() / 2;
-            if new_age >= MIN_ADULT_AGE {
-                return self.relocate_rejoining_peer(old_info.value, new_age);
-            }
-        }
-
         let sig = KeyedSig {
             public_key: self.network_knowledge.section_key(),
             signature,

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -123,17 +123,17 @@ impl Node {
                         BTreeSet::from_iter(decision.proposals.keys())
                     );
                     let public_key = self.network_knowledge.section_key();
-                    for (value, signature) in decision.proposals {
+                    for (value, signature) in decision.proposals.clone() {
                         let sig = KeyedSig {
                             public_key,
                             signature,
                         };
                         if membership.is_leaving_section(&value, prefix) {
                             cmds.push(Cmd::HandleNodeLeft(SectionAuth { value, sig }));
-                        } else {
-                            cmds.push(Cmd::HandleNewNodeOnline(SectionAuth { value, sig }));
                         }
                     }
+
+                    cmds.push(Cmd::HandleNewNodeOnline(decision));
                 }
             } else {
                 error!(

--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -9,14 +9,13 @@
 use crate::node::{
     bootstrap::JoiningAsRelocated,
     flow_ctrl::cmds::Cmd,
-    relocation::{find_nodes_to_relocate, ChurnId, RelocateDetailsUtils},
+    relocation::{find_nodes_to_relocate, ChurnId},
     Event, MembershipEvent, Node, Proposal, Result,
 };
 
 use sn_interface::{
     elder_count,
-    messaging::system::{MembershipState, NodeState as NodeStateMsg, RelocateDetails, SectionAuth},
-    network_knowledge::NodeState,
+    messaging::system::{MembershipState, NodeState as NodeStateMsg, SectionAuth},
     types::log_markers::LogMarker,
 };
 
@@ -56,25 +55,6 @@ impl Node {
         }
 
         Ok(cmds)
-    }
-
-    pub(crate) fn relocate_rejoining_peer(
-        &mut self,
-        node_state: NodeState,
-        age: u8,
-    ) -> Result<Vec<Cmd>> {
-        let peer = node_state.peer();
-        let relocate_details =
-            RelocateDetails::with_age(&self.network_knowledge, peer, peer.name(), age);
-
-        trace!(
-            "Relocating {:?} to {} with age {} due to rejoin",
-            peer,
-            relocate_details.dst,
-            relocate_details.age
-        );
-
-        self.propose(Proposal::Offline(node_state.relocate(relocate_details)))
     }
 
     pub(crate) async fn handle_relocate(

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -62,7 +62,7 @@ impl Proposal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sn_interface::network_knowledge::test_utils::gen_section_authority_provider;
+    use sn_interface::network_knowledge::test_utils::random_sap;
 
     use eyre::Result;
     use serde::Serialize;
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn serialize_for_signing() -> Result<()> {
         // Proposal::SectionInfo
-        let (section_auth, _, _) = gen_section_authority_provider(Prefix::default(), 4);
+        let (section_auth, _, _) = random_sap(Prefix::default(), 4);
         let proposal = Proposal::SectionInfo(section_auth.clone());
         verify_serialize_for_signing(&proposal, &section_auth)?;
 


### PR DESCRIPTION
This PR changes our Join approval flow to include the membership decision that approved the node to join the section.

Also we remove support for rejoins since that turns out to be unsound