### PR TITLE
refactor(anti-entropy): reduce AE msgs to one msg with a kind field

### DIFF
--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -336,24 +336,18 @@ impl NetworkKnowledge {
     /// Given a `NodeMsg` can we trust it (including verifying contents of an AE message)
     pub fn verify_node_msg_can_be_trusted(
         msg_authority: NodeMsgAuthority,
-        msg: SystemMsg,
+        msg: &SystemMsg,
         known_keys: &[BlsPublicKey],
     ) -> bool {
         if !msg_authority.verify_src_section_key_is_known(known_keys) {
             // In case the incoming message itself is trying to update our knowledge,
             // it shall be allowed.
-            if let SystemMsg::AntiEntropyUpdate {
-                ref proof_chain, ..
-            } = msg
-            {
+            if let SystemMsg::AntiEntropy { proof_chain, .. } = &msg {
                 // The attached chain shall contains a key known to us
                 if !proof_chain.check_trust(known_keys) {
                     return false;
                 } else {
-                    trace!(
-                        "Allows AntiEntropyUpdate msg({:?}) ahead of our knowledge",
-                        msg,
-                    );
+                    trace!("Allows AntiEntropyUpdate msg({msg:?}) ahead of our knowledge");
                 }
             } else {
                 return false;

--- a/sn_node/examples/routing_minimal.rs
+++ b/sn_node/examples/routing_minimal.rs
@@ -225,7 +225,7 @@ async fn handle_event(index: usize, node: &mut NodeApi, event: Event) -> bool {
             MemberLeft { name, age } => {
                 info!("Node #{} member left - name: {}, age: {}", index, name, age);
             }
-            ChurnJoinMissError => {
+            RemovedFromSection => {
                 info!("Node #{} detected churn join miss and will restart", index);
             }
             SectionSplit {

--- a/sn_node/src/bin/sn_node/main.rs
+++ b/sn_node/src/bin/sn_node/main.rs
@@ -206,8 +206,8 @@ async fn run_node(config: &Config) -> Result<()> {
     // This loop keeps the node going
     while let Some(event) = event_stream.next().await {
         trace!("Node event! {}", event);
-        if let Event::Membership(MembershipEvent::ChurnJoinMissError) = event {
-            return Err(NodeError::ChurnJoinMiss).map_err(ErrReport::msg);
+        if let Event::Membership(MembershipEvent::RemovedFromSection) = event {
+            return Err(NodeError::RemovedFromSection).map_err(ErrReport::msg);
         }
     }
 

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -100,8 +100,8 @@ pub enum Error {
     #[error("Timeout when trying to join the network")]
     JoinTimeout,
     /// Join occured during section churn and new elders missed it, need to re-join the network
-    #[error("Join occured during section churn and new elders missed it")]
-    ChurnJoinMiss,
+    #[error("Node was removed from the section")]
+    RemovedFromSection,
     /// Database error.
     #[error("Database error:: {0}")]
     Database(#[from] crate::dbs::Error),

--- a/sn_node/src/node/flow_ctrl/event.rs
+++ b/sn_node/src/node/flow_ctrl/event.rs
@@ -113,9 +113,8 @@ pub enum CmdProcessEvent {
 /// Still mostly used in tests.
 #[derive(custom_debug::Debug)]
 pub enum MembershipEvent {
-    /// Join occured during section churn and new elders missed it,
-    /// therefore the node is not a section member anymore, it needs to rejoin the network.
-    ChurnJoinMissError,
+    /// Node was removed from the section
+    RemovedFromSection,
     /// A new peer joined our section.
     MemberJoined {
         /// Name of the node

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -184,6 +184,6 @@ impl Node {
             self.network_knowledge.prefix_map()
         );
 
-        self.update_on_elder_change(snapshot).await
+        self.update_on_elder_change(&snapshot).await
     }
 }

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -304,7 +304,7 @@ impl Node {
             .network_knowledge
             .try_update_current_sap(key_share_pk, &sap.prefix())
         {
-            self.update_on_elder_change(snapshot).await
+            self.update_on_elder_change(&snapshot).await
         } else {
             // This proposal is sent to the current set of elders to be aggregated
             // and section signed.

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -149,9 +149,7 @@ impl Node {
 
                 if self.is_not_elder() {
                     trace!("Redirecting from adult to section elders");
-                    return Ok(vec![
-                        self.ae_redirect_to_our_elders(origin, &original_bytes)?
-                    ]);
+                    return Ok(vec![self.ae_redirect_to_our_elders(origin, original_bytes)?]);
                 }
 
                 // First we check if it's query and we have too many on the go at the moment...
@@ -188,11 +186,7 @@ impl Node {
     #[instrument(skip_all)]
     async fn verify_section_key(&self, msg_authority: &NodeMsgAuthority, msg: &SystemMsg) -> bool {
         let known_keys = self.network_knowledge.known_keys();
-        NetworkKnowledge::verify_node_msg_can_be_trusted(
-            msg_authority.clone(),
-            msg.clone(),
-            &known_keys,
-        )
+        NetworkKnowledge::verify_node_msg_can_be_trusted(msg_authority.clone(), msg, &known_keys)
     }
 
     /// Check if the origin needs to be updated on network structure/members.
@@ -219,9 +213,7 @@ impl Node {
         // TODO: consider changing the join and "join as relocated" flows to
         // make use of AntiEntropy retry/redirect responses.
         match msg {
-            SystemMsg::AntiEntropyRetry { .. }
-            | SystemMsg::AntiEntropyUpdate { .. }
-            | SystemMsg::AntiEntropyRedirect { .. }
+            SystemMsg::AntiEntropy { .. }
             | SystemMsg::JoinRequest(_)
             | SystemMsg::JoinAsRelocatedRequest(_) => {
                 trace!(

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -130,21 +130,6 @@ impl Node {
 
         let src_name = msg_authority.name();
         match msg {
-            SystemMsg::AntiEntropyUpdate {
-                section_auth,
-                section_signed,
-                proof_chain,
-                members,
-            } => {
-                trace!("Handling msg: AE-Update from {}: {:?}", sender, msg_id,);
-                self.handle_anti_entropy_update_msg(
-                    section_auth.into_state(),
-                    section_signed,
-                    proof_chain,
-                    members,
-                )
-                .await
-            }
             SystemMsg::Relocate(node_state) => {
                 trace!("Handling msg: Relocate from {}: {:?}", sender, msg_id);
                 Ok(self
@@ -195,40 +180,18 @@ impl Node {
                 );
                 Ok(vec![])
             }
-            SystemMsg::AntiEntropyRetry {
+            SystemMsg::AntiEntropy {
                 section_auth,
                 section_signed,
                 proof_chain,
-                bounced_msg,
+                kind,
             } => {
-                trace!("Handling msg: AE-Retry from {}: {:?}", sender, msg_id,);
-
-                #[cfg(feature = "traceroute")]
-                info!("Handling AE-Retry message with trace {:?}", traceroute);
-
-                self.handle_anti_entropy_retry_msg(
+                trace!("Handling msg: AE from {sender}: {msg_id:?}");
+                self.handle_anti_entropy_msg(
                     section_auth.into_state(),
                     section_signed,
                     proof_chain,
-                    bounced_msg,
-                    sender,
-                    #[cfg(feature = "traceroute")]
-                    traceroute,
-                )
-                .await
-            }
-            SystemMsg::AntiEntropyRedirect {
-                section_auth,
-                section_signed,
-                section_chain,
-                bounced_msg,
-            } => {
-                trace!("Handling msg: AE-Redirect from {}: {:?}", sender, msg_id);
-                self.handle_anti_entropy_redirect_msg(
-                    section_auth.into_state(),
-                    section_signed,
-                    section_chain,
-                    bounced_msg,
+                    kind,
                     sender,
                     #[cfg(feature = "traceroute")]
                     traceroute,

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -368,6 +368,12 @@ mod core {
                 section_key: self.network_knowledge.section_key(),
                 prefix: self.network_knowledge.prefix(),
                 elders: self.network_knowledge().authority_provider().names(),
+                members: self
+                    .network_knowledge()
+                    .members()
+                    .into_iter()
+                    .map(|p| p.name())
+                    .collect(),
             }
         }
 
@@ -748,5 +754,6 @@ mod core {
         pub(crate) section_key: bls::PublicKey,
         pub(crate) prefix: Prefix,
         pub(crate) elders: BTreeSet<XorName>,
+        pub(crate) members: BTreeSet<XorName>,
     }
 }

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -286,6 +286,10 @@ mod core {
             NodeInfo { keypair, addr }
         }
 
+        pub(crate) fn name(&self) -> XorName {
+            self.info().name()
+        }
+
         ////////////////////////////////////////////////////////////////////////////
         // Miscellaneous
         ////////////////////////////////////////////////////////////////////////////
@@ -528,7 +532,7 @@ mod core {
         /// Updates various state if elders changed.
         pub(crate) async fn update_on_elder_change(
             &mut self,
-            old: StateSnapshot,
+            old: &StateSnapshot,
         ) -> Result<Vec<Cmd>> {
             let new = self.state_snapshot();
 
@@ -630,7 +634,7 @@ mod core {
                     info!("{}: {:?}", LogMarker::StillElderAfterSplit, new.prefix);
                 }
 
-                cmds.extend(self.send_updates_to_sibling_section(&old)?);
+                cmds.extend(self.send_updates_to_sibling_section(old)?);
                 self.liveness_retain_only(
                     self.network_knowledge
                         .adults()
@@ -738,6 +742,7 @@ mod core {
         }
     }
 
+    #[derive(Clone)]
     pub(crate) struct StateSnapshot {
         pub(crate) is_elder: bool,
         pub(crate) section_key: bls::PublicKey,

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -739,9 +739,9 @@ mod core {
     }
 
     pub(crate) struct StateSnapshot {
-        is_elder: bool,
+        pub(crate) is_elder: bool,
         pub(crate) section_key: bls::PublicKey,
-        prefix: Prefix,
+        pub(crate) prefix: Prefix,
         pub(crate) elders: BTreeSet<XorName>,
     }
 }


### PR DESCRIPTION
This reduces the `SystemMsg::AntiEntopy{Update|Retry|Redirect}` msgs to a single `SystemMsg::AntiEntropy {.. kind }` msg to allow for de-duplication of logic.