### PR TITLE
fix(cli): backing up default prefix map file with genesis key in filename if not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,9 +197,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
+checksum = "9de18bc5f2e9df8f52da03856bf40e29b747de5a84e43aefff90e3dc4a21529b"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -565,10 +574,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
+checksum = "3f725f340c3854e3cb3ab736dc21f0cca183303acea3b3ffec30f141503ac8eb"
 dependencies = [
+ "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
@@ -765,6 +775,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.15",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1749,6 +1769,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1779539f58004e5dba1c1f093d44325ebeb244bfc04b791acdc0aaeca9c04570"
+dependencies = [
+ "android_system_properties",
+ "core-foundation",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,9 +1934,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "95f2a930906a03d4ee59113b31586c057c94f4d40c9fe90f21597a8b6822bfd8"
 
 [[package]]
 name = "linked-hash-map"
@@ -2834,7 +2867,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.12",
+ "time 0.3.13",
  "yasna",
 ]
 
@@ -3157,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
@@ -3185,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3207,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf855c7d1704095906013b4491af507f67cad13d778ff408ca9696e9d195cf5"
+checksum = "d4b5b007c1bccdc70f8d8b5804da305a64d4279f990f1ae9e3b06eaae46f42e0"
 dependencies = [
  "serde",
 ]
@@ -3371,7 +3404,7 @@ dependencies = [
  "sn_dbc",
  "sn_interface",
  "thiserror",
- "time 0.3.12",
+ "time 0.3.13",
  "tiny-keccak",
  "tokio",
  "tracing",
@@ -3618,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66a546409d653118303474ceeeaf0c4760babf0d69b66f7d680bc76354565e5"
+checksum = "c519629c0d4dbc4115362f758a39d0708dfffebd12201f549d2b17c37ea2c4c4"
 dependencies = [
  "clap 3.2.16",
  "color-eyre",
@@ -3947,12 +3980,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
  "itoa 1.0.3",
- "js-sys",
  "libc",
  "num_threads",
 ]
@@ -4239,7 +4271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.12",
+ "time 0.3.13",
  "tracing-subscriber 0.3.15",
 ]
 
@@ -4809,7 +4841,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
 dependencies = [
- "time 0.3.12",
+ "time 0.3.13",
 ]
 
 [[package]]

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -39,7 +39,7 @@ reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls
 rmp-serde = "1.0.0"
 sn_api = { path = "../sn_api", version = "^0.66.3", default-features = false, features = ["app"] }
 sn_dbc = { version = "7.2.0", features = ["serdes"] }
-sn_launch_tool = "~0.11.0"
+sn_launch_tool = "~0.11.1"
 serde = "1.0.123"
 serde_json = "1.0.62"
 serde_yaml = "~0.8"

--- a/sn_cli/src/operations/node.rs
+++ b/sn_cli/src/operations/node.rs
@@ -78,7 +78,8 @@ pub fn node_run(
     let mut sn_launch_tool_args =
         get_initial_sn_launch_args(node_directory_path, node_data_dir_name)?;
     sn_launch_tool_args.push("--interval".to_string());
-    sn_launch_tool_args.push(interval.clone().to_string());
+    let interval_msecs = 1000 * interval;
+    sn_launch_tool_args.push(interval_msecs.to_string());
     sn_launch_tool_args.push("--num-nodes".to_string());
     sn_launch_tool_args.push(num_of_nodes.to_string());
     if let Some(launch_ip) = ip {
@@ -102,6 +103,7 @@ pub fn node_join(
     clear_data: bool,
     local: bool,
     disable_port_forwarding: bool,
+    network_contacts_file: PathBuf,
 ) -> Result<()> {
     let mut sn_launch_tool_args =
         get_initial_sn_launch_args(node_directory_path, node_data_dir_name)?;
@@ -129,6 +131,9 @@ pub fn node_join(
         verbosity_arg.push_str(&v);
         sn_launch_tool_args.push(verbosity_arg);
     }
+
+    sn_launch_tool_args.push("--network-contacts-file".to_string());
+    sn_launch_tool_args.push(network_contacts_file.display().to_string());
 
     network_launcher.join(sn_launch_tool_args)?;
     Ok(())

--- a/sn_cli/src/subcommands/node.rs
+++ b/sn_cli/src/subcommands/node.rs
@@ -171,6 +171,9 @@ pub async fn node_commander(
                 path.push("node");
                 path
             };
+
+            let default_prefix_map_path = config.prefix_maps_dir.join(DEFAULT_PREFIX_HARDLINK_NAME);
+
             node_join(
                 network_launcher,
                 node_directory_path,
@@ -181,6 +184,7 @@ pub async fn node_commander(
                 clear_data,
                 local,
                 disable_port_forwarding,
+                default_prefix_map_path,
             )
         }
         Some(NodeSubCommands::Run {
@@ -443,7 +447,7 @@ mod run_command {
 
         assert!(result.is_ok());
         assert!(launcher.launch_args.iter().any(|x| x == "--interval"));
-        assert!(launcher.launch_args.iter().any(|x| x == "10"));
+        assert!(launcher.launch_args.iter().any(|x| x == "10000"));
 
         Ok(())
     }

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -96,7 +96,7 @@ grep="~0.2.8"
 proptest = "1.0.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rand_xorshift = "~0.2.0"
-sn_launch_tool = "~0.11.0"
+sn_launch_tool = "~0.11.1"
 termcolor="1.1.2"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 tokio-util = { version = "~0.6.7", features = ["time"] }

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -69,7 +69,7 @@ mod tests {
     use crate::utils::test_utils::{
         create_test_client_with, init_logger, read_genesis_dbc_from_first_node,
     };
-    use eyre::Result;
+    use eyre::{bail, Result};
     use sn_dbc::{rng, Hash, OwnerOnce, TransactionBuilder};
     use tokio::time::Duration;
 
@@ -111,34 +111,35 @@ mod tests {
             )
             .await?;
 
-        // Get spent proof shares for the key_image.
-        let spent_proof_shares = client.spent_proof_shares(*key_image).await?;
-
         // The query could be too close to the spend which make adult only accumulated
         // part of shares. To avoid assertion faiure, more attempts are needed.
         let mut attempts = 0;
-
-        // Note this test could have been run more than once thus the genesis DBC
-        // could have been spent a few times already, so we filter
-        // the SpentProofShares that belong to the TX we just spent in this run.
-        // TODO: once we have our Spentbook which prevents double spents
-        // we shouldnt't need this filtering.
         loop {
-            let valid_spent_proof_shares = spent_proof_shares
+            attempts += 1;
+
+            // Get spent proof shares for the key_image.
+            let spent_proof_shares = client.spent_proof_shares(*key_image).await?;
+
+            // Note this test could have been run more than once thus the genesis DBC
+            // could have been spent a few times already, so we filter
+            // the SpentProofShares that belong to the TX we just spent in this run.
+            // TODO: once we have our Spentbook which prevents double spents
+            // we shouldnt't need this filtering.
+            let num_of_spent_proof_shares = spent_proof_shares
                 .iter()
                 .filter(|proof| proof.content.transaction_hash == Hash::from(tx.hash()))
                 .count();
-            if (5..=7).contains(&valid_spent_proof_shares) {
-                break;
+
+            if (5..=7).contains(&num_of_spent_proof_shares) {
+                break Ok(());
+            } else if attempts == MAX_ATTEMPTS {
+                bail!(
+                    "Failed to obtained enough spent proof shares after {} attempts, {} retrieved in last attempt",
+                    MAX_ATTEMPTS, num_of_spent_proof_shares
+                );
             }
-            attempts += 1;
-            if attempts > MAX_ATTEMPTS {
-                break;
-            }
+
             tokio::time::sleep(SLEEP_DURATION).await;
         }
-        assert!(attempts <= MAX_ATTEMPTS);
-
-        Ok(())
     }
 }

--- a/testnet/Cargo.toml
+++ b/testnet/Cargo.toml
@@ -28,7 +28,7 @@ color-eyre = "~0.6.0"
 eyre = "~0.6.5"
 clap = { version = "3.0.0", features = ["derive", "env"]}
 dirs-next = "2.0.0"
-sn_launch_tool = "~0.11.0"
+sn_launch_tool = "~0.11.1"
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = { version = "~0.3.1", features = ["env-filter", "json"] }


### PR DESCRIPTION
- Since the sn_lauch_tool now copies the genesis node's prefix map file to `~/.safe/prefix_maps/default` (PR #1447), have the CLI to back it up using genesis key if not found after running a local testnet, i.e. copying the default prefix map to `~/.safe/prefix_maps/<genesis PK>`, before inserting the testnet to the CLI networks list.
- Fix CLI to convert nodes joining `interval` to millis before passing it to launch-tool.
- Also pass the default prefix map file path as the network contacts file path to CLI `node join` cmd.
