### PR TITLE
chore(client): remove extra bootstrap step

### DIFF
--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -167,11 +167,11 @@ impl Client {
         let (random_dst_addr, auth, serialised_cmd) = generate_probe_msg(&client, client_pk)?;
 
         // get bootstrap nodes
-        let bootstrap_nodes = {
+        let (bootstrap_nodes, section_pk) = {
             let sap = prefix_map
-                .closest_or_opposite(&xor_name::rand::random(), None)
+                .closest_or_opposite(&random_dst_addr, None)
                 .ok_or(Error::NoNetworkKnowledge)?;
-            sap.elders_vec()
+            (sap.elders_vec(), sap.section_key())
         };
         debug!(
             "Make contact with the bootstrap nodes: {:?}",
@@ -183,6 +183,7 @@ impl Client {
             .session
             .make_contact_with_nodes(
                 bootstrap_nodes.clone(),
+                section_pk,
                 random_dst_addr,
                 auth.clone(),
                 serialised_cmd,
@@ -210,6 +211,7 @@ impl Client {
                 .session
                 .make_contact_with_nodes(
                     bootstrap_nodes.clone(),
+                    section_pk,
                     random_dst_addr,
                     auth,
                     serialised_cmd,

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -53,8 +53,6 @@ pub(super) struct Session {
     network: Arc<NetworkPrefixMap>,
     /// A DAG containing all section chains of the whole network that we are aware of
     all_sections_chains: Arc<RwLock<SecuredLinkedList>>,
-    /// Network's genesis key
-    genesis_key: bls::PublicKey,
     /// Initial network comms MsgId
     initial_connection_check_msg_id: Arc<RwLock<Option<MsgId>>>,
     /// Standard time to await potential AE messages:
@@ -83,7 +81,6 @@ impl Session {
             pending_cmds: Arc::new(DashMap::default()),
             endpoint,
             network: Arc::new(prefix_map),
-            genesis_key,
             initial_connection_check_msg_id: Arc::new(RwLock::new(None)),
             cmd_ack_wait,
             peer_links,


### PR DESCRIPTION
Also remove `Session::genesis_key` as it's unused. Can be obtained from `NetworkPrefixMap` if required.