### PR TITLE
chore(style): organise usings, cleanup

### DIFF
--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -10,6 +10,12 @@ use super::{QueryResult, Session};
 
 use crate::{connections::CmdResponse, Error, Result};
 
+#[cfg(feature = "traceroute")]
+use sn_interface::{
+    messaging::{Entity, Traceroute},
+    types::PublicKey,
+};
+
 use sn_interface::{
     messaging::{
         data::{DataQuery, DataQueryVariant, QueryResponse},
@@ -28,15 +34,6 @@ use std::time::Duration;
 use tokio::{sync::mpsc::channel, task::JoinHandle};
 use tracing::{debug, error, trace, warn};
 use xor_name::XorName;
-
-#[cfg(feature = "traceroute")]
-use sn_interface::types::PublicKey;
-
-#[cfg(feature = "traceroute")]
-use sn_interface::messaging::Entity;
-
-#[cfg(feature = "traceroute")]
-use sn_interface::messaging::Traceroute;
 
 // Number of Elders subset to send queries to
 pub(crate) const NUM_OF_ELDERS_SUBSET_FOR_QUERIES: usize = 3;

--- a/sn_interface/src/messaging/mod.rs
+++ b/sn_interface/src/messaging/mod.rs
@@ -40,6 +40,9 @@ mod dst;
 // SectionAuthorityProvider
 mod sap;
 
+#[cfg(feature = "traceroute")]
+pub use self::serialisation::{Entity, Traceroute};
+
 pub use self::{
     auth_kind::AuthKind,
     authority::{
@@ -53,9 +56,6 @@ pub use self::{
     serialisation::{NodeMsgAuthority, WireMsg},
 };
 
-#[cfg(feature = "traceroute")]
-pub use self::serialisation::Entity;
-
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
@@ -63,6 +63,3 @@ use xor_name::XorName;
 // a SocketAddr at the Elders where the `EndUser` is proxied through.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub struct EndUser(pub XorName);
-
-#[cfg(feature = "traceroute")]
-pub use self::serialisation::Traceroute;

--- a/sn_interface/src/messaging/serialisation/mod.rs
+++ b/sn_interface/src/messaging/serialisation/mod.rs
@@ -10,18 +10,14 @@ mod wire_msg;
 mod wire_msg_header;
 
 pub use self::wire_msg::WireMsg;
-
-use crate::types::PublicKey;
+#[cfg(feature = "traceroute")]
+pub use self::wire_msg::{Entity, Traceroute};
 
 use super::{AuthorityProof, BlsShareAuth, NodeAuth, SectionAuth};
 
+use crate::types::PublicKey;
+
 use xor_name::XorName;
-
-#[cfg(feature = "traceroute")]
-pub use self::wire_msg::Entity;
-
-#[cfg(feature = "traceroute")]
-pub use self::wire_msg::Traceroute;
 
 /// Authority of a `NodeMsg`.
 /// Src of message and authority to send it. Authority is validated by the signature.

--- a/sn_node/src/node/bootstrap/relocate.rs
+++ b/sn_node/src/node/bootstrap/relocate.rs
@@ -15,11 +15,8 @@ use crate::node::{
 };
 
 use sn_interface::{
-    messaging::{
-        system::{
-            JoinAsRelocatedRequest, JoinAsRelocatedResponse, NodeState, SectionAuth, SystemMsg,
-        },
-        MsgId,
+    messaging::system::{
+        JoinAsRelocatedRequest, JoinAsRelocatedResponse, NodeState, SectionAuth, SystemMsg,
     },
     network_knowledge::{NodeInfo, SectionAuthorityProvider},
     types::{keys::ed25519, Peer, PublicKey},
@@ -27,7 +24,6 @@ use sn_interface::{
 
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::{Keypair, Signature};
-use sn_interface::messaging::Traceroute;
 use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
 use xor_name::{Prefix, XorName};
 
@@ -220,13 +216,8 @@ impl JoiningAsRelocated {
 
         info!("Sending {:?} to {:?}", join_request, recipients);
 
-        let cmd = Cmd::SendMsg {
-            msg: OutgoingMsg::System(SystemMsg::JoinAsRelocatedRequest(Box::new(join_request))),
-            msg_id: MsgId::new(),
-            recipients: Peers::Multiple(recipients),
-            #[cfg(feature = "traceroute")]
-            traceroute: Traceroute(vec![]),
-        };
+        let msg = SystemMsg::JoinAsRelocatedRequest(Box::new(join_request));
+        let cmd = Cmd::send_msg(OutgoingMsg::System(msg), Peers::Multiple(recipients));
 
         Ok(cmd)
     }

--- a/sn_node/src/node/data/records/mod.rs
+++ b/sn_node/src/node/data/records/mod.rs
@@ -15,8 +15,9 @@ use crate::node::{
     MAX_WAITING_PEERS_PER_QUERY,
 };
 
-use itertools::Itertools;
 use sn_dysfunction::IssueType;
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Traceroute;
 use sn_interface::{
     data_copy_count,
     messaging::{
@@ -26,12 +27,11 @@ use sn_interface::{
     },
     types::{log_markers::LogMarker, Peer, PublicKey, ReplicatedData},
 };
+
+use itertools::Itertools;
 use std::{cmp::Ordering, collections::BTreeSet};
 use tracing::info;
 use xor_name::XorName;
-
-#[cfg(feature = "traceroute")]
-use sn_interface::messaging::Traceroute;
 
 impl Node {
     // Locate ideal holders for this data, instruct them to store the data

--- a/sn_node/src/node/dkg/session.rs
+++ b/sn_node/src/node/dkg/session.rs
@@ -13,10 +13,7 @@ use crate::node::{
 };
 
 use sn_interface::{
-    messaging::{
-        system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SystemMsg},
-        MsgId,
-    },
+    messaging::system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SystemMsg},
     network_knowledge::{NodeInfo, SectionAuthorityProvider, SectionKeyShare},
     types::{keys::ed25519, log_markers::LogMarker, Peer},
 };
@@ -26,7 +23,6 @@ use bls_dkg::key_gen::{
     message::Message as DkgMessage, Error as DkgError, KeyGen, MessageAndTarget, Phase,
 };
 use itertools::Itertools;
-use sn_interface::messaging::Traceroute;
 use std::{
     collections::{BTreeMap, BTreeSet},
     iter, mem,
@@ -97,13 +93,10 @@ impl Session {
                 session_id: self.session_id.clone(),
                 message,
             };
-            cmds.push(Cmd::SendMsg {
-                msg: OutgoingMsg::System(msg),
-                msg_id: MsgId::new(),
-                recipients: Peers::Single(*peer),
-                #[cfg(feature = "traceroute")]
-                traceroute: Traceroute(vec![]),
-            });
+            cmds.push(Cmd::send_msg(
+                OutgoingMsg::System(msg),
+                Peers::Single(*peer),
+            ));
         } else {
             warn!(
                 "Failed to fetch peer of {:?} among {:?}",
@@ -203,14 +196,10 @@ impl Session {
                     session_id: self.session_id.clone(),
                     message: message.clone(),
                 };
-
-                cmds.push(Cmd::SendMsg {
-                    msg: OutgoingMsg::System(msg),
-                    msg_id: MsgId::new(),
-                    recipients: Peers::Single(*peer),
-                    #[cfg(feature = "traceroute")]
-                    traceroute: Traceroute(vec![]),
-                });
+                cmds.push(Cmd::send_msg(
+                    OutgoingMsg::System(msg),
+                    Peers::Single(*peer),
+                ));
             } else {
                 error!("Failed to find target {:?} among peers {:?}", target, peers);
             }
@@ -374,13 +363,7 @@ impl Session {
                     failed_participants,
                 };
                 trace!("{}", LogMarker::DkgSendFailureObservation);
-                Cmd::SendMsg {
-                    msg: OutgoingMsg::System(msg),
-                    msg_id: MsgId::new(),
-                    recipients: Peers::Multiple(self.recipients()),
-                    #[cfg(feature = "traceroute")]
-                    traceroute: Traceroute(vec![]),
-                }
+                Cmd::send_msg(OutgoingMsg::System(msg), Peers::Multiple(self.recipients()))
             }))
             .collect();
 

--- a/sn_node/src/node/dkg/voter.rs
+++ b/sn_node/src/node/dkg/voter.rs
@@ -14,10 +14,7 @@ use crate::node::{
 };
 
 use sn_interface::{
-    messaging::{
-        system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SystemMsg},
-        MsgId,
-    },
+    messaging::system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SystemMsg},
     network_knowledge::{supermajority, NodeInfo, SectionAuthorityProvider, SectionKeyShare},
     types::{
         keys::ed25519::{self, Digest256},
@@ -28,7 +25,6 @@ use sn_interface::{
 use bls::PublicKey as BlsPublicKey;
 use bls_dkg::key_gen::{message::Message as DkgMessage, KeyGen};
 use dashmap::DashMap;
-use sn_interface::messaging::Traceroute;
 use std::{collections::BTreeSet, sync::Arc};
 use xor_name::XorName;
 
@@ -181,18 +177,14 @@ impl DkgVoter {
                 &session_id,
                 &sender
             );
-
             let msg = SystemMsg::DkgSessionUnknown {
                 session_id: session_id.clone(),
                 message,
             };
-            cmds.push(Cmd::SendMsg {
-                msg: OutgoingMsg::System(msg),
-                msg_id: MsgId::new(),
-                recipients: Peers::Single(sender),
-                #[cfg(feature = "traceroute")]
-                traceroute: Traceroute(vec![]),
-            });
+            cmds.push(Cmd::send_msg(
+                OutgoingMsg::System(msg),
+                Peers::Single(sender),
+            ));
         }
         Ok(cmds)
     }

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -11,10 +11,10 @@ use crate::node::{
     Proposal, XorName,
 };
 
-use bytes::Bytes;
-use custom_debug::Debug;
 use sn_consensus::Decision;
 use sn_dysfunction::IssueType;
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
         data::{OperationId, ServiceMsg},
@@ -24,15 +24,15 @@ use sn_interface::{
     network_knowledge::{SectionAuthorityProvider, SectionKeyShare},
     types::{Peer, ReplicatedDataAddress},
 };
+
+use bytes::Bytes;
+use custom_debug::Debug;
 use std::{
     collections::BTreeSet,
     fmt,
     sync::atomic::{AtomicU64, Ordering},
     time::{Duration, SystemTime},
 };
-
-#[cfg(feature = "traceroute")]
-use sn_interface::messaging::Traceroute;
 
 /// A struct for the job of controlling the flow
 /// of a [`Cmd`] in the system.

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -12,14 +12,12 @@ use crate::node::{
     Cmd, Error, Node, Result,
 };
 
-use sn_interface::messaging::{AuthKind, Dst, MsgId};
-use sn_interface::{
-    messaging::{system::SystemMsg, WireMsg},
-    types::Peer,
-};
-
 #[cfg(feature = "traceroute")]
 use sn_interface::{messaging::Entity, messaging::Traceroute, types::PublicKey};
+use sn_interface::{
+    messaging::{system::SystemMsg, AuthKind, Dst, MsgId, WireMsg},
+    types::Peer,
+};
 
 use bytes::Bytes;
 use std::{collections::BTreeSet, sync::Arc, time::Duration};

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -19,6 +19,8 @@ pub(crate) use self::cmd_ctrl::CmdCtrl;
 use crate::comm::MsgEvent;
 use crate::node::{flow_ctrl::cmds::Cmd, messaging::Peers, Error, Node, Result};
 
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
         data::{DataQuery, DataQueryVariant, ServiceMsg},
@@ -35,9 +37,6 @@ use tokio::{
     task::{self, JoinHandle},
     time::MissedTickBehavior,
 };
-
-#[cfg(feature = "traceroute")]
-use sn_interface::messaging::Traceroute;
 
 const PROBE_INTERVAL: Duration = Duration::from_secs(30);
 const MISSING_VOTE_INTERVAL: Duration = Duration::from_secs(15);

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -20,6 +20,8 @@ use crate::node::{
 };
 
 use sn_consensus::Decision;
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Traceroute;
 use sn_interface::{
     elder_count, init_logger,
     messaging::{
@@ -48,7 +50,6 @@ use itertools::Itertools;
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use resource_proof::ResourceProof as ChallengeSolver;
 use secured_linked_list::SecuredLinkedList;
-use sn_interface::messaging::Traceroute;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     iter,
@@ -1106,12 +1107,7 @@ async fn msg_to_self() -> Result<()> {
         // don't use the cmd collection fn, as it skips Cmd::SendMsg
         let cmds = dispatcher
             .process_cmd(
-                Cmd::SendMsg {
-                    msg: OutgoingMsg::System(node_msg.clone()),
-                    msg_id: MsgId::new(),
-                    recipients: Peers::Single(info.peer()),
-                    #[cfg(feature = "traceroute")] traceroute: Traceroute(vec![]),
-                },
+                Cmd::send_msg(OutgoingMsg::System(node_msg.clone()), Peers::Single(info.peer()))
             )
             .await?;
 

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -11,11 +11,9 @@ use crate::node::{
     messaging::{OutgoingMsg, Peers},
     Error, Event, MembershipEvent, Node, Result, StateSnapshot,
 };
-use backoff::{backoff::Backoff, ExponentialBackoff};
-use bls::PublicKey as BlsPublicKey;
-use bytes::Bytes;
-use itertools::Itertools;
-use secured_linked_list::SecuredLinkedList;
+
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
         system::{KeyedSig, NodeCmd, SectionAuth, SectionPeers, SystemMsg},
@@ -24,11 +22,14 @@ use sn_interface::{
     network_knowledge::SectionAuthorityProvider,
     types::{log_markers::LogMarker, Peer, PublicKey},
 };
+
+use backoff::{backoff::Backoff, ExponentialBackoff};
+use bls::PublicKey as BlsPublicKey;
+use bytes::Bytes;
+use itertools::Itertools;
+use secured_linked_list::SecuredLinkedList;
 use std::{collections::BTreeSet, time::Duration};
 use xor_name::{Prefix, XorName};
-
-#[cfg(feature = "traceroute")]
-use sn_interface::messaging::Traceroute;
 
 impl Node {
     /// Send `AntiEntropyUpdate` message to all nodes in our own section.

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -13,17 +13,18 @@ use crate::node::{
 };
 
 use bytes::Bytes;
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
         system::{DkgFailureSig, DkgFailureSigSet, DkgSessionId, SigShare, SystemMsg},
-        AuthorityProof, BlsShareAuth, MsgId, NodeMsgAuthority, WireMsg,
+        AuthorityProof, BlsShareAuth, NodeMsgAuthority, WireMsg,
     },
     network_knowledge::{SectionAuthorityProvider, SectionKeyShare},
     types::{log_markers::LogMarker, Peer},
 };
 
 use bls_dkg::key_gen::message::Message as DkgMessage;
-use sn_interface::messaging::Traceroute;
 use std::collections::BTreeSet;
 use xor_name::XorName;
 
@@ -60,13 +61,10 @@ impl Node {
         let (auth, payload) = self.get_auth(msg.clone(), src_name)?;
 
         if !others.is_empty() {
-            cmds.push(Cmd::SendMsg {
-                msg: OutgoingMsg::DstAggregated((auth.clone(), payload.clone())),
-                msg_id: MsgId::new(),
-                recipients: Peers::Multiple(others),
-                #[cfg(feature = "traceroute")]
-                traceroute: Traceroute(vec![]),
-            });
+            cmds.push(Cmd::send_msg(
+                OutgoingMsg::DstAggregated((auth.clone(), payload.clone())),
+                Peers::Multiple(others),
+            ));
         }
 
         if handle {

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -16,6 +16,8 @@ use sn_dbc::{
     Commitment, Hash, IndexedSignatureShare, KeyImage, RingCtTransaction, SpentProof,
     SpentProofContent, SpentProofShare,
 };
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Traceroute;
 use sn_interface::{
     data_copy_count,
     messaging::{
@@ -36,9 +38,6 @@ use sn_interface::{
 use bytes::Bytes;
 use std::collections::{BTreeMap, BTreeSet};
 use xor_name::XorName;
-
-#[cfg(feature = "traceroute")]
-use sn_interface::messaging::Traceroute;
 
 impl Node {
     /// Forms a `CmdError` msg to send back to the client

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -17,6 +17,8 @@ use crate::{
     },
 };
 
+#[cfg(feature = "traceroute")]
+use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
         data::StorageLevel,
@@ -39,9 +41,6 @@ use sn_interface::{
 
 use bytes::Bytes;
 use xor_name::XorName;
-
-#[cfg(feature = "traceroute")]
-use sn_interface::messaging::Traceroute;
 
 impl Node {
     /// Send a (`SystemMsg`) message to all Elders in our section

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -84,6 +84,8 @@ mod core {
         UsedSpace,
     };
     use sn_dysfunction::{DysfunctionDetection, DysfunctionSeverity, IssueType};
+    #[cfg(feature = "traceroute")]
+    use sn_interface::messaging::Entity;
     use sn_interface::{
         messaging::{
             data::OperationId,
@@ -112,9 +114,6 @@ mod core {
         time::Duration,
     };
     use uluru::LRUCache;
-
-    #[cfg(feature = "traceroute")]
-    use sn_interface::messaging::Entity;
 
     /// Amount of tokens to be owned by the Genesis DBC.
     /// At the inception of the Network a total supply of 4,525,524,120 whole tokens will be created.

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -8,14 +8,10 @@
 
 use crate::node::{flow_ctrl::FlowCtrl, Node, Peer, Result};
 
-use sn_interface::{
-    messaging::{system::SystemMsg, MsgId},
-    network_knowledge::SectionAuthorityProvider,
-};
+use sn_interface::{messaging::system::SystemMsg, network_knowledge::SectionAuthorityProvider};
 
 use ed25519_dalek::PublicKey;
 use secured_linked_list::SecuredLinkedList;
-use sn_interface::messaging::Traceroute;
 use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
 use tokio::sync::RwLock;
 use xor_name::{Prefix, XorName};
@@ -98,13 +94,7 @@ impl NodeTestApi {
 
     /// Send a system msg.
     pub async fn send(&self, msg: SystemMsg, recipients: BTreeSet<Peer>) -> Result<()> {
-        let cmd = Cmd::SendMsg {
-            msg: OutgoingMsg::System(msg),
-            msg_id: MsgId::new(),
-            recipients: Peers::Multiple(recipients),
-            #[cfg(feature = "traceroute")]
-            traceroute: Traceroute(vec![]),
-        };
+        let cmd = Cmd::send_msg(OutgoingMsg::System(msg), Peers::Multiple(recipients));
         self.send_cmd(cmd).await
     }
 


### PR DESCRIPTION
- Removes some boilerplate, using fn of `Cmd` to instantiate a send cmd.
- Housekeeping, continuing to minimize bloat of usings, by colocating
them.
- Housekeeping, continuing keeping positions of usings in a file
according to a system, from closest (self) on top, down to furthest
away (3rd part).
