### PR TITLE
Revert "feat: make traceroute default for now"

### DIFF
--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -29,7 +29,7 @@ name = "query-adult"
 required-features = ["build-bin"]
 
 [features]
-default = ["traceroute"]
+default = []
 chaos = []
 unstable-wiremsg-debuginfo = []
 test-utils = ["eyre"]

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -23,7 +23,7 @@ name = "routing_minimal"
 name = "routing_stress"
 
 [features]
-default = ["traceroute"]
+default = []
 chaos = []
 back-pressure = ["sn_interface/back-pressure"]
 unstable-wiremsg-debuginfo = []


### PR DESCRIPTION
This reverts commit 175d1b909dff8c6729ac7f156ce1d0d22be8cc12.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
