### PR TITLE
Client/node cleanup and refactoring

### DIFF
--- a/sn_api/src/app/mod.rs
+++ b/sn_api/src/app/mod.rs
@@ -117,8 +117,8 @@ impl Safe {
     /// This is updated by as Anti-Entropy/update messages are received from the network.
     /// Any user of this API is responsible for caching it so it can use it for any new `Safe`
     /// instance, preventing it from learning all this information from the network all over again.
-    pub async fn get_prefix_map(&self) -> Result<NetworkPrefixMap> {
-        let prefix_map = self.get_safe_client()?.prefix_map().clone();
+    pub async fn prefix_map(&self) -> Result<&NetworkPrefixMap> {
+        let prefix_map = self.get_safe_client()?.prefix_map();
         Ok(prefix_map)
     }
 

--- a/sn_api/src/app/mod.rs
+++ b/sn_api/src/app/mod.rs
@@ -118,7 +118,7 @@ impl Safe {
     /// Any user of this API is responsible for caching it so it can use it for any new `Safe`
     /// instance, preventing it from learning all this information from the network all over again.
     pub async fn get_prefix_map(&self) -> Result<NetworkPrefixMap> {
-        let prefix_map = self.get_safe_client()?.prefix_map().await;
+        let prefix_map = self.get_safe_client()?.prefix_map().clone();
         Ok(prefix_map)
     }
 

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -71,9 +71,9 @@ pub async fn run() -> Result<()> {
 
     // If we were connected to a network, cache the up to date PrefixMap to disk before exiting
     if safe.is_connected() {
-        match safe.get_prefix_map().await {
+        match safe.prefix_map().await {
             Ok(prefix_map) => {
-                if let Err(err) = config.update_default_prefix_map(&prefix_map).await {
+                if let Err(err) = config.update_default_prefix_map(prefix_map).await {
                     warn!(
                         "Failed to cache up to date PrefixMap for genesis key {:?} to '{}': {:?}",
                         prefix_map.genesis_key(),

--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -110,8 +110,6 @@ impl Client {
             let sap = self
                 .session
                 .network
-                .read()
-                .await
                 .closest_or_opposite(&random_dst_addr, None)
                 .ok_or(Error::NoNetworkKnowledge)?;
             (sap.elders_vec(), sap.section_key())
@@ -187,12 +185,7 @@ impl Client {
     /// Check if the provided public key is a known section key
     /// based on our current knowledge of the network and sections chains.
     pub async fn is_known_section_key(&self, section_key: &sn_dbc::PublicKey) -> bool {
-        self.session
-            .network
-            .read()
-            .await
-            .get_sections_dag()
-            .has_key(section_key)
+        self.session.network.get_sections_dag().has_key(section_key)
     }
 
     /// NetworkPrefixMap used to bootstrap the client on the network.
@@ -200,8 +193,8 @@ impl Client {
     /// This is updated by the client as it receives Anti-Entropy/update messages from the network.
     /// Any user of this API is responsible for caching it so it can use it for any new `Client`
     /// instance not needing to obtain all this information from the network all over again.
-    pub async fn prefix_map(&self) -> NetworkPrefixMap {
-        self.session.network.read().await.clone()
+    pub fn prefix_map(&self) -> &NetworkPrefixMap {
+        &self.session.network
     }
 
     /// Create a builder to instantiate a [`Client`]

--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -110,7 +110,7 @@ impl Client {
             let sap = self
                 .session
                 .network
-                .closest_or_opposite(&random_dst_addr, None)
+                .closest(&random_dst_addr, None)
                 .ok_or(Error::NoNetworkKnowledge)?;
             (sap.elders_vec(), sap.section_key())
         };

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -369,7 +369,7 @@ impl Session {
 
         info!("Client startup... awaiting some network knowledge");
 
-        let mut known_sap = self.network.closest_or_opposite(&dst_address, None);
+        let mut known_sap = self.network.closest(&dst_address, None);
 
         // wait until we have sufficient network knowledge
         while known_sap.is_none() {
@@ -422,7 +422,7 @@ impl Session {
                     tokio::time::sleep(wait).await;
                 }
 
-                known_sap = self.network.closest_or_opposite(&dst_address, None);
+                known_sap = self.network.closest(&dst_address, None);
 
                 debug!("Known sap: {known_sap:?}");
             }
@@ -436,7 +436,7 @@ impl Session {
 
     async fn get_query_elders(&self, dst: XorName) -> Result<(bls::PublicKey, Vec<Peer>)> {
         // Get DataSection elders details. Resort to own section if DataSection is not available.
-        let sap = self.network.closest_or_opposite(&dst, None);
+        let sap = self.network.closest(&dst, None);
         let (section_pk, mut elders) = if let Some(sap) = &sap {
             (sap.section_key(), sap.elders_vec())
         } else {
@@ -463,7 +463,7 @@ impl Session {
     }
 
     async fn get_cmd_elders(&self, dst_address: XorName) -> Result<(bls::PublicKey, Vec<Peer>)> {
-        let a_close_sap = self.network.closest_or_opposite(&dst_address, None);
+        let a_close_sap = self.network.closest(&dst_address, None);
 
         // Get DataSection elders details.
         if let Some(sap) = a_close_sap {

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -369,11 +369,7 @@ impl Session {
 
         info!("Client startup... awaiting some network knowledge");
 
-        let mut known_sap = self
-            .network
-            .read()
-            .await
-            .closest_or_opposite(&dst_address, None);
+        let mut known_sap = self.network.closest_or_opposite(&dst_address, None);
 
         // wait until we have sufficient network knowledge
         while known_sap.is_none() {
@@ -381,7 +377,7 @@ impl Session {
                 return Err(Error::NetworkContact);
             }
 
-            let stats = self.network.read().await.known_sections_count();
+            let stats = self.network.known_sections_count();
             debug!("Client still has not received a complete section's AE-Retry message... Current sections known: {:?}", stats);
             knowledge_checks += 1;
 
@@ -426,17 +422,13 @@ impl Session {
                     tokio::time::sleep(wait).await;
                 }
 
-                known_sap = self
-                    .network
-                    .read()
-                    .await
-                    .closest_or_opposite(&dst_address, None);
+                known_sap = self.network.closest_or_opposite(&dst_address, None);
 
                 debug!("Known sap: {known_sap:?}");
             }
         }
 
-        let stats = self.network.read().await.known_sections_count();
+        let stats = self.network.known_sections_count();
         debug!("Client has received updated network knowledge. Current sections known: {:?}. Sap for our startup-query: {:?}", stats, known_sap);
 
         Ok(())
@@ -444,7 +436,7 @@ impl Session {
 
     async fn get_query_elders(&self, dst: XorName) -> Result<(bls::PublicKey, Vec<Peer>)> {
         // Get DataSection elders details. Resort to own section if DataSection is not available.
-        let sap = self.network.read().await.closest_or_opposite(&dst, None);
+        let sap = self.network.closest_or_opposite(&dst, None);
         let (section_pk, mut elders) = if let Some(sap) = &sap {
             (sap.section_key(), sap.elders_vec())
         } else {
@@ -471,11 +463,7 @@ impl Session {
     }
 
     async fn get_cmd_elders(&self, dst_address: XorName) -> Result<(bls::PublicKey, Vec<Peer>)> {
-        let a_close_sap = self
-            .network
-            .read()
-            .await
-            .closest_or_opposite(&dst_address, None);
+        let a_close_sap = self.network.closest_or_opposite(&dst_address, None);
 
         // Get DataSection elders details.
         if let Some(sap) = a_close_sap {

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -349,8 +349,6 @@ impl Session {
 
         send_msg_in_bg(self.clone(), initial_contacts, wire_msg.clone(), msg_id)?;
 
-        *self.initial_connection_check_msg_id.write().await = Some(msg_id);
-
         let mut knowledge_checks = 0;
         let mut outgoing_msg_rounds = 1;
         let mut last_start_pos = 0;

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -22,7 +22,7 @@ use sn_interface::{
 use dashmap::DashMap;
 use qp2p::{Config as QuicP2pConfig, Endpoint};
 use std::{net::SocketAddr, sync::Arc, time::Duration};
-use tokio::sync::{mpsc::Sender, RwLock};
+use tokio::sync::mpsc::Sender;
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
 type PendingQueryResponses = Arc<DashMap<OperationId, Vec<(MsgId, QueryResponseSender)>>>;
@@ -46,7 +46,7 @@ pub(super) struct Session {
     // Channels for sending CmdAck to upper layers
     pending_cmds: PendingCmdAcks,
     /// All elders we know about from AE messages
-    pub(super) network: Arc<RwLock<NetworkPrefixMap>>,
+    pub(super) network: NetworkPrefixMap,
     /// Standard time to await potential AE messages:
     cmd_ack_wait: Duration,
     /// Links to nodes
@@ -69,7 +69,7 @@ impl Session {
             pending_queries: Arc::new(DashMap::default()),
             pending_cmds: Arc::new(DashMap::default()),
             endpoint,
-            network: Arc::new(RwLock::new(prefix_map)),
+            network: prefix_map,
             cmd_ack_wait,
             peer_links,
         };

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -47,8 +47,6 @@ pub(super) struct Session {
     pending_cmds: PendingCmdAcks,
     /// All elders we know about from AE messages
     pub(super) network: Arc<RwLock<NetworkPrefixMap>>,
-    /// Initial network comms MsgId
-    initial_connection_check_msg_id: Arc<RwLock<Option<MsgId>>>,
     /// Standard time to await potential AE messages:
     cmd_ack_wait: Duration,
     /// Links to nodes
@@ -72,7 +70,6 @@ impl Session {
             pending_cmds: Arc::new(DashMap::default()),
             endpoint,
             network: Arc::new(RwLock::new(prefix_map)),
-            initial_connection_check_msg_id: Arc::new(RwLock::new(None)),
             cmd_ack_wait,
             peer_links,
         };

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -962,7 +962,7 @@ mod knowledge_tests {
         dysfunctional_detection.add_new_node(new_node);
 
         // Add just one issue to all, this gets us a baseline avg to not overly skew results
-        for node in nodes.clone() {
+        for node in nodes {
             dysfunctional_detection.track_issue(node, IssueType::AwaitingProbeResponse);
         }
 

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -458,13 +458,11 @@ impl NetworkKnowledge {
 
     // Get SectionAuthorityProvider of a known section with the given prefix,
     // along with its section chain.
-    pub fn get_closest_or_opposite_signed_sap(
+    pub fn closest_signed_sap(
         &self,
         name: &XorName,
     ) -> Option<(&SectionAuth<SectionAuthorityProvider>, SecuredLinkedList)> {
-        let closest_sap = self
-            .prefix_map
-            .closest_or_opposite(name, Some(&self.prefix()));
+        let closest_sap = self.prefix_map.closest(name, Some(&self.prefix()));
 
         if let Some(signed_sap) = closest_sap {
             if let Ok(proof_chain) = self

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -461,7 +461,7 @@ impl NetworkKnowledge {
     pub fn get_closest_or_opposite_signed_sap(
         &self,
         name: &XorName,
-    ) -> Option<(SectionAuth<SectionAuthorityProvider>, SecuredLinkedList)> {
+    ) -> Option<(&SectionAuth<SectionAuthorityProvider>, SecuredLinkedList)> {
         let closest_sap = self
             .prefix_map
             .closest_or_opposite(name, Some(&self.prefix()));

--- a/sn_interface/src/network_knowledge/prefix_map/mod.rs
+++ b/sn_interface/src/network_knowledge/prefix_map/mod.rs
@@ -102,12 +102,12 @@ impl NetworkPrefixMap {
         &self,
         name: &XorName,
         exclude: Option<&Prefix>,
-    ) -> Option<SectionAuth<SectionAuthorityProvider>> {
+    ) -> Option<&SectionAuth<SectionAuthorityProvider>> {
         self.sections
             .iter()
             .filter(|&(prefix, _)| Some(prefix) != exclude)
             .min_by(|&(prefix_lhs, _), &(prefix_rhs, _)| prefix_lhs.cmp_distance(prefix_rhs, name))
-            .map(|(_, sap)| sap.clone())
+            .map(|(_, sap)| sap)
     }
 
     /// Returns the known section that is closest to the given name,
@@ -118,13 +118,13 @@ impl NetworkPrefixMap {
         &self,
         name: &XorName,
         exclude: Option<&Prefix>,
-    ) -> Option<SectionAuth<SectionAuthorityProvider>> {
+    ) -> Option<&SectionAuth<SectionAuthorityProvider>> {
         self.closest(name, exclude).or_else(|| {
             self.sections
                 .iter()
                 .filter(|&(prefix, _)| prefix.matches(&name.with_bit(0, !name.bit(0))))
                 .max_by_key(|&(prefix, _)| prefix.bit_count())
-                .map(|(_, sap)| sap.clone())
+                .map(|(_, sap)| sap)
         })
     }
 
@@ -455,14 +455,14 @@ mod tests {
         assert_eq!(
             map.closest_or_opposite(&p1.substituted_in(xor_name::rand::random()), None)
                 .ok_or(Error::NoMatchingSection)?,
-            sap0
+            &sap0
         );
 
         let _changed = map.insert(sap0.clone());
         assert_eq!(
             map.closest_or_opposite(&p1.substituted_in(xor_name::rand::random()), None)
                 .ok_or(Error::NoMatchingSection)?,
-            sap0
+            &sap0
         );
 
         Ok(())

--- a/sn_interface/src/network_knowledge/prefix_map/mod.rs
+++ b/sn_interface/src/network_knowledge/prefix_map/mod.rs
@@ -98,7 +98,7 @@ impl NetworkPrefixMap {
     /// Returns the known section that is closest to the given name,
     /// regardless of whether `name` belongs in that section or not.
     /// If provided, it excludes any section matching the passed prefix.
-    fn closest(
+    pub fn closest(
         &self,
         name: &XorName,
         exclude: Option<&Prefix>,
@@ -108,24 +108,6 @@ impl NetworkPrefixMap {
             .filter(|&(prefix, _)| Some(prefix) != exclude)
             .min_by(|&(prefix_lhs, _), &(prefix_rhs, _)| prefix_lhs.cmp_distance(prefix_rhs, name))
             .map(|(_, sap)| sap)
-    }
-
-    /// Returns the known section that is closest to the given name,
-    /// regardless of whether `name` belongs in that section or not.
-    /// If there are no close matches in remote sections, return a SAP from an opposite prefix.
-    /// If provided, it excludes any section matching the passed prefix.
-    pub fn closest_or_opposite(
-        &self,
-        name: &XorName,
-        exclude: Option<&Prefix>,
-    ) -> Option<&SectionAuth<SectionAuthorityProvider>> {
-        self.closest(name, exclude).or_else(|| {
-            self.sections
-                .iter()
-                .filter(|&(prefix, _)| prefix.matches(&name.with_bit(0, !name.bit(0))))
-                .max_by_key(|&(prefix, _)| prefix.bit_count())
-                .map(|(_, sap)| sap)
-        })
     }
 
     /// Returns all known sections SAP.
@@ -453,14 +435,14 @@ mod tests {
 
         // There are no matching prefixes, so return an opposite prefix.
         assert_eq!(
-            map.closest_or_opposite(&p1.substituted_in(xor_name::rand::random()), None)
+            map.closest(&p1.substituted_in(xor_name::rand::random()), None)
                 .ok_or(Error::NoMatchingSection)?,
             &sap0
         );
 
         let _changed = map.insert(sap0.clone());
         assert_eq!(
-            map.closest_or_opposite(&p1.substituted_in(xor_name::rand::random()), None)
+            map.closest(&p1.substituted_in(xor_name::rand::random()), None)
                 .ok_or(Error::NoMatchingSection)?,
             &sap0
         );

--- a/sn_interface/src/network_knowledge/prefix_map/mod.rs
+++ b/sn_interface/src/network_knowledge/prefix_map/mod.rs
@@ -121,12 +121,12 @@ impl NetworkPrefixMap {
     /// Get `SectionAuthorityProvider` of a known section with the given prefix.
     #[allow(unused)]
     pub fn get(&self, prefix: &Prefix) -> Option<SectionAuthorityProvider> {
-        self.get_signed(prefix).map(|sap| sap.value)
+        self.get_signed(prefix).map(|sap| sap.value.clone())
     }
 
     /// Get signed `SectionAuthorityProvider` of a known section with the given prefix.
-    pub fn get_signed(&self, prefix: &Prefix) -> Option<SectionAuth<SectionAuthorityProvider>> {
-        self.sections.get(prefix).cloned()
+    pub fn get_signed(&self, prefix: &Prefix) -> Option<&SectionAuth<SectionAuthorityProvider>> {
+        self.sections.get(prefix)
     }
 
     /// Update our knowledge on the remote section's SAP and our sections DAG
@@ -177,7 +177,7 @@ impl NetworkPrefixMap {
         }
 
         match self.get_signed(incoming_prefix) {
-            Some(sap) if sap == signed_sap => {
+            Some(sap) if sap == &signed_sap => {
                 // It's the same SAP we are already aware of
                 return Ok(false);
             }

--- a/sn_node/src/bin/sn_node/log/appender.rs
+++ b/sn_node/src/bin/sn_node/log/appender.rs
@@ -70,8 +70,8 @@ impl FileRotateAppender {
         max_log_size: ContentLimit,
         compression: Compression,
     ) -> Self {
-        let log_directory = directory.as_ref().to_str().unwrap();
-        let log_filename_prefix = file_name_prefix.as_ref().to_str().unwrap();
+        let log_directory = directory.as_ref();
+        let log_filename_prefix = file_name_prefix.as_ref();
         let path = Path::new(&log_directory).join(&log_filename_prefix);
         let writer = FileRotate::new(&Path::new(&path), file_limit, max_log_size, compression);
 

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -324,7 +324,7 @@ impl Node {
                     // Redirect to the closest section
                     let ae_msg = SystemMsg::AntiEntropy {
                         section_auth: signed_sap.value.to_msg(),
-                        section_signed: signed_sap.sig,
+                        section_signed: signed_sap.sig.clone(),
                         proof_chain: section_dag,
                         kind: AntiEntropyKind::Redirect { bounced_msg },
                     };

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -314,10 +314,7 @@ impl Node {
                 "AE: prefix not matching. We are: {:?}, they sent to: {:?}",
                 our_prefix, dst_name
             );
-            return match self
-                .network_knowledge
-                .get_closest_or_opposite_signed_sap(&dst_name)
-            {
+            return match self.network_knowledge.closest_signed_sap(&dst_name) {
                 Some((signed_sap, section_dag)) => {
                     info!("Found a better matching prefix {:?}", signed_sap.prefix());
                     let bounced_msg = original_bytes;

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -222,7 +222,7 @@ async fn bootstrap_node(
         let prefix_map = read_prefix_map_from_disk(&path).await?;
         let section_elders = {
             let sap = prefix_map
-                .closest_or_opposite(&xor_name::rand::random(), None)
+                .closest(&xor_name::rand::random(), None)
                 .ok_or_else(|| Error::Configuration("Could not obtain closest SAP".to_string()))?;
             sap.elders_vec()
         };


### PR DESCRIPTION
Various tweaks that are chore/refactor. Also removes the `closest_or_opposite` method, as that wasn't used like it was designed. It actually is always used to find anything closest. In one case it's used to find a section closer than its own section, in which case an exclusion is passed in.

- chore: remove unused Session member
- chore(client): leave out unnecessary Arc<RwLock>
- chore: remove unnecessary unwrap
- refactor: circumvent clone to use reference
- refactor: SAP reference instead of clone
- refactor: clean up unused functionality

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
