### PR TITLE
fix: reduce client qp2p default idle timeout

### DIFF
--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -151,8 +151,14 @@ impl ClientBuilder {
             }
         };
 
+        let mut qp2p = self.qp2p.unwrap_or_default();
+        // If `idle_timeout` is not set, set it to 6 seconds (instead of 18s default).
+        if qp2p.idle_timeout.is_none() {
+            qp2p.idle_timeout = Some(Duration::from_secs(6));
+        }
+
         let session = Session::new(
-            self.qp2p.unwrap_or_default(),
+            qp2p,
             self.local_addr
                 .unwrap_or_else(|| SocketAddr::from(DEFAULT_LOCAL_ADDR)),
             cmd_ack_wait,


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
