### PR TITLE
tests(client): remove long lived client conn test

### DIFF
--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -209,7 +209,7 @@ mod tests {
     use crate::utils::test_utils::{
         create_test_client, create_test_client_with, get_dbc_owner_from_secret_key_hex,
     };
-    use sn_interface::{init_logger, types::utils::random_bytes};
+    use sn_interface::init_logger;
 
     use eyre::Result;
     use std::{
@@ -250,17 +250,6 @@ mod tests {
         let client = create_test_client_with(Some(full_id), None, None).await?;
         assert_eq!(pk, client.public_key());
 
-        Ok(())
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn long_lived_connection_survives() -> Result<()> {
-        init_logger();
-
-        let client = create_test_client().await?;
-        tokio::time::sleep(tokio::time::Duration::from_secs(40)).await;
-        let bytes = random_bytes(self_encryption::MIN_ENCRYPTABLE_BYTES / 2);
-        let _ = client.upload(bytes).await?;
         Ok(())
     }
 


### PR DESCRIPTION
No longer relevant, client conns can be cleaned up by nodes every X time.
So clients have to be resilient and retry (which they do). So this (long)
test can be dropped

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
