### PR TITLE
Remove node write lock on query

### DIFF
--- a/sn_interface/src/types/cache/mod.rs
+++ b/sn_interface/src/types/cache/mod.rs
@@ -76,17 +76,25 @@ where
     }
 
     /// Get a value from the cache if one is set and not expired.
-    ///
-    /// A clone of the value is returned, so this is only implemented when `V: Clone`.
-    pub fn get(&self, key: &T) -> Option<V>
+    pub fn get(&self, key: &T) -> Option<&V>
     where
         T: Eq + Hash,
-        V: Clone,
     {
         self.items
             .get(key)
             .filter(|&item| !item.expired())
-            .map(|k| k.object.clone())
+            .map(|k| &k.object)
+    }
+
+    /// Get a mut value from the cache if one is set and not expired.
+    pub fn get_mut(&mut self, key: &T) -> Option<&mut V>
+    where
+        T: Eq + Hash,
+    {
+        self.items
+            .get_mut(key)
+            .filter(|item| !item.expired())
+            .map(|k| &mut k.object)
     }
 
     /// Get a list of all items in the cache
@@ -185,7 +193,7 @@ mod tests {
         let mut cache = Cache::with_expiry_duration(Duration::from_secs(2));
         let _prev = cache.set(KEY, VALUE, None);
         let value = cache.get(&KEY);
-        assert_eq!(value, Some(VALUE), "value was not found in cache");
+        assert_eq!(value, Some(&VALUE), "value was not found in cache");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -193,7 +201,7 @@ mod tests {
         let mut cache = Cache::with_capacity(usize::MAX);
         let _prev = cache.set(KEY, VALUE, None);
         let value = cache.get(&KEY);
-        assert_eq!(value, Some(VALUE), "value was not found in cache");
+        assert_eq!(value, Some(&VALUE), "value was not found in cache");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -201,7 +209,7 @@ mod tests {
         let mut cache = Cache::with_expiry_duration(Duration::from_secs(0));
         let _prev = cache.set(KEY, VALUE, Some(Duration::from_secs(2)));
         let value = cache.get(&KEY);
-        assert_eq!(value, Some(VALUE), "value was not found in cache");
+        assert_eq!(value, Some(&VALUE), "value was not found in cache");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -231,7 +239,7 @@ mod tests {
         let _prev = cache.set(KEY, VALUE, None);
         let _prev = cache.set(KEY, NEW_VALUE, None);
         let value = cache.get(&KEY);
-        assert_eq!(value, Some(NEW_VALUE), "value was not found in cache");
+        assert_eq!(value, Some(&NEW_VALUE), "value was not found in cache");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -302,6 +310,6 @@ mod tests {
         let value: &str = "hello";
         let _prev = cache.set(key, value, None);
         assert!(cache.get(&KEY).is_none());
-        assert_eq!(cache.get(&key), Some(value));
+        assert_eq!(cache.get(&key), Some(&value));
     }
 }

--- a/sn_interface/src/types/log_markers.rs
+++ b/sn_interface/src/types/log_markers.rs
@@ -38,7 +38,6 @@ pub enum LogMarker {
     VotedOffline,
     // Messaging
     ServiceMsgToBeHandled,
-    QueryServiceMsgToBeHandled,
     SystemMsgToBeHandled,
     // Membership
     MembershipVotesBeingHandled,

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -755,7 +755,7 @@ impl ProbeTracker {
         let result = self
             .sections
             .iter_mut()
-            .find_map(|(prefix, cache)| cache.get(dst).map(|pk| (prefix, pk, cache)));
+            .find_map(|(prefix, cache)| cache.get(dst).cloned().map(|pk| (prefix, pk, cache)));
         let (_prefix, probe_state, cache) = match result {
             None => return,
             Some(state) => state,

--- a/sn_node/src/node/data/records/mod.rs
+++ b/sn_node/src/node/data/records/mod.rs
@@ -55,7 +55,7 @@ impl Node {
     }
 
     pub(crate) async fn read_data_from_adults(
-        &mut self,
+        &self,
         query: DataQuery,
         msg_id: MsgId,
         auth: AuthorityProof<ServiceAuth>,
@@ -74,17 +74,10 @@ impl Node {
         let targets = self.target_data_holders_including_full(address.name());
 
         // Query only the nth adult
-        let targets = BTreeSet::from_iter(
-            targets
-                .into_iter()
-                .nth(query.adult_index) // Grab only nth adult
-                .iter() // Get Iter of length 0 (if nth adult does not exists) or 1
-                .copied(), // &XorName -> XorName
-        );
-
-        if targets.is_empty() {
+        let target = if let Some(peer) = targets.into_iter().nth(query.adult_index) {
+            peer
+        } else {
             let error = convert_to_error_msg(Error::NoAdults(self.network_knowledge().prefix()));
-
             debug!("No targets found for {msg_id:?}");
             return Ok(vec![self.send_cmd_error_response(
                 CmdError::Data(error),
@@ -93,52 +86,30 @@ impl Node {
                 #[cfg(feature = "traceroute")]
                 traceroute,
             )]);
-        }
-
-        let mut op_was_already_underway = false;
-        let waiting_peers = if let Some(mut peers) = self.pending_data_queries.get(&operation_id) {
-            op_was_already_underway = peers.insert(origin);
-
-            peers
-        } else {
-            let mut peers = BTreeSet::new();
-            let _false_as_fresh = peers.insert(origin);
-            peers
         };
 
-        // drop if we exceed
-        if waiting_peers.len() > MAX_WAITING_PEERS_PER_QUERY {
-            warn!("Dropping query from {origin:?}, there are more than {MAX_WAITING_PEERS_PER_QUERY} waiting already");
-            return Ok(vec![]);
+        let mut cmds = vec![Cmd::AddToPendingQueries {
+            origin,
+            operation_id,
+        }];
+
+        if let Some(peers) = self.pending_data_queries.get(&operation_id) {
+            if peers.len() > MAX_WAITING_PEERS_PER_QUERY {
+                warn!("Dropping query from {origin:?}, there are more than {MAX_WAITING_PEERS_PER_QUERY} waiting already");
+                return Ok(vec![]);
+            } else {
+                // we don't respond to the actual query, as we're still within data query timeout
+                // we rely on the data query cache timeout to decide as/when we'll be re-sending a query to adults
+                return Ok(cmds);
+            }
         }
 
-        // only set pending data query cache if non existed.
-        // otherwise we've appended to the Peers above
-        // we rely on the data query cache timeout to decide as/when we'll be re-sending a query to adults
-        if op_was_already_underway {
-            // we don't do anything as we're still within data query timeout
-            return Ok(vec![]);
-        }
-
-        let mut cmds = vec![];
-
-        // ensure we only add a pending request when we're actually sending out requests.
-        for target in &targets {
-            trace!("adding pending req for {target:?} in dysfunction tracking");
-            cmds.push(Cmd::TrackNodeIssueInDysfunction {
-                name: target.name(),
-                issue: IssueType::PendingRequestOperation(Some(operation_id)),
-            })
-        }
-
-        trace!(
-            "Adding to pending data queries for op id: {:?}",
-            operation_id
-        );
-
-        let _prior_value = self
-            .pending_data_queries
-            .set(operation_id, waiting_peers, None);
+        // we only add a pending request when we're actually sending out requests
+        trace!("adding pending req for {target:?} in dysfunction tracking");
+        cmds.push(Cmd::TrackNodeIssueInDysfunction {
+            name: target.name(),
+            issue: IssueType::PendingRequestOperation(Some(operation_id)),
+        });
 
         let msg = SystemMsg::NodeQuery(NodeQuery::Data {
             query: query.variant,
@@ -149,7 +120,7 @@ impl Node {
 
         cmds.push(self.trace_system_msg(
             msg,
-            Peers::Multiple(targets),
+            Peers::Single(target),
             #[cfg(feature = "traceroute")]
             traceroute,
         ));

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -17,7 +17,7 @@ use sn_consensus::Decision;
 use sn_dysfunction::IssueType;
 use sn_interface::{
     messaging::{
-        data::ServiceMsg,
+        data::{OperationId, ServiceMsg},
         system::{DkgFailureSigSet, KeyedSig, NodeState, SectionAuth, SystemMsg},
         AuthorityProof, MsgId, NodeMsgAuthority, ServiceAuth, WireMsg,
     },
@@ -111,6 +111,12 @@ pub(crate) enum Cmd {
     },
     /// Log a Node's Punishment, this pulls dysfunction and write locks out of some functions
     TrackNodeIssueInDysfunction { name: XorName, issue: IssueType },
+    /// Adds peer to set of recipients of an already pending query,
+    /// or adds a pending query if it didn't already exist.
+    AddToPendingQueries {
+        operation_id: OperationId,
+        origin: Peer,
+    },
     HandleValidSystemMsg {
         msg_id: MsgId,
         msg: SystemMsg,
@@ -235,6 +241,8 @@ impl Cmd {
 
             Comm(_) => 7,
 
+            AddToPendingQueries { .. } => 6,
+
             // See [`MsgType`] for the priority constants and the range of possible values.
             HandleValidSystemMsg { msg, .. } => msg.priority(),
             HandleValidServiceMsg { msg, .. } => msg.priority(),
@@ -283,6 +291,7 @@ impl fmt::Display for Cmd {
                 write!(f, "TrackNodeIssueInDysfunction {:?}, {:?}", name, issue)
             }
             Cmd::ProposeOffline(_) => write!(f, "ProposeOffline"),
+            Cmd::AddToPendingQueries { .. } => write!(f, "AddToPendingQueries"),
             Cmd::TellEldersToStartConnectivityTest(_) => {
                 write!(f, "TellEldersToStartConnectivityTest")
             }

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -12,8 +12,9 @@ use crate::node::{
     Cmd, Error, Node, Result,
 };
 
+use sn_interface::messaging::{AuthKind, Dst, MsgId};
 use sn_interface::{
-    messaging::{data::ServiceMsg, system::SystemMsg, AuthKind, Dst, MsgId, WireMsg},
+    messaging::{system::SystemMsg, WireMsg},
     types::Peer,
 };
 
@@ -103,6 +104,25 @@ impl Dispatcher {
             Cmd::TrackNodeIssueInDysfunction { name, issue } => {
                 let mut node = self.node.write().await;
                 node.log_node_issue(name, issue)?;
+                Ok(vec![])
+            }
+            Cmd::AddToPendingQueries {
+                operation_id,
+                origin,
+            } => {
+                let mut node = self.node.write().await;
+
+                if let Some(peers) = node.pending_data_queries.get_mut(&operation_id) {
+                    trace!(
+                        "Adding to pending data queries for op id: {:?}",
+                        operation_id
+                    );
+                    let _ = peers.insert(origin);
+                } else {
+                    let _prior_value =
+                        node.pending_data_queries
+                            .set(operation_id, BTreeSet::from([origin]), None);
+                };
 
                 Ok(vec![])
             }
@@ -121,33 +141,18 @@ impl Dispatcher {
                 auth,
                 #[cfg(feature = "traceroute")]
                 traceroute,
-            } => match msg {
-                ServiceMsg::Query(_) => {
-                    let mut node = self.node.write().await;
-
-                    node.handle_valid_query_msg(
-                        msg_id,
-                        msg,
-                        auth,
-                        origin,
-                        #[cfg(feature = "traceroute")]
-                        traceroute,
-                    )
-                    .await
-                }
-                _ => {
-                    let node = self.node.read().await;
-
-                    node.handle_valid_service_msg(
-                        msg_id,
-                        msg,
-                        origin,
-                        #[cfg(feature = "traceroute")]
-                        traceroute,
-                    )
-                    .await
-                }
-            },
+            } => {
+                let node = self.node.read().await;
+                node.handle_valid_service_msg(
+                    msg_id,
+                    msg,
+                    auth,
+                    origin,
+                    #[cfg(feature = "traceroute")]
+                    traceroute,
+                )
+                .await
+            }
             Cmd::HandleValidSystemMsg {
                 origin,
                 msg_id,

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -124,9 +124,9 @@ impl FlowCtrl {
 
             loop {
                 let _instant = interval.tick().await;
-                let mut node = self.node.write().await;
+                let node = self.node.read().await;
 
-                if !node.is_elder() {
+                if node.is_not_elder() {
                     // don't send health checks as an adult
                     continue;
                 }
@@ -148,23 +148,14 @@ impl FlowCtrl {
                 let our_info = node.info();
                 let origin = our_info.peer();
 
-                let keypair = node.keypair.clone();
-                let payload = WireMsg::serialize_msg_payload(&msg)?;
-                let signature = keypair.sign(&payload);
-
-                let auth = ServiceAuth {
-                    public_key: PublicKey::Ed25519(keypair.public),
-                    signature: Signature::Ed25519(signature),
-                };
-
-                let proofed_auth = AuthorityProof::verify(auth, payload)?;
+                let auth = auth(&node, &msg)?;
 
                 // generate the cmds, and ensure we go through dysfunction tracking
                 let cmds = node
-                    .handle_valid_query_msg(
+                    .handle_valid_service_msg(
                         msg_id,
                         msg,
-                        proofed_auth,
+                        auth,
                         origin,
                         #[cfg(feature = "traceroute")]
                         vec![],
@@ -500,4 +491,17 @@ async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Rece
     }
 
     error!("Fatal error, the stream for incoming connections has been unexpectedly closed. No new connections or messages can be received from the network from here on.");
+}
+
+fn auth(node: &Node, msg: &ServiceMsg) -> Result<AuthorityProof<ServiceAuth>> {
+    let keypair = node.keypair.clone();
+    let payload = WireMsg::serialize_msg_payload(&msg)?;
+    let signature = keypair.sign(&payload);
+
+    let auth = ServiceAuth {
+        public_key: PublicKey::Ed25519(keypair.public),
+        signature: Signature::Ed25519(signature),
+    };
+
+    Ok(AuthorityProof::verify(auth, payload)?)
 }


### PR DESCRIPTION
This creates the `AddToPendingQieries` cmd, which adds asyncly to the
list.
Also cleans up the `read_data_from_adults` fn a bit.