### PR TITLE
refactor(network_knowledge): remove NetworkKnowledge::chain

### DIFF
--- a/sn_interface/src/network_knowledge/prefix_map/mod.rs
+++ b/sn_interface/src/network_knowledge/prefix_map/mod.rs
@@ -239,7 +239,7 @@ impl NetworkPrefixMap {
         }
 
         // Check the SAP's key is the last key of the proof chain
-        if proof_chain.last_key() != &signed_sap.section_key() {
+        if *proof_chain.last_key() != signed_sap.section_key() {
             return Err(Error::UntrustedSectionAuthProvider(format!(
                 "section key ({:?}, from prefix {:?}) isn't in the last key in the proof chain provided. (Which ends with ({:?}))",
                 signed_sap.section_key(),

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -80,8 +80,8 @@ impl Node {
         &self.network_knowledge
     }
 
-    pub(crate) fn section_chain(&self) -> SecuredLinkedList {
-        self.network_knowledge.section_chain()
+    pub(crate) fn our_section_dag(&self) -> SecuredLinkedList {
+        self.network_knowledge.our_section_dag()
     }
 
     /// Is this node an elder?

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -135,7 +135,7 @@ impl Node {
     ) -> Result<Vec<Cmd>> {
         trace!("{}", LogMarker::HandlingNewEldersAgreement);
         let snapshot = self.state_snapshot();
-        let old_chain = self.section_chain().clone();
+        let old_chain = self.our_section_dag().clone();
 
         let prefix = signed_section_auth.prefix();
         trace!("{}: for {:?}", LogMarker::NewSignedSap, prefix);

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -113,7 +113,7 @@ impl Node {
         }
 
         if !section_key_matches || is_age_invalid {
-            let proof_chain = self.network_knowledge.section_chain();
+            let proof_chain = self.network_knowledge.our_section_dag();
             let signed_sap = self.network_knowledge.section_signed_authority_provider();
             let msg = SystemMsg::JoinResponse(Box::new(JoinResponse::Retry {
                 section_auth: signed_sap.value.to_msg(),

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -271,7 +271,7 @@ impl Node {
                 .network_knowledge
                 .section_signed_authority_provider()
                 .into_authed_msg(),
-            section_chain: self.network_knowledge.section_chain(),
+            section_chain: self.network_knowledge.our_section_dag(),
             decision,
         }));
 

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -621,7 +621,7 @@ impl Node {
                         "Cannot verify DkgSessionInfo: {:?}. Unknown key: {:?}!",
                         &session_id, auth.sig.public_key
                     );
-                    let chain = self.network_knowledge().section_chain();
+                    let chain = self.network_knowledge().our_section_dag();
                     warn!("Chain: {:?}", chain);
                     return Ok(cmds);
                 };

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -704,7 +704,7 @@ mod core {
                 // In case this assumption is not correct (because we already progressed more than one
                 // key since the split) then this key would be unknown to them and they would send
                 // us back their whole section chain. However, this situation should be rare.
-                *self.network_knowledge.section_chain().prev_key()
+                *self.network_knowledge.our_section_dag().prev_key()
             } else {
                 *self.network_knowledge.genesis_key()
             }

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -59,7 +59,7 @@ impl NodeTestApi {
 
     /// Returns the Section Signed Chain
     pub async fn section_chain(&self) -> SecuredLinkedList {
-        self.node.read().await.section_chain()
+        self.node.read().await.our_section_dag()
     }
 
     /// Returns the Section Chain's genesis key


### PR DESCRIPTION
- Removes `NetworkKnowledge::chain` field as it can be obtained from `NetworkPrefixMap::sections_dag`