### PR TITLE
chore(tests): fix outdated comm tests

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -149,7 +149,6 @@ jobs:
           junit-path: junit.xml
           package: sn_interface
           release: true
-          filters: "messaging prefix_map types"
 
       - name: Run sn_dysfunction unit tests
         timeout-minutes: 15
@@ -170,7 +169,6 @@ jobs:
           junit-path: junit.xml
           package: sn_node
           release: true
-          filters: "dbs node routing"
 
       - name: Run CLI unit tests
         uses: maidsafe/cargo-nextest@main


### PR DESCRIPTION
- `sn_node::comm::send_to_subset` test was failing because of the changes to delivery_group_size
where we do not have subset sends anymore. Therefore this test has been removed.

- this commit also removes old filters from GHA workflow which prevented running
all the tests under sn_node and sn_interface.