### PR TITLE
chore(cli): make writes atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3415,6 +3415,7 @@ dependencies = [
  "sn_cmd_test_utilities",
  "sn_dbc",
  "sn_launch_tool",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber 0.2.25",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -46,6 +46,7 @@ serde_yaml = "~0.8"
 clap = { version = "3.0.0", features = ["derive", "env"] }
 clap_complete = { version = "3.0.0" }
 tokio = { version = "1.6.0", features = ["macros"] }
+tempfile = "3.2.0"
 tracing = "~0.1.26"
 tracing-subscriber = "~0.2.15"
 url = "2.2.2"


### PR DESCRIPTION
Fixes the write corruption when running CLI tests using multiple threads.