### PR TITLE
refactor(client): sn_client to only read a default prefix map file, updates to be cached on disk by user

### DIFF
--- a/sn_api/src/app/mod.rs
+++ b/sn_api/src/app/mod.rs
@@ -19,7 +19,7 @@ pub mod wallet;
 
 pub use crate::safeurl::*;
 pub use consts::DEFAULT_XORURL_BASE;
-pub use sn_client::DEFAULT_PREFIX_HARDLINK_NAME;
+pub use sn_client::DEFAULT_PREFIX_MAP_FILE_NAME;
 pub use sn_interface::network_knowledge::prefix_map::NetworkPrefixMap;
 pub use xor_name::{XorName, XOR_NAME_LEN};
 
@@ -110,6 +110,16 @@ impl Safe {
     /// Returns true if we already have a connection with the network
     pub fn is_connected(&self) -> bool {
         self.client.is_some()
+    }
+
+    /// NetworkPrefixMap used to bootstrap on the network.
+    ///
+    /// This is updated by as Anti-Entropy/update messages are received from the network.
+    /// Any user of this API is responsible for caching it so it can use it for any new `Safe`
+    /// instance, preventing it from learning all this information from the network all over again.
+    pub async fn get_prefix_map(&self) -> Result<NetworkPrefixMap> {
+        let prefix_map = self.get_safe_client()?.get_prefix_map().await;
+        Ok(prefix_map)
     }
 
     // Private helper to obtain the Client instance

--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -200,7 +200,7 @@ impl Client {
     /// This is updated by the client as it receives Anti-Entropy/update messages from the network.
     /// Any user of this API is responsible for caching it so it can use it for any new `Client`
     /// instance not needing to obtain all this information from the network all over again.
-    pub async fn get_prefix_map(&self) -> NetworkPrefixMap {
+    pub async fn prefix_map(&self) -> NetworkPrefixMap {
         self.session.network.read().await.clone()
     }
 

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -654,7 +654,6 @@ mod tests {
     use eyre::{eyre, Result};
     use qp2p::Config;
     use std::{
-        env::temp_dir,
         net::{Ipv4Addr, SocketAddr},
         time::Duration,
     };
@@ -689,7 +688,6 @@ mod tests {
             SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
             Duration::from_secs(10),
             prefix_map,
-            temp_dir(),
         )?;
 
         let mut rng = rand::thread_rng();

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -21,7 +21,7 @@ use sn_interface::{
 
 use dashmap::DashMap;
 use qp2p::{Config as QuicP2pConfig, Endpoint};
-use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::sync::{mpsc::Sender, RwLock};
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
@@ -53,8 +53,6 @@ pub(super) struct Session {
     cmd_ack_wait: Duration,
     /// Links to nodes
     peer_links: PeerLinks,
-    /// Path where to read/store cached PrefixMaps
-    prefix_maps_dir: PathBuf,
 }
 
 impl Session {
@@ -65,7 +63,6 @@ impl Session {
         local_addr: SocketAddr,
         cmd_ack_wait: Duration,
         prefix_map: NetworkPrefixMap,
-        prefix_maps_dir: PathBuf,
     ) -> Result<Session> {
         let endpoint = Endpoint::new_client(local_addr, qp2p_config)?;
         let peer_links = PeerLinks::new(endpoint.clone());
@@ -78,7 +75,6 @@ impl Session {
             initial_connection_check_msg_id: Arc::new(RwLock::new(None)),
             cmd_ack_wait,
             peer_links,
-            prefix_maps_dir,
         };
 
         Ok(session)

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -54,7 +54,7 @@ mod connections;
 mod errors;
 
 // Export public API.
-pub use api::{Client, RegisterWriteAheadLog, DEFAULT_PREFIX_HARDLINK_NAME};
+pub use api::{Client, RegisterWriteAheadLog, DEFAULT_PREFIX_MAP_FILE_NAME};
 pub use errors::{Error, Result};
 pub use qp2p::Config as QuicP2pConfig;
 pub use sn_interface::messaging::data::Error as ErrorMsg;

--- a/sn_interface/src/types/errors.rs
+++ b/sn_interface/src/types/errors.rs
@@ -45,8 +45,8 @@ pub enum Error {
     /// Serialization error
     #[error("Serialisation error: {0}")]
     Serialisation(String),
-    /// Error creating File at given path
-    #[error("File Creation error: {0}")]
+    /// Error reading/writing a file
+    #[error("File read/write error: {0}")]
     FileHandling(String),
     /// Error creating Directory  at given path
     #[error("Directory Creation error: {0}")]


### PR DESCRIPTION
- CLI to cache the up to date PrefixMap after all commands were executed and right before exiting.
- Refactoring sn_cli::Config to remove some redundant code.