### PR TITLE
chore(ci): increase node startup interval to 5s

### DIFF
--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -46,7 +46,7 @@ const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
 
 const BASE_TRACING_DIRECTIVES: &str = "testnet=info,sn_launch_tool=debug";
 const NODES_DIR: &str = "local-test-network";
-const DEFAULT_INTERVAL: &str = "100";
+const DEFAULT_INTERVAL: &str = "5000";
 const DEFAULT_NODE_COUNT: u32 = 30;
 
 #[derive(Debug, clap::StructOpt)]


### PR DESCRIPTION
This not only removes the ci join issues, but also the fairly common other test errors (not enough spendproof shares, failed to obtain response, not enough chunks etc - seems this could be due to ghost nodes).

With this we do not need to override our ci all the time due to these tests failing.

Also it removes the risk of hiding new bugs introduced, behind what we assume were those join related errors.

***

Interval could probably be lowered some. But that'd optimally be done while working on fixing the underlying problem.

Goal for that would be to not have any join-rate that is capable of throwing off the network like that.