### PR TITLE
chore(CI): cancel old CI run on new commit

### DIFF
--- a/.github/workflows/benchmark_prs.yml
+++ b/.github/workflows/benchmark_prs.yml
@@ -2,6 +2,10 @@ name: Benchmarks
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_INCREMENTAL: '0'
   RUST_BACKTRACE: 1

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [staging, trying]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_INCREMENTAL: 0  # bookkeeping for incremental builds has overhead, not useful in CI.
   RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
Stops the old CI run on force push/ new commit.

Eg: any push to `my_branch` will create group with name,
"PR Check-my_branch" and subsequent updates to the branch
will stop any running CI for the same group.

