### PR TITLE
feat(churnid): make the content explicit

### DIFF
--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -1512,8 +1512,7 @@ fn create_relocation_trigger(
         let decision = section_decision(sk_set, node_state.clone())?;
 
         let sig: Signature = decision.proposals[&node_state].clone();
-
-        let churn_id = ChurnId(sig.to_bytes().to_vec());
+        let churn_id = ChurnId(sig.to_bytes());
 
         if relocation_check(age, &churn_id) && !relocation_check(age + 1, &churn_id) {
             return Ok(decision);

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -195,7 +195,7 @@ impl Node {
         }
 
         if let Some((_, sig)) = decision.proposals.iter().max_by_key(|(_, sig)| *sig) {
-            let churn_id = ChurnId(sig.to_bytes().to_vec());
+            let churn_id = ChurnId(sig.to_bytes());
             let excluded_from_relocation =
                 BTreeSet::from_iter(joining_nodes.iter().map(|(n, _)| n.name));
 

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -21,7 +21,7 @@ use std::{
 use xor_name::XorName;
 
 // Unique identifier for a churn event, which is used to select nodes to relocate.
-pub(crate) struct ChurnId(pub(crate) Vec<u8>);
+pub(crate) struct ChurnId(pub(crate) [u8; bls::SIG_SIZE]);
 
 impl Display for ChurnId {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
@@ -196,11 +196,8 @@ mod tests {
         }
 
         // Simulate a churn event whose signature has the given number of trailing zeros.
-        let churn_id = ChurnId(
-            signature_with_trailing_zeros(signature_trailing_zeros as u32)
-                .to_bytes()
-                .to_vec(),
-        );
+        let churn_id =
+            ChurnId(signature_with_trailing_zeros(signature_trailing_zeros as u32).to_bytes());
 
         let relocations =
             find_nodes_to_relocate(&network_knowledge, &churn_id, BTreeSet::default());


### PR DESCRIPTION
We previously allowed any length vec, while we only based it on
signatures. Therefore, we could restrict it to the signature contents
boundary.
