### PR TITLE
Do not require node write lock on query

### DIFF
--- a/sn_interface/src/messaging/location.rs
+++ b/sn_interface/src/messaging/location.rs
@@ -12,7 +12,7 @@ use xor_name::{Prefix, XorName};
 
 /// An `EndUser` is represented by a name which is mapped to
 // a SocketAddr at the Elders where the `EndUser` is proxied through.
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub struct EndUser(pub XorName);
 
 /// Message source location.
@@ -64,7 +64,7 @@ impl SrcLocation {
 }
 
 /// Message destination location.
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub enum DstLocation {
     /// An EndUser.
     EndUser(EndUser),

--- a/sn_interface/src/types/cache/mod.rs
+++ b/sn_interface/src/types/cache/mod.rs
@@ -76,17 +76,25 @@ where
     }
 
     /// Get a value from the cache if one is set and not expired.
-    ///
-    /// A clone of the value is returned, so this is only implemented when `V: Clone`.
-    pub fn get(&self, key: &T) -> Option<V>
+    pub fn get(&self, key: &T) -> Option<&V>
     where
         T: Eq + Hash,
-        V: Clone,
     {
         self.items
             .get(key)
             .filter(|&item| !item.expired())
-            .map(|k| k.object.clone())
+            .map(|k| &k.object)
+    }
+
+    /// Get a mut value from the cache if one is set and not expired.
+    pub fn get_mut(&mut self, key: &T) -> Option<&mut V>
+    where
+        T: Eq + Hash,
+    {
+        self.items
+            .get_mut(key)
+            .filter(|item| !item.expired())
+            .map(|k| &mut k.object)
     }
 
     /// Get a list of all items in the cache
@@ -185,7 +193,7 @@ mod tests {
         let mut cache = Cache::with_expiry_duration(Duration::from_secs(2));
         let _prev = cache.set(KEY, VALUE, None);
         let value = cache.get(&KEY);
-        assert_eq!(value, Some(VALUE), "value was not found in cache");
+        assert_eq!(value, Some(&VALUE), "value was not found in cache");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -193,7 +201,7 @@ mod tests {
         let mut cache = Cache::with_capacity(usize::MAX);
         let _prev = cache.set(KEY, VALUE, None);
         let value = cache.get(&KEY);
-        assert_eq!(value, Some(VALUE), "value was not found in cache");
+        assert_eq!(value, Some(&VALUE), "value was not found in cache");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -201,7 +209,7 @@ mod tests {
         let mut cache = Cache::with_expiry_duration(Duration::from_secs(0));
         let _prev = cache.set(KEY, VALUE, Some(Duration::from_secs(2)));
         let value = cache.get(&KEY);
-        assert_eq!(value, Some(VALUE), "value was not found in cache");
+        assert_eq!(value, Some(&VALUE), "value was not found in cache");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -231,7 +239,7 @@ mod tests {
         let _prev = cache.set(KEY, VALUE, None);
         let _prev = cache.set(KEY, NEW_VALUE, None);
         let value = cache.get(&KEY);
-        assert_eq!(value, Some(NEW_VALUE), "value was not found in cache");
+        assert_eq!(value, Some(&NEW_VALUE), "value was not found in cache");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -302,6 +310,6 @@ mod tests {
         let value: &str = "hello";
         let _prev = cache.set(key, value, None);
         assert!(cache.get(&KEY).is_none());
-        assert_eq!(cache.get(&key), Some(value));
+        assert_eq!(cache.get(&key), Some(&value));
     }
 }

--- a/sn_interface/src/types/log_markers.rs
+++ b/sn_interface/src/types/log_markers.rs
@@ -38,7 +38,6 @@ pub enum LogMarker {
     VotedOffline,
     // Messaging
     ServiceMsgToBeHandled,
-    QueryServiceMsgToBeHandled,
     SystemMsgToBeHandled,
     // Membership
     MembershipVotesBeingHandled,

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -764,7 +764,7 @@ impl ProbeTracker {
         let result = self
             .sections
             .iter_mut()
-            .find_map(|(prefix, cache)| cache.get(dst).map(|pk| (prefix, pk, cache)));
+            .find_map(|(prefix, cache)| cache.get(dst).cloned().map(|pk| (prefix, pk, cache)));
         let (_prefix, probe_state, cache) = match result {
             None => return,
             Some(state) => state,

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -443,19 +443,16 @@ impl Network {
         // section health to appear lower than it actually is.
 
         // just some valid message
-        let node_msg = SystemMsg::NodeMsgError {
+        let msg = SystemMsg::NodeMsgError {
             error: FailedToWriteFile,
             correlation_id: MsgId::new(),
         };
-
-        let dst_location = DstLocation::Section {
+        let dst = DstLocation::Section {
             name: dst,
             section_pk: public_key_set.public_key(),
         };
 
-        let wire_msg = node.sign_single_src_msg(node_msg, dst_location).await?;
-
-        match node.send_msg_to_nodes(wire_msg).await {
+        match node.send(msg, dst).await {
             Ok(()) => Ok(true),
             Err(error) => {
                 Err(error).context(format!("failed to send probe by {}", node.name().await))

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -44,8 +44,6 @@ pub enum Error {
     ChaoticStartupCrash,
     #[error("Node prioritisation semaphore was closed early.")]
     SemaphoreClosed,
-    #[error("Only messages requiring auth accumulation should be sent via \"send_messages_to_all_nodes_or_directly_handle_for_accumulation\"")]
-    SendOrHandlingNormalMsg,
     #[error("There was a problem during acquisition of a tokio::sync::semaphore permit.")]
     PermitAcquisitionFailed,
     #[error("Section authority provider cannot be trusted: {0}")]

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -17,7 +17,7 @@ use sn_consensus::Decision;
 use sn_dysfunction::IssueType;
 use sn_interface::{
     messaging::{
-        data::ServiceMsg,
+        data::{OperationId, ServiceMsg},
         system::{DkgFailureSigSet, KeyedSig, NodeState, SectionAuth, SystemMsg},
         AuthorityProof, MsgId, NodeMsgAuthority, ServiceAuth, WireMsg,
     },
@@ -111,6 +111,12 @@ pub(crate) enum Cmd {
     },
     /// Log a Node's Punishment, this pulls dysfunction and write locks out of some functions
     TrackNodeIssueInDysfunction { name: XorName, issue: IssueType },
+    /// Adds peer to set of recipients of an already pending query,
+    /// or adds a pending query if it didn't already exist.
+    AddToPendingQueries {
+        operation_id: OperationId,
+        origin: Peer,
+    },
     HandleValidSystemMsg {
         msg_id: MsgId,
         msg: SystemMsg,
@@ -211,6 +217,8 @@ impl Cmd {
 
             Comm(_) => 7,
 
+            AddToPendingQueries { .. } => 6,
+
             // See [`MsgType`] for the priority constants and the range of possible values.
             HandleValidSystemMsg { msg, .. } => msg.priority(),
             HandleValidServiceMsg { msg, .. } => msg.priority(),
@@ -259,6 +267,7 @@ impl fmt::Display for Cmd {
                 write!(f, "TrackNodeIssueInDysfunction {:?}, {:?}", name, issue)
             }
             Cmd::ProposeOffline(_) => write!(f, "ProposeOffline"),
+            Cmd::AddToPendingQueries { .. } => write!(f, "AddToPendingQueries"),
             Cmd::TellEldersToStartConnectivityTest(_) => {
                 write!(f, "TellEldersToStartConnectivityTest")
             }

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -15,16 +15,21 @@ pub(super) mod event_channel;
 pub(crate) mod tests;
 
 pub(crate) use self::cmd_ctrl::CmdCtrl;
+
 use crate::comm::MsgEvent;
-use crate::node::{flow_ctrl::cmds::Cmd, messages::WireMsgUtils, Error, Node, Result};
+use crate::node::{
+    flow_ctrl::cmds::Cmd,
+    messaging::{OutgoingMsg, Recipients},
+    Error, Node, Result,
+};
+
 use sn_interface::{
     messaging::{
         data::{DataQuery, DataQueryVariant, ServiceMsg},
         system::{NodeCmd, SystemMsg},
-        MsgId, WireMsg,
+        MsgId,
     },
-    types::log_markers::LogMarker,
-    types::ChunkAddress,
+    types::{log_markers::LogMarker, ChunkAddress},
 };
 
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
@@ -276,19 +281,15 @@ impl FlowCtrl {
 
                 let mut this_batch_address = None;
 
-                let (src_section_pk, our_info, data_queued) = {
+                let data_queued = {
                     let node = self.node.read().await;
-                    // get info for the WireMsg
-                    let src_section_pk = node.network_knowledge().section_key();
-                    let our_info = node.info();
                     // choose a data to replicate at random
                     let data_queued = node
                         .pending_data_to_replicate_to_peers
                         .iter()
                         .choose(&mut rng)
                         .map(|(address, _)| *address);
-
-                    (src_section_pk, our_info, data_queued)
+                    data_queued
                 };
 
                 if let Some(data_addr) = data_queued {
@@ -324,32 +325,20 @@ impl FlowCtrl {
                             .data_storage
                             .get_from_local_store(&address)
                             .await?;
-                        let system_msg =
-                            SystemMsg::NodeCmd(NodeCmd::ReplicateData(vec![data_to_send]));
-
-                        let name = recipients[0].name();
-                        let dst = sn_interface::messaging::DstLocation::Node {
-                            name,
-                            section_pk: src_section_pk,
-                        };
-                        let wire_msg = WireMsg::single_src(
-                            &our_info,
-                            dst,
-                            system_msg.clone(),
-                            src_section_pk,
-                        )?;
 
                         debug!(
-                            "{:?} Data {:?} to: {:?} w/ {:?} ",
+                            "{:?} Data {:?} to: {:?}",
                             LogMarker::SendingMissingReplicatedData,
                             address,
                             recipients,
-                            wire_msg.msg_id()
                         );
 
+                        let msg = SystemMsg::NodeCmd(NodeCmd::ReplicateData(vec![data_to_send]));
                         let cmd = Cmd::SendMsg {
-                            wire_msg,
-                            recipients,
+                            msg: OutgoingMsg::System(msg),
+                            recipients: Recipients::from(&recipients),
+                            #[cfg(feature = "traceroute")]
+                            traceroute: vec![],
                         };
 
                         if let Err(e) = self.cmd_ctrl.push(cmd).await {
@@ -421,7 +410,6 @@ impl FlowCtrl {
         });
     }
 
-    #[cfg(feature = "back-pressure")]
     /// Periodically send back-pressure reports to our section.
     ///
     /// We do not send reports outside of the section as most messages will come from within our section
@@ -429,9 +417,8 @@ impl FlowCtrl {
     /// Worst case is after a split, nodes sending messaging from a sibling section to update us may not
     /// know about our load just now. Though that would only be AE messages... and if backpressure is working we should
     /// not be overloaded...
+    #[cfg(feature = "back-pressure")]
     fn start_backpressure_reporting(self) {
-        use sn_interface::messaging::DstLocation;
-
         info!("Firing off backpressure reports");
         let _handle = tokio::task::spawn_local(async move {
             let mut interval = tokio::time::interval(BACKPRESSURE_INTERVAL);
@@ -446,7 +433,6 @@ impl FlowCtrl {
                 let our_name = our_info.name();
 
                 let members = node.network_knowledge().section_members();
-                let section_pk = node.network_knowledge().section_key();
                 drop(node);
 
                 if let Some(load_report) =
@@ -457,33 +443,15 @@ impl FlowCtrl {
                     // TODO: use comms to send report to anyone connected? (can we ID end users there?)
                     for member in members {
                         let peer = member.peer();
-
                         if peer.name() == our_name {
                             continue;
                         }
 
-                        let wire_msg = match WireMsg::single_src(
-                            &our_info,
-                            DstLocation::Node {
-                                name: peer.name(),
-                                section_pk,
-                            },
-                            SystemMsg::BackPressure(load_report),
-                            section_pk,
-                        ) {
-                            Ok(msg) => msg,
-                            Err(e) => {
-                                error!(
-                                    "Error forming backpressure message to section member {:?}",
-                                    e
-                                );
-                                continue;
-                            }
-                        };
-
                         let cmd = Cmd::SendMsg {
-                            wire_msg,
-                            recipients: vec![*peer],
+                            msg: OutgoingMsg::System(SystemMsg::BackPressure(load_report)),
+                            recipients: Recipients::from_single(*peer),
+                            #[cfg(feature = "traceroute")]
+                            traceroute: vec![],
                         };
 
                         if let Err(e) = self.cmd_ctrl.push(cmd).await {

--- a/sn_node/src/node/messaging/handover.rs
+++ b/sn_node/src/node/messaging/handover.rs
@@ -341,16 +341,8 @@ impl Node {
                 Err(Error::RequestHandoverAntiEntropy(gen)) => {
                     // We hit an error while processing this vote, perhaps we are missing information.
                     // We'll send a handover AE request to see if they can help us catch up.
-                    let sap = self.network_knowledge.authority_provider();
-                    let dst_section_pk = sap.section_key();
-                    let section_name = self.network_knowledge.prefix().name();
                     let msg = SystemMsg::HandoverAE(gen);
-                    let cmd = self.send_direct_msg_to_nodes(
-                        vec![peer],
-                        msg,
-                        section_name,
-                        dst_section_pk,
-                    )?;
+                    let cmd = self.send_direct_msg(vec![peer], msg)?;
 
                     debug!("{:?}", LogMarker::HandoverSendingAeUpdateRequest);
                     cmds.push(cmd);
@@ -382,11 +374,7 @@ impl Node {
         let cmds = if let Some(handover) = self.handover_voting.as_ref() {
             match handover.anti_entropy(gen) {
                 Ok(catchup_votes) => {
-                    vec![self.send_direct_msg(
-                        peer,
-                        SystemMsg::HandoverVotes(catchup_votes),
-                        self.network_knowledge.section_key(),
-                    )?]
+                    vec![self.send_direct_msg(vec![peer], SystemMsg::HandoverVotes(catchup_votes))?]
                 }
                 Err(e) => {
                     error!("Handover - Error while processing anti-entropy {:?}", e);

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -69,11 +69,7 @@ impl Node {
 
             trace!("Sending {:?} to {}", node_msg, peer);
             trace!("{}", LogMarker::SendJoinRedirected);
-            return Ok(vec![self.send_direct_msg(
-                peer,
-                node_msg,
-                our_section_key,
-            )?]);
+            return Ok(vec![self.send_direct_msg(vec![peer], node_msg)?]);
         }
 
         if !self.joins_allowed {
@@ -88,11 +84,7 @@ impl Node {
             trace!("{}", LogMarker::SendJoinsDisallowed);
 
             trace!("Sending {:?} to {}", node_msg, peer);
-            return Ok(vec![self.send_direct_msg(
-                peer,
-                node_msg,
-                our_section_key,
-            )?]);
+            return Ok(vec![self.send_direct_msg(vec![peer], node_msg)?]);
         }
 
         let (is_age_invalid, expected_age) = self.verify_joining_node_age(&peer);
@@ -136,11 +128,7 @@ impl Node {
             }));
 
             trace!("Sending {:?} to {}", node_msg, peer);
-            return Ok(vec![self.send_direct_msg(
-                peer,
-                node_msg,
-                our_section_key,
-            )?]);
+            return Ok(vec![self.send_direct_msg(vec![peer], node_msg)?]);
         }
 
         // Do reachability check only for the initial join request
@@ -152,7 +140,7 @@ impl Node {
             trace!("{}", LogMarker::SendJoinRejected);
 
             trace!("Sending {:?} to {}", node_msg, peer);
-            self.send_direct_msg(peer, node_msg, our_section_key)?
+            self.send_direct_msg(vec![peer], node_msg)?
         } else {
             // It's reachable, let's then send the proof challenge
             self.send_resource_proof_challenge(peer)?
@@ -220,11 +208,7 @@ impl Node {
             trace!("{} b", LogMarker::SendJoinAsRelocatedResponse);
 
             trace!("Sending {node_msg:?} to {peer}");
-            return Ok(vec![self.send_direct_msg(
-                peer,
-                node_msg,
-                self.network_knowledge.section_key(),
-            )?]);
+            return Ok(vec![self.send_direct_msg(vec![peer], node_msg)?]);
         }
 
         let relocate_details = if let MembershipState::Relocated(ref details) =
@@ -263,11 +247,7 @@ impl Node {
             trace!("{}", LogMarker::SendJoinAsRelocatedResponse);
 
             trace!("Sending {:?} to {}", node_msg, peer);
-            return Ok(vec![self.send_direct_msg(
-                peer,
-                node_msg,
-                self.network_knowledge.section_key(),
-            )?]);
+            return Ok(vec![self.send_direct_msg(vec![peer], node_msg)?]);
         };
 
         self.propose_membership_change(join_request.relocate_proof.value)

--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -104,8 +104,6 @@ impl Node {
 
         // Create a new instance of JoiningAsRelocated to start the relocation
         // flow. This same instance will handle responses till relocation is complete.
-        let genesis_key = *self.network_knowledge.genesis_key();
-
         let bootstrap_addrs = if let Ok(sap) = self.network_knowledge.section_by_name(&dst_xorname)
         {
             sap.addresses()
@@ -114,7 +112,6 @@ impl Node {
         };
         let (joining_as_relocated, cmd) = JoiningAsRelocated::start(
             node,
-            genesis_key,
             relocate_proof,
             bootstrap_addrs,
             dst_xorname,

--- a/sn_node/src/node/messaging/resource_proof.rs
+++ b/sn_node/src/node/messaging/resource_proof.rs
@@ -56,6 +56,6 @@ impl Node {
         }));
 
         trace!("{}", LogMarker::SendResourceProofChallenge);
-        self.send_direct_msg(peer, response, self.network_knowledge.section_key())
+        self.send_direct_msg(vec![peer], response)
     }
 }

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -223,6 +223,7 @@ impl Node {
         &self,
         msg_id: MsgId,
         msg: ServiceMsg,
+        auth: AuthorityProof<ServiceAuth>,
         origin: Peer,
         #[cfg(feature = "traceroute")] traceroute: Vec<Entity>,
     ) -> Result<Vec<Cmd>> {
@@ -250,6 +251,18 @@ impl Node {
                 }
             }
             ServiceMsg::Cmd(DataCmd::StoreChunk(chunk)) => ReplicatedData::Chunk(chunk),
+            ServiceMsg::Query(query) => {
+                return self
+                    .read_data_from_adults(
+                        query,
+                        msg_id,
+                        auth,
+                        origin,
+                        #[cfg(feature = "traceroute")]
+                        traceroute,
+                    )
+                    .await;
+            }
             _ => {
                 warn!(
                     "!!!! Unexpected ServiceMsg received, and it was not handled: {:?}",
@@ -290,40 +303,6 @@ impl Node {
         )?);
 
         Ok(cmds)
-    }
-
-    /// Handle incoming service msgs.
-    pub(crate) async fn handle_valid_query_msg(
-        &mut self,
-        msg_id: MsgId,
-        msg: ServiceMsg,
-        auth: AuthorityProof<ServiceAuth>,
-        origin: Peer,
-        #[cfg(feature = "traceroute")] traceroute: Vec<Entity>,
-    ) -> Result<Vec<Cmd>> {
-        trace!("{:?} {:?}", LogMarker::QueryServiceMsgToBeHandled, msg);
-        // Check we're handling a query and continue
-        match msg {
-            ServiceMsg::Query(query) => {
-                return self
-                    .read_data_from_adults(
-                        query,
-                        msg_id,
-                        auth,
-                        origin,
-                        #[cfg(feature = "traceroute")]
-                        traceroute,
-                    )
-                    .await;
-            }
-            _ => {
-                warn!(
-                    "Unexpected ServiceMsg received while handling QUERY msgs, and it was not handled: {:?}",
-                    msg
-                );
-                Ok(vec![])
-            }
-        }
     }
 
     // Private helper to generate spent proof share

--- a/sn_node/src/node/messaging/signing.rs
+++ b/sn_node/src/node/messaging/signing.rs
@@ -1,0 +1,99 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::OutgoingMsg;
+
+use crate::node::{Node, Result};
+
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Entity;
+use sn_interface::{
+    messaging::{
+        data::ServiceMsg, system::SystemMsg, AuthKind, DstLocation, MsgId, NodeAuth, ServiceAuth,
+        WireMsg,
+    },
+    types::{PublicKey, Signature},
+};
+
+use bytes::Bytes;
+use signature::Signer;
+use xor_name::XorName;
+
+// Message handling
+impl Node {
+    /// Signing an outgoing msg.
+    ///
+    /// We don't need the destination,
+    /// as that is always set on the WireMsg
+    /// when handled in comms together with specified recipients.
+    pub(crate) fn sign_msg(
+        &self,
+        msg: OutgoingMsg,
+        #[cfg(feature = "traceroute")] traceroute: Vec<Entity>,
+    ) -> Result<WireMsg> {
+        let (auth, payload) = match msg {
+            OutgoingMsg::System(msg) => self.sign_system_msg(msg)?,
+            OutgoingMsg::Service(msg) => self.sign_service_msg(msg)?,
+            OutgoingMsg::DstAggregated((auth, payload)) => (AuthKind::NodeBlsShare(auth), payload),
+        };
+
+        #[allow(unused_mut)]
+        let mut wire_msg = WireMsg::new_msg(MsgId::new(), payload, auth, self.dst())?;
+
+        #[cfg(feature = "traceroute")]
+        {
+            let mut trace = traceroute;
+            trace.push(self.entity());
+            wire_msg.add_trace(&mut trace);
+        }
+
+        #[cfg(feature = "test-utils")]
+        let wire_msg = wire_msg.set_payload_debug(msg);
+
+        Ok(wire_msg)
+    }
+
+    /// Currently using node's Ed key. May need to use bls key share for consensus purpose.
+    fn sign_service_msg(&self, msg: ServiceMsg) -> Result<(AuthKind, Bytes)> {
+        let payload = WireMsg::serialize_msg_payload(&msg)?;
+        let signature = self.keypair.sign(&payload);
+
+        let auth = AuthKind::Service(ServiceAuth {
+            public_key: PublicKey::Ed25519(self.keypair.public),
+            signature: Signature::Ed25519(signature),
+        });
+
+        Ok((auth, payload))
+    }
+
+    /// Currently using node's Ed key. May need to use bls key share for consensus purpose.
+    fn sign_system_msg(&self, msg: SystemMsg) -> Result<(AuthKind, Bytes)> {
+        let payload = WireMsg::serialize_msg_payload(&msg)?;
+        let src_section_pk = self.network_knowledge.section_key();
+        let auth = AuthKind::Node(
+            NodeAuth::authorize(src_section_pk, &self.keypair, &payload).into_inner(),
+        );
+
+        Ok((auth, payload))
+    }
+
+    fn dst(&self) -> DstLocation {
+        let section_pk = self.network_knowledge.section_key();
+        let name = XorName::from_content(&[]); // random name because it is overwritten in comms (which is somewhat iffy.. but tbd)
+        DstLocation::Section { name, section_pk }
+    }
+
+    #[cfg(feature = "traceroute")]
+    fn entity(&self) -> Entity {
+        if self.is_elder() {
+            Entity::Elder(PublicKey::Ed25519(self.info().keypair.public))
+        } else {
+            Entity::Adult(PublicKey::Ed25519(self.info().keypair.public))
+        }
+    }
+}


### PR DESCRIPTION
This creates the `AddToPendingQieries` cmd, which adds asyncly to the
list.
Also cleans up the `read_data_from_adults` fn a bit.

**NB**: Draft while on top of pending PR #1386 (simplify send msg).
