### PR TITLE
fix: reintroduce Arc<RwLock> for section tree

### DIFF
--- a/sn_api/src/app/mod.rs
+++ b/sn_api/src/app/mod.rs
@@ -117,8 +117,8 @@ impl Safe {
     /// This is updated by as Anti-Entropy/update messages are received from the network.
     /// Any user of this API is responsible for caching it so it can use it for any new `Safe`
     /// instance, preventing it from learning all this information from the network all over again.
-    pub async fn section_tree(&self) -> Result<&SectionTree> {
-        let section_tree = self.get_safe_client()?.section_tree();
+    pub async fn section_tree(&self) -> Result<SectionTree> {
+        let section_tree = self.get_safe_client()?.section_tree().await;
         Ok(section_tree)
     }
 

--- a/sn_api/src/app/wallet.rs
+++ b/sn_api/src/app/wallet.rs
@@ -47,7 +47,7 @@ impl sn_dbc::SpentProofKeyVerifier for SpentProofKeyVerifier<'_> {
     // Called by sn_dbc API when it needs to verify a SpentProof is signed by a known key,
     // we check if the key is any of the network sections keys we are aware of
     fn verify_known_key(&self, key: &PublicKey) -> Result<()> {
-        if !self.client.is_known_section_key(key) {
+        if !futures::executor::block_on(self.client.is_known_section_key(key)) {
             Err(Error::DbcVerificationFailed(format!(
                 "SpentProof key is an unknown section key: {}",
                 key.to_hex()

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -74,7 +74,7 @@ pub async fn run() -> Result<()> {
     if safe.is_connected() {
         match safe.section_tree().await {
             Ok(section_tree) => {
-                if let Err(err) = config.update_default_network_contacts(section_tree).await {
+                if let Err(err) = config.update_default_network_contacts(&section_tree).await {
                     warn!(
                         "Failed to cache up to date network contacts for genesis key {:?} to '{}': {:?}",
                         section_tree.genesis_key(),

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -145,8 +145,14 @@ impl Session {
         sender: Peer,
     ) -> Result<(), Error> {
         // Check that the message can be trusted w.r.t. our known keys
-        let known_keys: Vec<BlsPublicKey> =
-            self.network.get_sections_dag().keys().cloned().collect();
+        let known_keys: Vec<BlsPublicKey> = self
+            .network
+            .read()
+            .await
+            .get_sections_dag()
+            .keys()
+            .cloned()
+            .collect();
 
         if !NetworkKnowledge::verify_node_msg_can_be_trusted(msg_authority, &msg, &known_keys) {
             warn!("Untrusted message has been dropped, from {sender:?}: {msg:?} ");
@@ -355,7 +361,7 @@ impl Session {
         sender: Peer,
     ) {
         // Update our network PrefixMap based upon passed in knowledge
-        let result = self.network.update(
+        let result = self.network.write().await.update(
             SectionAuth {
                 value: sap.clone(),
                 sig: section_signed,

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -22,7 +22,7 @@ use sn_interface::{
 use dashmap::DashMap;
 use qp2p::{Config as QuicP2pConfig, Endpoint};
 use std::{net::SocketAddr, sync::Arc, time::Duration};
-use tokio::sync::mpsc::Sender;
+use tokio::sync::{mpsc::Sender, RwLock};
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
 type PendingQueryResponses = Arc<DashMap<OperationId, Vec<(MsgId, QueryResponseSender)>>>;
@@ -46,7 +46,7 @@ pub(super) struct Session {
     // Channels for sending CmdAck to upper layers
     pending_cmds: PendingCmdAcks,
     /// All elders we know about from AE messages
-    pub(super) network: SectionTree,
+    pub(super) network: Arc<RwLock<SectionTree>>,
     /// Standard time to await potential AE messages:
     cmd_ack_wait: Duration,
     /// Links to nodes
@@ -69,7 +69,7 @@ impl Session {
             pending_queries: Arc::new(DashMap::default()),
             pending_cmds: Arc::new(DashMap::default()),
             endpoint,
-            network: network_contacts,
+            network: Arc::new(RwLock::new(network_contacts)),
             cmd_ack_wait,
             peer_links,
         };


### PR DESCRIPTION
The RwLock was mistakenly removed by me. This meant that network updates
to the section tree were not propagated back to the client's session.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
