### PR TITLE
chore(dsyfunction): relax knowledge penalty.

### DIFF
--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -14,9 +14,9 @@ use xor_name::XorName;
 use std::time::Duration;
 static RECENT_ISSUE_DURATION: Duration = Duration::from_secs(60 * 10); // 10 minutes
 
-static CONN_WEIGHTING: f32 = 3.0;
+static CONN_WEIGHTING: f32 = 2.0;
 static OP_WEIGHTING: f32 = 1.0;
-static KNOWLEDGE_WEIGHTING: f32 = 4.0;
+static KNOWLEDGE_WEIGHTING: f32 = 3.0;
 static DKG_WEIGHTING: f32 = 5.0;
 
 /// Z-score value above which a node is dysfunctional


### PR DESCRIPTION
We've seen some CI nodes being booted due to knowledge issues, so relaxing
this should help there'

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
