### PR TITLE
feat(logging): simplify log format to '<timestamp> [module] LEVEL <msg>'

### DIFF
--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -96,9 +96,11 @@ where
         let module = event.metadata().module_path().unwrap_or("<unknown module>");
         let time = SystemTime::default();
 
+        write!(writer, "[")?;
         time.format_time(&mut writer)?;
-
-        write!(writer, " [{module}] {level} ")?;
+        write!(writer, " {level} {module}")?;
+        ctx.visit_spans(|span| write!(writer, "/{}", span.name()))?;
+        write!(writer, "] ")?;
 
         // Add the log message and any fields associated with the event
         ctx.field_format().format_fields(writer.by_ref(), event)?;


### PR DESCRIPTION
I've found our logging format to be very difficult to parse, IMO it's cluttered with a ton of unnecessary information making command line tools ineffective following what's going on.

The format proposed in this PR is:

     [<timestamp> LEVEL module::path/span1/span2/span3] <msg>

e.g.
```
[2022-08-16T13:58:25.869826Z TRACE sn_node::node::messaging/validate_msg/apply_ae] Entropy check skipped for MsgId(d6aa..ccd7), handling message directly
```

The entire log is on one line making it simple to filter down a large collection of logs using the unix tools.

e.g. `rg -v` can be used to prune out messages we don't care for:

```
tail -f .../sn-node-*/*.log | rg -v 'qp2p|quinn|sn_node::comm'
```
This will filter out logs related to `qp2p`, `quinn`, `sn_node::comm`, you can add to this set interactively as you explore the logs.

