### PR TITLE
cli: serialize NetworkPrefixMap into JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "bls_dkg"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c3ef085d692a85269dc03e10428993965d5b41743f5380575232880705c8df"
+checksum = "25098bcdb34e1d12570f3b218b52743c3ebbd9a54b7cb0b7befc983828c5da43"
 dependencies = [
  "aes 0.7.5",
  "bincode",
@@ -3095,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "self_encryption"
-version = "0.27.4"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636472c0b4e0354c08736d6a3f86ddf2746c739cd6605d2d9dc4472ba28351cf"
+checksum = "fd6e0bb4adf6f555179dcbcf67ac1998517ca25b7acfd8bcf2fc3b6e99dbe84b"
 dependencies = [
  "aes 0.8.1",
  "bincode",
@@ -4776,9 +4776,9 @@ dependencies = [
 
 [[package]]
 name = "xor_name"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f36afbc2c601f713127a618e7ab9c537e9014d2a35b88452a255b820979bbad"
+checksum = "7fd9dddecfdbc7c17ae93da6d28a5a9c4f5564abe7b735d2530c7a159b6b55e8"
 dependencies = [
  "hex",
  "rand 0.8.5",

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -54,7 +54,7 @@ uhttp_uri = "~0.5"
 url = "2.2.0"
 urlencoding = "1.1.1"
 walkdir = "2.3.1"
-xor_name = "4.0.1"
+xor_name = "~5.0.0"
 
 [features]
 authenticator = [ "rand-07" ]

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -50,7 +50,7 @@ tempfile = "3.2.0"
 tracing = "~0.1.26"
 tracing-subscriber = "~0.2.15"
 url = "2.2.2"
-xor_name = "4.0.1"
+xor_name = "~5.0.0"
 
 [dependencies.self_update]
 version = "~0.28.0"
@@ -76,7 +76,7 @@ predicates = "2.0"
 criterion = "~0.3"
 walkdir = "2.3.1"
 multibase = "~0.9.1"
-xor_name = "4.0.1"
+xor_name = "~5.0.0"
 futures = "0.3.21"
 sn_api = { path = "../sn_api", version = "^0.66.3", features = ["app", "test-utils"] }
 

--- a/sn_cli/src/operations/config.rs
+++ b/sn_cli/src/operations/config.rs
@@ -623,13 +623,13 @@ impl Config {
     }
 
     fn deserialise_prefix_map(bytes: &[u8]) -> Result<NetworkPrefixMap> {
-        let prefix_map = rmp_serde::from_slice(bytes)
+        let prefix_map = serde_json::from_slice(bytes)
             .wrap_err_with(|| "Failed to deserialize NetworkPrefixMap")?;
         Ok(prefix_map)
     }
 
     fn serialise_prefix_map(prefix_map: &NetworkPrefixMap) -> Result<Vec<u8>> {
-        rmp_serde::to_vec(prefix_map).wrap_err_with(|| "Failed to serialise NetworkPrefixMap")
+        serde_json::to_vec(prefix_map).wrap_err_with(|| "Failed to serialise NetworkPrefixMap")
     }
 }
 
@@ -823,7 +823,11 @@ mod constructor {
         let mut settings = Settings::default();
         settings.networks.insert(
             "network_1".to_string(),
-            NetworkInfo::Remote("https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/PublicKey(08d5..60a1)".to_string(), None)
+            NetworkInfo::Remote(
+                "https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/prefix_map"
+                    .to_string(),
+                None,
+            ),
         );
         settings.networks.insert(
             "network_2".to_string(),
@@ -949,11 +953,15 @@ mod sync_prefix_maps_and_settings {
         let mut settings = Settings::default();
         settings.networks.insert(
             "network_1".to_string(),
-            NetworkInfo::Remote("https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/PublicKey(08d5..60a1)".to_string(), None)
+            NetworkInfo::Remote(
+                "https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/prefix_map"
+                    .to_string(),
+                None,
+            ),
         );
         settings.networks.insert(
             "network_2".to_string(),
-            NetworkInfo::Remote("https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/PublicKey(16b0..6ec8)".to_string(), None)
+            NetworkInfo::Remote("https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/prefix_map_1".to_string(), None)
         );
         prefix_maps
             .iter()
@@ -983,7 +991,11 @@ mod sync_prefix_maps_and_settings {
         let mut settings = Settings::default();
         settings.networks.insert(
             "network_1".to_string(),
-            NetworkInfo::Remote("https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/PublicKey(0000..0000)".to_string(), None)
+            NetworkInfo::Remote(
+                "https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/error"
+                    .to_string(),
+                None,
+            ),
         );
         settings.networks.insert(
             "network_2".to_string(),
@@ -1008,7 +1020,11 @@ mod sync_prefix_maps_and_settings {
         let mut settings = Settings::default();
         settings.networks.insert(
             "network_1".to_string(),
-            NetworkInfo::Remote("https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/PublicKey(08d5..60a1)".to_string(), None)
+            NetworkInfo::Remote(
+                "https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/prefix_map"
+                    .to_string(),
+                None,
+            ),
         );
         settings.networks.insert(
             "network_2".to_string(),
@@ -1187,7 +1203,8 @@ mod networks {
         let mut config = Config::create_config(&tmp_dir, None).await?;
 
         let network_1 = NetworkInfo::Remote(
-            "https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/PublicKey(08d5..60a1)".to_string(),
+            "https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/sn_cli_resources/prefix_map"
+                .to_string(),
             None,
         );
         let network_2 = NetworkInfo::Local(prefix_map_path, None);

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -42,7 +42,7 @@ backoff = { version = "~0.4.0", features = [ "tokio" ] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "7.0.0" }
-bls_dkg = "~0.10.4"
+bls_dkg = "~0.10.5"
 bytes = { version = "1.0.1", features = ["serde"] }
 clap = { version = "3.0.0", features = ["derive"], optional = true }
 crdts = { version = "7.1", default-features = false, features = ["merkle"] }
@@ -65,7 +65,7 @@ rand = "~0.8.5"
 rayon = "1.5.1"
 rmp-serde = "1.0.0"
 secured_linked_list = "~0.5.3"
-self_encryption = "~0.27.4"
+self_encryption = "~0.27.5"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
@@ -82,7 +82,7 @@ tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 uluru = "3.0.0"
 url = "2.2.0"
 walkdir = "2"
-xor_name = "4.0.1"
+xor_name = "~5.0.0"
 
 [dependencies.tokio]
 version = "1.17.0"

--- a/sn_dysfunction/Cargo.toml
+++ b/sn_dysfunction/Cargo.toml
@@ -20,7 +20,7 @@ rand = "~0.8"
 thiserror = "1.0.23"
 tokio = { version = "1.0.23", features = [ "sync" ] }
 tracing = "~0.1.26"
-xor_name = "4.0.1"
+xor_name = "~5.0.0"
 sn_interface = { path = "../sn_interface", version = "^0.8.2" }
 
 [dev-dependencies]

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -24,7 +24,7 @@ backoff = { version = "~0.4.0", features = ["tokio"] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "7.0.0" }
-bls_dkg = "~0.10.4"
+bls_dkg = "~0.10.5"
 bytes = { version = "1.0.1", features = ["serde"] }
 crdts = { version = "7.1", default-features=false, features = ["merkle"] }
 custom_debug = "~0.5.0"
@@ -47,7 +47,7 @@ rand-07 = { package = "rand", version = "0.7.3" } # required till ed25519-dalek 
 rayon = "1.5.1"
 rmp-serde = "1.0.0"
 secured_linked_list = "~0.5.3"
-self_encryption = "~0.27.1"
+self_encryption = "~0.27.5"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
@@ -64,7 +64,7 @@ tracing-core = "~0.1.21"
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 uluru="3.0.0"
 url = "2.2.0"
-xor_name = "4.0.1"
+xor_name = "~5.0.0"
 
 [dependencies.tokio]
 version = "~1.17.0"

--- a/sn_interface/src/network_knowledge/utils/mod.rs
+++ b/sn_interface/src/network_knowledge/utils/mod.rs
@@ -38,7 +38,7 @@ pub async fn write_prefix_map_to_disk(prefix_map: &NetworkPrefixMap, path: &Path
     })?;
 
     let serialized =
-        rmp_serde::to_vec(prefix_map).map_err(|e| Error::Serialisation(e.to_string()))?;
+        serde_json::to_vec(prefix_map).map_err(|e| Error::Serialisation(e.to_string()))?;
 
     temp_file
         .write_all(serialized.as_slice())
@@ -69,7 +69,7 @@ pub async fn read_prefix_map_from_disk(path: &Path) -> Result<NetworkPrefixMap> 
                     ))
                 })?;
 
-            let prefix_map: NetworkPrefixMap = rmp_serde::from_slice(&prefix_map_contents)
+            let prefix_map: NetworkPrefixMap = serde_json::from_slice(&prefix_map_contents)
                 .map_err(|err| {
                     Error::FileHandling(format!(
                         "Error deserializing PrefixMap from disk: {:?}",

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -37,7 +37,7 @@ backoff = { version = "~0.4.0", features = [ "tokio" ] }
 base64 = "~0.13.0"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "7.0.0" }
-bls_dkg = "~0.10.4"
+bls_dkg = "~0.10.5"
 bytes = { version = "1.0.1", features = ["serde"] }
 chrono = "0.4.19"
 color-eyre = "~0.6.0"
@@ -68,7 +68,7 @@ rayon = "1.5.1"
 resource_proof = "1.0.39"
 rmp-serde = "1.0.0"
 secured_linked_list = "~0.5.3"
-self_encryption = "~0.27.4"
+self_encryption = "~0.27.5"
 sn_consensus = "3.1.2"
 sn_dbc = { version = "7.2.0", features = ["serdes"] }
 sn_dysfunction = { path = "../sn_dysfunction", version = "^0.7.1" }
@@ -93,7 +93,7 @@ tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 uluru="3.0.0"
 url = "2.2.0"
 walkdir = "2"
-xor_name = "4.0.1"
+xor_name = "~5.0.0"
 
 [dependencies.self_update]
 version = "~0.28.0"


### PR DESCRIPTION
Depends on https://github.com/maidsafe/bls_dkg/pull/134 and https://github.com/maidsafe/self_encryption/pull/356 
- serialize `NetworkPrefixMap` into JSON
- Also fixes the case where we will loose the network pointed by `default` prefix map if the original file is absent. 