### PR TITLE
chore(node): simplify the send funcitonality

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -348,7 +348,7 @@ jobs:
           action: 'destroy'
 
   bump_version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: kill-testnet
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Previously we've had a send to client and a send ot nodes, the latter
which would only send to a subset (with the delivery group setting), and
reported errors.

We've stripped out the delivery group stuff already as unnecessary. So here
we just have one function to send from nodes, any errors are handled
appropriately if the recipient is in our section, otherwise ignored.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
