### PR TITLE
sn_node OTLP support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,9 +736,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c5fd425783d81668ed68ec98408a80498fb4ae2fd607797539e1a9dfa3618f"
 dependencies = [
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
+ "tonic 0.7.2",
  "tracing-core",
 ]
 
@@ -754,13 +754,13 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "humantime",
- "prost-types",
+ "prost-types 0.10.1",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.7.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.14",
@@ -1235,6 +1235,12 @@ dependencies = [
  "redox_syscall",
  "windows-sys",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -2057,6 +2063,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,6 +2171,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "prost 0.9.0",
+ "thiserror",
+ "tokio",
+ "tonic 0.6.2",
+ "tonic-build",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
 name = "os_pipe"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2318,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -2427,12 +2497,55 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.10.1",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools 0.10.3",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.3",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2450,12 +2563,22 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost 0.9.0",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.10.4",
 ]
 
 [[package]]
@@ -3530,6 +3653,9 @@ dependencies = [
  "lazy_static",
  "multibase",
  "num_cpus",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "priority-queue",
  "proptest",
  "qp2p",
@@ -3561,6 +3687,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-core",
+ "tracing-opentelemetry",
  "tracing-subscriber 0.3.14",
  "uluru",
  "url",
@@ -3863,7 +3990,10 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",
@@ -3953,6 +4083,37 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
@@ -3971,8 +4132,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.10.4",
+ "prost-derive 0.10.1",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.2",
@@ -3981,6 +4142,18 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4108,6 +4281,20 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.14",
 ]
 
 [[package]]
@@ -4440,6 +4627,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -29,6 +29,7 @@ back-pressure = ["sn_interface/back-pressure"]
 unstable-wiremsg-debuginfo = []
 # Needs to be built with RUSTFLAGS="--cfg tokio_unstable"
 tokio-console = ["console-subscriber"]
+otlp = [ "opentelemetry", "opentelemetry-otlp", "opentelemetry-semantic-conventions", "tracing-opentelemetry" ]
 
 [dependencies]
 backoff = { version = "~0.4.0", features = [ "tokio" ] }
@@ -55,6 +56,9 @@ itertools = "~0.10.0"
 lazy_static = "1"
 multibase = "~0.9.1"
 num_cpus = "1.13.0"
+opentelemetry = { version = "0.17", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.10", optional = true }
+opentelemetry-semantic-conventions = { version = "0.9.0", optional = true }
 priority-queue = "1.2.1"
 qp2p = "~0.28.3"
 rand = "~0.8"
@@ -83,6 +87,7 @@ tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-appender = "~0.2.0"
+tracing-opentelemetry = { version = "0.17", optional = true }
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 uluru="3.0.0"
 url = "2.2.0"

--- a/sn_node/README.md
+++ b/sn_node/README.md
@@ -1,9 +1,33 @@
-# safe_network
+# sn_node
 
-The Safe Network Core. API message definitions, routing and nodes, client core api.
+The Safe Network Node Implementation.
 
-| [![](https://img.shields.io/crates/v/sn_client)](https://crates.io/crates/sn_client) | [![Documentation](https://docs.rs/sn_client/badge.svg)](https://docs.rs/sn_client) |
-|:----------:|:----------:|
+## Building
+
+### OpenTelemetry Protocol (OTLP)
+
+OTLP allows for inspecting and visualizing log spans.
+
+By specifying the `otlp` feature for the `sn_node` binary, logs will be sent to an OTLP endpoint. This endpoint can be configured by environment variables. (See [opentelemetry.io/docs/...](https://opentelemetry.io/docs/reference/specification/protocol/exporter/) for more information.)
+
+```sh
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" # Already the default
+export RUST_LOG=sn_node=info # This filters the output for stdout/files, not OTLP
+export RUST_LOG_OTLP=sn_node=trace # This filters what is sent to OTLP endpoint 
+cargo run --release --bin sn_node --features otlp -- --first --skip-auto-port-forwarding --local-addr=127.0.0.1:0
+```
+
+Before running the node, an OTLP endpoint should be available. An example of an OTLP-supporting endpoint is Jaeger, which can be launched with Docker like this (see [documentation](https://www.jaegertracing.io/docs/1.36/getting-started/#all-in-one)):
+```
+docker run --name jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:1.36
+```
+
+In the web interface of Jaeger (http://localhost:16686) one can filter several things, e.g. the tag `service.instance.id=<PID>`, where PID is the process ID of the node. The service name is `sn_node`.
 
 ## License
 

--- a/sn_node/src/bin/sn_node/main.rs
+++ b/sn_node/src/bin/sn_node/main.rs
@@ -32,12 +32,11 @@ use sn_node::node::{start_node, Config, Error as NodeError, Event, MembershipEve
 use clap::{CommandFactory, Parser};
 use clap_complete::{generate, Shell};
 use color_eyre::{Section, SectionExt};
-use eyre::Error;
 use eyre::{eyre, Context, ErrReport, Result};
 use self_update::{cargo_crate_version, Status};
 use std::{io::Write, process::exit};
 use tokio::time::{sleep, Duration};
-use tracing::{self, debug, error, info, trace, warn};
+use tracing::{self, error, info, trace, warn};
 
 const JOIN_TIMEOUT_SEC: u64 = 30;
 const BOOTSTRAP_RETRY_TIME_SEC: u64 = 5;
@@ -46,31 +45,8 @@ mod log;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    #[cfg(feature = "tokio-console")]
-    console_subscriber::init();
 
-    // first, let's grab the config. We do this outwith of the node, so we can init logging
-    // with the config, and so it can persists across node restarts
-    let config_rt = tokio::runtime::Runtime::new()?;
-    let config = config_rt.block_on(Config::new())?;
-    // shut down this runtime, we do not need it anymore
-    config_rt.shutdown_timeout(Duration::from_secs(1));
-
-    trace!("Initial node config: {config:?}");
-
-    let _guard = log::init_node_logging(&config).map_err(Error::from)?;
-
-    loop {
-        create_runtime_and_node()?;
-    }
-}
-
-/// Create a tokio runtime per `run_node` instance.
-///
-fn create_runtime_and_node() -> Result<()> {
-    info!("Node runtime started");
-
-    // start a new runtime for a node.
+    // Create a new runtime for a node
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .thread_name("sn_node")
@@ -78,39 +54,43 @@ fn create_runtime_and_node() -> Result<()> {
         .thread_stack_size(16 * 1024 * 1024)
         .build()?;
 
-    let _res = rt.block_on(async move {
-        // pull config again in case it has been updated meanwhile
-        let config = Config::new().await?;
+    rt.block_on(async {
+        let mut config = Config::new().await?;
+        let _guard = log::init_node_logging(&config)?;
+        trace!("Initial node config: {config:?}");
 
-        let local = tokio::task::LocalSet::new();
+        loop {
+            info!("Node runtime started");
+            create_runtime_and_node(&config).await?;
 
-        local
-            .run_until(async move {
-                // we want logging to persist
-                // loops ready to catch any ChurnJoinMiss
-                match run_node(config).await {
-                    Ok(_) => {
-                        info!("Node has finished running, no runtime errors were reported");
-                    }
-                    Err(error) => {
-                        warn!("Node instance finished with an error: {error:?}");
-                    }
-                };
-            })
-            .await;
+            // pull config again in case it has been updated meanwhile
+            config = Config::new().await?;
+        }
+    })
+}
 
-        Result::<(), NodeError>::Ok(())
-    });
+/// Create a tokio runtime per `run_node` instance.
+async fn create_runtime_and_node(config: &Config) -> Result<()> {
+    let local = tokio::task::LocalSet::new();
 
-    info!("Shutting down node runtime");
+    local
+        .run_until(async move {
+            // loops ready to catch any ChurnJoinMiss
+            match run_node(config).await {
+                Ok(_) => {
+                    info!("Node has finished running, no runtime errors were reported");
+                }
+                Err(error) => {
+                    warn!("Node instance finished with an error: {error:?}");
+                }
+            };
+        })
+        .await;
 
-    // doesn't really matter the outcome here.
-    rt.shutdown_timeout(Duration::from_secs(2));
-    debug!("Node runtime should be shutdown now");
     Ok(())
 }
 
-async fn run_node(config: Config) -> Result<()> {
+async fn run_node(config: &Config) -> Result<()> {
     if let Some(c) = &config.completions() {
         let shell = c.parse().map_err(|err: String| eyre!(err))?;
         let buf = gen_completions_for_shell(shell, Config::command()).map_err(|err| eyre!(err))?;
@@ -150,7 +130,7 @@ async fn run_node(config: Config) -> Result<()> {
     let bootstrap_retry_duration = Duration::from_secs(BOOTSTRAP_RETRY_TIME_SEC);
 
     let (_ref, mut event_stream) = loop {
-        match start_node(&config, join_timeout).await {
+        match start_node(config, join_timeout).await {
             Ok(result) => break result,
             Err(NodeError::CannotConnectEndpoint(qp2p::EndpointError::Upnp(error))) => {
                 return Err(error).suggestion(


### PR DESCRIPTION
OTLP is a protocol that logs tracing spans to an endpoint. This OpenTelemetry Protocol is supported by quite some vendors that can process these logs.

At the moment, the OTLP logging layer for `tracing` seems to require it to be initialized within a Tokio runtime, which is why the node was refactored to start a main runtime that also instantiates the logging. This is because logging is integral to the startup and must be done early, so the runtime it is instantiated in also needs to be in or close to `main` in the node binary.