### PR TITLE
chore: remove wiremsg.priority as uneeded

### DIFF
--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -532,7 +532,6 @@ pub(super) async fn send_msg(
     wire_msg: WireMsg,
     msg_id: MsgId,
 ) -> Result<()> {
-    let priority = wire_msg.priority();
     let msg_bytes = wire_msg.serialize()?;
 
     let mut last_error = None;
@@ -558,10 +557,7 @@ pub(super) async fn send_msg(
             let mut retries = 0;
 
             let send_and_retry = || async {
-                match link
-                    .send_with(msg_bytes_clone.clone(), priority, None, listen)
-                    .await
-                {
+                match link.send_with(msg_bytes_clone.clone(), None, listen).await {
                     Ok(()) => Ok(()),
                     Err(error) => match error {
                         SendToOneError::Connection(err) => Err(Error::QuicP2pConnection(err)),

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -229,26 +229,6 @@ impl WireMsg {
         &self.header.msg_envelope.auth
     }
 
-    /// Return the priority of this message
-    ///
-    /// The priority of the msg will be that of the underlying
-    /// [`MsgType`] variant, i.e. [`SystemMsg`] or [`ServiceMsg`].
-    /// This means that we do the same ordering in both incoming
-    /// and outgoing msg queues. We decide which outgoing `WireMsg`
-    /// should be sent first, and which incoming `WireMsg` should
-    /// be deserialized and handled first, in the same way that
-    /// the underlying Cmd/Query/Event will be prioritized when
-    /// handled at dst.
-    ///
-    /// TODO: rework priority so that we dont need to deserialise payload to determine priority.
-    pub fn priority(&self) -> i32 {
-        if let Ok(msg) = self.clone().into_msg() {
-            msg.priority()
-        } else {
-            0
-        }
-    }
-
     /// Return the destination section `PublicKey` for this message
     pub fn dst_section_key(&self) -> bls::PublicKey {
         self.header.msg_envelope.dst.section_key

--- a/sn_interface/src/types/connections/link.rs
+++ b/sn_interface/src/types/connections/link.rs
@@ -112,7 +112,7 @@ impl Link {
         msg: Bytes,
         listen: F,
     ) -> Result<(), SendToOneError> {
-        self.send_with(msg, 0, None, listen).await
+        self.send_with(msg, None, listen).await
     }
 
     /// Send a message to the peer using the given configuration.
@@ -122,10 +122,10 @@ impl Link {
     pub async fn send_with<F: Fn(qp2p::Connection, IncomingMsgs)>(
         &self,
         msg: Bytes,
-        priority: i32,
         retry_config: Option<&RetryConfig>,
         listen: F,
     ) -> Result<(), SendToOneError> {
+        let default_priority = 10;
         let conn = self.get_or_connect(listen).await?;
         let queue_len = { self.queue.read().await.len() };
         trace!(
@@ -133,7 +133,7 @@ impl Link {
             queue_len,
             self.peer
         );
-        match conn.send_with(msg, priority, retry_config).await {
+        match conn.send_with(msg, default_priority, retry_config).await {
             Ok(()) => {
                 self.remove_expired().await;
                 Ok(())

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -338,7 +338,7 @@ impl Comm {
     #[instrument(skip(self, wire_msg))]
     async fn send_to_one(&self, recipient: Peer, wire_msg: WireMsg) -> Result<SendWatcher> {
         let msg_id = wire_msg.msg_id();
-        let priority = wire_msg.priority();
+
         let msg_bytes = match wire_msg.serialize() {
             Ok(bytes) => bytes,
             Err(error) => {
@@ -354,7 +354,7 @@ impl Comm {
             recipient,
         );
         let peer = self.get_or_create(&recipient).await;
-        peer.send(msg_id, priority, msg_bytes).await
+        peer.send(msg_id, msg_bytes).await
     }
 }
 

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -79,13 +79,8 @@ impl PeerSession {
         }
     }
 
-    #[instrument(skip(self, msg_bytes, _msg_priority))]
-    pub(crate) async fn send(
-        &self,
-        msg_id: MsgId,
-        _msg_priority: i32, // TODO: priority is temporarily disabled
-        msg_bytes: Bytes,
-    ) -> Result<SendWatcher> {
+    #[instrument(skip(self, msg_bytes))]
+    pub(crate) async fn send(&self, msg_id: MsgId, msg_bytes: Bytes) -> Result<SendWatcher> {
         let (watcher, reporter) = status_watching();
 
         let job = SendJob {


### PR DESCRIPTION
Remove the Wiremssg priority as it's not actually used in sending from the nodes and can be quite CPU intensive. (accounting for 35% of CPU time here)

![](https://files.slack.com/files-pri/T02KSMR3M-F03THL798HX/screen_shot_2022-08-10_at_17.46.02.png)

The Cmds themselves are prioritised in the node, so they should all get sent out in that order anyway