### PR TITLE
fix(node): Add braces around expected age calc; use membership

### DIFF
--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -33,6 +33,8 @@ pub enum Error {
     // section keys are not in chain.
     #[error("Dkg prefix is shorter than our prefix, so dropping the message.")]
     InvalidDkgPrefix,
+    #[error("No membership data exists when it is needed.")]
+    NoMembershipFound,
     #[error("Max retries reached for processing cmd, cmd dropped.")]
     MaxCmdRetriesReached(usize),
     #[error("Cmd job watcher dropped for some unknown reason.")]


### PR DESCRIPTION
Previously we were occasionally seeing _large_ expected ages (246 eg),
here we add braces for clarity and hopefully prevent such calculatory oddness.

We also use membership to know the current section size instead of SAP which
may well be outdated.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
