### PR TITLE
Refactor joinrequest

### DIFF
--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -15,18 +15,25 @@ use serde::{Deserialize, Serialize};
 use sn_consensus::Decision;
 use std::{collections::VecDeque, net::SocketAddr};
 
-/// Request to join a section
+/// Response to a request to join a section
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct JoinRequest {
-    /// The public key of the section to join.
-    pub section_key: BlsPublicKey,
-    /// Proof of the resource proofing.
-    pub resource_proof_response: Option<ResourceProofResponse>,
+#[allow(clippy::large_enum_variant)]
+pub enum JoinRequest {
+    Initiate {
+        /// The public key of the section to join.
+        section_key: BlsPublicKey,
+    },
+    SubmitResourceProof {
+        /// The public key of the section to join.
+        section_key: BlsPublicKey,
+        /// The challenge solution
+        proof: Box<ResourceProof>,
+    },
 }
 
 /// Joining peer's proof of resolvement of given resource proofing challenge.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
-pub struct ResourceProofResponse {
+pub struct ResourceProof {
     #[allow(missing_docs)]
     pub solution: u64,
     #[allow(missing_docs)]
@@ -72,7 +79,7 @@ pub enum JoinResponse {
     Redirect(SectionAuthorityProvider),
     /// Message sent to joining peer containing the necessary
     /// info to become a member of the section.
-    Approval {
+    Approved {
         /// Network genesis key (needed to validate) section_chain
         genesis_key: BlsPublicKey,
         /// SectionAuthorityProvider Signed by (current section)

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -15,7 +15,7 @@ mod node_state;
 mod signed;
 
 pub use agreement::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, Proposal, SectionAuth};
-pub use join::{JoinRejectionReason, JoinRequest, JoinResponse, ResourceProofResponse};
+pub use join::{JoinRejectionReason, JoinRequest, JoinResponse, ResourceProof};
 pub use join_as_relocated::{JoinAsRelocatedRequest, JoinAsRelocatedResponse};
 pub use msg_authority::NodeMsgAuthorityUtils;
 pub use node_msgs::{NodeCmd, NodeEvent, NodeQuery, NodeQueryResponse};
@@ -99,7 +99,7 @@ pub enum SystemMsg {
     /// Membership Anti-Entropy request
     MembershipAE(Generation),
     /// Sent from a bootstrapping peer to the section requesting to join as a new member
-    JoinRequest(Box<JoinRequest>),
+    JoinRequest(JoinRequest),
     /// Response to a `JoinRequest`
     JoinResponse(Box<JoinResponse>),
     /// Sent from a peer to the section requesting to join as relocated from another section

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -31,19 +31,22 @@ impl Node {
     ) -> Result<Option<Cmd>> {
         debug!("Received {:?} from {}", join_request, peer);
 
-        // Require resource signed if joining as a new node.
-        if let Some(response) = join_request.resource_proof_response {
-            if !self.validate_resource_proof_response(&peer.name(), response) {
-                debug!("Ignoring JoinRequest from {peer} - invalid resource signed response");
-                return Ok(None);
-            }
+        let provided_section_key = match join_request {
+            JoinRequest::Initiate { section_key } => section_key,
+            JoinRequest::SubmitResourceProof { proof, .. } => {
+                // Require resource signed if joining as a new node.
+                if !self.validate_resource_proof(&peer.name(), *proof) {
+                    debug!("Ignoring JoinRequest from {peer} - invalid resource signed response");
+                    return Ok(None);
+                }
 
-            let node_state = NodeState::joined(peer.name(), peer.addr(), None);
-            return Ok(self.propose_membership_change(node_state));
-        }
+                let node_state = NodeState::joined(peer.name(), peer.addr(), None);
+                return Ok(self.propose_membership_change(node_state));
+            }
+        };
 
         let our_section_key = self.network_knowledge.section_key();
-        let section_key_matches = join_request.section_key == our_section_key;
+        let section_key_matches = provided_section_key == our_section_key;
 
         // Ignore `JoinRequest` if we are not elder, unless the join request
         // is outdated in which case we'll reply with `JoinResponse::Retry`
@@ -60,11 +63,8 @@ impl Node {
         let our_prefix = self.network_knowledge.prefix();
         if !our_prefix.matches(&peer.name()) {
             debug!("Redirecting JoinRequest from {peer} - name doesn't match our prefix {our_prefix:?}.");
-
             let retry_sap = self.matching_section(&peer.name())?;
-
             let msg = SystemMsg::JoinResponse(Box::new(JoinResponse::Redirect(retry_sap.to_msg())));
-
             trace!("Sending {:?} to {}", msg, peer);
             trace!("{}", LogMarker::SendJoinRedirected);
             return Ok(Some(self.send_system_msg(msg, Peers::Single(peer))));
@@ -95,10 +95,10 @@ impl Node {
         if !section_key_matches {
             trace!("{}", LogMarker::SendJoinRetryNotCorrectKey);
             trace!(
-                "JoinRequest from {} doesn't have our latest section_key {:?}, presented {:?}.",
+                "JoinRequest from {} doesn't have our latest section_key {:?}, provided {:?}.",
                 peer,
                 our_section_key,
-                join_request.section_key
+                provided_section_key,
             );
         }
 

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -265,7 +265,7 @@ impl Node {
         let prefix = self.network_knowledge.prefix();
         info!("Section {prefix:?} has approved new peers {peers:?}.");
 
-        let msg = SystemMsg::JoinResponse(Box::new(JoinResponse::Approval {
+        let msg = SystemMsg::JoinResponse(Box::new(JoinResponse::Approved {
             genesis_key: *self.network_knowledge.genesis_key(),
             section_auth: self
                 .network_knowledge

--- a/sn_node/src/node/messaging/resource_proof.rs
+++ b/sn_node/src/node/messaging/resource_proof.rs
@@ -12,7 +12,7 @@ use crate::node::{
 };
 
 use sn_interface::{
-    messaging::system::{JoinResponse, ResourceProofResponse, SystemMsg},
+    messaging::system::{JoinResponse, ResourceProof, SystemMsg},
     types::{keys::ed25519, log_markers::LogMarker, Peer},
 };
 
@@ -21,12 +21,12 @@ use xor_name::XorName;
 
 // Resource signed
 impl Node {
-    pub(crate) fn validate_resource_proof_response(
+    pub(crate) fn validate_resource_proof(
         &self,
         peer_name: &XorName,
-        response: ResourceProofResponse,
+        proof: ResourceProof,
     ) -> bool {
-        let serialized = if let Ok(serialized) = bincode::serialize(&(peer_name, &response.nonce)) {
+        let serialized = if let Ok(serialized) = bincode::serialize(&(peer_name, &proof.nonce)) {
             serialized
         } else {
             return false;
@@ -35,14 +35,14 @@ impl Node {
         if self
             .keypair
             .public
-            .verify(&serialized, &response.nonce_signature)
+            .verify(&serialized, &proof.nonce_signature)
             .is_err()
         {
             return false;
         }
 
         self.resource_proof
-            .validate_all(&response.nonce, &response.data, response.solution)
+            .validate_all(&proof.nonce, &proof.data, proof.solution)
     }
 
     pub(crate) fn send_resource_proof_challenge(&self, peer: Peer) -> Result<Cmd> {

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -238,7 +238,7 @@ impl Node {
             // The AcceptedOnlineShare for relocation will be received here.
             SystemMsg::JoinResponse(join_response) => {
                 match *join_response {
-                    JoinResponse::Approval {
+                    JoinResponse::Approved {
                         section_auth,
                         section_chain,
                         ..
@@ -314,7 +314,7 @@ impl Node {
                 .collect()),
             SystemMsg::JoinRequest(join_request) => {
                 trace!("Handling msg: JoinRequest from {}", sender);
-                self.handle_join_request(sender, *join_request, comm)
+                self.handle_join_request(sender, join_request, comm)
                     .await
                     .map(|c| c.into_iter().collect())
             }


### PR DESCRIPTION
Remove optional field and model the actual requests separately, instead of combining two types of requests into one.