### PR TITLE
chore(node): hash the cmd itself for priority queue dedupe

### DIFF
--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -25,7 +25,7 @@ static DIFF_THRESHOLD: f32 = 1.0;
 /// Z-score value above which a node is dysfunctional
 static DYSFUNCTIONAL_DEVIATION: f32 = 2.0;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 /// Represents the different type of issues that can be recorded by the Dysfunction Detection
 /// system.
 /// Issues have a xorname so they can be reliable assignd to the same nodes

--- a/sn_interface/src/network_knowledge/section_keys.rs
+++ b/sn_interface/src/network_knowledge/section_keys.rs
@@ -14,7 +14,7 @@ use uluru::LRUCache;
 const KEY_CACHE_SIZE: usize = 50;
 
 /// All the key material needed to sign or combine signature for our section key.
-#[derive(custom_debug::Debug, Clone)]
+#[derive(custom_debug::Debug, Clone, PartialEq)]
 pub struct SectionKeyShare {
     /// Public key set to verify threshold signatures and combine shares.
     pub public_key_set: bls::PublicKeySet,

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -51,7 +51,7 @@ pub(crate) struct Comm {
 
 /// Commands for interacting with Comm.
 #[allow(unused)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Cmd {
     #[cfg(feature = "back-pressure")]
     /// Set message rate for peer to the desired msgs per second

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -96,7 +96,7 @@ impl CmdJob {
 /// and prioritization, which is not something e.g. tokio tasks allow.
 /// In other words, it enables enhanced flow control.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Cmd {
     /// Cleanup node's PeerLinks, removing any unsused, unconnected peers
     CleanupPeerLinks,

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -34,7 +34,7 @@ use bytes::Bytes;
 use itertools::Itertools;
 use std::collections::BTreeSet;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum OutgoingMsg {
     System(SystemMsg),
@@ -42,7 +42,7 @@ pub(crate) enum OutgoingMsg {
     DstAggregated((BlsShareAuth, Bytes)),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Peers {
     Single(Peer),
     Multiple(BTreeSet<Peer>),


### PR DESCRIPTION
Critical part here is that we use the hash of the cmd for the PriorityQueue to decide if it's the same instead of the (always unique) job id.

https://github.com/maidsafe/safe_network/compare/main...joshuef:HashCmdForPrio?expand=1#diff-eac741114cd6f272ef32eee6e13c6f1931d1ee6e051a94f10981decf624e8b42L273