### PR TITLE
chore: Cleanup non-joined member sessions, regardless of connected st…

### DIFF
--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -24,7 +24,7 @@ use tracing::{debug, info_span};
 
 // We divide the total query timeout by this number.
 // This also represents the max retries possible, while still staying within the max_timeout.
-const MAX_RETRY_COUNT: f32 = 20.0;
+const MAX_RETRY_COUNT: f32 = 60.0;
 
 impl Client {
     /// Send a Query to the network and await a response.

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -25,14 +25,17 @@ use self::{
 use crate::node::{Error, RateLimits, Result};
 use peer_session::SendStatus;
 
-use sn_dysfunction::DysfunctionDetection;
-use sn_interface::{messaging::WireMsg, types::Peer};
+use sn_interface::{
+    messaging::{system::MembershipState, WireMsg},
+    network_knowledge::NodeState,
+    types::Peer,
+};
 
 use bytes::Bytes;
 use dashmap::DashMap;
 use futures::stream::{FuturesUnordered, StreamExt};
 use qp2p::{Endpoint, IncomingConnections};
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::BTreeSet, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{
     sync::mpsc::{self, Receiver, Sender},
     task,
@@ -119,34 +122,38 @@ impl Comm {
         self.our_endpoint.public_addr()
     }
 
-    pub(crate) async fn cleanup_peers(
-        &self,
-        retain_peers: Vec<Peer>,
-        mut dysfunction: DysfunctionDetection,
-    ) -> Result<()> {
+    pub(crate) async fn cleanup_peers(&self, section_members: BTreeSet<NodeState>) -> Result<()> {
+        debug!(
+            "Cleanup peers , known section members: {:?}",
+            section_members
+        );
+
         let mut peers_to_cleanup = vec![];
-        for entry in self.sessions.iter() {
-            let peer = entry.key();
-            let session = entry.value();
 
-            session.remove_expired().await;
+        let mut retain_peers = vec![];
 
-            let is_connected = session.is_connected();
-
-            if !is_connected {
-                if !retain_peers.contains(peer) {
-                    peers_to_cleanup.push(*peer);
-                }
-
-                dysfunction.track_issue(peer.name(), sn_dysfunction::IssueType::Communication)?;
+        // first lets look out for members only.
+        for member in section_members {
+            if MembershipState::Joined == member.state() {
+                retain_peers.push(member.name());
             }
         }
 
-        // cleanup any and all conns that are not connected
-        // TODO: check if we need to remove client conns manually, or if we can assume they're disconnected...
-        // Perhaps above a threshold we cleanup non-section conns?
+        // let mut peers_with_a_session_already = BTreeSet::default();
+        for entry in self.sessions.iter() {
+            let peer = entry.key();
+            let session = entry.value();
+            session.remove_expired().await;
+
+            if !retain_peers.contains(&peer.name()) {
+                peers_to_cleanup.push(*peer);
+            }
+        }
+
+        // cleanup any and all conns that are not active section members
         if !peers_to_cleanup.is_empty() {
             for peer in peers_to_cleanup {
+                debug!("cleaning up peer: {peer:?}");
                 let perhaps_peer = self.sessions.remove(&peer);
 
                 if let Some((_peer, session)) = perhaps_peer {
@@ -155,7 +162,7 @@ impl Comm {
             }
         }
 
-        debug!("PeerLink count post-cleanup: ${:?}", self.sessions.len());
+        debug!("PeerSessions count post-cleanup: {:?}", self.sessions.len());
         Ok(())
     }
 

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -61,10 +61,6 @@ impl PeerSession {
         }
     }
 
-    pub(crate) fn is_connected(&self) -> bool {
-        !self.channel.is_closed()
-    }
-
     // this must be restricted somehow, we can't allow an unbounded inflow
     // of connections from a peer...
     pub(crate) async fn add(&self, conn: qp2p::Connection) {

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -53,17 +53,8 @@ impl Dispatcher {
     pub(crate) async fn process_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
         match cmd {
             Cmd::CleanupPeerLinks => {
-                // Scoping access to the RwLock
-                let (elders, dysfunction_tracking) = {
-                    let node = self.node.read().await;
-                    (
-                        node.network_knowledge.elders(),
-                        node.dysfunction_tracking.clone(),
-                    )
-                };
-                self.comm
-                    .cleanup_peers(elders, dysfunction_tracking)
-                    .await?;
+                let members = { self.node.read().await.network_knowledge.section_members() };
+                self.comm.cleanup_peers(members).await?;
                 Ok(vec![])
             }
             Cmd::SignOutgoingSystemMsg { msg, dst } => {


### PR DESCRIPTION
…ate.

We've seen that we can get a crazy number of sessions (almost 1k), with no network activity if they are
never cleaned up. They may well still be conncted (but the node name cycles... so the conn lives on).

So here, anything not currently joined, is cleaned up. nodes we can reconnect to. clients can retry.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
