### PR TITLE
chore: remove SendMsgDeliveryGroup Cmd

### DIFF
--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -321,28 +321,12 @@ impl Comm {
     pub(crate) async fn send(
         &self,
         recipients: &[Peer],
-        delivery_group_size: usize,
         wire_msg: WireMsg,
     ) -> Result<DeliveryStatus> {
         // todo: this type of task needs a send job, that we can come back to
 
         let msg_id = wire_msg.msg_id();
-        trace!(
-            "Sending message (msg_id: {:?}) to {} of {:?}",
-            msg_id,
-            delivery_group_size,
-            recipients
-        );
-
-        if recipients.len() < delivery_group_size {
-            warn!(
-                "Less than delivery_group_size valid recipients - delivery_group_size: {}, recipients: {:?}",
-                delivery_group_size,
-                recipients,
-            );
-        }
-
-        let delivery_group_size = delivery_group_size.min(recipients.len());
+        trace!("Sending message (msg_id: {:?}) to {:?}", msg_id, recipients);
 
         if recipients.is_empty() {
             return Err(Error::EmptyRecipientList);
@@ -353,7 +337,7 @@ impl Comm {
         // Run all the sends concurrently (using `FuturesUnordered`). If any of them fails, pick
         // the next recipient and try to send to them. Proceed until the needed number of sends
         // succeeds or if there are no more recipients to pick.
-        let mut tasks: FuturesUnordered<_> = recipients[0..delivery_group_size]
+        let mut tasks: FuturesUnordered<_> = recipients
             .iter()
             .map(|recipient| {
                 let mut msg = wire_msg.clone();
@@ -362,6 +346,7 @@ impl Comm {
             })
             .collect();
 
+        let delivery_group_size = recipients.len();
         let mut next = delivery_group_size;
         let mut successes = 0;
         let mut failed_recipients = vec![];
@@ -457,15 +442,11 @@ impl Comm {
             if failed_recipients.is_empty() {
                 Ok(DeliveryStatus::AllRecipients)
             } else {
-                Ok(DeliveryStatus::MinDeliveryGroupSizeReached(
-                    failed_recipients,
-                ))
+                Ok(DeliveryStatus::DeliveredToAll(failed_recipients))
             }
         } else {
             // todo: is this really a success case..?
-            Ok(DeliveryStatus::MinDeliveryGroupSizeFailed(
-                failed_recipients,
-            ))
+            Ok(DeliveryStatus::FailedToDeliverAll(failed_recipients))
         }
     }
 
@@ -633,8 +614,8 @@ pub(crate) enum MsgEvent {
 #[derive(Debug, Clone)]
 pub(crate) enum DeliveryStatus {
     AllRecipients,
-    MinDeliveryGroupSizeReached(Vec<Peer>),
-    MinDeliveryGroupSizeFailed(Vec<Peer>),
+    DeliveredToAll(Vec<Peer>),
+    FailedToDeliverAll(Vec<Peer>),
 }
 
 #[cfg(test)]
@@ -675,9 +656,7 @@ mod tests {
 
                 let original_message = new_test_msg()?;
 
-                let status = comm
-                    .send(&[peer0, peer1], 2, original_message.clone())
-                    .await?;
+                let status = comm.send(&[peer0, peer1], original_message.clone()).await?;
 
                 assert_matches!(status, DeliveryStatus::AllRecipients);
 
@@ -718,9 +697,7 @@ mod tests {
                 let (peer1, mut rx1) = new_peer().await?;
 
                 let original_message = new_test_msg()?;
-                let status = comm
-                    .send(&[peer0, peer1], 1, original_message.clone())
-                    .await?;
+                let status = comm.send(&[peer0, peer1], original_message.clone()).await?;
 
                 assert_matches!(status, DeliveryStatus::AllRecipients);
 
@@ -765,11 +742,11 @@ mod tests {
                 let invalid_peer = get_invalid_peer().await?;
                 let invalid_addr = invalid_peer.addr();
 
-                let status = comm.send(&[invalid_peer], 1, new_test_msg()?).await?;
+                let status = comm.send(&[invalid_peer], new_test_msg()?).await?;
 
                 assert_matches!(
                     &status,
-                    &DeliveryStatus::MinDeliveryGroupSizeFailed(_) => vec![invalid_addr]
+                    &DeliveryStatus::FailedToDeliverAll(_) => vec![invalid_addr]
                 );
 
                 Result::<()>::Ok(())
@@ -783,38 +760,40 @@ mod tests {
         let local = tokio::task::LocalSet::new();
 
         // Run the local task set.
-        local.run_until(async move {
-            let (tx, _rx) = mpsc::channel(1);
-            let comm = Comm::first_node(
-                local_addr(),
-                Config {
-                    idle_timeout: Some(Duration::from_millis(1)),
-                    ..Config::default()
-                },
-                RateLimits::new(),
-                tx,
-            )
-            .await?;
-            let (peer, mut rx) = new_peer().await?;
-            let invalid_peer = get_invalid_peer().await?;
+        local
+            .run_until(async move {
+                let (tx, _rx) = mpsc::channel(1);
+                let comm = Comm::first_node(
+                    local_addr(),
+                    Config {
+                        idle_timeout: Some(Duration::from_millis(1)),
+                        ..Config::default()
+                    },
+                    RateLimits::new(),
+                    tx,
+                )
+                .await?;
+                let (peer, mut rx) = new_peer().await?;
+                let invalid_peer = get_invalid_peer().await?;
 
-            let message = new_test_msg()?;
-            let status = comm.send(&[invalid_peer, peer], 1, message.clone()).await?;
-            assert_matches!(status, DeliveryStatus::MinDeliveryGroupSizeReached(failed_recipients) => {
-                assert_eq!(&failed_recipients, &[invalid_peer])
-            });
+                let message = new_test_msg()?;
+                let status = comm.send(&[invalid_peer, peer], message.clone()).await?;
+                assert_matches!(status, DeliveryStatus::DeliveredToAll(failed_recipients) => {
+                    assert_eq!(&failed_recipients, &[invalid_peer])
+                });
 
-            if let Some(bytes) = rx.recv().await {
-                // the dst location name is updated per sender, so
-                // we need to update that here before we check
-                let mut check_msg = message.clone();
-                check_msg.set_dst_xorname(peer.name());
+                if let Some(bytes) = rx.recv().await {
+                    // the dst location name is updated per sender, so
+                    // we need to update that here before we check
+                    let mut check_msg = message.clone();
+                    check_msg.set_dst_xorname(peer.name());
 
-                assert_eq!(WireMsg::from(bytes)?, check_msg);
-            }
+                    assert_eq!(WireMsg::from(bytes)?, check_msg);
+                }
 
-            Result::<()>::Ok(())
-        }).await
+                Result::<()>::Ok(())
+            })
+            .await
     }
 
     #[tokio::test]
@@ -840,11 +819,11 @@ mod tests {
                 let invalid_peer = get_invalid_peer().await?;
 
                 let message = new_test_msg()?;
-                let status = comm.send(&[invalid_peer, peer], 2, message.clone()).await?;
+                let status = comm.send(&[invalid_peer, peer], message.clone()).await?;
 
                 assert_matches!(
                     status,
-                    DeliveryStatus::MinDeliveryGroupSizeFailed(_) => vec![invalid_peer]
+                    DeliveryStatus::FailedToDeliverAll(_) => vec![invalid_peer]
                 );
 
                 if let Some(bytes) = rx.recv().await {
@@ -880,7 +859,7 @@ mod tests {
 
                 let msg0 = new_test_msg()?;
                 let status = send_comm
-                    .send(&[Peer::new(name, recv_addr)], 1, msg0.clone())
+                    .send(&[Peer::new(name, recv_addr)], msg0.clone())
                     .await?;
                 assert_matches!(status, DeliveryStatus::AllRecipients);
 
@@ -905,7 +884,7 @@ mod tests {
 
                 let msg1 = new_test_msg()?;
                 let status = send_comm
-                    .send(&[Peer::new(name, recv_addr)], 1, msg1.clone())
+                    .send(&[Peer::new(name, recv_addr)], msg1.clone())
                     .await?;
                 assert_matches!(status, DeliveryStatus::AllRecipients);
 
@@ -952,7 +931,6 @@ mod tests {
                 let status = comm1
                     .send(
                         &[Peer::new(xor_name::rand::random(), addr0)],
-                        1,
                         new_test_msg()?,
                     )
                     .await?;

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -132,7 +132,7 @@ impl Node {
     // Send message to peers on the network.
     pub(crate) fn send_msg_on_to_nodes(&self, mut wire_msg: WireMsg) -> Result<Option<Cmd>> {
         let dst_location = wire_msg.dst_location();
-        let (targets, dg_size) = delivery_group::delivery_targets(
+        let (targets, _dg_size) = delivery_group::delivery_targets(
             dst_location,
             &self.info().name(),
             &self.network_knowledge,
@@ -154,9 +154,8 @@ impl Node {
         }
 
         trace!(
-            "relay {:?} to first {:?} of {:?} (Section PK: {:?})",
+            "relay {:?} to {:?} (Section PK: {:?})",
             wire_msg,
-            dg_size,
             targets,
             wire_msg.src_section_pk(),
         );
@@ -164,9 +163,8 @@ impl Node {
         let dst_pk = self.section_key_by_name(&target_name);
         wire_msg.set_dst_section_pk(dst_pk);
 
-        let cmd = Cmd::SendMsgDeliveryGroup {
+        let cmd = Cmd::SendMsg {
             recipients: targets.into_iter().collect(),
-            delivery_group_size: dg_size,
             wire_msg,
         };
 

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -516,13 +516,9 @@ async fn send_messages(
     comm: &Comm,
 ) -> Result<()> {
     while let Some((wire_msg, recipients)) = outgoing_msgs.recv().await {
-        match comm
-            .send(&recipients, recipients.len(), wire_msg.clone())
-            .await
-        {
-            Ok(DeliveryStatus::AllRecipients)
-            | Ok(DeliveryStatus::MinDeliveryGroupSizeReached(_)) => {}
-            Ok(DeliveryStatus::MinDeliveryGroupSizeFailed(recipients)) => {
+        match comm.send(&recipients, wire_msg.clone()).await {
+            Ok(DeliveryStatus::AllRecipients) | Ok(DeliveryStatus::DeliveredToAll(_)) => {}
+            Ok(DeliveryStatus::FailedToDeliverAll(recipients)) => {
                 error!("Failed to send message {:?} to {:?}", wire_msg, recipients)
             }
             Err(err) => {

--- a/sn_node/src/node/node_api/cmds.rs
+++ b/sn_node/src/node/node_api/cmds.rs
@@ -158,13 +158,6 @@ pub(crate) enum Cmd {
     /// Performs serialisation and signing for sending of NodeMsg.
     /// This cmd only send this to other nodes
     SignOutgoingSystemMsg { msg: SystemMsg, dst: DstLocation },
-    /// Send a message to `delivery_group_size` peers out of the given `recipients`,
-    /// Keeps trying to send until `delivery_group_size` have been reached
-    SendMsgDeliveryGroup {
-        recipients: Vec<Peer>,
-        delivery_group_size: usize,
-        wire_msg: WireMsg,
-    },
     /// Schedule a timeout after the given duration. When the timeout expires, a `HandleDkgTimeout`
     /// cmd is raised. The token is used to identify the timeout.
     ScheduleDkgTimeout { duration: Duration, token: u64 },
@@ -209,7 +202,6 @@ impl Cmd {
             HandleValidServiceMsg { msg, .. } => msg.priority(),
             SendMsg { wire_msg, .. } => wire_msg.priority(),
             SignOutgoingSystemMsg { msg, .. } => msg.priority(),
-            SendMsgDeliveryGroup { wire_msg, .. } => wire_msg.priority(),
 
             ValidateMsg { .. } => -9, // before it's validated, we cannot give it high prio, as it would be a spam vector
         }
@@ -265,19 +257,6 @@ impl fmt::Display for Cmd {
             }
             Cmd::SignOutgoingSystemMsg { .. } => write!(f, "SignOutgoingSystemMsg"),
             Cmd::EnqueueDataForReplication { .. } => write!(f, "ThrottledSendBatchMsgs"),
-            #[cfg(not(feature = "test-utils"))]
-            Cmd::SendMsgDeliveryGroup { wire_msg, .. } => {
-                write!(f, "SendMsgDeliveryGroup {:?}", wire_msg.msg_id())
-            }
-            #[cfg(feature = "test-utils")]
-            Cmd::SendMsgDeliveryGroup { wire_msg, .. } => {
-                write!(
-                    f,
-                    "SendMsg {:?} {:?}",
-                    wire_msg.msg_id(),
-                    wire_msg.payload_debug
-                )
-            }
             Cmd::ProposeOffline(_) => write!(f, "ProposeOffline"),
             Cmd::StartConnectivityTest(_) => write!(f, "StartConnectivityTest"),
             Cmd::TestConnectivity(_) => write!(f, "TestConnectivity"),


### PR DESCRIPTION
This is not needed or really utilised in any real way.

We can just use SendMsg cmds

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
