### PR TITLE
feat(cli): wallet CLI cmd to allow storing output DBC to a file upon reissuing it

### DIFF
--- a/sn_cli/src/operations/config.rs
+++ b/sn_cli/src/operations/config.rs
@@ -333,6 +333,7 @@ impl Config {
     pub fn networks_iter(&self) -> impl Iterator<Item = (&String, &NetworkInfo)> {
         self.settings.networks.iter()
     }
+
     pub async fn add_network(
         &mut self,
         name: &str,


### PR DESCRIPTION
Allows to pass a file path to write the output DBC when reissuing with `wallet reissue` CLI cmd. If there is a problem writing to the file the CLI falls back to print the DBC data out. This arg can be extended to also support a wallet xorurl, so the user can reissue and get the output DBC either written to a file, or automatically deposited to another wallet the user owns.

This PR also renames the `--public-key` argument of `wallet reissue` command to `--to` as agreed in the review herein.

Example outputs:
```
$ safe wallet reissue 3.5 --save ./reissued_dbc.txt --from safe://hyryynywwgpr4yofnhpsm8kkcskjmtu6bq8m8834j88qia9djdzxfhy7mdhb6o
DBC content written at './reissued_dbc.txt'.
Reissued DBC with 3.5 safecoins.
This is a bearer DBC that can be spent by anyone.
```

```
$ safe wallet reissue 1.25 --save /invalid/file/path --from safe://hyryynywwgpr4yofnhpsm8kkcskjmtu6bq8m8834j88qia9djdzxfhy7mdhb6o
Error: Unable to write DBC at '/invalid/file/path': No such file or directory (os error 2).
Reissued DBC with 1.25 safecoins.
-------- DBC DATA --------
4c34acb4552a7a...e1de4400000000
--------------------------
This is a bearer DBC that can be spent by anyone.
```