### PR TITLE
chore: cleanup unnecessary options and results

### DIFF
--- a/sn_dysfunction/src/error.rs
+++ b/sn_dysfunction/src/error.rs
@@ -19,9 +19,6 @@ pub enum Error {
     /// System time error
     #[error("Could not calculate system time")]
     CouldNotCalculateSystemTime,
-    /// Error when an operation ID is not supplied when adding a pending request operation.
-    #[error("An operation ID must be supplied for a pending request operation.")]
-    OpIdNotSupplied(String),
     /// Error when an operation ID is supplied that doesn't apply to this type of issue.
     #[error("An operation ID only applies to pending unfulfilled requests.")]
     UnusedOpIdSupplied(String),

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -120,7 +120,7 @@ impl Comm {
         self.our_endpoint.public_addr()
     }
 
-    pub(crate) async fn cleanup_peers(&self, section_members: BTreeSet<NodeState>) -> Result<()> {
+    pub(crate) async fn cleanup_peers(&self, section_members: BTreeSet<NodeState>) {
         debug!(
             "Cleanup peers , known section members: {:?}",
             section_members
@@ -161,7 +161,6 @@ impl Comm {
         }
 
         debug!("PeerSessions count post-cleanup: {:?}", self.sessions.len());
-        Ok(())
     }
 
     /// Fake function used as replacement for testing only.

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -136,7 +136,7 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         debug!("{}", LogMarker::TriggeringPromotionAndDemotion);
         let mut cmds = vec![];
-        for session_id in self.promote_and_demote_elders(excluded_names)? {
+        for session_id in self.promote_and_demote_elders(excluded_names) {
             cmds.extend(self.send_dkg_start(session_id)?);
         }
 

--- a/sn_node/src/node/connectivity.rs
+++ b/sn_node/src/node/connectivity.rs
@@ -12,22 +12,21 @@ use xor_name::XorName;
 
 impl Node {
     /// Track comms issue if this is a peer we know and care about
-    pub(crate) fn handle_failed_send(&mut self, addr: &SocketAddr) -> Result<()> {
+    pub(crate) fn handle_failed_send(&mut self, addr: &SocketAddr) {
         let name = if let Some(peer) = self.network_knowledge.find_member_by_addr(addr) {
             debug!("Lost known peer {}", peer);
             peer.name()
         } else {
             trace!("Lost unknown peer {}", addr);
-            return Ok(());
+            return;
         };
 
         if self.is_not_elder() {
             // Adults cannot complain about connectivity.
-            return Ok(());
+            return;
         }
 
-        self.log_comm_issue(name)?;
-        Ok(())
+        self.log_comm_issue(name);
     }
 
     pub(crate) fn cast_offline_proposals(&mut self, names: &BTreeSet<XorName>) -> Result<Vec<Cmd>> {

--- a/sn_node/src/node/data/records/mod.rs
+++ b/sn_node/src/node/data/records/mod.rs
@@ -108,7 +108,7 @@ impl Node {
         trace!("adding pending req for {target:?} in dysfunction tracking");
         cmds.push(Cmd::TrackNodeIssueInDysfunction {
             name: target.name(),
-            issue: IssueType::PendingRequestOperation(Some(operation_id)),
+            issue: IssueType::PendingRequestOperation(operation_id),
         });
 
         let msg = SystemMsg::NodeQuery(NodeQuery::Data {

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -62,7 +62,7 @@ impl Dispatcher {
         match cmd {
             Cmd::CleanupPeerLinks => {
                 let members = { self.node.read().await.network_knowledge.section_members() };
-                self.comm.cleanup_peers(members).await?;
+                self.comm.cleanup_peers(members).await;
                 Ok(vec![])
             }
             Cmd::SendMsg {
@@ -103,7 +103,7 @@ impl Dispatcher {
             }
             Cmd::TrackNodeIssueInDysfunction { name, issue } => {
                 let mut node = self.node.write().await;
-                node.log_node_issue(name, issue)?;
+                node.log_node_issue(name, issue);
                 Ok(vec![])
             }
             Cmd::AddToPendingQueries {
@@ -202,7 +202,7 @@ impl Dispatcher {
             }
             Cmd::HandlePeerFailedSend(peer) => {
                 let mut node = self.node.write().await;
-                node.handle_failed_send(&peer.addr())?;
+                node.handle_failed_send(&peer.addr());
                 Ok(vec![])
             }
             Cmd::HandleDkgOutcome {
@@ -214,7 +214,7 @@ impl Dispatcher {
             }
             Cmd::HandleDkgFailure(signeds) => {
                 let mut node = self.node.write().await;
-                Ok(vec![node.handle_dkg_failure(signeds)?])
+                Ok(vec![node.handle_dkg_failure(signeds)])
             }
             Cmd::EnqueueDataForReplication {
                 // throttle_duration,
@@ -265,8 +265,7 @@ impl Dispatcher {
                 if let Some(member_info) = node_state {
                     if self.comm.is_reachable(&member_info.addr()).await.is_err() {
                         let mut node = self.node.write().await;
-
-                        node.log_comm_issue(member_info.name())?
+                        node.log_comm_issue(member_info.name());
                     }
                 }
                 Ok(vec![])

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -77,7 +77,7 @@ impl Node {
         //       elders excluded, this check here uses the empty set for the
         //       excluded_candidates which would prevent a dkg-retry from
         //       succeeding.
-        let dkg_sessions = self.promote_and_demote_elders(&BTreeSet::new())?;
+        let dkg_sessions = self.promote_and_demote_elders(&BTreeSet::new());
 
         let agreeing_elders = BTreeSet::from_iter(signed_section_auth.names());
         if dkg_sessions

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -249,7 +249,7 @@ impl Node {
         let generation = self.network_knowledge.chain_len();
 
         let dkg_session = if let Some(dkg_session) = self
-            .promote_and_demote_elders(&BTreeSet::new())?
+            .promote_and_demote_elders(&BTreeSet::new())
             .into_iter()
             .find(|session_id| failure_set.verify(session_id))
         {
@@ -315,12 +315,12 @@ impl Node {
         }
     }
 
-    pub(crate) fn handle_dkg_failure(&mut self, failure_set: DkgFailureSigSet) -> Result<Cmd> {
+    pub(crate) fn handle_dkg_failure(&mut self, failure_set: DkgFailureSigSet) -> Cmd {
         // track those failed participants
         for name in &failure_set.failed_participants {
             trace!("Logging {name} as having Dkg issue in dysfunction");
-            self.log_dkg_issue(*name)?;
+            self.log_dkg_issue(*name);
         }
-        Ok(self.send_msg_to_our_elders(SystemMsg::DkgFailureAgreement(failure_set)))
+        self.send_msg_to_our_elders(SystemMsg::DkgFailureAgreement(failure_set))
     }
 }

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -332,27 +332,22 @@ mod core {
         }
 
         /// Log an issue in dysfunction
-        pub(crate) fn log_node_issue(&mut self, name: XorName, issue: IssueType) -> Result<()> {
+        pub(crate) fn log_node_issue(&mut self, name: XorName, issue: IssueType) {
             trace!("Logging issue {issue:?} in dysfunction");
-            self.dysfunction_tracking
-                .track_issue(name, issue)
-                .map_err(Error::from)
+            self.dysfunction_tracking.track_issue(name, issue)
         }
 
         /// Log a communication problem
-        pub(crate) fn log_comm_issue(&mut self, name: XorName) -> Result<()> {
+        pub(crate) fn log_comm_issue(&mut self, name: XorName) {
             trace!("Logging comms issue in dysfunction");
             self.dysfunction_tracking
                 .track_issue(name, IssueType::Communication)
-                .map_err(Error::from)
         }
 
         /// Log a dkg issue (ie, an initialised but unfinished dkg round for a given participant)
-        pub(crate) fn log_dkg_issue(&mut self, name: XorName) -> Result<()> {
+        pub(crate) fn log_dkg_issue(&mut self, name: XorName) {
             trace!("Logging Dkg issue in dysfunction");
-            self.dysfunction_tracking
-                .track_issue(name, IssueType::Dkg)
-                .map_err(Error::from)
+            self.dysfunction_tracking.track_issue(name, IssueType::Dkg)
         }
 
         /// Log a dkg session as responded to
@@ -376,7 +371,7 @@ mod core {
         pub(crate) fn promote_and_demote_elders(
             &mut self,
             excluded_names: &BTreeSet<XorName>,
-        ) -> Result<Vec<DkgSessionId>> {
+        ) -> Vec<DkgSessionId> {
             let sap = self.network_knowledge.authority_provider();
             let chain_len = self.network_knowledge.chain_len();
 
@@ -393,7 +388,7 @@ mod core {
                 error!(
                 "attempted to promote and demote elders when we don't have a membership instance"
             );
-                return Ok(vec![]);
+                return vec![];
             };
 
             // Try splitting
@@ -413,15 +408,15 @@ mod core {
                 // So, shall only track the side that we are in as well.
                 if zero_dkg_id.elders.contains_key(&self.info().name()) {
                     for candidate in zero_dkg_id.elders.keys() {
-                        self.log_dkg_issue(*candidate)?;
+                        self.log_dkg_issue(*candidate);
                     }
                 } else if one_dkg_id.elders.contains_key(&self.info().name()) {
                     for candidate in one_dkg_id.elders.keys() {
-                        self.log_dkg_issue(*candidate)?;
+                        self.log_dkg_issue(*candidate);
                     }
                 }
 
-                return Ok(vec![zero_dkg_id, one_dkg_id]);
+                return vec![zero_dkg_id, one_dkg_id];
             }
 
             // Candidates for elders out of all the nodes in the section, even out of the
@@ -477,13 +472,13 @@ mod core {
                 };
                 // track init of DKG
                 for candidate in session_id.elders.keys() {
-                    self.log_dkg_issue(*candidate)?;
+                    self.log_dkg_issue(*candidate);
                 }
 
                 vec![session_id]
             };
 
-            Ok(res)
+            res
         }
 
         fn initialize_membership(&mut self, sap: SectionAuthorityProvider) -> Result<()> {


### PR DESCRIPTION
These were remaining in places where there was no path for None or
Error.
Cleaning these up removes accidental complexity.