### PR TITLE
refactor: remove one layer of indirection

### DIFF
--- a/sn_node/src/node/messaging/proposal.rs
+++ b/sn_node/src/node/messaging/proposal.rs
@@ -184,8 +184,8 @@ impl Node {
             Ok(serialised_proposal) => {
                 match proposal_aggregator.add(&serialised_proposal, sig_share) {
                     Ok(sig) => match proposal {
-                        Proposal::NewElders(_) => {
-                            cmds.push(Cmd::HandleNewEldersAgreement { proposal, sig })
+                        Proposal::NewElders(new_elders) => {
+                            cmds.push(Cmd::HandleNewEldersAgreement { new_elders, sig })
                         }
                         _ => cmds.push(Cmd::HandleAgreement { proposal, sig }),
                     },

--- a/sn_node/src/node/node_api/cmds.rs
+++ b/sn_node/src/node/node_api/cmds.rs
@@ -130,7 +130,10 @@ pub(crate) enum Cmd {
     /// Handle a Node leaving agreement.
     HandleNodeLeft(SectionAuth<NodeState>),
     /// Handle agree on elders. This blocks node message processing until complete.
-    HandleNewEldersAgreement { proposal: Proposal, sig: KeyedSig },
+    HandleNewEldersAgreement {
+        new_elders: SectionAuth<SectionAuthorityProvider>,
+        sig: KeyedSig,
+    },
     /// Handle the outcome of a DKG session where we are one of the participants (that is, one of
     /// the proposed new elders).
     HandleDkgOutcome {

--- a/sn_node/src/node/node_api/dispatcher.rs
+++ b/sn_node/src/node/node_api/dispatcher.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::{messages::WireMsgUtils, node_api::Cmd, Node, Proposal, Result};
+use crate::node::{messages::WireMsgUtils, node_api::Cmd, Node, Result};
 
 use crate::comm::{Comm, DeliveryStatus};
 use sn_interface::{
@@ -139,17 +139,11 @@ impl Dispatcher {
 
                 node.handle_node_left(auth.value.into_state(), auth.sig)
             }
-            Cmd::HandleNewEldersAgreement { proposal, sig } => match proposal {
-                Proposal::NewElders(section_auth) => {
-                    let mut node = self.node.write().await;
+            Cmd::HandleNewEldersAgreement { new_elders, sig } => {
+                let mut node = self.node.write().await;
 
-                    node.handle_new_elders_agreement(section_auth, sig).await
-                }
-                _ => {
-                    error!("Other agreement messages should be handled in `HandleAgreement`, which is non-blocking ");
-                    Ok(vec![])
-                }
-            },
+                node.handle_new_elders_agreement(new_elders, sig).await
+            }
             Cmd::HandlePeerLost(peer) => {
                 let mut node = self.node.write().await;
 


### PR DESCRIPTION
`HandleNewEldersAgreement` variant of `Cmd` had an unnecessary wrapper
of `Proposal` around the actual object being conveyed.
