### PR TITLE
refactor: expose known keys on network knowledge

### DIFF
--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -614,6 +614,14 @@ impl NetworkKnowledge {
         self.chain.has_key(key)
     }
 
+    /// Return weather current section chain has the provided key
+    pub fn known_keys(&self) -> Vec<bls::PublicKey> {
+        let mut known_keys: Vec<_> = self.section_chain().keys().copied().collect();
+        known_keys.extend(self.prefix_map().section_keys());
+        known_keys.push(*self.genesis_key());
+        known_keys
+    }
+
     /// Return a copy of current SAP
     pub fn authority_provider(&self) -> SectionAuthorityProvider {
         self.signed_sap.value.clone()

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -614,7 +614,7 @@ impl NetworkKnowledge {
         self.chain.has_key(key)
     }
 
-    /// Return weather current section chain has the provided key
+    /// Return a vec of all known keys
     pub fn known_keys(&self) -> Vec<bls::PublicKey> {
         let mut known_keys: Vec<_> = self.section_chain().keys().copied().collect();
         known_keys.extend(self.prefix_map().section_keys());

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -111,7 +111,6 @@ pub(crate) enum Cmd {
         msg: SystemMsg,
         origin: Peer,
         msg_authority: NodeMsgAuthority,
-        known_keys: Vec<bls::PublicKey>,
         #[debug(skip)]
         wire_msg_payload: Bytes,
         #[cfg(feature = "traceroute")]

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -131,7 +131,6 @@ impl Dispatcher {
                 msg_id,
                 msg,
                 msg_authority,
-                known_keys,
                 wire_msg_payload,
                 #[cfg(feature = "traceroute")]
                 traceroute,
@@ -147,7 +146,6 @@ impl Dispatcher {
                         msg_authority,
                         msg,
                         origin,
-                        known_keys,
                         &self.comm,
                         #[cfg(feature = "traceroute")]
                         traceroute,

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -18,7 +18,6 @@ use sn_interface::{
     types::{log_markers::LogMarker, Peer},
 };
 
-use bls::PublicKey as BlsPublicKey;
 use std::vec;
 
 const FIRST_SECTION_MIN_ELDER_AGE: u8 = 82;
@@ -201,7 +200,6 @@ impl Node {
         &mut self,
         peer: Peer,
         join_request: JoinAsRelocatedRequest,
-        known_keys: Vec<BlsPublicKey>,
         comm: &Comm,
     ) -> Result<Vec<Cmd>> {
         debug!("Received JoinAsRelocatedRequest {join_request:?} from {peer}",);
@@ -237,6 +235,7 @@ impl Node {
                 debug!("Ignoring JoinAsRelocatedRequest from {peer} - invalid sig.");
                 return Ok(vec![]);
             }
+            let known_keys = self.network_knowledge.known_keys();
             if !known_keys.contains(&join_request.relocate_proof.sig.public_key) {
                 debug!("Ignoring JoinAsRelocatedRequest from {peer} - untrusted src.");
                 return Ok(vec![]);

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -192,7 +192,6 @@ impl Node {
         msg_authority: NodeMsgAuthority,
         msg: SystemMsg,
         sender: Peer,
-        known_keys: Vec<BlsPublicKey>,
         comm: &Comm,
         #[cfg(feature = "traceroute")] traceroute: Vec<Entity>,
     ) -> Result<Vec<Cmd>> {
@@ -401,7 +400,7 @@ impl Node {
                     return Ok(vec![]);
                 }
 
-                self.handle_join_as_relocated_request(sender, *join_request, known_keys, comm)
+                self.handle_join_as_relocated_request(sender, *join_request, comm)
                     .await
             }
             SystemMsg::MembershipVotes(votes) => {


### PR DESCRIPTION
The method can be called directly instead of passing known keys in the
cmds.