### PR TITLE
refactor(node): nodes to cache their own individual prefix map file on disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
 
 [[package]]
 name = "arrayvec"
@@ -3575,7 +3575,6 @@ dependencies = [
  "crdts",
  "custom_debug",
  "dashmap",
- "dirs-next 2.0.0",
  "ed25519",
  "ed25519-dalek",
  "eyre",
@@ -3619,9 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb24fcaae67df60c8fa1091bd6974291e746c8e64d334bcc892c570efb01cde1"
+checksum = "a66a546409d653118303474ceeeaf0c4760babf0d69b66f7d680bc76354565e5"
 dependencies = [
  "clap 3.2.16",
  "color-eyre",

--- a/sn_api/src/app/helpers.rs
+++ b/sn_api/src/app/helpers.rs
@@ -8,13 +8,9 @@
 
 #[cfg(feature = "app")]
 use crate::{Error, Result};
-use ::time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
+use ::time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use sn_dbc::{Error as DbcError, Token};
-pub use sn_interface::network_knowledge::{
-    prefix_map::NetworkPrefixMap,
-    utils::{DEFAULT_PREFIX_HARDLINK_NAME, SN_PREFIX_MAP_DIR},
-};
 use sn_interface::types::PublicKey;
 use std::{
     str::{self, FromStr},

--- a/sn_api/src/app/mod.rs
+++ b/sn_api/src/app/mod.rs
@@ -19,9 +19,8 @@ pub mod wallet;
 
 pub use crate::safeurl::*;
 pub use consts::DEFAULT_XORURL_BASE;
-pub use helpers::{
-    parse_tokens_amount, NetworkPrefixMap, DEFAULT_PREFIX_HARDLINK_NAME, SN_PREFIX_MAP_DIR,
-};
+pub use sn_client::DEFAULT_PREFIX_HARDLINK_NAME;
+pub use sn_interface::network_knowledge::prefix_map::NetworkPrefixMap;
 pub use xor_name::{XorName, XOR_NAME_LEN};
 
 // --------------------------------------------------------------------

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -39,7 +39,7 @@ reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls
 rmp-serde = "1.0.0"
 sn_api = { path = "../sn_api", version = "^0.66.3", default-features = false, features = ["app"] }
 sn_dbc = { version = "7.2.0", features = ["serdes"] }
-sn_launch_tool = "~0.10.0"
+sn_launch_tool = "~0.11.0"
 serde = "1.0.123"
 serde_json = "1.0.62"
 serde_yaml = "~0.8"

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -33,7 +33,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 use tracing::debug;
 
-use sn_api::SN_PREFIX_MAP_DIR;
 const DEFAULT_OPERATION_TIMEOUT_SECS: u64 = 120; // 2mins
 const SN_CLI_QUERY_TIMEOUT: &str = "SN_CLI_QUERY_TIMEOUT";
 
@@ -181,8 +180,6 @@ async fn get_config() -> Result<Config> {
     cli_config_path.push("config.json");
     let mut prefix_maps_path = config_path;
     prefix_maps_path.push("prefix_maps");
-    let prefix_maps_path_string = prefix_maps_path.as_path().display().to_string();
-    env::set_var(SN_PREFIX_MAP_DIR, prefix_maps_path_string);
     let mut config = Config::new(cli_config_path, prefix_maps_path).await?;
     config.sync().await?;
     Ok(config)

--- a/sn_cli/src/operations/config.rs
+++ b/sn_cli/src/operations/config.rs
@@ -629,12 +629,9 @@ pub mod test_utils {
     use crate::operations::config::Settings;
     use assert_fs::{prelude::*, TempDir};
     use color_eyre::{eyre::eyre, Result};
-    use sn_api::{NetworkPrefixMap, DEFAULT_PREFIX_HARDLINK_NAME, SN_PREFIX_MAP_DIR};
+    use sn_api::{NetworkPrefixMap, DEFAULT_PREFIX_HARDLINK_NAME};
     use std::collections::BTreeMap;
-    use std::{
-        env,
-        path::{Path, PathBuf},
-    };
+    use std::path::{Path, PathBuf};
     use tokio::fs;
 
     pub async fn store_dummy_prefix_maps(
@@ -666,8 +663,6 @@ pub mod test_utils {
             }
 
             let prefix_maps_dir = tmp_dir.child(".safe/prefix_maps");
-            let prefix_maps_dir_string = prefix_maps_dir.path().display().to_string();
-            env::set_var(SN_PREFIX_MAP_DIR, prefix_maps_dir_string);
             Config::new(
                 PathBuf::from(cli_config_file.path()),
                 PathBuf::from(prefix_maps_dir.path()),

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -96,7 +96,7 @@ grep="~0.2.8"
 proptest = "1.0.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rand_xorshift = "~0.2.0"
-sn_launch_tool = "~0.10.0"
+sn_launch_tool = "~0.11.0"
 termcolor="1.1.2"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 tokio-util = { version = "~0.6.7", features = ["time"] }

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -13,7 +13,7 @@ use crate::{
         messaging::{send_msg, NUM_OF_ELDERS_SUBSET_FOR_QUERIES},
         PendingCmdAcks,
     },
-    Error, Result,
+    Error, Result, DEFAULT_PREFIX_HARDLINK_NAME,
 };
 
 use sn_interface::{
@@ -35,7 +35,8 @@ use itertools::Itertools;
 use qp2p::{Close, ConnectionError, ConnectionIncoming as IncomingMsgs, SendError};
 use rand::{rngs::OsRng, seq::SliceRandom};
 use secured_linked_list::SecuredLinkedList;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::Path};
+use tokio::fs;
 use tracing::Instrument;
 
 impl Session {
@@ -403,25 +404,35 @@ impl Session {
         sender: Peer,
     ) {
         // Update our network PrefixMap based upon passed in knowledge
-        match session.network.write().await.update(
+        let result = session.network.write().await.update(
             SectionAuth {
                 value: sap.clone(),
                 sig: section_signed,
             },
             &proof_chain,
-        ) {
+        );
+
+        let prefix_map = session.network.read().await.clone();
+        match result {
             Ok(true) => {
                 debug!(
                     "Anti-Entropy: updated remote section SAP updated for {:?}",
                     sap.prefix()
                 );
+                let path_with_genesis_key = session
+                    .prefix_maps_dir
+                    .join(format!("{:?}", prefix_map.genesis_key()));
+
                 // Update the PrefixMap on disk
-                if let Err(e) = write_prefix_map_to_disk(&*session.network.read().await).await {
+                if let Err(e) = write_prefix_map_to_disk(&prefix_map, &path_with_genesis_key).await
+                {
                     error!(
                         "Error writing freshly updated PrefixMap to client dir: {:?}",
                         e
                     );
                 }
+
+                set_default_prefix_map(&session.prefix_maps_dir, &path_with_genesis_key).await;
             }
             Ok(false) => {
                 debug!(
@@ -529,5 +540,39 @@ impl Session {
         }
 
         Ok(Some((msg_id, target_elders, service_msg, dst, auth)))
+    }
+}
+
+// Create hardlink '.safe/prefix_maps/default' that points to the PrefixMap corresponding to
+// the given genesis_key
+async fn set_default_prefix_map(prefix_maps_dir: &Path, path_with_genesis_key: &Path) {
+    let prefix_map_hardlink = prefix_maps_dir.join(DEFAULT_PREFIX_HARDLINK_NAME);
+
+    if prefix_map_hardlink.exists() {
+        trace!(
+            "Remove default prefix_map hardlink since it already exists: '{}'",
+            prefix_map_hardlink.display()
+        );
+        if let Err(e) = fs::remove_file(&prefix_map_hardlink).await {
+            error!(
+                "Error removing previous PrefixMap hardlink from '{}': {:?}",
+                prefix_map_hardlink.display(),
+                e
+            );
+            return;
+        }
+    }
+
+    trace!(
+        "Creating hardlink for PrefixMap from {} to {}",
+        path_with_genesis_key.display(),
+        prefix_map_hardlink.display()
+    );
+    if let Err(e) = fs::hard_link(&path_with_genesis_key, &prefix_map_hardlink).await {
+        error!(
+            "Error creating default PrefixMap hardlink '{}': {:?}",
+            prefix_map_hardlink.display(),
+            e
+        );
     }
 }

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -658,6 +658,7 @@ mod tests {
     use eyre::{eyre, Result};
     use qp2p::Config;
     use std::{
+        env::temp_dir,
         net::{Ipv4Addr, SocketAddr},
         time::Duration,
     };
@@ -692,6 +693,7 @@ mod tests {
             SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
             Duration::from_secs(10),
             prefix_map,
+            temp_dir(),
         )?;
 
         let mut rng = rand::thread_rng();

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -21,7 +21,7 @@ use sn_interface::{
 
 use dashmap::DashMap;
 use qp2p::{Config as QuicP2pConfig, Endpoint};
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use tokio::sync::{mpsc::Sender, RwLock};
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
@@ -53,6 +53,8 @@ pub(super) struct Session {
     cmd_ack_wait: Duration,
     /// Links to nodes
     peer_links: PeerLinks,
+    /// Path where to read/store cached PrefixMaps
+    prefix_maps_dir: PathBuf,
 }
 
 impl Session {
@@ -63,6 +65,7 @@ impl Session {
         local_addr: SocketAddr,
         cmd_ack_wait: Duration,
         prefix_map: NetworkPrefixMap,
+        prefix_maps_dir: PathBuf,
     ) -> Result<Session> {
         let endpoint = Endpoint::new_client(local_addr, qp2p_config)?;
         let peer_links = PeerLinks::new(endpoint.clone());
@@ -75,6 +78,7 @@ impl Session {
             initial_connection_check_msg_id: Arc::new(RwLock::new(None)),
             cmd_ack_wait,
             peer_links,
+            prefix_maps_dir,
         };
 
         Ok(session)

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -26,6 +26,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
+    /// Failed to obtain network contacts to bootstrap to
+    #[error("Failed to obtain network contacts to bootstrap to: {0}")]
+    NetworkContacts(String),
     /// Message auth checks failed
     #[error("Message's authority could not be trusted.")]
     UntrustedMessage,

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -55,7 +55,7 @@ mod connections;
 mod errors;
 
 // Export public API.
-pub use api::{Client, RegisterWriteAheadLog};
+pub use api::{Client, RegisterWriteAheadLog, DEFAULT_PREFIX_HARDLINK_NAME};
 pub use config_handler::{ClientConfig, DEFAULT_ACK_WAIT, DEFAULT_OPERATION_TIMEOUT};
 pub use errors::{Error, Result};
 pub use qp2p::Config as QuicP2pConfig;

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -29,7 +29,6 @@ bytes = { version = "1.0.1", features = ["serde"] }
 crdts = { version = "7.1", default-features=false, features = ["merkle"] }
 custom_debug = "~0.5.0"
 dashmap = {version = "5.1.0", features = ["serde"]}
-dirs-next = "2.0.0"
 ed25519 = { version = "1.2.0", features = ["serde_bytes"] }
 ed25519-dalek = { version = "1.0.0", features = ["serde"] }
 eyre = "~0.6.5"

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -131,6 +131,9 @@ mod core {
 
     const BACKOFF_CACHE_LIMIT: usize = 100;
 
+    // File name where to cache this node's prefix map (stored at this node's set root storage dir)
+    const PREFIX_MAP_FILE_NAME: &str = "prefix_map";
+
     // How long to hold on to correlated `Peer`s for data queries. Since data queries are forwarded
     // from elders (with whom the client is connected) to adults (who hold the data), the elder handling
     // the query cannot reply immediately. For now, they stash a reference to the client `Peer` in
@@ -153,6 +156,7 @@ mod core {
     pub(crate) struct Node {
         pub(crate) addr: SocketAddr, // does this change? if so... when? only at node start atm?
         pub(crate) event_sender: EventSender,
+        root_storage_dir: PathBuf,
         pub(crate) data_storage: DataStorage, // Adult only before cache
         pub(crate) keypair: Arc<Keypair>,
         /// queue up all batch data to be replicated (as a result of churn events atm)
@@ -253,6 +257,7 @@ mod core {
                 keypair,
                 network_knowledge,
                 section_keys_provider,
+                root_storage_dir,
                 dkg_sessions: HashMap::default(),
                 proposal_aggregator: SignatureAggregator::default(),
                 split_barrier: SplitBarrier::new(),
@@ -275,6 +280,7 @@ mod core {
                 membership,
             };
 
+            // Write the prefix map to this node's root storage directory
             node.write_prefix_map().await;
 
             Ok(node)
@@ -717,13 +723,16 @@ mod core {
         }
 
         pub(crate) async fn write_prefix_map(&self) {
-            info!("Writing our latest PrefixMap to disk");
             let prefix_map = self.network_knowledge.prefix_map().clone();
+            let path = self.root_storage_dir.clone().join(PREFIX_MAP_FILE_NAME);
 
             let _ = tokio::spawn(async move {
-                // write Prefix to `~/.safe/prefix_maps` dir
-                if let Err(e) = write_prefix_map_to_disk(&prefix_map).await {
-                    error!("Error writing PrefixMap to `~/.safe` dir: {:?}", e);
+                if let Err(err) = write_prefix_map_to_disk(&prefix_map, &path).await {
+                    error!(
+                        "Error writing PrefixMap to `{}` dir: {:?}",
+                        path.display(),
+                        err
+                    );
                 }
             });
         }

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -216,7 +216,10 @@ async fn bootstrap_node(
         let node_name = ed25519::name(&keypair.public);
         info!("{} Bootstrapping as a new node.", node_name);
 
-        let prefix_map = read_prefix_map_from_disk().await?;
+        let path = config.network_contacts_file().ok_or_else(|| {
+            Error::Configuration("Could not obtain network contacts file path".to_string())
+        })?;
+        let prefix_map = read_prefix_map_from_disk(&path).await?;
         let section_elders = {
             let sap = prefix_map
                 .closest_or_opposite(&xor_name::rand::random(), None)

--- a/testnet/Cargo.toml
+++ b/testnet/Cargo.toml
@@ -28,7 +28,7 @@ color-eyre = "~0.6.0"
 eyre = "~0.6.5"
 clap = { version = "3.0.0", features = ["derive", "env"]}
 dirs-next = "2.0.0"
-sn_launch_tool = "~0.10.0"
+sn_launch_tool = "~0.11.0"
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = { version = "~0.3.1", features = ["env-filter", "json"] }

--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -33,7 +33,10 @@ use eyre::{eyre, Result, WrapErr as _};
 use sn_launch_tool::Launch;
 #[cfg(not(target_os = "windows"))]
 use std::process::{Command, Stdio};
-use std::{io, path::PathBuf};
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 use tokio::fs::{create_dir_all, remove_dir_all};
 use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
@@ -77,7 +80,7 @@ async fn main() -> Result<()> {
     color_eyre::install()?;
     init_tracing()?;
 
-    let path = std::path::Path::new("nodes");
+    let path = Path::new("nodes");
     remove_dir_all(&path)
         .await
         .or_else(|error| match error.kind() {


### PR DESCRIPTION
This depends on https://github.com/maidsafe/sn_launch_tool/pull/119

- Nodes don't share a file for their own cache of the `PrefixMap`, they keep their own file stored at the node's root storage dir named `prefix_map`.
- The `sn_node` binary now requires a file path to be provided with `--network-contacts-file` argument where to read the network contacts from, unless it's meant to be the first node on the network.