### PR TITLE
chore: remove the write lock on node while validating msgs

### DIFF
--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -337,19 +337,19 @@ mod core {
                 .map_err(Error::from)
         }
 
+        /// Log an issue in dysfunction
+        pub(crate) fn log_node_issue(&mut self, name: XorName, issue: IssueType) -> Result<()> {
+            trace!("Logging issue {issue:?} in dysfunction");
+            self.dysfunction_tracking
+                .track_issue(name, issue)
+                .map_err(Error::from)
+        }
+
         /// Log a communication problem
         pub(crate) fn log_comm_issue(&mut self, name: XorName) -> Result<()> {
             trace!("Logging comms issue in dysfunction");
             self.dysfunction_tracking
                 .track_issue(name, IssueType::Communication)
-                .map_err(Error::from)
-        }
-
-        /// Log a knowledge issue
-        pub(crate) fn log_knowledge_issue(&mut self, name: XorName) -> Result<()> {
-            trace!("Logging Knowledge issue in dysfunction");
-            self.dysfunction_tracking
-                .track_issue(name, IssueType::Knowledge)
                 .map_err(Error::from)
         }
 


### PR DESCRIPTION
This adds a new Cmd for tracking dysfunction, so we can pull the
write locks out of longer running Cmd processes

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
