### PR TITLE
chore(node): do not merge client requests to different adult indexes

### DIFF
--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -116,6 +116,7 @@ pub(crate) enum Cmd {
     AddToPendingQueries {
         operation_id: OperationId,
         origin: Peer,
+        target_adult: XorName,
     },
     HandleValidSystemMsg {
         msg_id: MsgId,

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -108,19 +108,27 @@ impl Dispatcher {
             Cmd::AddToPendingQueries {
                 operation_id,
                 origin,
+                target_adult,
             } => {
                 let mut node = self.node.write().await;
+                // cleanup
+                node.pending_data_queries.remove_expired();
 
-                if let Some(peers) = node.pending_data_queries.get_mut(&operation_id) {
+                if let Some(peers) = node
+                    .pending_data_queries
+                    .get_mut(&(operation_id, origin.name()))
+                {
                     trace!(
                         "Adding to pending data queries for op id: {:?}",
                         operation_id
                     );
                     let _ = peers.insert(origin);
                 } else {
-                    let _prior_value =
-                        node.pending_data_queries
-                            .set(operation_id, BTreeSet::from([origin]), None);
+                    let _prior_value = node.pending_data_queries.set(
+                        (operation_id, target_adult),
+                        BTreeSet::from([origin]),
+                        None,
+                    );
                 };
 
                 Ok(vec![])

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -151,7 +151,7 @@ impl Node {
         );
 
         let node_id = XorName::from(sending_node_pk);
-        let query_peers = self.pending_data_queries.remove(&op_id);
+        let query_peers = self.pending_data_queries.remove(&(op_id, node_id));
         // Clear expired queries from the cache.
         self.pending_data_queries.remove_expired();
 
@@ -193,7 +193,9 @@ impl Node {
             // if no more responses come in this query should eventually time out
             // TODO: What happens if we keep getting queries / client for some data that's always not found?
             // We need to handle that
-            let _prev = self.pending_data_queries.set(op_id, waiting_peers, None);
+            let _prev = self
+                .pending_data_queries
+                .set((op_id, node_id), waiting_peers, None);
             trace!(
                 "Node {:?}, reported data not found {:?}",
                 sending_node_pk,

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -127,6 +127,8 @@ mod core {
     // This prevents pending query limit unbound growth
     pub(crate) const DATA_QUERY_LIMIT: usize = 100;
     // per query we can have this many peers, so the total peers waiting can be QUERY_LIMIT * MAX_WAITING_PEERS_PER_QUERY
+    // It's worth noting that nodes clean up all connections every two mins, so this max can only last that long.
+    // (and yes, some clients may unfortunately be disconnected quickly)
     pub(crate) const MAX_WAITING_PEERS_PER_QUERY: usize = 100;
 
     const BACKOFF_CACHE_LIMIT: usize = 100;
@@ -184,7 +186,8 @@ mod core {
         // Trackers
         pub(crate) capacity: Capacity,
         pub(crate) dysfunction_tracking: DysfunctionDetection,
-        pub(crate) pending_data_queries: Cache<OperationId, BTreeSet<Peer>>,
+        /// Cache the request combo,  (OperationId -> An adult xorname), to waiting Clients peers for that combo
+        pub(crate) pending_data_queries: Cache<(OperationId, XorName), BTreeSet<Peer>>,
         // Caches
         pub(crate) ae_backoff_cache: AeBackoffCache,
     }


### PR DESCRIPTION
We previously were merging all client requests for responses coming in, now we have adult indexes in queries, but were still doing this at nodes... now it's per adult.