### PR TITLE
sn_cli: changes to Config::settings

### DIFF
--- a/.github/workflows/benchmark_prs.yml
+++ b/.github/workflows/benchmark_prs.yml
@@ -95,6 +95,12 @@ jobs:
         # passes to tee which displays it in the terminal and writes to output.txt
         run: cargo criterion -p sn_node --output-format bencher 2>&1 | tee -a output.txt
 
+      - name: Bench sn_cli
+        shell: bash
+        # Criterion outputs the actual bench results to stderr "2>&1 tee output.txt" takes stderr,
+        # passes to tee which displays it in the terminal and writes to output.txt
+        run: cargo criterion -p sn_cli --output-format bencher 2>&1 | tee -a output.txt
+
       #################################
       ### Log any regression alerts ###
       #################################

--- a/sn_cli/src/subcommands/node.rs
+++ b/sn_cli/src/subcommands/node.rs
@@ -143,8 +143,6 @@ pub async fn node_commander(
                 path.push("node");
                 path
             };
-            println!("config: {:?}", config);
-            println!("dir: {:?}", target_dir_path);
             // We run this command in a separate thread to overcome a conflict with
             // the self_update crate as it seems to be creating its own runtime.
             let handler = std::thread::spawn(|| node_install(target_dir_path, version));


### PR DESCRIPTION
- Make a copy of the `default` network contact when switching networks and not during `sync()`
- Remove a redundant file read during `sync()`
- Include `sn_cli` bench during PR run. Takes ~11 minutes to complete including compilation