### PR TITLE
refactor(send): simplify send msg

### DIFF
--- a/sn_interface/src/messaging/location.rs
+++ b/sn_interface/src/messaging/location.rs
@@ -12,7 +12,7 @@ use xor_name::{Prefix, XorName};
 
 /// An `EndUser` is represented by a name which is mapped to
 // a SocketAddr at the Elders where the `EndUser` is proxied through.
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub struct EndUser(pub XorName);
 
 /// Message source location.
@@ -64,7 +64,7 @@ impl SrcLocation {
 }
 
 /// Message destination location.
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub enum DstLocation {
     /// An EndUser.
     EndUser(EndUser),

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -443,19 +443,16 @@ impl Network {
         // section health to appear lower than it actually is.
 
         // just some valid message
-        let node_msg = SystemMsg::NodeMsgError {
+        let msg = SystemMsg::NodeMsgError {
             error: FailedToWriteFile,
             correlation_id: MsgId::new(),
         };
-
-        let dst_location = DstLocation::Section {
+        let dst = DstLocation::Section {
             name: dst,
             section_pk: public_key_set.public_key(),
         };
 
-        let wire_msg = node.sign_single_src_msg(node_msg, dst_location).await?;
-
-        match node.send_msg_to_nodes(wire_msg).await {
+        match node.send(msg, dst).await {
             Ok(()) => Ok(true),
             Err(error) => {
                 Err(error).context(format!("failed to send probe by {}", node.name().await))

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -44,8 +44,6 @@ pub enum Error {
     ChaoticStartupCrash,
     #[error("Node prioritisation semaphore was closed early.")]
     SemaphoreClosed,
-    #[error("Only messages requiring auth accumulation should be sent via \"send_messages_to_all_nodes_or_directly_handle_for_accumulation\"")]
-    SendOrHandlingNormalMsg,
     #[error("There was a problem during acquisition of a tokio::sync::semaphore permit.")]
     PermitAcquisitionFailed,
     #[error("Section authority provider cannot be trusted: {0}")]

--- a/sn_node/src/node/messaging/handover.rs
+++ b/sn_node/src/node/messaging/handover.rs
@@ -341,16 +341,8 @@ impl Node {
                 Err(Error::RequestHandoverAntiEntropy(gen)) => {
                     // We hit an error while processing this vote, perhaps we are missing information.
                     // We'll send a handover AE request to see if they can help us catch up.
-                    let sap = self.network_knowledge.authority_provider();
-                    let dst_section_pk = sap.section_key();
-                    let section_name = self.network_knowledge.prefix().name();
                     let msg = SystemMsg::HandoverAE(gen);
-                    let cmd = self.send_direct_msg_to_nodes(
-                        vec![peer],
-                        msg,
-                        section_name,
-                        dst_section_pk,
-                    )?;
+                    let cmd = self.send_direct_msg(vec![peer], msg)?;
 
                     debug!("{:?}", LogMarker::HandoverSendingAeUpdateRequest);
                     cmds.push(cmd);
@@ -382,11 +374,7 @@ impl Node {
         let cmds = if let Some(handover) = self.handover_voting.as_ref() {
             match handover.anti_entropy(gen) {
                 Ok(catchup_votes) => {
-                    vec![self.send_direct_msg(
-                        peer,
-                        SystemMsg::HandoverVotes(catchup_votes),
-                        self.network_knowledge.section_key(),
-                    )?]
+                    vec![self.send_direct_msg(vec![peer], SystemMsg::HandoverVotes(catchup_votes))?]
                 }
                 Err(e) => {
                     error!("Handover - Error while processing anti-entropy {:?}", e);

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -69,11 +69,7 @@ impl Node {
 
             trace!("Sending {:?} to {}", node_msg, peer);
             trace!("{}", LogMarker::SendJoinRedirected);
-            return Ok(vec![self.send_direct_msg(
-                peer,
-                node_msg,
-                our_section_key,
-            )?]);
+            return Ok(vec![self.send_direct_msg(vec![peer], node_msg)?]);
         }
 
         if !self.joins_allowed {
@@ -88,11 +84,7 @@ impl Node {
             trace!("{}", LogMarker::SendJoinsDisallowed);
 
             trace!("Sending {:?} to {}", node_msg, peer);
-            return Ok(vec![self.send_direct_msg(
-                peer,
-                node_msg,
-                our_section_key,
-            )?]);
+            return Ok(vec![self.send_direct_msg(vec![peer], node_msg)?]);
         }
 
         let (is_age_invalid, expected_age) = self.verify_joining_node_age(&peer);
@@ -136,11 +128,7 @@ impl Node {
             }));
 
             trace!("Sending {:?} to {}", node_msg, peer);
-            return Ok(vec![self.send_direct_msg(
-                peer,
-                node_msg,
-                our_section_key,
-            )?]);
+            return Ok(vec![self.send_direct_msg(vec![peer], node_msg)?]);
         }
 
         // Do reachability check only for the initial join request
@@ -152,7 +140,7 @@ impl Node {
             trace!("{}", LogMarker::SendJoinRejected);
 
             trace!("Sending {:?} to {}", node_msg, peer);
-            self.send_direct_msg(peer, node_msg, our_section_key)?
+            self.send_direct_msg(vec![peer], node_msg)?
         } else {
             // It's reachable, let's then send the proof challenge
             self.send_resource_proof_challenge(peer)?
@@ -220,11 +208,7 @@ impl Node {
             trace!("{} b", LogMarker::SendJoinAsRelocatedResponse);
 
             trace!("Sending {node_msg:?} to {peer}");
-            return Ok(vec![self.send_direct_msg(
-                peer,
-                node_msg,
-                self.network_knowledge.section_key(),
-            )?]);
+            return Ok(vec![self.send_direct_msg(vec![peer], node_msg)?]);
         }
 
         let relocate_details = if let MembershipState::Relocated(ref details) =
@@ -263,11 +247,7 @@ impl Node {
             trace!("{}", LogMarker::SendJoinAsRelocatedResponse);
 
             trace!("Sending {:?} to {}", node_msg, peer);
-            return Ok(vec![self.send_direct_msg(
-                peer,
-                node_msg,
-                self.network_knowledge.section_key(),
-            )?]);
+            return Ok(vec![self.send_direct_msg(vec![peer], node_msg)?]);
         };
 
         self.propose_membership_change(join_request.relocate_proof.value)

--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -104,8 +104,6 @@ impl Node {
 
         // Create a new instance of JoiningAsRelocated to start the relocation
         // flow. This same instance will handle responses till relocation is complete.
-        let genesis_key = *self.network_knowledge.genesis_key();
-
         let bootstrap_addrs = if let Ok(sap) = self.network_knowledge.section_by_name(&dst_xorname)
         {
             sap.addresses()
@@ -114,7 +112,6 @@ impl Node {
         };
         let (joining_as_relocated, cmd) = JoiningAsRelocated::start(
             node,
-            genesis_key,
             relocate_proof,
             bootstrap_addrs,
             dst_xorname,

--- a/sn_node/src/node/messaging/resource_proof.rs
+++ b/sn_node/src/node/messaging/resource_proof.rs
@@ -56,6 +56,6 @@ impl Node {
         }));
 
         trace!("{}", LogMarker::SendResourceProofChallenge);
-        self.send_direct_msg(peer, response, self.network_knowledge.section_key())
+        self.send_direct_msg(vec![peer], response)
     }
 }

--- a/sn_node/src/node/messaging/signing.rs
+++ b/sn_node/src/node/messaging/signing.rs
@@ -1,0 +1,99 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::OutgoingMsg;
+
+use crate::node::{Node, Result};
+
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Entity;
+use sn_interface::{
+    messaging::{
+        data::ServiceMsg, system::SystemMsg, AuthKind, DstLocation, MsgId, NodeAuth, ServiceAuth,
+        WireMsg,
+    },
+    types::{PublicKey, Signature},
+};
+
+use bytes::Bytes;
+use signature::Signer;
+use xor_name::XorName;
+
+// Message handling
+impl Node {
+    /// Signing an outgoing msg.
+    ///
+    /// We don't need the destination,
+    /// as that is always set on the WireMsg
+    /// when handled in comms together with specified recipients.
+    pub(crate) fn sign_msg(
+        &self,
+        msg: OutgoingMsg,
+        #[cfg(feature = "traceroute")] traceroute: Vec<Entity>,
+    ) -> Result<WireMsg> {
+        let (auth, payload) = match msg {
+            OutgoingMsg::System(msg) => self.sign_system_msg(msg)?,
+            OutgoingMsg::Service(msg) => self.sign_service_msg(msg)?,
+            OutgoingMsg::DstAggregated((auth, payload)) => (AuthKind::NodeBlsShare(auth), payload),
+        };
+
+        #[allow(unused_mut)]
+        let mut wire_msg = WireMsg::new_msg(MsgId::new(), payload, auth, self.dst())?;
+
+        #[cfg(feature = "traceroute")]
+        {
+            let mut trace = traceroute;
+            trace.push(self.entity());
+            wire_msg.add_trace(&mut trace);
+        }
+
+        #[cfg(feature = "test-utils")]
+        let wire_msg = wire_msg.set_payload_debug(msg);
+
+        Ok(wire_msg)
+    }
+
+    /// Currently using node's Ed key. May need to use bls key share for consensus purpose.
+    fn sign_service_msg(&self, msg: ServiceMsg) -> Result<(AuthKind, Bytes)> {
+        let payload = WireMsg::serialize_msg_payload(&msg)?;
+        let signature = self.keypair.sign(&payload);
+
+        let auth = AuthKind::Service(ServiceAuth {
+            public_key: PublicKey::Ed25519(self.keypair.public),
+            signature: Signature::Ed25519(signature),
+        });
+
+        Ok((auth, payload))
+    }
+
+    /// Currently using node's Ed key. May need to use bls key share for consensus purpose.
+    fn sign_system_msg(&self, msg: SystemMsg) -> Result<(AuthKind, Bytes)> {
+        let payload = WireMsg::serialize_msg_payload(&msg)?;
+        let src_section_pk = self.network_knowledge.section_key();
+        let auth = AuthKind::Node(
+            NodeAuth::authorize(src_section_pk, &self.keypair, &payload).into_inner(),
+        );
+
+        Ok((auth, payload))
+    }
+
+    fn dst(&self) -> DstLocation {
+        let section_pk = self.network_knowledge.section_key();
+        let name = XorName::from_content(&[]); // random name because it is overwritten in comms (which is somewhat iffy.. but tbd)
+        DstLocation::Section { name, section_pk }
+    }
+
+    #[cfg(feature = "traceroute")]
+    fn entity(&self) -> Entity {
+        if self.is_elder() {
+            Entity::Elder(PublicKey::Ed25519(self.info().keypair.public))
+        } else {
+            Entity::Adult(PublicKey::Ed25519(self.info().keypair.public))
+        }
+    }
+}


### PR DESCRIPTION
This places signing and wire msg instantiation in one location, and
removes lots of old variables that aren't used in the flow anymore.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
