### PR TITLE
fix(joins): check reachability before sending msgs

### DIFF
--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -78,7 +78,6 @@ impl Dispatcher {
                 mut traceroute,
             } => {
                 let node = self.node.read().await;
-
                 let src_section_pk = node.network_knowledge().section_key();
 
                 #[allow(unused_mut)]


### PR DESCRIPTION
We tried to send a msg to the peer that failed the check. That wouldn't work though.
Also, other branches in same flow were sending msgs before doing that check.
