### PR TITLE
chore(client): remove messaging layer retries & Err if we insufficien…

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -271,6 +271,8 @@ jobs:
 
       - name: Run client tests
         uses: maidsafe/cargo-nextest@main
+        env:
+          RUST_LOG: "sn_client=trace"
         with:
           test-run-name: e2e-client-${{ matrix.os }}
           profile: ci
@@ -566,6 +568,8 @@ jobs:
 
       - name: Run API tests
         uses: maidsafe/cargo-nextest@main
+        env:
+          RUST_LOG: "sn_client=trace"
         with:
           test-run-name: api-${{ matrix.os }}
           profile: ci
@@ -676,6 +680,8 @@ jobs:
 
       - name: Run CLI tests
         uses: maidsafe/cargo-nextest@main
+        env:
+          RUST_LOG: "sn_client=trace"
         with:
           test-run-name: cli-${{ matrix.os }}
           profile: ci

--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -40,7 +40,7 @@ pub const ENV_AE_WAIT: &str = "SN_AE_WAIT";
 /// Bind by default to all network interfaces on a OS assigned port
 pub const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 /// Default timeout to use before timing out queries and commands
-pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(30);
+pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(45);
 /// Max retries to be attempted in the DEFAULT_QUERY_CMD_TIMEOUT; DEFAULT_QUERY_CMD_TIMEOUT / DEFAULT_MAX_QUERY_CMD_RETRIES ~ tries per second
 /// (though exponential backoff exists)
 pub const DEFAULT_MAX_QUERY_CMD_RETRIES: usize = 15;
@@ -156,7 +156,6 @@ impl ClientBuilder {
         let max_retries = self.max_retries.unwrap_or(DEFAULT_MAX_QUERY_CMD_RETRIES);
         let query_timeout = self.query_timeout.unwrap_or(DEFAULT_QUERY_CMD_TIMEOUT);
         let cmd_timeout = self.cmd_timeout.unwrap_or(DEFAULT_QUERY_CMD_TIMEOUT);
-        let cmd_ack_wait = self.cmd_ack_wait.unwrap_or(DEFAULT_ACK_WAIT);
 
         let network_contacts = match self.network_contacts {
             Some(pm) => pm,
@@ -178,7 +177,6 @@ impl ClientBuilder {
             qp2p,
             self.local_addr
                 .unwrap_or_else(|| SocketAddr::from(DEFAULT_LOCAL_ADDR)),
-            cmd_ack_wait,
             network_contacts,
         )?;
 

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -58,10 +58,10 @@ impl Client {
         let op_limit = self.cmd_timeout;
 
         let mut backoff = ExponentialBackoff {
-            initial_interval: Duration::from_secs(3),
-            max_interval: Duration::from_secs(60),
+            initial_interval: Duration::from_millis(500),
+            max_interval: Duration::from_secs(20),
             max_elapsed_time: Some(op_limit),
-            // randomization_factor: 0.5,
+            randomization_factor: 0.5,
             ..Default::default()
         };
 

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -68,7 +68,6 @@ impl Client {
         let mut attempts = 1;
         let dst = query.variant.dst_name();
 
-
         loop {
             let msg = ServiceMsg::Query(query.clone());
             let serialised_query = WireMsg::serialize_msg_payload(&msg)?;

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -93,7 +93,6 @@ impl Client {
             .await;
 
             match res {
-                // TODO: when we return errors, check if it's a NotFound error and retry.
                 Ok(Ok(query_result)) => break Ok(query_result),
                 Ok(Err(err)) if attempts > self.max_retries => {
                     debug!(

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -93,6 +93,7 @@ impl Client {
             .await;
 
             match res {
+                // TODO: when we return errors, check if it's a NotFound error and retry.
                 Ok(Ok(query_result)) => break Ok(query_result),
                 Ok(Err(err)) if attempts > self.max_retries => {
                     debug!(

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -67,11 +67,12 @@ impl Client {
         let _ = span.enter();
         let mut attempts = 1;
         let dst = query.variant.dst_name();
+
+
         loop {
             let msg = ServiceMsg::Query(query.clone());
             let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
             let signature = self.keypair.sign(&serialised_query);
-
             debug!(
                 "Attempting {:?} (attempt #{}) with a query timeout of {:?}",
                 query, attempts, attempt_timeout

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 use qp2p::UsrMsgBytes;
+use dashmap::DashSet;
 use sn_interface::{
     at_least_one_correct_elder,
     messaging::{
@@ -31,6 +32,7 @@ use qp2p::{Close, ConnectionError, ConnectionIncoming as IncomingMsgs, SendError
 use rand::{rngs::OsRng, seq::SliceRandom};
 use secured_linked_list::SecuredLinkedList;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tracing::Instrument;
 
 impl Session {
@@ -197,19 +199,18 @@ impl Session {
         src: SocketAddr,
         error: Option<CmdError>,
     ) {
-        if let Some(sender) = cmds.get(&correlation_id) {
-            trace!(
-                "Sending cmd response from {:?} for cmd w/{:?} via channel.",
-                src,
-                correlation_id
-            );
-            let result = sender.try_send((src, error));
-            if result.is_err() {
-                trace!("Error sending cmd response on a channel for cmd_id {:?}: {:?}. (It has likely been removed)", correlation_id, result)
-            }
+        if error.is_some() {
+            debug!("CmdError was received for {correlation_id:?}: {:?}", error);
+        }
+
+        if let Some(mut received_acks) = cmds.get_mut(&correlation_id) {
+            let acks = received_acks.value_mut();
+
+            let _prior = acks.insert((src, error));
         } else {
-            // Likely the channel is removed when received majority of Acks
-            trace!("No channel found for cmd Ack of {:?}", correlation_id);
+            let received = DashSet::new();
+            let _nonexistent = received.insert((src, error));
+            let _non_prior = cmds.insert(correlation_id, Arc::new(received));
         }
     }
 
@@ -280,7 +281,6 @@ impl Session {
                     correlation_id,
                     ..
                 } => {
-                    warn!("CmdError was received for {correlation_id:?}: {:?}", error);
                     Self::send_cmd_response(cmds, correlation_id, src_peer.addr(), Some(error));
                 }
                 ServiceMsg::CmdAck { correlation_id } => {

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -13,8 +13,8 @@ use crate::{
     Error, Result,
 };
 
-use qp2p::UsrMsgBytes;
 use dashmap::DashSet;
+use qp2p::UsrMsgBytes;
 use sn_interface::{
     at_least_one_correct_elder,
     messaging::{

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -626,7 +626,7 @@ impl Session {
         }
 
         if failures > successful_sends {
-            warn!("More errors when sending a message than successes");
+            warn!("More errors when sending a message than successes, last_error: {:?}", last_error);
             // If we've only had connection errors, those are not stored in `last_error` (but they are logged)
             // Such errors are not fatal to the program and you can normally simply retry by calling
             // send_msg again.

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -85,9 +85,6 @@ impl Session {
         wire_msg.append_trace(&mut Traceroute(vec![Entity::Client(client_pk)]));
 
         // The insertion of channel will be executed AFTER the completion of the `send_message`.
-        // let (sender, mut receiver) = channel::<CmdResponse>(elders_len);
-        // let _ = self.pending_cmds.insert(msg_id, sender);
-
         self.send_msg(elders, wire_msg, msg_id).await?;
         trace!("Cmd msg {:?} sent", msg_id);
 
@@ -527,14 +524,12 @@ impl Session {
     pub(super) async fn send_msg(
         &self,
         nodes: Vec<Peer>,
-        mut wire_msg: WireMsg,
+        wire_msg: WireMsg,
         msg_id: MsgId,
     ) -> Result<()> {
-        let bytes = wire_msg.serialize_and_cache_bytes()?;
+        let bytes = wire_msg.serialize()?;
 
         let mut last_error = None;
-        drop(wire_msg);
-
         // Send message to all Elders concurrently
         let mut tasks = Vec::default();
 

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -8,7 +8,7 @@
 
 use super::{QueryResult, Session};
 
-use crate::{connections::CmdResponse, Error, Result};
+use crate::{Error, Result};
 
 #[cfg(feature = "traceroute")]
 use sn_interface::{
@@ -85,69 +85,78 @@ impl Session {
         wire_msg.append_trace(&mut Traceroute(vec![Entity::Client(client_pk)]));
 
         // The insertion of channel will be executed AFTER the completion of the `send_message`.
-        let (sender, mut receiver) = channel::<CmdResponse>(elders_len);
-        let _ = self.pending_cmds.insert(msg_id, sender);
-        trace!("Inserted channel for cmd {:?}", msg_id);
+        // let (sender, mut receiver) = channel::<CmdResponse>(elders_len);
+        // let _ = self.pending_cmds.insert(msg_id, sender);
 
         self.send_msg(elders, wire_msg, msg_id).await?;
+        trace!("Cmd msg {:?} sent", msg_id);
 
         let expected_acks = elders_len * 2 / 3 + 1;
 
         // We are not wait for the receive of majority of cmd Acks.
         // This could be further strict to wait for ALL the Acks get received.
         // The period is expected to have AE completed, hence no extra wait is required.
-        let mut received_ack = 0;
-        let mut received_err = 0;
-        let mut attempts = 0;
-        let interval = Duration::from_millis(50);
-        let expected_cmd_ack_wait_attempts =
-            std::cmp::max(200, self.cmd_ack_wait.as_millis() / interval.as_millis());
-        loop {
-            match receiver.try_recv() {
-                Ok((src, None)) => {
-                    received_ack += 1;
-                    trace!("received CmdAck of {msg_id:?} from {src:?}, so far {received_ack} / {expected_acks}");
 
-                    if received_ack >= expected_acks {
-                        let _ = self.pending_cmds.remove(&msg_id);
-                        break;
+        let mut ack_checks = 0;
+        let max_ack_checks = 200;
+        let interval = Duration::from_millis(50);
+
+        loop {
+            if let Some(acks_we_have) = self.pending_cmds.get(&msg_id) {
+                let acks = acks_we_have.value();
+
+                let received_ack_count = acks.len();
+
+                let mut error_count = 0;
+                let mut return_error = None;
+
+                for refmulti in acks.iter() {
+                    let (ack_src, error) = refmulti.key();
+                    if return_error.is_none() {
+                        return_error = error.clone();
+                    }
+
+                    if error.is_some() {
+                        error!(
+                            "received error response {:?} of cmd {:?} from {:?}, so far {} acks vs. {} errors",
+                            error, msg_id, ack_src, received_ack_count, error_count
+                        );
+                        error_count += 1;
                     }
                 }
-                Ok((src, Some(error))) => {
-                    received_err += 1;
+
+                // first exit if too many errors:
+                if error_count >= expected_acks {
                     error!(
-                        "received error response {:?} of cmd {:?} from {:?}, so far {} acks vs. {} errors",
-                        error, msg_id, src, received_ack, received_err
+                        "Received majority of error response for cmd {:?}: {:?}",
+                        msg_id, return_error
                     );
-                    if received_err >= expected_acks {
-                        error!("Received majority of error response for cmd {:?}", msg_id);
-                        let _ = self.pending_cmds.remove(&msg_id);
-                        let CmdError::Data(source) = error;
+                    // attempt to cleanup... though more acks may come in..
+                    let _ = self.pending_cmds.remove(&msg_id);
+
+                    if let Some(CmdError::Data(source)) = return_error {
                         return Err(Error::ErrorCmd { source, msg_id });
                     }
                 }
-                Err(_err) => {
-                    // this is not an error..the channel is just empty atm
-                }
-            }
-            attempts += 1;
-            if attempts >= expected_cmd_ack_wait_attempts {
-                warn!(
-                    "Terminated with insufficient CmdAcks for {:?}, {} / {} acks received",
-                    msg_id, received_ack, expected_acks
-                );
 
+                if received_ack_count >= expected_acks {
+                    break;
+                }
+
+                debug!("insufficient acks returned so far: {received_ack_count}/{expected_acks}");
+            }
+
+            if ack_checks >= max_ack_checks {
                 return Err(Error::InsufficientAcksReceived);
             }
-            trace!(
-                "current ack waiting loop count {}/{}",
-                attempts,
-                expected_cmd_ack_wait_attempts
-            );
+
+            ack_checks += 1;
+
+            trace!("{:?} current ack waiting loop count {}", msg_id, ack_checks,);
             tokio::time::sleep(interval).await;
         }
 
-        trace!("Wait for any cmd response/reaction (AE msgs eg), is over)");
+        trace!("Wait for any cmd response/reaction (AE msgs eg), is over. We've had sufficient success.)");
         Ok(())
     }
 
@@ -641,10 +650,7 @@ mod tests {
 
     use eyre::{eyre, Result};
     use qp2p::Config;
-    use std::{
-        net::{Ipv4Addr, SocketAddr},
-        time::Duration,
-    };
+    use std::net::{Ipv4Addr, SocketAddr};
     use xor_name::Prefix;
 
     fn prefix(s: &str) -> Result<Prefix> {
@@ -674,7 +680,6 @@ mod tests {
         let session = Session::new(
             Config::default(),
             SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
-            Duration::from_secs(10),
             network_contacts,
         )?;
 

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -44,9 +44,6 @@ pub(crate) const NODES_TO_CONTACT_PER_STARTUP_BATCH: usize = 3;
 // Duration of wait for the node to have chance to pickup network knowledge at the beginning
 const INITIAL_WAIT: u64 = 1;
 
-// Number of retries for sending a message due to a connection issue.
-const CLIENT_SEND_RETRIES: usize = 3; // nodes will clean up connections reasonably often, so we try a few times here.
-
 impl Session {
     #[instrument(
         skip(self, auth, payload, client_pk),
@@ -139,7 +136,8 @@ impl Session {
                     "Terminated with insufficient CmdAcks for {:?}, {} / {} acks received",
                     msg_id, received_ack, expected_acks
                 );
-                break;
+
+                return Err(Error::InsufficientAcksReceived);
             }
             trace!(
                 "current ack waiting loop count {}/{}",
@@ -567,30 +565,13 @@ impl Session {
                     Self::spawn_msg_listener_thread(session.clone(), peer, conn, incoming_msgs);
                 };
 
-                let mut retries = 0;
-
-                let send_and_retry = || async {
-                    match link.send(bytes.clone(), listen).await {
-                        Ok(()) => Ok(()),
-                        Err(SendToOneError::Connection(err)) => {
-                            Err(Error::QuicP2pConnection { peer, error: err })
-                        }
-                        Err(SendToOneError::Send(err)) => {
-                            Err(Error::QuicP2pSend { peer, error: err })
-                        }
+                let result = match link.send(bytes.clone(), listen).await {
+                    Ok(()) => Ok(()),
+                    Err(SendToOneError::Connection(err)) => {
+                        Err(Error::QuicP2pConnection { peer, error: err })
                     }
+                    Err(SendToOneError::Send(err)) => Err(Error::QuicP2pSend { peer, error: err }),
                 };
-                let mut result = send_and_retry().await;
-
-                while result.is_err() && retries < CLIENT_SEND_RETRIES {
-                    warn!(
-                        "Attempting to send msg again {msg_id:?}, attempt #{:?}",
-                        retries.clone()
-                    );
-                    retries += 1;
-                    result = send_and_retry().await;
-                }
-
                 (peer_name, result)
             });
 

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -524,12 +524,6 @@ impl Session {
     }
 
     #[instrument(skip_all, level = "trace")]
-    /// Send the msg over the wire. This should be used in a loop in case any errors
-    /// here mean we could not send the message.
-    ///
-    /// Any non-critical errors here are logged, but not returned.
-    ///
-    /// The calling function is expected to handle retry logic atop this.
     pub(super) async fn send_msg(
         &self,
         nodes: Vec<Peer>,
@@ -578,24 +572,34 @@ impl Session {
             match r {
                 Ok((peer_name, send_result)) => match send_result {
                     Err(Error::QuicP2pSend {
+                        peer,
                         error:
                             SendError::ConnectionLost(ConnectionError::Closed(Close::Application {
                                 reason,
-                                ..
+                                error_code,
                             })),
-                        ..
                     }) => {
                         warn!(
                             "Connection was closed by node {}, reason: {:?}",
                             peer_name,
                             String::from_utf8(reason.to_vec())
                         );
+                        last_error = Some(Error::QuicP2pSend {
+                            peer,
+                            error: SendError::ConnectionLost(ConnectionError::Closed(
+                                Close::Application { reason, error_code },
+                            )),
+                        });
                     }
                     Err(Error::QuicP2pSend {
+                        peer,
                         error: SendError::ConnectionLost(error),
-                        ..
                     }) => {
                         warn!("Connection to {} was lost: {:?}", peer_name, error);
+                        last_error = Some(Error::QuicP2pSend {
+                            peer,
+                            error: SendError::ConnectionLost(error),
+                        });
                     }
                     Err(error) => {
                         warn!(

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -625,7 +625,10 @@ impl Session {
         }
 
         if failures > successful_sends {
-            warn!("More errors when sending a message than successes, last_error: {:?}", last_error);
+            warn!(
+                "More errors when sending a message than successes, last_error: {:?}",
+                last_error
+            );
             // If we've only had connection errors, those are not stored in `last_error` (but they are logged)
             // Such errors are not fatal to the program and you can normally simply retry by calling
             // send_msg again.

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -19,9 +19,9 @@ use sn_interface::{
     types::PeerLinks,
 };
 
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use qp2p::{Config as QuicP2pConfig, Endpoint};
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::{mpsc::Sender, RwLock};
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
@@ -29,7 +29,10 @@ type PendingQueryResponses = Arc<DashMap<OperationId, Vec<(MsgId, QueryResponseS
 type QueryResponseSender = Sender<QueryResponse>;
 
 type CmdResponse = (SocketAddr, Option<CmdError>);
-type PendingCmdAcks = Arc<DashMap<MsgId, Sender<CmdResponse>>>;
+
+/// As we receive ACKs, we write the ACKd peer here for checking.
+/// TODO: This could be a mem leak for long running clients.
+type PendingCmdAcks = Arc<DashMap<MsgId, Arc<DashSet<CmdResponse>>>>;
 
 #[derive(Debug)]
 pub struct QueryResult {
@@ -47,8 +50,6 @@ pub(super) struct Session {
     pending_cmds: PendingCmdAcks,
     /// All elders we know about from AE messages
     pub(super) network: Arc<RwLock<SectionTree>>,
-    /// Standard time to await potential AE messages:
-    cmd_ack_wait: Duration,
     /// Links to nodes
     peer_links: PeerLinks,
 }
@@ -59,7 +60,6 @@ impl Session {
     pub(crate) fn new(
         qp2p_config: QuicP2pConfig,
         local_addr: SocketAddr,
-        cmd_ack_wait: Duration,
         network_contacts: SectionTree,
     ) -> Result<Self> {
         let endpoint = Endpoint::new_client(local_addr, qp2p_config)?;
@@ -70,7 +70,6 @@ impl Session {
             pending_cmds: Arc::new(DashMap::default()),
             endpoint,
             network: Arc::new(RwLock::new(network_contacts)),
-            cmd_ack_wait,
             peer_links,
         };
 

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -30,6 +30,9 @@ pub enum Error {
     /// Failed to obtain network contacts to bootstrap to
     #[error("Failed to obtain network contacts to bootstrap to: {0}")]
     NetworkContacts(String),
+    /// InsufficientAcksReceived
+    #[error("Did not receive sufficient ACK messages from elders to be sure this cmd passed.")]
+    InsufficientAcksReceived,
     /// Message auth checks failed
     #[error("Message's authority could not be trusted, unknown section key: {0:?}.")]
     UntrustedMessage(PublicKey),

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -352,6 +352,8 @@ impl Comm {
             recipient,
         );
         let peer = self.get_or_create(&recipient).await;
+
+        trace!("Peer session got.");
         peer.send(msg_id, bytes).await
     }
 }

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -94,7 +94,7 @@ impl PeerSession {
             error!("Error while sending Send command {e:?}");
         }
 
-        trace!("Send job sent");
+        trace!("Send job sent: {msg_id:?}");
         Ok(watcher)
     }
 
@@ -189,6 +189,10 @@ impl PeerSessionWorker {
 
     async fn send(&mut self, mut job: SendJob) -> SessionStatus {
         let id = job.msg_id;
+
+
+        trace!("Performing sendjob: {id:?}");
+
         if job.retries > MAX_SENDJOB_RETRIES {
             job.reporter.send(SendStatus::MaxRetriesReached);
             return SessionStatus::Ok;

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -94,6 +94,7 @@ impl PeerSession {
             error!("Error while sending Send command {e:?}");
         }
 
+        trace!("Send job sent");
         Ok(watcher)
     }
 

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -190,7 +190,6 @@ impl PeerSessionWorker {
     async fn send(&mut self, mut job: SendJob) -> SessionStatus {
         let id = job.msg_id;
 
-
         trace!("Performing sendjob: {id:?}");
 
         if job.retries > MAX_SENDJOB_RETRIES {

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -29,7 +29,7 @@ use tokio::{sync::mpsc, time::Instant};
 
 /// These retries are how may _new_ connection attempts do we make.
 /// If we fail all of these, HandlePeerFailedSend will be triggered
-/// for section nodes, which in turn kicks off a ConnectivityTest
+/// for section nodes, which in turn kicks off Dysfunction tracking
 const MAX_SENDJOB_RETRIES: usize = 3;
 const DEFAULT_DESIRED_RATE: f64 = 10.0; // 10 msgs / s
 
@@ -188,6 +188,7 @@ impl PeerSessionWorker {
     }
 
     async fn send(&mut self, mut job: SendJob) -> SessionStatus {
+        let id = job.msg_id;
         if job.retries > MAX_SENDJOB_RETRIES {
             job.reporter.send(SendStatus::MaxRetriesReached);
             return SessionStatus::Ok;
@@ -217,14 +218,14 @@ impl PeerSessionWorker {
                 return SessionStatus::Terminating;
             }
             Err(err) => {
-                warn!("Transient error while attempting to send, re-enqueing job {err:?}");
+                warn!("Transient error while attempting to send, re-enqueing job {id:?} {err:?}");
                 job.reporter
                     .send(SendStatus::TransientError(format!("{err:?}")));
 
                 job.retries += 1;
 
                 if let Err(e) = self.queue.send(SessionCmd::Send(job)).await {
-                    warn!("Failed to re-enqueue job after transient error {e:?}");
+                    warn!("Failed to re-enqueue job {id:?} after transient error {e:?}");
                     return SessionStatus::Terminating;
                 }
             }

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -95,7 +95,6 @@ impl Node {
             target_adult: target.name(),
         }];
 
-        // here we conflate adults targetted!!
         if let Some(peers) = self
             .pending_data_queries
             .get(&(operation_id, target.name()))

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -118,7 +118,6 @@ impl CmdCtrl {
         let id = job.id();
         let cmd = job.clone().into_cmd();
 
-
         trace!("Processing cmd: {cmd:?}");
 
         let cmd_string = cmd.clone().to_string();
@@ -128,16 +127,15 @@ impl CmdCtrl {
         let monitoring = self.monitoring.clone();
 
         node_event_sender
-        .send(Event::CmdProcessing(CmdProcessEvent::Started {
-            id,
-            parent_id: job.parent_id(),
-            priority,
-            cmd_creation_time: job.created_at(),
-            time: SystemTime::now(),
-            cmd_string: cmd.to_string(),
-        }))
-        .await;
-
+            .send(Event::CmdProcessing(CmdProcessEvent::Started {
+                id,
+                parent_id: job.parent_id(),
+                priority,
+                cmd_creation_time: job.created_at(),
+                time: SystemTime::now(),
+                cmd_string: cmd.to_string(),
+            }))
+            .await;
 
         trace!("about to spawn for processing cmd: {cmd:?}");
         let dispatcher = self.dispatcher.clone();
@@ -150,7 +148,6 @@ impl CmdCtrl {
 
             match dispatcher.process_cmd(cmd).await {
                 Ok(cmds) => {
-
                     for cmd in cmds {
                         monitoring.increment_cmds().await;
                         match cmd_process_api.send((cmd, Some(id))).await {

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -221,11 +221,7 @@ impl Cmd {
     pub(crate) fn priority(&self) -> i32 {
         use Cmd::*;
         match self {
-            SendMsg { msg, .. } => match msg {
-                OutgoingMsg::System(_) => 20,
-                _ => 19,
-            },
-
+            SendMsg { .. } => 20,
             HandleAgreement { .. } => 10,
             HandleNewEldersAgreement { .. } => 10,
             HandleDkgOutcome { .. } => 10,

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -148,7 +148,7 @@ pub enum Cmd {
     /// Handle a timeout previously scheduled with `ScheduleDkgTimeout`.
     HandleDkgTimeout(u64),
     /// Handle peer that's been detected as lost.
-    HandlePeerFailedSend(Peer),
+    HandlePeerFailedSend { peer: Peer, msg_id: MsgId },
     /// Handle agreement on a proposal.
     HandleAgreement { proposal: Proposal, sig: KeyedSig },
     /// Handle a membership decision.
@@ -233,7 +233,7 @@ impl Cmd {
             HandleDkgTimeout(_) => 10,
             ProposeVoteNodesOffline(_) => 10,
 
-            HandlePeerFailedSend(_) => 9,
+            HandlePeerFailedSend { .. } => 9,
             TrackNodeIssueInDysfunction { .. } => 9,
             HandleMembershipDecision(_) => 9,
             EnqueueDataForReplication { .. } => 9,
@@ -259,7 +259,7 @@ impl Cmd {
             Cmd::CleanupPeerLinks => State::Comms,
             Cmd::SendMsg { .. } => State::Comms,
             Cmd::Comm(_) => State::Comms,
-            Cmd::HandlePeerFailedSend(_) => State::Comms,
+            Cmd::HandlePeerFailedSend { .. } => State::Comms,
             Cmd::ValidateMsg { .. } => State::Validation,
             Cmd::HandleValidSystemMsg { msg, .. } => msg.statemap_states(),
             Cmd::HandleValidServiceMsg { .. } => State::ServiceMsg,
@@ -305,7 +305,9 @@ impl fmt::Display for Cmd {
             Cmd::HandleValidServiceMsg { msg_id, msg, .. } => {
                 write!(f, "HandleValidServiceMsg {:?}: {:?}", msg_id, msg)
             }
-            Cmd::HandlePeerFailedSend(peer) => write!(f, "HandlePeerFailedSend({:?})", peer.name()),
+            Cmd::HandlePeerFailedSend { peer, msg_id } => {
+                write!(f, "HandlePeerFailedSend({:?}, {:?})", peer.name(), msg_id)
+            }
             Cmd::HandleAgreement { .. } => write!(f, "HandleAgreement"),
             Cmd::HandleNewEldersAgreement { .. } => write!(f, "HandleNewEldersAgreement"),
             Cmd::HandleMembershipDecision(_) => write!(f, "HandleMembershipDecision"),

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -60,6 +60,8 @@ impl Dispatcher {
 
     /// Handles a single cmd.
     pub(crate) async fn process_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
+        trace!("doing actual processing cmd: {cmd:?}");
+
         match cmd {
             Cmd::CleanupPeerLinks => {
                 let members = { self.node.read().await.network_knowledge.section_members() };

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -73,6 +73,9 @@ impl Dispatcher {
                 #[cfg(feature = "traceroute")]
                 traceroute,
             } => {
+                let is_service_msg = matches!(msg, OutgoingMsg::Service(_));
+
+                trace!("Sending msg: {msg_id:?}");
                 let peer_msgs = {
                     let node = self.node.read().await;
                     into_msg_bytes(
@@ -95,7 +98,14 @@ impl Dispatcher {
                 let cmds = results
                     .into_iter()
                     .filter_map(|result| match result {
-                        Err(Error::FailedSend(peer)) => Some(Cmd::HandlePeerFailedSend(peer)),
+                        Err(Error::FailedSend(peer)) => {
+                            if is_service_msg {
+                                warn!("Service msg send failed to: {peer}, for {msg_id:?}");
+                                None
+                            } else {
+                                Some(Cmd::HandlePeerFailedSend { peer, msg_id })
+                            }
+                        }
                         _ => None,
                     })
                     .collect();
@@ -208,7 +218,8 @@ impl Dispatcher {
                 let mut node = self.node.write().await;
                 node.handle_new_elders_agreement(new_elders, sig).await
             }
-            Cmd::HandlePeerFailedSend(peer) => {
+            Cmd::HandlePeerFailedSend { peer, msg_id } => {
+                warn!("Message sending failed to {peer}, for {msg_id:?}");
                 let mut node = self.node.write().await;
                 node.handle_failed_send(&peer.addr());
                 Ok(vec![])

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -33,7 +33,7 @@ use tokio::{
     time::Instant,
 };
 
-const PROCESS_BATCH_COUNT: usize = 25;
+// const PROCESS_BATCH_COUNT: usize = 25;
 
 /// Listens for incoming msgs and forms Cmds for each,
 /// Periodically triggers other Cmd Processes (eg health checks, dysfunction etc)
@@ -159,15 +159,15 @@ impl FlowCtrl {
                 break;
             }
 
-            let mut process_batch_count = 0;
+            // let mut process_batch_count = 0;
 
-            let mut continue_with_periodics = false;
+            // let mut continue_with_periodics = false;
             // we go through all pending cmds in this loop
             while self.cmd_ctrl.has_items_queued()
             // && !continue_with_periodics
             {
 
-                process_batch_count += 1;
+                // process_batch_count += 1;
                 self.process_next_cmd().await;
 
                 if let Err(error) = self.enqeue_new_cmds_from_channel().await {

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -166,7 +166,6 @@ impl FlowCtrl {
             while self.cmd_ctrl.has_items_queued()
             // && !continue_with_periodics
             {
-
                 // process_batch_count += 1;
                 self.process_next_cmd().await;
 

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -33,7 +33,7 @@ use tokio::{
     time::Instant,
 };
 
-const PROCESS_BATCH_COUNT: usize = 5;
+const PROCESS_BATCH_COUNT: usize = 25;
 
 /// Listens for incoming msgs and forms Cmds for each,
 /// Periodically triggers other Cmd Processes (eg health checks, dysfunction etc)
@@ -164,6 +164,11 @@ impl FlowCtrl {
             let mut continue_with_periodics = false;
             // we go through all pending cmds in this loop
             while self.cmd_ctrl.has_items_queued() && !continue_with_periodics {
+                if let Err(error) = self.enqeue_new_cmds_from_channel().await {
+                    error!("{error:?}");
+                    break;
+                }
+
                 process_batch_count += 1;
                 self.process_next_cmd().await;
 

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -66,6 +66,7 @@ impl Node {
         msg_id: MsgId,
         #[cfg(feature = "traceroute")] traceroute: Traceroute,
     ) -> Cmd {
+        debug!("Sending cmd ack to {target} for {msg_id:?}");
         let the_ack_msg = ServiceMsg::CmdAck {
             correlation_id: msg_id,
         };
@@ -84,6 +85,9 @@ impl Node {
         recipients: Peers,
         #[cfg(feature = "traceroute")] traceroute: Traceroute,
     ) -> Cmd {
+        let new_msg_id = MsgId::new();
+
+        debug!("SendMSg formed for {:?}", new_msg_id);
         Cmd::SendMsg {
             msg: OutgoingMsg::Service(msg),
             msg_id: MsgId::new(),


### PR DESCRIPTION
…t ACKs

Simplify the client retry logic to just be at the cmd/queries retry layer. We were already retrying before we even got to do _any_ retries at this lower layer. So let's just remove it all and KISS.
