### PR TITLE
fix(file_store): use correct data address type

### DIFF
--- a/sn_interface/src/messaging/data/cmd.rs
+++ b/sn_interface/src/messaging/data/cmd.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{CmdError, Error, RegisterCmd, SpentbookCmd};
-use crate::types::{Chunk, DataAddress};
+use crate::types::{Chunk, ReplicatedDataAddress as DataAddress};
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
@@ -53,7 +53,7 @@ impl DataCmd {
     /// Returns the DataAddress of the corresponding variant.
     pub fn address(&self) -> DataAddress {
         match self {
-            Self::StoreChunk(chunk) => DataAddress::Bytes(*chunk.address()),
+            Self::StoreChunk(chunk) => DataAddress::Chunk(*chunk.address()),
             Self::Register(register_cmd) => DataAddress::Register(register_cmd.dst_address()),
             Self::Spentbook(spentbook_cmd) => DataAddress::Spentbook(spentbook_cmd.dst_address()),
         }

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -6,9 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::types::register::User;
-use crate::types::DataAddress;
-use crate::types::PublicKey;
+use crate::types::{register::User, PublicKey, ReplicatedDataAddress as DataAddress};
 use serde::{Deserialize, Serialize};
 use std::result;
 use thiserror::Error;

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -34,8 +34,9 @@ pub use self::{
 use crate::messaging::{data::Error as ErrorMsg, MsgId};
 use crate::types::{
     register::{Entry, EntryHash, Permissions, Policy, Register, User},
-    utils, Chunk, ChunkAddress, DataAddress,
+    utils, Chunk, ChunkAddress, ReplicatedDataAddress as DataAddress,
 };
+
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use sn_dbc::SpentProofShare;
@@ -300,7 +301,7 @@ impl QueryResponse {
             GetChunk(result) => match result {
                 Ok(chunk) => chunk_operation_id(chunk.address()),
                 Err(ErrorMsg::ChunkNotFound(name)) => chunk_operation_id(&ChunkAddress(*name)),
-                Err(ErrorMsg::DataNotFound(DataAddress::Bytes(address))) => {
+                Err(ErrorMsg::DataNotFound(DataAddress::Chunk(address))) => {
                     chunk_operation_id(address)
                 }
                 Err(ErrorMsg::DataNotFound(another_address)) => {

--- a/sn_interface/src/types/address/mod.rs
+++ b/sn_interface/src/types/address/mod.rs
@@ -15,7 +15,6 @@ pub use register::RegisterAddress;
 pub use spentbook::SpentbookAddress;
 
 use super::{utils, Result};
-use crate::types::Error;
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
@@ -72,15 +71,6 @@ impl DataAddress {
     pub fn spentbook(name: XorName) -> DataAddress {
         DataAddress::Spentbook(SpentbookAddress::new(name))
     }
-
-    pub fn to_replicated_data_address(self) -> Result<ReplicatedDataAddress> {
-        match self {
-            Self::Bytes(addr) => Ok(ReplicatedDataAddress::Chunk(addr)),
-            Self::Register(addr) => Ok(ReplicatedDataAddress::Register(addr)),
-            Self::Spentbook(addr) => Ok(ReplicatedDataAddress::Spentbook(addr)),
-            _ => Err(Error::InvalidOperation),
-        }
-    }
 }
 
 /// An address of data on the network
@@ -102,6 +92,16 @@ impl ReplicatedDataAddress {
             Self::Register(address) => address.name(),
             Self::Spentbook(address) => address.name(),
         }
+    }
+
+    /// Returns the Address serialised and encoded in z-base-32.
+    pub fn encode_to_zbase32(&self) -> Result<String> {
+        utils::encode(&self)
+    }
+
+    /// Creates from z-base-32 encoded string.
+    pub fn decode_from_zbase32<T: AsRef<str>>(encoded: T) -> Result<Self> {
+        utils::decode(encoded)
     }
 }
 

--- a/sn_node/benches/data_storage.rs
+++ b/sn_node/benches/data_storage.rs
@@ -175,11 +175,8 @@ fn bench_data_storage_reads(c: &mut Criterion) -> Result<()> {
                 }
             }
 
-            b.to_async(&runtime).iter(|| async {
-                match storage.keys() {
-                    Ok(_) => {}
-                    Err(error) => panic!("Reading store register keys failed with {:?}", error),
-                }
+            b.iter(|| {
+                let _keys = storage.keys();
             })
         });
     }
@@ -202,11 +199,8 @@ fn bench_data_storage_reads(c: &mut Criterion) -> Result<()> {
                 };
             }
 
-            b.to_async(&runtime).iter(|| async {
-                match &storage.keys() {
-                    Ok(_keys) => {}
-                    Err(error) => panic!("Reading store chunk keys failed with {:?}", error),
-                }
+            b.iter(|| {
+                let _keys = storage.keys();
             })
         });
     }

--- a/sn_node/src/dbs/errors.rs
+++ b/sn_node/src/dbs/errors.rs
@@ -8,7 +8,7 @@
 
 use sn_interface::{
     messaging::data::Error as ErrorMsg,
-    types::{convert_dt_error_to_error_msg, DataAddress, PublicKey, ReplicatedDataAddress},
+    types::{convert_dt_error_to_error_msg, PublicKey, ReplicatedDataAddress as DataAddress},
 };
 
 use std::io;
@@ -41,15 +41,9 @@ pub enum Error {
     /// Data id not found.
     #[error("Data id not found: {0:?}")]
     DataIdNotFound(DataAddress),
-    /// Cannot delete public data
-    #[error("Cannot delete public data {0:?}")]
-    CannotDeletePublicData(DataAddress),
     /// Data not found.
     #[error("No such data: {0:?}")]
     NoSuchData(DataAddress),
-    /// Data not found for replication
-    #[error("No such data for replication: {0:?}")]
-    NoSuchDataForReplication(ReplicatedDataAddress),
     /// Chunk not found.
     #[error("Chunk not found: {0:?}")]
     ChunkNotFound(XorName),

--- a/sn_node/src/node/data/storage/mod.rs
+++ b/sn_node/src/node/data/storage/mod.rs
@@ -206,21 +206,21 @@ impl DataStorage {
     }
 
     /// Retrieve all keys/ReplicatedDataAddresses of stored data
-    pub fn keys(&self) -> Result<Vec<ReplicatedDataAddress>> {
+    pub fn keys(&self) -> Vec<ReplicatedDataAddress> {
         let mut all_addrs = vec![];
 
         // TODO: Parallelize this below loops
-        let chunk_keys = self.chunks.keys()?;
+        let chunk_keys = self.chunks.keys();
         for addr in chunk_keys {
-            all_addrs.push(addr.to_replicated_data_address()?)
+            all_addrs.push(addr)
         }
 
-        let reg_keys = self.registers.keys()?;
+        let reg_keys = self.registers.keys();
         for addr in reg_keys {
-            all_addrs.push(addr.to_replicated_data_address()?)
+            all_addrs.push(addr)
         }
 
-        Ok(all_addrs)
+        all_addrs
     }
 }
 

--- a/sn_node/src/node/data/storage/registers.rs
+++ b/sn_node/src/node/data/storage/registers.rs
@@ -20,7 +20,8 @@ use sn_interface::{
     },
     types::{
         register::{Action, EntryHash, Permissions, Policy, Register, User},
-        DataAddress, Keypair, PublicKey, RegisterAddress, SPENTBOOK_TYPE_TAG,
+        Keypair, PublicKey, RegisterAddress, ReplicatedDataAddress as DataAddress,
+        SPENTBOOK_TYPE_TAG,
     },
 };
 
@@ -71,7 +72,7 @@ impl RegisterStorage {
         Ok(())
     }
 
-    pub(crate) fn keys(&self) -> Result<Vec<DataAddress>> {
+    pub(crate) fn keys(&self) -> Vec<DataAddress> {
         self.file_db.list_all_data_addresses()
     }
 
@@ -148,7 +149,7 @@ impl RegisterStorage {
     pub(crate) async fn get_data_of(&mut self, prefix: Prefix) -> Result<RegisterStoreExport> {
         let mut the_data = vec![];
 
-        let all_keys = self.keys()?;
+        let all_keys = self.keys();
 
         // TODO: make this concurrent
         for addr in all_keys {

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -12,7 +12,7 @@ use crate::node::handover::Error as HandoverError;
 
 use sn_interface::{
     messaging::data::Error as ErrorMsg,
-    types::{convert_dt_error_to_error_msg, DataAddress, Peer, PublicKey},
+    types::{convert_dt_error_to_error_msg, Peer, PublicKey, ReplicatedDataAddress as DataAddress},
 };
 
 use secured_linked_list::error::Error as SecuredLinkedListError;

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -171,7 +171,7 @@ impl Node {
         if updated && self.is_not_elder() {
             // only done if adult, since as an elder we dont want to get any more
             // data for our name (elders will eventually be caching data in general)
-            cmds.push(self.ask_for_any_new_data()?);
+            cmds.push(self.ask_for_any_new_data());
         }
 
         Ok(cmds)

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -524,8 +524,10 @@ impl Node {
                     LogMarker::RequestForAnyMissingData,
                     msg_id
                 );
-
-                self.get_missing_data_for_node(sender, known_data_addresses)
+                Ok(self
+                    .get_missing_data_for_node(sender, known_data_addresses)
+                    .into_iter()
+                    .collect())
             }
             SystemMsg::NodeQuery(node_query) => {
                 match node_query {


### PR DESCRIPTION
The type including `SafeKey` had been incorrectly used (since it is not
a network side concept), which caused a lot of `Result` return values
bloating the upstream call tree unnecessarily.