### PR TITLE
chore: upgrade blsttc to 7.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "bls_dkg"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defbd49a1a2f8ab594dfbf50d4b5066027128ef8aee77e5c12f41194fec86262"
+checksum = "37c3ef085d692a85269dc03e10428993965d5b41743f5380575232880705c8df"
 dependencies = [
  "aes 0.7.5",
  "bincode",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "blsttc"
-version = "6.2.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6654e89f9f433a0bb0f4117a8702bf4ccc99f7f599e27699e1c3d08913e2688c"
+checksum = "94a0229f4c58487248ec1f2dee608d55fef1c4aaf626d45708fffdbea0c34410"
 dependencies = [
  "blst",
  "blstrs",
@@ -3080,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "secured_linked_list"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e061cddee0a14a0b0abec9eb1d26064ed96cd1bee1ec9a05e232cea2447509"
+checksum = "195ddd4a60dadbd1e54268fb71bc87a3b2cd5ee78c74573f7d45d3380cc27e22"
 dependencies = [
  "bincode",
  "blsttc",
@@ -3505,9 +3505,9 @@ dependencies = [
 
 [[package]]
 name = "sn_consensus"
-version = "2.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b853378b69e183aa1157180e77b7b240395100af1f1ebc234b27fb9818d4511"
+checksum = "db1d5bc1be2b7aca0f256b7661fee4867acab26b48ca30b7fceba1c859e58d8f"
 dependencies = [
  "bincode",
  "blsttc",
@@ -3519,9 +3519,9 @@ dependencies = [
 
 [[package]]
 name = "sn_dbc"
-version = "7.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93bcc5fe531b28eb2962b290745786522b4d250e60ac2d60a24523d3f3c71b55"
+checksum = "feb659f3d5bba169fcbd1fb3a1c3ac62d92fef95c2dff766288dfa6173c9236a"
 dependencies = [
  "bincode",
  "bls_ringct",

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib", "rlib"]
 anyhow = { version = "1.0.38", optional = true }
 async_once = { version = "~0.2.6", optional = true }
 bincode = "1.3.3"
-bls = { package = "blsttc", version = "6.0.0" }
+bls = { package = "blsttc", version = "7.0.0" }
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "~0.6"
 dirs-next = "2.0.0"
@@ -42,7 +42,7 @@ serde = "1.0.123"
 serde_json = "1.0.62"
 sha3 = "~0.9"
 sn_client = { path = "../sn_client", version = "^0.68.2" }
-sn_dbc = { version = "7.0.0", features = ["serdes"] }
+sn_dbc = { version = "7.0.1", features = ["serdes"] }
 sn_interface = { path = "../sn_interface", version = "^0.8.2" }
 thiserror = "1.0.23"
 time = { version = "~0.3.4", features = ["formatting"] }

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 ansi_term = "~0.12"
 bincode = "1.3.3"
-bls = { package = "blsttc", version = "6.0.0" }
+bls = { package = "blsttc", version = "7.0.0" }
 bytes = { version = "1.0.1", features = ["serde"] }
 chrono = "~0.4"
 color-eyre = "~0.6"
@@ -38,7 +38,7 @@ relative-path = "1.3.2"
 reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls"] }
 rmp-serde = "1.0.0"
 sn_api = { path = "../sn_api", version = "^0.66.3", default-features = false, features = ["app"] }
-sn_dbc = { version = "7.0.0", features = ["serdes"] }
+sn_dbc = { version = "7.0.1", features = ["serdes"] }
 sn_launch_tool = "~0.10.0"
 serde = "1.0.123"
 serde_json = "1.0.62"

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -41,8 +41,8 @@ build-bin = ["clap", "eyre"]
 backoff = { version = "~0.4.0", features = [ "tokio" ] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
-bls = { package = "blsttc", version = "6.0.0" }
-bls_dkg = "~0.10.3"
+bls = { package = "blsttc", version = "7.0.0" }
+bls_dkg = "~0.10.4"
 bytes = { version = "1.0.1", features = ["serde"] }
 clap = { version = "3.0.0", features = ["derive"], optional = true }
 crdts = { version = "7.1", default-features = false, features = ["merkle"] }
@@ -64,13 +64,13 @@ qp2p = "~0.28.3"
 rand = "~0.8.5"
 rayon = "1.5.1"
 rmp-serde = "1.0.0"
-secured_linked_list = "~0.5.2"
+secured_linked_list = "~0.5.3"
 self_encryption = "~0.27.4"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
-sn_dbc = { version = "7.0.0", features = ["serdes"] }
+sn_dbc = { version = "7.0.1", features = ["serdes"] }
 sn_interface = { path = "../sn_interface", version = "^0.8.2" }
 strum = "~0.23.0"
 strum_macros = "~0.23.1"

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -23,8 +23,8 @@ test-utils=["proptest"]
 backoff = { version = "~0.4.0", features = ["tokio"] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
-bls = { package = "blsttc", version = "6.0.0" }
-bls_dkg = "~0.10.3"
+bls = { package = "blsttc", version = "7.0.0" }
+bls_dkg = "~0.10.4"
 bytes = { version = "1.0.1", features = ["serde"] }
 crdts = { version = "7.1", default-features=false, features = ["merkle"] }
 custom_debug = "~0.5.0"
@@ -47,14 +47,14 @@ rand = "~0.8.5"
 rand-07 = { package = "rand", version = "0.7.3" } # required till ed25519-dalek upgrades to rand v0.8
 rayon = "1.5.1"
 rmp-serde = "1.0.0"
-secured_linked_list = "~0.5.2"
+secured_linked_list = "~0.5.3"
 self_encryption = "~0.27.1"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
-sn_consensus = "2.1.1"
-sn_dbc = { version = "7.0.0", features = ["serdes"] }
+sn_consensus = "3.1.2"
+sn_dbc = { version = "7.0.1", features = ["serdes"] }
 strum = "~0.23.0"
 strum_macros = "~0.23.1"
 tempfile = "3.2.0"

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -36,8 +36,8 @@ otlp = [ "opentelemetry", "opentelemetry-otlp", "opentelemetry-semantic-conventi
 backoff = { version = "~0.4.0", features = [ "tokio" ] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
-bls = { package = "blsttc", version = "6.0.0" }
-bls_dkg = "~0.10.3"
+bls = { package = "blsttc", version = "7.0.0" }
+bls_dkg = "~0.10.4"
 bytes = { version = "1.0.1", features = ["serde"] }
 chrono = "0.4.19"
 color-eyre = "~0.6.0"
@@ -67,10 +67,10 @@ rand-07 = { package = "rand", version = "~0.7.3" }
 rayon = "1.5.1"
 resource_proof = "1.0.39"
 rmp-serde = "1.0.0"
-secured_linked_list = "~0.5.2"
+secured_linked_list = "~0.5.3"
 self_encryption = "~0.27.4"
-sn_consensus = "2.1.1"
-sn_dbc = { version = "7.0.0", features = ["serdes"] }
+sn_consensus = "3.1.2"
+sn_dbc = { version = "7.0.1", features = ["serdes"] }
 sn_dysfunction = { path = "../sn_dysfunction", version = "^0.7.1" }
 sn_interface = { path = "../sn_interface", version = "^0.8.2" }
 serde = { version = "1.0.111", features = ["derive", "rc"] }


### PR DESCRIPTION
This version has a more helpful error message for the shares interpolation problem.
