### PR TITLE
chore(naming): reflect the semantics not the type

### DIFF
--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -79,10 +79,10 @@ impl Session {
             section_pk,
         };
 
-        let auth_kind = AuthKind::Service(auth);
+        let auth = AuthKind::Service(auth);
 
         #[allow(unused_mut)]
-        let mut wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
+        let mut wire_msg = WireMsg::new_msg(msg_id, payload, auth, dst_location)?;
 
         #[cfg(feature = "traceroute")]
         wire_msg.add_trace(&mut vec![Entity::Client(client_pk)]);
@@ -209,10 +209,10 @@ impl Session {
             name: dst,
             section_pk,
         };
-        let auth_kind = AuthKind::Service(auth);
+        let auth = AuthKind::Service(auth);
 
         #[allow(unused_mut)]
-        let mut wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
+        let mut wire_msg = WireMsg::new_msg(msg_id, payload, auth, dst_location)?;
 
         #[cfg(feature = "traceroute")]
         wire_msg.add_trace(&mut vec![Entity::Client(client_pk)]);
@@ -338,8 +338,8 @@ impl Session {
             name: dst_address,
             section_pk,
         };
-        let auth_kind = AuthKind::Service(auth);
-        let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
+        let auth = AuthKind::Service(auth);
+        let wire_msg = WireMsg::new_msg(msg_id, payload, auth, dst_location)?;
 
         let initial_contacts = nodes
             .clone()

--- a/sn_interface/src/messaging/serialisation/wire_msg_header.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg_header.rs
@@ -41,7 +41,7 @@ pub struct WireMsgHeader {
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MsgEnvelope {
     pub msg_id: MsgId,
-    pub auth_kind: AuthKind,
+    pub auth: AuthKind,
     pub dst_location: DstLocation,
     #[cfg(feature = "traceroute")]
     pub traceroute: Vec<Entity>,
@@ -80,7 +80,7 @@ impl WireMsgHeader {
     // Instantiate a WireMsgHeader as per current supported version.
     pub fn new(
         msg_id: MsgId,
-        auth_kind: AuthKind,
+        auth: AuthKind,
         dst_location: DstLocation,
         #[cfg(feature = "traceroute")] traceroute: Vec<Entity>,
     ) -> Self {
@@ -89,7 +89,7 @@ impl WireMsgHeader {
             version: MESSAGING_PROTO_VERSION,
             msg_envelope: MsgEnvelope {
                 msg_id,
-                auth_kind,
+                auth,
                 dst_location,
                 #[cfg(feature = "traceroute")]
                 traceroute,

--- a/sn_node/src/comm/listener.rs
+++ b/sn_node/src/comm/listener.rs
@@ -69,7 +69,7 @@ impl MsgListener {
                         }
                     };
 
-                    let src_name = wire_msg.auth_kind().src().name();
+                    let src_name = wire_msg.auth().src().name();
 
                     if first {
                         first = false;

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -472,7 +472,7 @@ impl<'a> Joiner<'a> {
             let (join_response, sender) = match event {
                 MsgEvent::Received {
                     sender, wire_msg, ..
-                } => match wire_msg.auth_kind() {
+                } => match wire_msg.auth() {
                     AuthKind::Service(_) => continue,
                     AuthKind::NodeBlsShare(_) => {
                         trace!(

--- a/sn_node/src/node/messages.rs
+++ b/sn_node/src/node/messages.rs
@@ -51,11 +51,11 @@ impl WireMsgUtils for WireMsg {
         let msg_payload =
             WireMsg::serialize_msg_payload(&msg).map_err(|_| Error::InvalidMessage)?;
 
-        let auth_kind = AuthKind::NodeBlsShare(
+        let auth = AuthKind::NodeBlsShare(
             bls_share_authorize(src_section_pk, src_name, key_share, &msg_payload).into_inner(),
         );
 
-        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth_kind, dst)?;
+        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth, dst)?;
 
         #[cfg(feature = "test-utils")]
         let wire_msg = wire_msg.set_payload_debug(msg);
@@ -73,11 +73,11 @@ impl WireMsgUtils for WireMsg {
         let msg_payload =
             WireMsg::serialize_msg_payload(&msg).map_err(|_| Error::InvalidMessage)?;
 
-        let auth_kind = AuthKind::Node(
+        let auth = AuthKind::Node(
             NodeAuth::authorize(src_section_pk, &node.keypair, &msg_payload).into_inner(),
         );
 
-        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth_kind, dst)?;
+        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth, dst)?;
 
         #[cfg(feature = "test-utils")]
         let wire_msg = wire_msg.set_payload_debug(msg);

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -985,9 +985,9 @@ mod tests {
 
             let node_auth = NodeAuth::authorize(src_section_pk, &src_node_keypair, &payload);
 
-            let auth_kind = AuthKind::Node(node_auth.into_inner());
+            let auth = AuthKind::Node(node_auth.into_inner());
 
-            let wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst_location)?;
+            let wire_msg = WireMsg::new_msg(msg_id, payload, auth, dst_location)?;
 
             let src_location = SrcLocation::Node {
                 name: sender_name,

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -130,7 +130,7 @@ impl Node {
                     }
                 };
 
-                let src_location = wire_msg.auth_kind().src();
+                let src_location = wire_msg.auth().src();
 
                 if self.is_not_elder() {
                     trace!("Redirecting from adult to section elders");

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -85,10 +85,10 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         let dst = DstLocation::EndUser(EndUser(target.name()));
 
-        let (auth_kind, payload) = self.ed_sign_client_msg(&msg)?;
+        let (auth, payload) = self.ed_sign_client_msg(&msg)?;
 
         #[allow(unused_mut)]
-        let mut wire_msg = WireMsg::new_msg(MsgId::new(), payload, auth_kind, dst)?;
+        let mut wire_msg = WireMsg::new_msg(MsgId::new(), payload, auth, dst)?;
 
         #[cfg(feature = "traceroute")]
         {
@@ -242,7 +242,7 @@ impl Node {
             response: query_response,
             correlation_id,
         };
-        let (auth_kind, payload) = self.ed_sign_client_msg(&msg)?;
+        let (auth, payload) = self.ed_sign_client_msg(&msg)?;
 
         // set a random xorname first. We set it specifically per peer thereafter
         // This is overwritten in comm.send_to_client
@@ -250,7 +250,7 @@ impl Node {
         let dst = DstLocation::EndUser(EndUser(xor_name::XorName::random(&mut rng)));
 
         #[allow(unused_mut)]
-        let mut wire_msg = WireMsg::new_msg(msg_id, payload, auth_kind, dst)?;
+        let mut wire_msg = WireMsg::new_msg(msg_id, payload, auth, dst)?;
 
         #[cfg(feature = "traceroute")]
         {

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -117,7 +117,7 @@ impl Node {
         let our_name = self.info().name();
         for recipient in recipients.into_iter() {
             if recipient.name() == our_name {
-                match wire_msg.auth_kind() {
+                match wire_msg.auth() {
                     AuthKind::NodeBlsShare(_) => {
                         // do nothing, continue we should be accumulating this
                         handle = true;


### PR DESCRIPTION
The type is named Kind but the semantics of it is Auth.
Often we mindlessly name things after the type names instead of what they
represent in the domain.
BREAKING CHANGE: fields of public msg renamed