### PR TITLE
feat(traceroute): trace a message's flow in the network

### DIFF
--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -33,6 +33,7 @@ default = []
 chaos = []
 unstable-wiremsg-debuginfo = []
 test-utils = ["eyre"]
+traceroute = ["sn_interface/traceroute"]
 # Dependencies only when building binary (`query-adult`)
 build-bin = ["clap", "eyre"]
 

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -115,7 +115,13 @@ impl Client {
         };
 
         self.session
-            .send_cmd(dst_address, auth, serialised_cmd)
+            .send_cmd(
+                dst_address,
+                auth,
+                serialised_cmd,
+                #[cfg(feature = "traceroute")]
+                self.public_key(),
+            )
             .await
     }
 

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -128,6 +128,14 @@ impl Client {
             signature,
         };
 
-        self.session.send_query(query, auth, serialised_query).await
+        self.session
+            .send_query(
+                query,
+                auth,
+                serialised_query,
+                #[cfg(feature = "traceroute")]
+                self.public_key(),
+            )
+            .await
     }
 }

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -106,7 +106,18 @@ impl Session {
     ) -> Result<Option<MsgType>, Error> {
         if let Some(msg) = incoming_msgs.next().await? {
             trace!("Incoming msg from {:?}", src);
-            let msg_type = WireMsg::deserialize(msg)?;
+            let wire_msg = WireMsg::from(msg)?;
+            let msg_type = wire_msg.into_msg()?;
+
+            #[cfg(feature = "traceroute")]
+            {
+                info!(
+                    "Message {} with the Traceroute received at client: {:?}", msg_type,
+                    wire_msg.show_trace()
+                )
+            }
+
+
             Ok(Some(msg_type))
         } else {
             Ok(None)

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -112,11 +112,11 @@ impl Session {
             #[cfg(feature = "traceroute")]
             {
                 info!(
-                    "Message {} with the Traceroute received at client: {:?}", msg_type,
+                    "Message {} with the Traceroute received at client: {:?}",
+                    msg_type,
                     wire_msg.show_trace()
                 )
             }
-
 
             Ok(Some(msg_type))
         } else {

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -196,6 +196,8 @@ impl Session {
             section_pk,
         };
         let auth_kind = AuthKind::Service(auth);
+
+        #[allow(unused_mut)]
         let mut wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
 
         #[cfg(feature = "traceroute")]

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -16,6 +16,7 @@ back-pressure = []
 chunks = []
 registers = []
 spentbook = []
+traceroute = []
 test-utils=["proptest"]
 
 [dependencies]

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -170,10 +170,14 @@ impl Display for ServiceMsg {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             ServiceMsg::Cmd(cmd) => write!(f, "ServiceMsg::Cmd({:?})", cmd),
-            ServiceMsg::CmdAck{ correlation_id } => write!(f, "ServiceMsg::CmdAck({:?})", correlation_id),
-            ServiceMsg::CmdError{ error, .. } => write!(f, "ServiceMsg::CmdError({:?})", error),
+            ServiceMsg::CmdAck { correlation_id } => {
+                write!(f, "ServiceMsg::CmdAck({:?})", correlation_id)
+            }
+            ServiceMsg::CmdError { error, .. } => write!(f, "ServiceMsg::CmdError({:?})", error),
             ServiceMsg::Query(query) => write!(f, "ServiceMsg::Query({:?})", query),
-            ServiceMsg::QueryResponse{ response, .. } => write!(f, "ServiceMsg::QueryResponse({:?})", response),
+            ServiceMsg::QueryResponse { response, .. } => {
+                write!(f, "ServiceMsg::QueryResponse({:?})", response)
+            }
             ServiceMsg::ServiceError(error) => write!(f, "ServiceMsg::ServiceError({:?})", error),
         }
     }

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -166,6 +166,19 @@ impl ServiceMsg {
     }
 }
 
+impl Display for ServiceMsg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ServiceMsg::Cmd(cmd) => write!(f, "ServiceMsg::Cmd({:?})", cmd),
+            ServiceMsg::CmdAck{ correlation_id } => write!(f, "ServiceMsg::CmdAck({:?})", correlation_id),
+            ServiceMsg::CmdError{ error, .. } => write!(f, "ServiceMsg::CmdError({:?})", error),
+            ServiceMsg::Query(query) => write!(f, "ServiceMsg::Query({:?})", query),
+            ServiceMsg::QueryResponse{ response, .. } => write!(f, "ServiceMsg::QueryResponse({:?})", response),
+            ServiceMsg::ServiceError(error) => write!(f, "ServiceMsg::ServiceError({:?})", error),
+        }
+    }
+}
+
 /// An error response to a [`Cmd`].
 ///
 /// [`Cmd`]: ServiceMsg::Cmd

--- a/sn_interface/src/messaging/mod.rs
+++ b/sn_interface/src/messaging/mod.rs
@@ -52,3 +52,6 @@ pub use self::{
     sap::SectionAuthorityProvider,
     serialisation::{NodeMsgAuthority, WireMsg},
 };
+
+#[cfg(feature = "traceroute")]
+pub use self::serialisation::Entity;

--- a/sn_interface/src/messaging/msg_type.rs
+++ b/sn_interface/src/messaging/msg_type.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use std::fmt::{Display, Formatter};
 use super::{
     data::ServiceMsg, system::SystemMsg, AuthorityProof, DstLocation, MsgId, NodeMsgAuthority,
     ServiceAuth,
@@ -71,6 +72,15 @@ impl MsgType {
             // client <-> node service comms
             #[cfg(any(feature = "chunks", feature = "registers"))]
             MsgType::Service { msg, .. } => msg.priority(),
+        }
+    }
+}
+
+impl Display for MsgType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MsgType::System { msg, .. } => write!(f, "MsgType::System({})", msg),
+            MsgType::Service { msg, .. } => write!(f, "MsgType::Service({})", msg),
         }
     }
 }

--- a/sn_interface/src/messaging/msg_type.rs
+++ b/sn_interface/src/messaging/msg_type.rs
@@ -6,11 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::fmt::{Display, Formatter};
 use super::{
     data::ServiceMsg, system::SystemMsg, AuthorityProof, DstLocation, MsgId, NodeMsgAuthority,
     ServiceAuth,
 };
+use std::fmt::{Display, Formatter};
 
 // highest priority, since we must sort out membership first of all
 pub(crate) const DKG_MSG_PRIORITY: i32 = 8;

--- a/sn_interface/src/messaging/serialisation/mod.rs
+++ b/sn_interface/src/messaging/serialisation/mod.rs
@@ -17,6 +17,9 @@ use super::{AuthorityProof, BlsShareAuth, NodeAuth, SectionAuth};
 
 use xor_name::XorName;
 
+#[cfg(feature = "traceroute")]
+pub use self::wire_msg::Entity;
+
 /// Authority of a `NodeMsg`.
 /// Src of message and authority to send it. Authority is validated by the signature.
 #[derive(Eq, PartialEq, Debug, Clone)]

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -44,7 +44,7 @@ pub struct WireMsg {
 }
 
 #[cfg(feature = "traceroute")]
-/// PublicKey of the entity that created/handled it's associated WireMsg
+/// PublicKey of the entity that created/handled its associated WireMsg
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Entity {
     Elder(PublicKey),

--- a/sn_interface/src/messaging/serialisation/wire_msg_header.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg_header.rs
@@ -16,6 +16,9 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::mem::size_of;
 
+#[cfg(feature = "traceroute")]
+use crate::messaging::Entity;
+
 // Current version of the messaging protocol.
 // At this point this implementation supports only this version.
 const MESSAGING_PROTO_VERSION: u16 = 1u16;
@@ -40,6 +43,8 @@ pub struct MsgEnvelope {
     pub msg_id: MsgId,
     pub auth_kind: AuthKind,
     pub dst_location: DstLocation,
+    #[cfg(feature = "traceroute")]
+    pub traceroute: Vec<Entity>,
 }
 
 // The first two fields in the header. This is not part of the public interface.
@@ -73,7 +78,12 @@ lazy_static! {
 
 impl WireMsgHeader {
     // Instantiate a WireMsgHeader as per current supported version.
-    pub fn new(msg_id: MsgId, auth_kind: AuthKind, dst_location: DstLocation) -> Self {
+    pub fn new(
+        msg_id: MsgId,
+        auth_kind: AuthKind,
+        dst_location: DstLocation,
+        #[cfg(feature = "traceroute")] traceroute: Vec<Entity>,
+    ) -> Self {
         Self {
             //header_size: Self::max_size(),
             version: MESSAGING_PROTO_VERSION,
@@ -81,6 +91,8 @@ impl WireMsgHeader {
                 msg_id,
                 auth_kind,
                 dst_location,
+                #[cfg(feature = "traceroute")]
+                traceroute,
             },
         }
     }

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -267,39 +267,47 @@ impl SystemMsg {
 impl Display for SystemMsg {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            SystemMsg::AntiEntropyRetry{ .. } => write!(f, "SystemMsg::AntiEntropyRetry"),
-            SystemMsg::AntiEntropyRedirect{ .. } => write!(f, "SystemMsg::AntiEntropyRedirect"),
-            SystemMsg::AntiEntropyUpdate{ .. } => write!(f, "SystemMsg::AntiEntropyUpdate"),
-            SystemMsg::AntiEntropyProbe{ .. } => write!(f, "SystemMsg::AntiEntropyProbe"),
-            SystemMsg::Relocate{ .. } => write!(f, "SystemMsg::Relocate"),
-            SystemMsg::MembershipVotes{ .. } => write!(f, "SystemMsg::MembershipVotes"),
-            SystemMsg::MembershipAE{ .. } => write!(f, "SystemMsg::MembershipAE"),
-            SystemMsg::JoinRequest{ .. } => write!(f, "SystemMsg::JoinRequest"),
-            SystemMsg::JoinResponse{ .. } => write!(f, "SystemMsg::JoinResponse"),
-            SystemMsg::JoinAsRelocatedRequest{ .. } => write!(f, "SystemMsg::JoinAsRelocatedRequest"),
-            SystemMsg::JoinAsRelocatedResponse{ .. } => write!(f, "SystemMsg::JoinAsRelocatedResponse"),
-            SystemMsg::DkgStart{ .. } => write!(f, "SystemMsg::DkgStart"),
-            SystemMsg::DkgSessionUnknown{ .. } => write!(f, "SystemMsg::DkgSessionUnknown"),
-            SystemMsg::DkgSessionInfo{ .. } => write!(f, "SystemMsg::DkgSessionInfo"),
-            SystemMsg::DkgMessage{ .. } => write!(f, "SystemMsg::DkgMessage"),
-            SystemMsg::DkgNotReady{ .. } => write!(f, "SystemMsg::DkgNotReady"),
-            SystemMsg::DkgRetry{ .. } => write!(f, "SystemMsg::DkgRetry"),
-            SystemMsg::DkgFailureObservation{ .. } => write!(f, "SystemMsg::DkgFailureObservation"),
-            SystemMsg::DkgFailureAgreement{ .. } => write!(f, "SystemMsg::DkgFailureAgreement"),
-            SystemMsg::HandoverVotes{ .. } => write!(f, "SystemMsg::HandoverVotes"),
-            SystemMsg::HandoverAE{ .. } => write!(f, "SystemMsg::HandoverAE"),
-            SystemMsg::Propose{ .. } => write!(f, "SystemMsg::Propose"),
-            SystemMsg::StartConnectivityTest{ .. } => write!(f, "SystemMsg::StartConnectivityTest"),
-            SystemMsg::NodeEvent{ .. } => write!(f, "SystemMsg::NodeEvent"),
-            SystemMsg::NodeMsgError{ .. } => write!(f, "SystemMsg::NodeMsgError"),
+            SystemMsg::AntiEntropyRetry { .. } => write!(f, "SystemMsg::AntiEntropyRetry"),
+            SystemMsg::AntiEntropyRedirect { .. } => write!(f, "SystemMsg::AntiEntropyRedirect"),
+            SystemMsg::AntiEntropyUpdate { .. } => write!(f, "SystemMsg::AntiEntropyUpdate"),
+            SystemMsg::AntiEntropyProbe { .. } => write!(f, "SystemMsg::AntiEntropyProbe"),
+            SystemMsg::Relocate { .. } => write!(f, "SystemMsg::Relocate"),
+            SystemMsg::MembershipVotes { .. } => write!(f, "SystemMsg::MembershipVotes"),
+            SystemMsg::MembershipAE { .. } => write!(f, "SystemMsg::MembershipAE"),
+            SystemMsg::JoinRequest { .. } => write!(f, "SystemMsg::JoinRequest"),
+            SystemMsg::JoinResponse { .. } => write!(f, "SystemMsg::JoinResponse"),
+            SystemMsg::JoinAsRelocatedRequest { .. } => {
+                write!(f, "SystemMsg::JoinAsRelocatedRequest")
+            }
+            SystemMsg::JoinAsRelocatedResponse { .. } => {
+                write!(f, "SystemMsg::JoinAsRelocatedResponse")
+            }
+            SystemMsg::DkgStart { .. } => write!(f, "SystemMsg::DkgStart"),
+            SystemMsg::DkgSessionUnknown { .. } => write!(f, "SystemMsg::DkgSessionUnknown"),
+            SystemMsg::DkgSessionInfo { .. } => write!(f, "SystemMsg::DkgSessionInfo"),
+            SystemMsg::DkgMessage { .. } => write!(f, "SystemMsg::DkgMessage"),
+            SystemMsg::DkgNotReady { .. } => write!(f, "SystemMsg::DkgNotReady"),
+            SystemMsg::DkgRetry { .. } => write!(f, "SystemMsg::DkgRetry"),
+            SystemMsg::DkgFailureObservation { .. } => {
+                write!(f, "SystemMsg::DkgFailureObservation")
+            }
+            SystemMsg::DkgFailureAgreement { .. } => write!(f, "SystemMsg::DkgFailureAgreement"),
+            SystemMsg::HandoverVotes { .. } => write!(f, "SystemMsg::HandoverVotes"),
+            SystemMsg::HandoverAE { .. } => write!(f, "SystemMsg::HandoverAE"),
+            SystemMsg::Propose { .. } => write!(f, "SystemMsg::Propose"),
+            SystemMsg::StartConnectivityTest { .. } => {
+                write!(f, "SystemMsg::StartConnectivityTest")
+            }
+            SystemMsg::NodeEvent { .. } => write!(f, "SystemMsg::NodeEvent"),
+            SystemMsg::NodeMsgError { .. } => write!(f, "SystemMsg::NodeMsgError"),
             #[cfg(any(feature = "chunks", feature = "registers"))]
-            SystemMsg::NodeCmd{ .. } => write!(f, "SystemMsg::NodeCmd"),
+            SystemMsg::NodeCmd { .. } => write!(f, "SystemMsg::NodeCmd"),
             #[cfg(any(feature = "chunks", feature = "registers"))]
-            SystemMsg::NodeQuery{ .. } => write!(f, "SystemMsg::NodeQuery"),
+            SystemMsg::NodeQuery { .. } => write!(f, "SystemMsg::NodeQuery"),
             #[cfg(any(feature = "chunks", feature = "registers"))]
-            SystemMsg::NodeQueryResponse{ .. } => write!(f, "SystemMsg::NodeQueryResponse"),
+            SystemMsg::NodeQueryResponse { .. } => write!(f, "SystemMsg::NodeQueryResponse"),
             #[cfg(feature = "back-pressure")]
-            SystemMsg::BackPressure{ .. } => write!(f, "SystemMsg::BackPressure"),
+            SystemMsg::BackPressure { .. } => write!(f, "SystemMsg::BackPressure"),
         }
     }
 }

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -34,6 +34,7 @@ use bytes::Bytes;
 use secured_linked_list::SecuredLinkedList;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+use std::fmt::{Display, Formatter};
 use xor_name::XorName;
 
 /// List of peers of a section
@@ -259,6 +260,46 @@ impl SystemMsg {
             | SystemMsg::NodeEvent(NodeEvent::CouldNotStoreData { .. })
             | SystemMsg::NodeQuery(_)
             | SystemMsg::NodeQueryResponse { .. } => NODE_DATA_MSG_PRIORITY,
+        }
+    }
+}
+
+impl Display for SystemMsg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SystemMsg::AntiEntropyRetry{ .. } => write!(f, "SystemMsg::AntiEntropyRetry"),
+            SystemMsg::AntiEntropyRedirect{ .. } => write!(f, "SystemMsg::AntiEntropyRedirect"),
+            SystemMsg::AntiEntropyUpdate{ .. } => write!(f, "SystemMsg::AntiEntropyUpdate"),
+            SystemMsg::AntiEntropyProbe{ .. } => write!(f, "SystemMsg::AntiEntropyProbe"),
+            SystemMsg::Relocate{ .. } => write!(f, "SystemMsg::Relocate"),
+            SystemMsg::MembershipVotes{ .. } => write!(f, "SystemMsg::MembershipVotes"),
+            SystemMsg::MembershipAE{ .. } => write!(f, "SystemMsg::MembershipAE"),
+            SystemMsg::JoinRequest{ .. } => write!(f, "SystemMsg::JoinRequest"),
+            SystemMsg::JoinResponse{ .. } => write!(f, "SystemMsg::JoinResponse"),
+            SystemMsg::JoinAsRelocatedRequest{ .. } => write!(f, "SystemMsg::JoinAsRelocatedRequest"),
+            SystemMsg::JoinAsRelocatedResponse{ .. } => write!(f, "SystemMsg::JoinAsRelocatedResponse"),
+            SystemMsg::DkgStart{ .. } => write!(f, "SystemMsg::DkgStart"),
+            SystemMsg::DkgSessionUnknown{ .. } => write!(f, "SystemMsg::DkgSessionUnknown"),
+            SystemMsg::DkgSessionInfo{ .. } => write!(f, "SystemMsg::DkgSessionInfo"),
+            SystemMsg::DkgMessage{ .. } => write!(f, "SystemMsg::DkgMessage"),
+            SystemMsg::DkgNotReady{ .. } => write!(f, "SystemMsg::DkgNotReady"),
+            SystemMsg::DkgRetry{ .. } => write!(f, "SystemMsg::DkgRetry"),
+            SystemMsg::DkgFailureObservation{ .. } => write!(f, "SystemMsg::DkgFailureObservation"),
+            SystemMsg::DkgFailureAgreement{ .. } => write!(f, "SystemMsg::DkgFailureAgreement"),
+            SystemMsg::HandoverVotes{ .. } => write!(f, "SystemMsg::HandoverVotes"),
+            SystemMsg::HandoverAE{ .. } => write!(f, "SystemMsg::HandoverAE"),
+            SystemMsg::Propose{ .. } => write!(f, "SystemMsg::Propose"),
+            SystemMsg::StartConnectivityTest{ .. } => write!(f, "SystemMsg::StartConnectivityTest"),
+            SystemMsg::NodeEvent{ .. } => write!(f, "SystemMsg::NodeEvent"),
+            SystemMsg::NodeMsgError{ .. } => write!(f, "SystemMsg::NodeMsgError"),
+            #[cfg(any(feature = "chunks", feature = "registers"))]
+            SystemMsg::NodeCmd{ .. } => write!(f, "SystemMsg::NodeCmd"),
+            #[cfg(any(feature = "chunks", feature = "registers"))]
+            SystemMsg::NodeQuery{ .. } => write!(f, "SystemMsg::NodeQuery"),
+            #[cfg(any(feature = "chunks", feature = "registers"))]
+            SystemMsg::NodeQueryResponse{ .. } => write!(f, "SystemMsg::NodeQueryResponse"),
+            #[cfg(feature = "back-pressure")]
+            SystemMsg::BackPressure{ .. } => write!(f, "SystemMsg::BackPressure"),
         }
     }
 }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -27,6 +27,7 @@ default = []
 chaos = []
 back-pressure = ["sn_interface/back-pressure"]
 unstable-wiremsg-debuginfo = []
+traceroute = ["sn_interface/traceroute"]
 # Needs to be built with RUSTFLAGS="--cfg tokio_unstable"
 tokio-console = ["console-subscriber"]
 

--- a/sn_node/src/node/data/records/mod.rs
+++ b/sn_node/src/node/data/records/mod.rs
@@ -37,7 +37,7 @@ impl Node {
     pub(crate) fn replicate_data(
         &self,
         data: ReplicatedData,
-        #[cfg(feature = "traceroute")] traceroute: Vec<Entity>,
+        #[cfg(feature = "traceroute")] mut traceroute: Vec<Entity>,
     ) -> Result<Vec<Cmd>> {
         trace!("{:?}: {:?}", LogMarker::DataStoreReceivedAtElder, data);
         if self.is_elder() {
@@ -54,7 +54,7 @@ impl Node {
                 msg,
                 targets,
                 #[cfg(feature = "traceroute")]
-                &mut traceroute.clone(),
+                &mut traceroute,
             )
         } else {
             Err(Error::InvalidState)
@@ -306,12 +306,13 @@ impl Node {
         };
 
         // separate this into form_wire_msg based on agg
+        #[allow(unused_mut)]
         let mut wire_msg = WireMsg::single_src(&self.info(), dummy_dst_location, msg, section_pk)?;
 
         #[cfg(feature = "traceroute")]
         {
             traceroute.push(Entity::Elder(PublicKey::Ed25519(
-                self.info().keypair.public.clone(),
+                self.info().keypair.public,
             )));
             wire_msg.add_trace(traceroute);
         }

--- a/sn_node/src/node/data/records/mod.rs
+++ b/sn_node/src/node/data/records/mod.rs
@@ -94,7 +94,13 @@ impl Node {
             let error = convert_to_error_msg(Error::NoAdults(self.network_knowledge().prefix()));
 
             debug!("No targets found for {msg_id:?}");
-            return self.send_cmd_error_response(CmdError::Data(error), origin, msg_id);
+            return self.send_cmd_error_response(
+                CmdError::Data(error),
+                origin,
+                msg_id,
+                #[cfg(feature = "traceroute")]
+                traceroute,
+            );
         }
 
         let mut op_was_already_underway = false;

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -27,6 +27,9 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Entity;
+
 /// A struct for the job of controlling the flow
 /// of a [`Cmd`] in the system.
 ///
@@ -110,6 +113,8 @@ pub(crate) enum Cmd {
         known_keys: Vec<bls::PublicKey>,
         #[debug(skip)]
         wire_msg_payload: Bytes,
+        #[cfg(feature = "traceroute")]
+        traceroute: Vec<Entity>,
     },
     HandleValidServiceMsg {
         msg_id: MsgId,
@@ -117,6 +122,8 @@ pub(crate) enum Cmd {
         origin: Peer,
         /// Requester's authority over this message
         auth: AuthorityProof<ServiceAuth>,
+        #[cfg(feature = "traceroute")]
+        traceroute: Vec<Entity>,
     },
     /// Handle a timeout previously scheduled with `ScheduleDkgTimeout`.
     HandleDkgTimeout(u64),
@@ -157,7 +164,12 @@ pub(crate) enum Cmd {
     },
     /// Performs serialisation and signing for sending of NodeMsg.
     /// This cmd only send this to other nodes
-    SignOutgoingSystemMsg { msg: SystemMsg, dst: DstLocation },
+    SignOutgoingSystemMsg {
+        msg: SystemMsg,
+        dst: DstLocation,
+        #[cfg(feature = "traceroute")]
+        traceroute: Vec<Entity>,
+    },
     /// Schedule a timeout after the given duration. When the timeout expires, a `HandleDkgTimeout`
     /// cmd is raised. The token is used to identify the timeout.
     ScheduleDkgTimeout { duration: Duration, token: u64 },

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -80,6 +80,8 @@ impl Dispatcher {
                 let node = self.node.read().await;
 
                 let src_section_pk = node.network_knowledge().section_key();
+
+                #[allow(unused_mut)]
                 let mut wire_msg = WireMsg::single_src(&node.info(), dst, msg, src_section_pk)?;
 
                 #[cfg(feature = "traceroute")]

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -96,6 +96,9 @@ impl Node {
                     return Ok(vec![ae_cmd]);
                 }
 
+                #[cfg(feature = "traceroute")]
+                let traceroute = wire_msg.show_trace();
+
                 Ok(vec![Cmd::HandleValidSystemMsg {
                     origin,
                     msg_id,
@@ -103,6 +106,8 @@ impl Node {
                     msg_authority,
                     known_keys,
                     wire_msg_payload,
+                    #[cfg(feature = "traceroute")]
+                    traceroute,
                 }])
             }
             MsgType::Service {
@@ -179,6 +184,8 @@ impl Node {
                     msg,
                     origin,
                     auth,
+                    #[cfg(feature = "traceroute")]
+                    traceroute: wire_msg.show_trace(),
                 }])
             }
         }

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -217,13 +217,15 @@ impl Node {
         // This is overwritten in comm.send_to_client
         let mut rng = thread_rng();
         let dst = DstLocation::EndUser(EndUser(xor_name::XorName::random(&mut rng)));
+
+        #[allow(unused_mut)]
         let mut wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst)?;
 
         #[cfg(feature = "traceroute")]
         {
             let mut trace = traceroute.clone();
             trace.push(Entity::Elder(PublicKey::Ed25519(
-                self.info().keypair.public.clone(),
+                self.info().keypair.public,
             )));
             wire_msg.add_trace(&mut trace);
         }

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -185,6 +185,7 @@ impl Node {
 
     // Handler for data messages which have successfully
     // passed all signature checks and msg verifications
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn handle_valid_system_msg(
         &mut self,
         msg_id: MsgId,

--- a/sn_node/src/node/messaging/update_section.rs
+++ b/sn_node/src/node/messaging/update_section.rs
@@ -123,6 +123,8 @@ impl Node {
                     NodeCmd::SendAnyMissingRelevantData(data_i_have.clone()).clone(),
                 ),
                 dst: DstLocation::Node { name, section_pk },
+                #[cfg(feature = "traceroute")]
+                traceroute: vec![],
             })
         }
 

--- a/testnet/Cargo.toml
+++ b/testnet/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.1.0"
 default = []
 # required to pass on flag to node builds
 chaos = []
+traceroute = []
 
 [[bin]]
 path="bin.rs"

--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -93,7 +93,7 @@ async fn main() -> Result<()> {
     // got resoved within the new version of Rust.
     #[cfg(not(target_os = "windows"))]
     // For Windows guys, rember to use
-    // `cargo build --release --features=test-utils --bins`
+    // `cargo build --release --bins`
     // before executing the testnet.exe.
     {
         let cmd_args = Cmd::from_args();
@@ -104,6 +104,13 @@ async fn main() -> Result<()> {
             println!("*** Building testnet with CHAOS enabled. Watch out. ***");
             build_args.push("--features");
             build_args.push("chaos");
+        }
+
+        // Keep features consistent to avoid recompiling when possible
+        if cfg!(feature = "traceroute") {
+            println!("*** Building testnet with TRACEROUTE enabled. Watch out for traces. ***");
+            build_args.push("--features");
+            build_args.push("traceroute");
         }
 
         if cfg!(feature = "unstable-wiremsg-debuginfo") {


### PR DESCRIPTION
Implements a feature to trace a message's flow through the network. `WireMsgHeader` piggybacks a list to which entities(Clients, Elders, Adults) attach their identities(PublicKey) wherever they process the message.

This is currently implemented for Client's queries, commands, and commandACKs(all of which fall under `ServiceMsg`). This will be extended to support inter-node messages(`SystemMsg`) in the near future.

Build and run with `--features=traceroute` to log traceroutes.