### PR TITLE
ci(nightly): slack notifications for nightly run

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -17,6 +17,8 @@ env:
   AWS_DEFAULT_REGION: 'eu-west-2'
   INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.sh
   POWERSHELL_INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.ps1
+  TESTNET_BUCKET_URL: https://safe-testnet-tool.s3.eu-west-2.amazonaws.com
+  WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
 
 jobs:
   cli-install-tests:
@@ -445,8 +447,18 @@ jobs:
             "$TESTNET_ID-run.tar.gz" \
             "s3://safe-testnet-tool/$TESTNET_ID-run.tar.gz" \
             --acl public-read
+          echo "The logs should be available at $TESTNET_BUCKET_URL/$TESTNET_ID-run.tar.gz"
+
+      - name: post notification to slack
+        if: always()
+        uses: bryannice/gitactions-slack-notification@2.0.0
+        env:
+          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+          SLACK_MESSAGE: 'Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}'
+          SLACK_TITLE: 'Nightly Run Failed'
 
       - name: Kill testnet
+        if: always()
         uses: maidsafe/sn_testnet_action@main
         with:
           do-token: ${{ secrets.DO_TOKEN }}


### PR DESCRIPTION
When the run fails, use a custom action to post a message to a Slack incoming webhook. For some
reason the content of the message to be sent is defined using environment variables, so you are
limited in terms of the amount of information that can be included in the notification. I checked a
few more actions and they all operated in this fashion. With that in mind, the best thing I thought
to do was for the failure to have a direct link to the run, so we can get people to the logs as
quickly as possible.

Also made a little change to output the direct URL of the server logs that get uploaded.
