### PR TITLE
ci: use system-wide location for genesis dbc

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -262,11 +262,7 @@ jobs:
         shell: bash
         run: |
           curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-genesis-dbc \
-            > ~/.safe/genesis_dbc
-
-      - name: Set TEST_ENV_GENESIS_DBC_PATH env
-        shell: bash
-        run: echo "TEST_ENV_GENESIS_DBC_PATH=~/.safe/genesis_dbc" >> $GITHUB_ENV
+            > /tmp/genesis_dbc
 
       - name: Run API tests
         uses: jacderida/cargo-nextest@main
@@ -280,6 +276,7 @@ jobs:
         timeout-minutes: 60
         env:
           SN_QUERY_TIMEOUT: 10
+          TEST_ENV_GENESIS_DBC_PATH: /tmp/genesis_dbc
 
   cli:
     name: cli tests
@@ -312,6 +309,11 @@ jobs:
         run: |
           mkdir -p ~/.safe/prefix_maps
           curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-prefix-map > ~/.safe/prefix_maps/default
+      - name: Download genesis DBC
+        shell: bash
+        run: |
+          curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-genesis-dbc \
+            > /tmp/genesis_dbc
 
       - name: Build all CLI tests
         run: cargo test --no-run -p sn_cli --release
@@ -330,6 +332,7 @@ jobs:
         timeout-minutes: 60
         env:
           SN_QUERY_TIMEOUT: 10
+          TEST_ENV_GENESIS_DBC_PATH: /tmp/genesis_dbc
 
   kill-testnet:
     name: kill testnet


### PR DESCRIPTION
Previously the file was being placed under the profile directory, but the test process was
complaining it couldn't find the file. The custom action for running Nextest should be running on
the same machine and user, meaning it really shouldn't be a problem to put the file there, but
nonetheless it apparently couldn't be found. Thus, I'm going to try a system-wide location.

Also changed the mechanism for setting the variable to be defined on the invocation of the Nextest
action.