### PR TITLE
Simplified cmd ctrl refactor

### DIFF
--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -115,9 +115,8 @@ impl DysfunctionDetection {
         }
 
         debug!("node {node} {issue_type:?} count: {:?}", node_issue_count);
-        let all_tracked_nodes = &self.nodes;
         let mut other_node_counts = Vec::new();
-        for itr in all_tracked_nodes {
+        for itr in &self.nodes {
             if itr == node {
                 continue;
             }

--- a/sn_node/src/bin/sn_node/main.rs
+++ b/sn_node/src/bin/sn_node/main.rs
@@ -129,7 +129,7 @@ async fn run_node(config: &Config) -> Result<()> {
     let join_timeout = Duration::from_secs(JOIN_TIMEOUT_SEC);
     let bootstrap_retry_duration = Duration::from_secs(BOOTSTRAP_RETRY_TIME_SEC);
 
-    let (_ref, mut event_stream) = loop {
+    let (_node, mut event_stream) = loop {
         match start_node(config, join_timeout).await {
             Ok(result) => break result,
             Err(NodeError::CannotConnectEndpoint(qp2p::EndpointError::Upnp(error))) => {
@@ -205,7 +205,7 @@ async fn run_node(config: &Config) -> Result<()> {
         }
     }
 
-    // This loop keeps the node going
+    // this keeps node running
     while let Some(event) = event_stream.next().await {
         trace!("Node event! {}", event);
         if let Event::Membership(MembershipEvent::RemovedFromSection) = event {

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -151,6 +151,7 @@ impl<'a> Joiner<'a> {
         recipients: Vec<Peer>,
         response_timeout: Duration,
     ) -> Result<(NodeInfo, NetworkKnowledge)> {
+        debug!("Initiating join with {recipients:?}");
         // We first use genesis key as the target section key, we'll be getting
         // a response with the latest section key for us to retry with.
         // Once we are approved to join, we will make sure the SAP we receive can

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -140,6 +140,9 @@ pub enum Error {
     /// Network data error.
     #[error("Network data error:: {0}")]
     NetworkData(#[from] sn_interface::types::Error),
+    /// Error Sending Cmd in to node for processing
+    #[error("Error Sending Cmd in to node for processing.")]
+    CmdSendError,
     /// Network Knowledge error.
     #[error("Network data error:: {0}")]
     NetworkKnowledge(#[from] sn_interface::network_knowledge::Error),

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -253,7 +253,6 @@ impl Eq for EnqueuedJob {}
 
 impl std::hash::Hash for EnqueuedJob {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        //self.job.hash(state);
         self.job.id().hash(state);
     }
 }

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -13,6 +13,7 @@ pub(super) mod event;
 pub(super) mod event_channel;
 #[cfg(test)]
 pub(crate) mod tests;
+use crate::log_sleep;
 
 pub(crate) use self::cmd_ctrl::CmdCtrl;
 
@@ -39,7 +40,7 @@ use tokio::{
         mpsc::{self, error::TryRecvError},
         RwLock,
     },
-    time::{sleep, Instant},
+    time::Instant,
 };
 
 const PROBE_INTERVAL: Duration = Duration::from_secs(30);
@@ -57,26 +58,38 @@ const ELDER_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(3);
 
 const LOOP_SLEEP_INTERVAL: Duration = Duration::from_millis(10);
 
+/// Listens for incoming msgs and forms Cmds for each,
+/// Periodically triggers other Cmd Processes (eg health checks, dysfunction etc)
 pub(crate) struct FlowCtrl {
     node: Arc<RwLock<Node>>,
     cmd_ctrl: CmdCtrl,
     incoming_msg_events: mpsc::Receiver<MsgEvent>,
+    incoming_cmds_from_apis: mpsc::Receiver<Cmd>,
 }
 
 impl FlowCtrl {
-    pub(crate) fn new(cmd_ctrl: CmdCtrl, incoming_msg_events: mpsc::Receiver<MsgEvent>) -> Self {
+    pub(crate) fn new(
+        cmd_ctrl: CmdCtrl,
+        incoming_msg_events: mpsc::Receiver<MsgEvent>,
+    ) -> (Self, mpsc::Sender<Cmd>) {
         let node = cmd_ctrl.node();
-        Self {
-            cmd_ctrl,
-            node,
-            incoming_msg_events,
-        }
+        let (cmd_sender, incoming_cmds_from_apis) = mpsc::channel(1);
+
+        (
+            Self {
+                cmd_ctrl,
+                node,
+                incoming_msg_events,
+                incoming_cmds_from_apis,
+            },
+            cmd_sender,
+        )
     }
 
     /// This is a never ending loop as long as the node is live.
     /// This loop drives the periodic events internal to the node.
     pub(crate) async fn process_messages_and_periodic_checks(mut self) {
-        debug!("Starting internal------------------------------------------");
+        debug!("Starting internal processing...");
         let mut last_probe = Instant::now();
         let mut last_section_probe = Instant::now();
         let mut last_adult_health_check = Instant::now();
@@ -91,9 +104,38 @@ impl FlowCtrl {
         // the internal process loop
         loop {
             let now = Instant::now();
-            let is_elder = self.node.read().await.is_elder();
-
             let mut cmds = vec![];
+
+            let (info, is_elder) = {
+                let node = self.node.read().await;
+
+                (node.info(), node.is_elder())
+            };
+
+            // Finally, handle any incoming conn messages
+            // this requires mut self
+            match self.incoming_cmds_from_apis.try_recv() {
+                Ok(cmd) => cmds.push(cmd),
+                Err(TryRecvError::Empty) => {
+                    // do nothing
+                }
+                Err(TryRecvError::Disconnected) => {
+                    trace!("Senders to `incoming_cmds_from_apis` have disconnected.");
+                }
+            }
+
+            // Finally, handle any incoming conn messages
+            // this requires mut self
+            match self.incoming_msg_events.try_recv() {
+                Ok(msg) => cmds.push(self.handle_new_msg_event(info.clone(), msg).await),
+                Err(TryRecvError::Empty) => {
+                    // do nothing
+                }
+                Err(TryRecvError::Disconnected) => {
+                    trace!("Senders to `incoming_msg_events` have disconnected. Stopping node periodic tasks.");
+                    break;
+                }
+            }
 
             // happens regardless of if elder or adult
             if last_link_cleanup.elapsed() > LINK_CLEANUP_INTERVAL {
@@ -105,7 +147,11 @@ impl FlowCtrl {
             if last_backpressure_check.elapsed() > BACKPRESSURE_INTERVAL {
                 last_backpressure_check = now;
 
-                cmds.extend(Self::report_backpressure(self.node.clone(), &self.cmd_ctrl).await)
+                if let Some(cmd) =
+                    Self::report_backpressure(self.node.clone(), &self.cmd_ctrl).await
+                {
+                    cmds.push(cmd)
+                }
             }
 
             // Things that should only happen to non elder nodes
@@ -118,6 +164,18 @@ impl FlowCtrl {
                     }
                 }
 
+                if cmds.is_empty() {
+                    log_sleep!(LOOP_SLEEP_INTERVAL);
+                }
+
+                for cmd in cmds {
+                    if let Err(error) = self.fire_and_forget(cmd).await {
+                        error!("Error pushing node process cmd to controller: {error:?}");
+                    }
+                }
+
+                // remaining cmds are for elders only.
+                // we've pushed what we have so we can continue
                 continue;
             }
 
@@ -180,22 +238,8 @@ impl FlowCtrl {
                 cmds.extend(dysf_cmds);
             }
 
-            // Finally, handle any incoming conn messages
-            // this requires mut self
-            match self.incoming_msg_events.try_recv() {
-                Ok(msg) => {
-                    let node_info = self.node.read().await.info();
-                    cmds.push(self.handle_new_msg_event(node_info.clone(), msg).await)
-                }
-                Err(TryRecvError::Empty) => {
-                    // prevent cpu racing
-                    sleep(LOOP_SLEEP_INTERVAL).await;
-                    continue;
-                }
-                Err(TryRecvError::Disconnected) => {
-                    trace!("Senders to `incoming_msg_events` have disconnected. Stopping node periodic tasks.");
-                    break;
-                }
+            if cmds.is_empty() {
+                log_sleep!(LOOP_SLEEP_INTERVAL);
             }
 
             for cmd in cmds {
@@ -204,6 +248,8 @@ impl FlowCtrl {
                 }
             }
         }
+
+        error!("Internal processing ended.")
     }
 
     /// Does not await the completion of the cmd.
@@ -227,7 +273,7 @@ impl FlowCtrl {
                 CtrlStatus::Enqueued => {
                     // this block should be unreachable, as Enqueued is the initial state
                     // but let's handle it anyway..
-                    sleep(Duration::from_millis(100)).await;
+                    log_sleep!(Duration::from_millis(100));
                     continue;
                 }
                 CtrlStatus::WatcherDropped => {
@@ -246,8 +292,6 @@ impl FlowCtrl {
         info!("Starting to check the section's health");
         let node = node.read().await;
         let our_prefix = node.network_knowledge.prefix();
-        let our_info = node.info();
-        let keypair = node.keypair.clone();
 
         // random chunk addr will be sent to relevant nodes in the section.
         let chunk_addr = xor_name::rand::random();
@@ -299,7 +343,7 @@ impl FlowCtrl {
         }
     }
 
-    /// Generates a probe msg, which goes to a random section in order to
+    /// Generates a probe msg, which goes to our elders in order to
     /// passively maintain network knowledge over time
     async fn probe_the_section(node: Arc<RwLock<Node>>) -> Option<Cmd> {
         let node = node.read().await;
@@ -372,9 +416,7 @@ impl FlowCtrl {
         use rand::seq::IteratorRandom;
         let mut rng = rand::rngs::OsRng;
 
-        let mut this_batch_address = None;
-
-        let (src_section_pk, our_info, data_queued) = {
+        let (_src_section_pk, _our_info, data_queued) = {
             let node = node.read().await;
             // get info for the WireMsg
             let src_section_pk = node.network_knowledge().section_key();
@@ -389,7 +431,7 @@ impl FlowCtrl {
             (src_section_pk, our_info, data_queued)
         };
 
-        if let Some(address) = this_batch_address {
+        if let Some(address) = data_queued {
             trace!("Data found in queue to send out");
 
             let target_peer = {
@@ -461,58 +503,27 @@ impl FlowCtrl {
     /// know about our load just now. Though that would only be AE messages... and if backpressure is working we should
     /// not be overloaded...
     #[cfg(feature = "back-pressure")]
-    async fn start_backpressure_reporting(node: Arc<RwLock<Node>>, cmd_ctrl: &CmdCtrl) -> Vec<Cmd> {
-        use sn_interface::messaging::DstLocation;
-
+    async fn report_backpressure(the_node: Arc<RwLock<Node>>, cmd_ctrl: &CmdCtrl) -> Option<Cmd> {
         info!("Firing off backpressure reports");
-        let node = node.read().await;
+        let node = the_node.read().await;
         let our_info = node.info();
-        let our_name = our_info.name();
-
-        let mut members = node.network_knowledge().section_members();
-        let section_pk = node.network_knowledge().section_key();
-        drop(node);
-
+        let mut members = node.network_knowledge().members();
         let _ = members.remove(&our_info.peer());
 
-        if let Some(load_report) = self.cmd_ctrl.dispatcher.comm().tolerated_msgs_per_s().await {
+        drop(node);
+
+        if let Some(load_report) = cmd_ctrl.dispatcher.comm().tolerated_msgs_per_s().await {
             trace!("New BackPressure report to disseminate: {:?}", load_report);
             // TODO: use comms to send report to anyone connected? (can we ID end users there?)
-            let node = self.node.read().await;
-            let cmd = node.send_system_msg(
+            let cmd = the_node.read().await.send_system_msg(
                 SystemMsg::BackPressure(load_report),
                 Peers::Multiple(members),
             );
-            if let Err(e) = self.cmd_ctrl.push(cmd).await {
-                error!("Error sending backpressure to section members: {e:?}");
-            }
+
+            Some(cmd)
+        } else {
+            None
         }
-
-        let wire_msg = match WireMsg::single_src(
-            &our_info,
-            DstLocation::Node {
-                name: peer.name(),
-                section_pk,
-            },
-            SystemMsg::BackPressure(load_report),
-            section_pk,
-        ) {
-            Ok(msg) => msg,
-            Err(e) => {
-                error!(
-                    "Error forming backpressure message to section member {:?}",
-                    e
-                );
-                continue;
-            }
-        };
-
-        cmds.push(Cmd::SendMsg {
-            wire_msg,
-            recipients: vec![*peer],
-        });
-
-        cmds
     }
 
     // Listen for a new incoming connection event and handle it.

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use self::cmd_ctrl::CmdCtrl;
 use crate::comm::MsgEvent;
 use crate::node::{flow_ctrl::cmds::Cmd, messaging::Peers, Error, Node, Result};
 
+use ed25519_dalek::Signer;
 #[cfg(feature = "traceroute")]
 use sn_interface::messaging::Traceroute;
 use sn_interface::{
@@ -27,15 +28,18 @@ use sn_interface::{
         system::{NodeCmd, SystemMsg},
         AuthorityProof, MsgId, ServiceAuth, WireMsg,
     },
-    types::{log_markers::LogMarker, ChunkAddress, PublicKey, Signature},
+    network_knowledge::NodeInfo,
+    types::log_markers::LogMarker,
+    types::{ChunkAddress, PublicKey, Signature},
 };
 
-use signature::Signer;
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use tokio::{
-    sync::{mpsc, RwLock},
-    task::{self, JoinHandle},
-    time::MissedTickBehavior,
+    sync::{
+        mpsc::{self, error::TryRecvError},
+        RwLock,
+    },
+    time::{sleep, Instant},
 };
 
 const PROBE_INTERVAL: Duration = Duration::from_secs(30);
@@ -50,31 +54,144 @@ const DYSFUNCTION_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 // Which should hopefully trigger dysfunction if we're not getting responses back
 const ADULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(2);
 const ELDER_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(3);
+const LOOP_SLEEP_INTERVAL: Duration = Duration::from_millis(10);
 
-#[derive(Clone)]
 pub(crate) struct FlowCtrl {
     node: Arc<RwLock<Node>>,
     cmd_ctrl: CmdCtrl,
+    incoming_msg_events: mpsc::Receiver<MsgEvent>,
 }
 
 impl FlowCtrl {
-    pub(crate) fn new(cmd_ctrl: CmdCtrl, incoming_conns: mpsc::Receiver<MsgEvent>) -> Self {
+    pub(crate) fn new(cmd_ctrl: CmdCtrl, incoming_msg_events: mpsc::Receiver<MsgEvent>) -> Self {
         let node = cmd_ctrl.node();
-        let ctrl = Self { cmd_ctrl, node };
+        Self {
+            cmd_ctrl,
+            node,
+            incoming_msg_events,
+        }
+    }
 
-        ctrl.clone().start_connection_listening(incoming_conns);
-        ctrl.clone().start_network_probing();
-        ctrl.clone().start_running_health_checks();
-        ctrl.clone().health_check_elders_in_section();
-        ctrl.clone().start_checking_for_missed_votes();
-        ctrl.clone().start_section_probing();
-        ctrl.clone().start_data_replication();
-        ctrl.clone().start_dysfunction_detection();
-        ctrl.clone().start_cleaning_peer_links();
+    /// This is a never ending loop as long as the node is live.
+    /// This loop drives the periodic events internal to the node.
+    pub(crate) async fn process_messages_and_periodic_checks(mut self) {
+        debug!("Starting internal------------------------------------------");
+        let mut last_probe = Instant::now();
+        let mut last_section_probe = Instant::now();
+        let mut last_health_check = Instant::now();
+        // ctrl.clone().health_check_elders_in_section();
+        let mut last_vote_check = Instant::now();
+        let mut last_data_batch_check = Instant::now();
+        let mut last_link_cleanup = Instant::now();
+        let mut last_dysfunction_check = Instant::now();
         #[cfg(feature = "back-pressure")]
-        ctrl.clone().start_backpressure_reporting();
+        let mut last_backpressure_check = Instant::now();
 
-        ctrl
+        // the internal process loop
+        loop {
+            let now = Instant::now();
+            let is_elder = self.node.read().await.is_elder();
+
+            let mut cmds = vec![];
+
+            // happens regardless of if elder or adult
+            if last_link_cleanup.elapsed() > LINK_CLEANUP_INTERVAL {
+                last_link_cleanup = now;
+                cmds.push(Cmd::CleanupPeerLinks);
+            }
+
+            #[cfg(feature = "back-pressure")]
+            if last_backpressure_check.elapsed() > BACKPRESSURE_INTERVAL {
+                last_backpressure_check = now;
+                cmds.extend(Self::start_backpressure_reporting(node))
+            }
+
+            // Things that should only happen to non elder nodes
+            if !is_elder {
+                // if we've passed enough time, section probe
+                if last_section_probe.elapsed() > SECTION_PROBE_INTERVAL {
+                    last_section_probe = now;
+                    if let Some(cmd) = Self::probe_the_section(self.node.clone()).await {
+                        cmds.push(cmd);
+                    }
+                }
+
+                continue;
+            }
+
+            // Okay, so the node is currently an elder...
+
+            // if we've passed enough time, network probe
+            if last_probe.elapsed() > PROBE_INTERVAL {
+                last_probe = now;
+                if let Some(cmd) = Self::probe_the_network(self.node.clone()).await {
+                    cmds.push(cmd);
+                }
+            }
+
+            // if we've passed enough time, batch outgoing data
+            if last_data_batch_check.elapsed() > DATA_BATCH_INTERVAL {
+                last_data_batch_check = now;
+                if let Some(cmd) = match Self::replicate_queued_data(self.node.clone()).await {
+                    Ok(cmd) => cmd,
+                    Err(error) => {
+                        error!("Error handling getting cmds for data queued for replication: {error:?}");
+                        None
+                    }
+                } {
+                    cmds.push(cmd);
+                }
+            }
+
+            if last_health_check.elapsed() > HEALTH_CHECK_INTERVAL {
+                last_health_check = now;
+                let health_cmds = match Self::perform_health_checks(self.node.clone()).await {
+                    Ok(cmds) => cmds,
+                    Err(error) => {
+                        error!("Error handling service msg to perform health check: {error:?}");
+                        vec![]
+                    }
+                };
+                cmds.extend(health_cmds);
+            }
+
+            if last_vote_check.elapsed() > MISSING_VOTE_INTERVAL {
+                last_vote_check = now;
+                if let Some(cmd) = Self::check_for_missed_votes(self.node.clone()).await {
+                    cmds.push(cmd);
+                };
+            }
+
+            if last_dysfunction_check.elapsed() > DYSFUNCTION_CHECK_INTERVAL {
+                last_dysfunction_check = now;
+                let dysf_cmds = Self::check_for_dysfunction(self.node.clone()).await;
+                cmds.extend(dysf_cmds);
+            }
+
+            // Finally, handle any incoming conn messages
+            // this requires mut self
+            match self.incoming_msg_events.try_recv() {
+                Ok(msg) => {
+                    let node_info = self.node.read().await.info();
+                    cmds.push(self.handle_new_msg_event(node_info.clone(), msg).await)
+                }
+                Err(TryRecvError::Empty) => {
+                    // prevent cpu racing
+                    sleep(LOOP_SLEEP_INTERVAL).await;
+                    continue;
+                }
+                Err(TryRecvError::Disconnected) => {
+                    trace!("Senders to `incoming_msg_events` have disconnected. Stopping node periodic tasks.");
+                    break;
+                }
+            }
+
+            for cmd in cmds {
+                if let Err(error) = self.fire_and_forget(cmd).await {
+                    error!("Error pushing node process cmd to controller: {error:?}");
+                }
+            }
+        }
     }
 
     /// Does not await the completion of the cmd.
@@ -98,7 +215,7 @@ impl FlowCtrl {
                 CtrlStatus::Enqueued => {
                     // this block should be unreachable, as Enqueued is the initial state
                     // but let's handle it anyway..
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    sleep(Duration::from_millis(100)).await;
                     continue;
                 }
                 CtrlStatus::WatcherDropped => {
@@ -112,65 +229,40 @@ impl FlowCtrl {
         }
     }
 
-    fn start_connection_listening(self, incoming_conns: mpsc::Receiver<MsgEvent>) {
-        // Start listening to incoming connections.
-        let _handle = task::spawn_local(handle_connection_events(self, incoming_conns));
-    }
-
-    fn start_running_health_checks(self) {
+    /// Initiates and generates all the subsequent Cmds to perform a healthcheck
+    async fn perform_health_checks(node: Arc<RwLock<Node>>) -> Result<Vec<Cmd>> {
         info!("Starting to check the section's health");
-        let _handle: JoinHandle<Result<()>> = tokio::task::spawn_local(async move {
-            let mut interval = tokio::time::interval(ADULT_HEALTH_CHECK_INTERVAL);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let node = node.read().await;
+        let our_prefix = node.network_knowledge.prefix();
+        let our_info = node.info();
+        let keypair = node.keypair.clone();
 
-            loop {
-                let _instant = interval.tick().await;
-                let node = self.node.read().await;
+        // random chunk addr will be sent to relevant nodes in the section.
+        let chunk_addr = xor_name::rand::random();
 
-                if node.is_not_elder() {
-                    // don't send health checks as an adult
-                    continue;
-                }
+        let chunk_addr = our_prefix.substituted_in(chunk_addr);
 
-                // random chunk addr will be sent to relevant nodes in the section.
-                let chunk_addr = xor_name::rand::random();
-                // lets make sure it's relevant to our section, to avoid any
-                // potential discards
-                let our_prefix = node.network_knowledge.prefix();
-
-                let chunk_addr = our_prefix.substituted_in(chunk_addr);
-
-                let msg = ServiceMsg::Query(DataQuery {
-                    variant: DataQueryVariant::GetChunk(ChunkAddress(chunk_addr)),
-                    adult_index: 0,
-                });
-
-                let msg_id = MsgId::new();
-                let our_info = node.info();
-                let origin = our_info.peer();
-
-                let auth = auth(&node, &msg)?;
-
-                // generate the cmds, and ensure we go through dysfunction tracking
-                let cmds = node
-                    .handle_valid_service_msg(
-                        msg_id,
-                        msg,
-                        auth,
-                        origin,
-                        #[cfg(feature = "traceroute")]
-                        Traceroute(vec![]),
-                    )
-                    .await?;
-
-                for cmd in cmds {
-                    info!("Sending healthcheck chunk query {:?}", msg_id);
-                    if let Err(e) = self.cmd_ctrl.push(cmd).await {
-                        error!("Error sending a health check msg to the network: {:?}", e);
-                    }
-                }
-            }
+        let msg = ServiceMsg::Query(DataQuery {
+            variant: DataQueryVariant::GetChunk(ChunkAddress(chunk_addr)),
+            adult_index: 0,
         });
+
+        let msg_id = MsgId::new();
+        let our_info = node.info();
+        let origin = our_info.peer();
+
+        let auth = auth(&node, &msg)?;
+
+        // generate the cmds, and ensure we go through dysfunction tracking
+        node.handle_valid_service_msg(
+            msg_id,
+            msg,
+            auth,
+            origin,
+            #[cfg(feature = "traceroute")]
+            Traceroute(vec![]),
+        )
+        .await
     }
 
     /// Generates a probe msg, which goes to all section elders in order to
@@ -212,80 +304,54 @@ impl FlowCtrl {
         });
     }
 
-    fn start_network_probing(self) {
-        info!("Starting to probe network");
-        let _handle = tokio::task::spawn_local(async move {
-            let mut interval = tokio::time::interval(PROBE_INTERVAL);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    /// Generates a probe msg, which goes to a random section in order to
+    /// passively maintain network knowledge over time
+    async fn probe_the_network(node: Arc<RwLock<Node>>) -> Option<Cmd> {
+        let node = node.read().await;
+        let prefix = node.network_knowledge().prefix();
 
-            loop {
-                let _instant = interval.tick().await;
-                let node = self.node.read().await;
-                let is_elder = node.is_elder();
-                let prefix = node.network_knowledge().prefix();
-                drop(node);
-
-                // Send a probe message if we are an elder
-                if is_elder && !prefix.is_empty() {
-                    let probe = self.node.read().await.generate_probe_msg();
-
-                    match probe {
-                        Ok(cmd) => {
-                            info!("Sending probe msg");
-                            if let Err(e) = self.cmd_ctrl.push(cmd).await {
-                                error!("Error sending a probe msg to the network: {:?}", e);
-                            }
-                        }
-                        Err(error) => error!("Problem generating probe msg: {:?}", error),
-                    }
+        // Send a probe message if we are an elder
+        // but dont bother if we're the first section
+        if !prefix.is_empty() {
+            info!("Probing network");
+            match node.generate_probe_msg() {
+                Ok(cmd) => Some(cmd),
+                Err(error) => {
+                    error!("Could not generate probe msg: {error:?}");
+                    None
                 }
             }
-        });
+        } else {
+            None
+        }
     }
 
-    fn start_section_probing(self) {
+    /// Generates a probe msg, which goes to a random section in order to
+    /// passively maintain network knowledge over time
+    async fn probe_the_section(node: Arc<RwLock<Node>>) -> Option<Cmd> {
+        let node = node.read().await;
+
+        // Send a probe message to an elder
         info!("Starting to probe section");
-        let _handle = tokio::task::spawn_local(async move {
-            let mut interval = tokio::time::interval(SECTION_PROBE_INTERVAL);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-            loop {
-                let _instant = interval.tick().await;
+        let prefix = node.network_knowledge().prefix();
 
-                let prefix = self.node.read().await.network_knowledge().prefix();
-
-                // Send a probe message to an elder
-                if !prefix.is_empty() {
-                    let cmd = self.node.read().await.generate_section_probe_msg();
-                    info!("Sending section probe msg");
-                    if let Err(e) = self.cmd_ctrl.push(cmd).await {
-                        error!("Error sending section probe msg: {:?}", e);
-                    }
-                }
-            }
-        });
+        // Send a probe message to an elder
+        if !prefix.is_empty() {
+            Some(node.generate_section_probe_msg())
+        } else {
+            None
+        }
     }
 
     /// Checks the interval since last vote received during a generation
-    fn start_checking_for_missed_votes(self) {
-        info!("Starting to check for missed votes");
-        let _handle: JoinHandle<Result<()>> = tokio::task::spawn_local(async move {
-            let dispatcher = self.clone();
-            let mut interval = tokio::time::interval(MISSING_VOTE_INTERVAL);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    async fn check_for_missed_votes(node: Arc<RwLock<Node>>) -> Option<Cmd> {
+        info!("Checking for missed votes");
+        let node = node.read().await;
+        let membership = &node.membership;
 
-            loop {
-                let _instant = interval.tick().await;
-
-                if !dispatcher.node.read().await.is_elder() {
-                    continue;
-                }
-                trace!("looping vote check in elder");
-                let node = dispatcher.node.read().await;
-                let membership = &node.membership;
-
-                if let Some(membership) = &membership {
-                    let last_received_vote_time = membership.last_received_vote_time();
+        if let Some(membership) = &membership {
+            let last_received_vote_time = membership.last_received_vote_time();
 
                     if let Some(time) = last_received_vote_time {
                         // we want to resend the prev vote
@@ -305,138 +371,91 @@ impl FlowCtrl {
     }
 
     /// Periodically loop over any pending data batches and queue up `send_msg` for those
-    fn start_data_replication(self) {
+    async fn replicate_queued_data(node: Arc<RwLock<Node>>) -> Result<Option<Cmd>> {
         info!("Starting sending any queued data for replication in batches");
 
-        let _handle: JoinHandle<Result<()>> = tokio::task::spawn_local(async move {
-            let mut interval = tokio::time::interval(DATA_BATCH_INTERVAL);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        use rand::seq::IteratorRandom;
+        let mut rng = rand::rngs::OsRng;
 
-            use rand::seq::IteratorRandom;
-            let mut rng = rand::rngs::OsRng;
+        let mut this_batch_address = None;
 
-            loop {
-                let _ = interval.tick().await;
+        let (src_section_pk, our_info, data_queued) = {
+            let node = node.read().await;
+            // get info for the WireMsg
+            let src_section_pk = node.network_knowledge().section_key();
+            let our_info = node.info();
+            // choose a data to replicate at random
+            let data_queued = node
+                .pending_data_to_replicate_to_peers
+                .iter()
+                .choose(&mut rng)
+                .map(|(address, _)| *address);
 
-                let mut this_batch_address = None;
+            (src_section_pk, our_info, data_queued)
+        };
 
-                let data_queued = {
-                    let node = self.node.read().await;
-                    // choose a data to replicate at random
-                    let data_queued = node
-                        .pending_data_to_replicate_to_peers
-                        .iter()
-                        .choose(&mut rng)
-                        .map(|(address, _)| *address);
-                    data_queued
-                };
+        if let Some(address) = this_batch_address {
+            trace!("Data found in queue to send out");
 
-                if let Some(data_addr) = data_queued {
-                    this_batch_address = Some(data_addr);
+            let target_peer = {
+                // careful now, if we're holding any ref into the read above we'll lock here.
+                let mut node = node.write().await;
+                node.pending_data_to_replicate_to_peers.remove(&address)
+            };
+
+            if let Some(data_recipients) = target_peer {
+                debug!("Data queued to be replicated");
+
+                if data_recipients.is_empty() {
+                    return Ok(None);
                 }
 
-                if let Some(address) = this_batch_address {
-                    trace!("Data found in queue to send out");
+                let data_to_send = node
+                    .read()
+                    .await
+                    .data_storage
+                    .get_from_local_store(&address)
+                    .await?;
 
-                    let target_peer = {
-                        // careful now, if we're holding any ref into the read above we'll lock here.
-                        let mut node = self.node.write().await;
-                        node.pending_data_to_replicate_to_peers.remove(&address)
-                    };
+                debug!(
+                    "{:?} Data {:?} to: {:?}",
+                    LogMarker::SendingMissingReplicatedData,
+                    address,
+                    data_recipients,
+                );
 
-                    if let Some(data_recipients) = target_peer {
-                        debug!("Data queued to be replicated");
-
-                        if data_recipients.is_empty() {
-                            continue;
-                        }
-
-                        let data_to_send = self
-                            .node
-                            .read()
-                            .await
-                            .data_storage
-                            .get_from_local_store(&address)
-                            .await?;
-
-                        debug!(
-                            "{:?} Data {:?} to: {:?}",
-                            LogMarker::SendingMissingReplicatedData,
-                            address,
-                            data_recipients,
-                        );
-
-                        let msg = SystemMsg::NodeCmd(NodeCmd::ReplicateData(vec![data_to_send]));
-                        let node = self.node.read().await;
-                        let cmd = node.send_system_msg(msg, Peers::Multiple(data_recipients));
-
-                        if let Err(e) = self.cmd_ctrl.push(cmd).await {
-                            error!("Error in data replication loop: {:?}", e);
-                        }
-                    }
-                }
+                let msg = SystemMsg::NodeCmd(NodeCmd::ReplicateData(vec![data_to_send]));
+                let node = node.read().await;
+                return Ok(Some(
+                    node.send_system_msg(msg, Peers::Multiple(data_recipients)),
+                ));
             }
-        });
+        }
+
+        Ok(None)
     }
 
-    fn start_cleaning_peer_links(self) {
-        info!("Starting cleaning up network links");
-        let _handle = tokio::task::spawn_local(async move {
-            let mut interval = tokio::time::interval(LINK_CLEANUP_INTERVAL);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-            let _ = interval.tick().await;
-
-            loop {
-                let _ = interval.tick().await;
-                if let Err(e) = self.cmd_ctrl.push(Cmd::CleanupPeerLinks).await {
-                    error!(
-                        "Error requesting a cleaning up of unused PeerLinks: {:?}",
-                        e
-                    );
-                }
+    async fn check_for_dysfunction(node: Arc<RwLock<Node>>) -> Vec<Cmd> {
+        info!("Performing dysfunction checking");
+        let mut cmds = vec![];
+        let dysfunctional_nodes = node.write().await.get_dysfunctional_node_names();
+        let unresponsive_nodes = match dysfunctional_nodes {
+            Ok(nodes) => nodes,
+            Err(error) => {
+                error!("Error getting dysfunctional nodes: {error}");
+                BTreeSet::default()
             }
-        });
-    }
+        };
 
-    fn start_dysfunction_detection(self) {
-        info!("Starting dysfunction checking");
-        let _handle = tokio::task::spawn_local(async move {
-            let mut interval = tokio::time::interval(DYSFUNCTION_CHECK_INTERVAL);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-
-            loop {
-                let _instant = interval.tick().await;
-
-                let dysfunctional_nodes = self.node.write().await.get_dysfunctional_node_names();
-                let unresponsive_nodes = match dysfunctional_nodes {
-                    Ok(nodes) => nodes,
-                    Err(error) => {
-                        error!("Error getting dysfunctional nodes: {error}");
-                        BTreeSet::default()
-                    }
-                };
-
-                if !unresponsive_nodes.is_empty() {
-                    debug!("{:?} : {unresponsive_nodes:?}", LogMarker::ProposeOffline);
-                    for name in &unresponsive_nodes {
-                        if let Err(e) = self
-                            .cmd_ctrl
-                            .push(Cmd::TellEldersToStartConnectivityTest(*name))
-                            .await
-                        {
-                            error!("Error sending TellEldersToStartConnectivityTest for dysfunctional nodes: {e:?}");
-                        }
-                    }
-                    if let Err(e) = self
-                        .cmd_ctrl
-                        .push(Cmd::ProposeVoteNodesOffline(unresponsive_nodes))
-                        .await
-                    {
-                        error!("Error sending Propose Offline for dysfunctional nodes: {e:?}");
-                    }
-                }
+        if !unresponsive_nodes.is_empty() {
+            debug!("{:?} : {unresponsive_nodes:?}", LogMarker::ProposeOffline);
+            for name in &unresponsive_nodes {
+                cmds.push(Cmd::TellEldersToStartConnectivityTest(*name))
             }
-        });
+            cmds.push(Cmd::ProposeOffline(unresponsive_nodes))
+        }
+
+        cmds
     }
 
     /// Periodically send back-pressure reports to our section.
@@ -447,45 +466,62 @@ impl FlowCtrl {
     /// know about our load just now. Though that would only be AE messages... and if backpressure is working we should
     /// not be overloaded...
     #[cfg(feature = "back-pressure")]
-    fn start_backpressure_reporting(self) {
+    fn start_backpressure_reporting(node: Arc<RwLock<Node>>, cmd_ctrl: &CmdCtrl) -> Vec<Cmd> {
+        use sn_interface::messaging::DstLocation;
+
         info!("Firing off backpressure reports");
-        let _handle = tokio::task::spawn_local(async move {
-            let mut interval = tokio::time::interval(BACKPRESSURE_INTERVAL);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-            let _ = interval.tick().await;
+        let node = node.read().await;
+        let our_info = node.info();
+        let our_name = our_info.name();
 
-            loop {
-                let _ = interval.tick().await;
+        let mut members = node.network_knowledge().section_members();
+        let section_pk = node.network_knowledge().section_key();
+        drop(node);
 
-                let node = self.node.read().await;
-                let our_info = node.info();
-                let mut members = node.network_knowledge().members();
-                let _ = members.remove(&our_info.peer());
+        let _ = members.remove(&our_info.peer());
 
-                drop(node);
-
-                if let Some(load_report) =
-                    self.cmd_ctrl.dispatcher.comm().tolerated_msgs_per_s().await
-                {
-                    trace!("New BackPressure report to disseminate: {:?}", load_report);
-                    // TODO: use comms to send report to anyone connected? (can we ID end users there?)
-                    let node = self.node.read().await;
-                    let cmd = node.send_system_msg(
-                        SystemMsg::BackPressure(load_report),
-                        Peers::Multiple(members),
-                    );
-                    if let Err(e) = self.cmd_ctrl.push(cmd).await {
-                        error!("Error sending backpressure to section members: {e:?}");
-                    }
-                }
+        if let Some(load_report) = self.cmd_ctrl.dispatcher.comm().tolerated_msgs_per_s().await {
+            trace!("New BackPressure report to disseminate: {:?}", load_report);
+            // TODO: use comms to send report to anyone connected? (can we ID end users there?)
+            let node = self.node.read().await;
+            let cmd = node.send_system_msg(
+                SystemMsg::BackPressure(load_report),
+                Peers::Multiple(members),
+            );
+            if let Err(e) = self.cmd_ctrl.push(cmd).await {
+                error!("Error sending backpressure to section members: {e:?}");
             }
-        });
-    }
-}
+        }
 
-// Listen for incoming connection events and handle them.
-async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Receiver<MsgEvent>) {
-    while let Some(event) = incoming_conns.recv().await {
+        let wire_msg = match WireMsg::single_src(
+            &our_info,
+            DstLocation::Node {
+                name: peer.name(),
+                section_pk,
+            },
+            SystemMsg::BackPressure(load_report),
+            section_pk,
+        ) {
+            Ok(msg) => msg,
+            Err(e) => {
+                error!(
+                    "Error forming backpressure message to section member {:?}",
+                    e
+                );
+                continue;
+            }
+        };
+
+        cmds.push(Cmd::SendMsg {
+            wire_msg,
+            recipients: vec![*peer],
+        });
+
+        cmds
+    }
+
+    // Listen for a new incoming connection event and handle it.
+    async fn handle_new_msg_event(&self, node_info: NodeInfo, event: MsgEvent) -> Cmd {
         match event {
             MsgEvent::Received {
                 sender,
@@ -499,8 +535,7 @@ async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Rece
                 );
 
                 let span = {
-                    let node = &ctrl.node;
-                    let name = node.read().await.info().name();
+                    let name = node_info.name();
                     trace_span!("handle_message", name = %name, ?sender, msg_id = ?wire_msg.msg_id())
                 };
                 let _span_guard = span.enter();
@@ -525,12 +560,10 @@ async fn handle_connection_events(ctrl: FlowCtrl, mut incoming_conns: mpsc::Rece
                     original_bytes,
                 };
 
-                let _res = ctrl.cmd_ctrl.push(cmd).await;
+                return cmd;
             }
         }
     }
-
-    error!("Fatal error, the stream for incoming connections has been unexpectedly closed. No new connections or messages can be received from the network from here on.");
 }
 
 fn auth(node: &Node, msg: &ServiceMsg) -> Result<AuthorityProof<ServiceAuth>> {

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -31,7 +31,6 @@ use sn_interface::{
 };
 
 use bytes::Bytes;
-use itertools::Itertools;
 use std::collections::BTreeSet;
 
 #[derive(Debug, Clone)]
@@ -161,6 +160,8 @@ impl Node {
                     }
                 }
 
+                // TODO: track clients for spam
+
                 // Then we perform AE checks
                 if let Some(cmd) =
                     self.check_for_entropy(original_bytes, &dst.section_key, dst_name, &origin)?
@@ -226,17 +227,11 @@ impl Node {
                 if let Some(ae_cmd) =
                     self.check_for_entropy(msg_bytes, &dst.section_key, dst.name, origin)?
                 {
-                    // we want to log issues with an elder who is out of sync here...
-                    let knowledge = self.network_knowledge.elders();
-                    let mut known_elders = knowledge.iter().map(|peer| peer.name());
-
-                    if known_elders.contains(&origin.name()) {
-                        // we track a dysfunction against our elder here
-                        cmds.push(Cmd::TrackNodeIssueInDysfunction {
-                            name: origin.name(),
-                            issue: sn_dysfunction::IssueType::Knowledge,
-                        });
-                    }
+                    // we want to log issues with any node repeatedly out of sync here...
+                    cmds.push(Cmd::TrackNodeIssueInDysfunction {
+                        name: origin.name(),
+                        issue: sn_dysfunction::IssueType::Knowledge,
+                    });
 
                     cmds.push(ae_cmd);
 

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -6,11 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::{
-    flow_ctrl::cmds::Cmd,
-    messaging::{OutgoingMsg, Peers},
-    Error, Node, Result,
-};
+use crate::node::messaging::{OutgoingMsg, Peers};
+
+use crate::node::{flow_ctrl::cmds::Cmd, Error, Node, Result};
+use bytes::Bytes;
 
 use sn_dbc::{
     Commitment, Hash, IndexedSignatureShare, KeyImage, RingCtTransaction, SpentProof,
@@ -35,7 +34,6 @@ use sn_interface::{
     },
 };
 
-use bytes::Bytes;
 use std::collections::{BTreeMap, BTreeSet};
 use xor_name::XorName;
 

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -18,6 +18,8 @@ use crate::{
 };
 
 use bytes::Bytes;
+use std::collections::BTreeSet;
+
 #[cfg(feature = "traceroute")]
 use sn_interface::messaging::Traceroute;
 use sn_interface::{
@@ -39,7 +41,6 @@ use sn_interface::{
     network_knowledge::NetworkKnowledge,
     types::{log_markers::LogMarker, Keypair, Peer, PublicKey},
 };
-use std::collections::BTreeSet;
 use xor_name::XorName;
 
 impl Node {
@@ -213,7 +214,6 @@ impl Node {
                 let mut recipients = BTreeSet::new();
                 let _existed = recipients.insert(sender);
                 cmds.push(self.send_ae_update_to_nodes(recipients, section_key));
-                trace!("cmds for responding to ae to {sender} formed");
                 Ok(cmds)
             }
             #[cfg(feature = "back-pressure")]

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -41,6 +41,7 @@ use self::{
         cmds::Cmd,
         event::{CmdProcessEvent, Elders},
     },
+    node_starter::CmdChannel,
     proposal::Proposal,
 };
 pub use self::{

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -233,7 +233,7 @@ mod core {
             info!("Creating DysfunctionDetection checks");
             let node_dysfunction_detector = DysfunctionDetection::new(
                 network_knowledge
-                    .adults()
+                    .members()
                     .iter()
                     .map(|peer| peer.name())
                     .collect::<Vec<XorName>>(),

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -10,6 +10,7 @@ use crate::comm::Comm;
 use crate::node::{
     cfg::keypair_storage::{get_reward_pk, store_network_keypair, store_new_reward_keypair},
     flow_ctrl::{
+        cmds::Cmd,
         dispatcher::Dispatcher,
         event::{Elders, Event, MembershipEvent, NodeElderChange},
         event_channel,
@@ -52,13 +53,15 @@ const GENESIS_DBC_FILENAME: &str = "genesis_dbc";
 
 static EVENT_CHANNEL_SIZE: usize = 20;
 
+pub(crate) type CmdChannel = mpsc::Sender<Cmd>;
+
 /// Test only
 pub async fn new_test_api(
     config: &Config,
     join_timeout: Duration,
 ) -> Result<(super::NodeTestApi, EventReceiver)> {
-    let (node, flow_ctrl, event_receiver) = new_node(config, join_timeout).await?;
-    Ok((super::NodeTestApi::new(node, flow_ctrl), event_receiver))
+    let (node, cmd_channel, event_receiver) = new_node(config, join_timeout).await?;
+    Ok((super::NodeTestApi::new(node, cmd_channel), event_receiver))
 }
 
 /// A reference held to the node to keep it running.
@@ -68,6 +71,8 @@ pub async fn new_test_api(
 #[allow(missing_debug_implementations, dead_code)]
 pub struct NodeRef {
     node: Arc<RwLock<Node>>,
+    /// Sender which can be used to add a Cmd to the Node's CmdQueue
+    cmd_channel: CmdChannel,
 }
 
 /// Start a new node.
@@ -75,21 +80,16 @@ pub async fn start_node(
     config: &Config,
     join_timeout: Duration,
 ) -> Result<(NodeRef, EventReceiver)> {
-    let (node, flow_ctrl, event_receiver) = new_node(config, join_timeout).await?;
+    let (node, cmd_channel, event_receiver) = new_node(config, join_timeout).await?;
 
-    let _ =
-        tokio::task::spawn_local(
-            async move { flow_ctrl.process_messages_and_periodic_checks().await },
-        );
-
-    Ok((NodeRef { node }, event_receiver))
+    Ok((NodeRef { node, cmd_channel }, event_receiver))
 }
 
 // Private helper to create a new node using the given config and bootstraps it to the network.
 async fn new_node(
     config: &Config,
     join_timeout: Duration,
-) -> Result<(Arc<RwLock<Node>>, FlowCtrl, EventReceiver)> {
+) -> Result<(Arc<RwLock<Node>>, CmdChannel, EventReceiver)> {
     let root_dir_buf = config.root_dir()?;
     let root_dir = root_dir_buf.as_path();
     fs::create_dir_all(root_dir).await?;
@@ -106,7 +106,7 @@ async fn new_node(
 
     let used_space = UsedSpace::new(config.max_capacity());
 
-    let (node, flow_ctrl, network_events) =
+    let (node, cmd_channel, network_events) =
         bootstrap_node(config, used_space, root_dir, join_timeout).await?;
 
     {
@@ -135,7 +135,7 @@ async fn new_node(
 
     run_system_logger(LogCtx::new(node.clone()), config.resource_logs).await;
 
-    Ok((node, flow_ctrl, network_events))
+    Ok((node, cmd_channel, network_events))
 }
 
 // Private helper to create a new node using the given config and bootstraps it to the network.
@@ -144,7 +144,7 @@ async fn bootstrap_node(
     used_space: UsedSpace,
     root_storage_dir: &Path,
     join_timeout: Duration,
-) -> Result<(Arc<RwLock<Node>>, FlowCtrl, EventReceiver)> {
+) -> Result<(Arc<RwLock<Node>>, CmdChannel, EventReceiver)> {
     let (connection_event_tx, mut connection_event_rx) = mpsc::channel(1);
 
     let local_addr = config
@@ -285,7 +285,13 @@ async fn bootstrap_node(
         monitoring,
         event_sender,
     );
-    let flow_ctrl = FlowCtrl::new(cmd_ctrl, connection_event_rx);
+    let (msg_and_period_ctrl, cmd_channel) = FlowCtrl::new(cmd_ctrl, connection_event_rx);
 
-    Ok((node, flow_ctrl, event_receiver))
+    let _ = tokio::task::spawn_local(async move {
+        msg_and_period_ctrl
+            .process_messages_and_periodic_checks()
+            .await
+    });
+
+    Ok((node, cmd_channel, event_receiver))
 }

--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -49,7 +49,7 @@ const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
 
 const BASE_TRACING_DIRECTIVES: &str = "testnet=info,sn_launch_tool=debug";
 const NODES_DIR: &str = "local-test-network";
-const DEFAULT_INTERVAL: &str = "100";
+const DEFAULT_INTERVAL: &str = "5000";
 const DEFAULT_NODE_COUNT: u32 = 30;
 
 #[derive(Debug, clap::StructOpt)]

--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -49,7 +49,7 @@ const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
 
 const BASE_TRACING_DIRECTIVES: &str = "testnet=info,sn_launch_tool=debug";
 const NODES_DIR: &str = "local-test-network";
-const DEFAULT_INTERVAL: &str = "5000";
+const DEFAULT_INTERVAL: &str = "100";
 const DEFAULT_NODE_COUNT: u32 = 30;
 
 #[derive(Debug, clap::StructOpt)]


### PR DESCRIPTION
Removes a lot of node cmd looping, and the `Clone` requirement on `CmdCtrl`, which will hopefully let us remove `RwLock` inside there in a follow up PR.