### PR TITLE
chore: update tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4015,10 +4015,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -67,7 +67,7 @@ url = "2.2.0"
 xor_name = "~5.0.0"
 
 [dependencies.tokio]
-version = "~1.17.0"
+version = "^1.19"
 features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 
 [dev-dependencies]


### PR DESCRIPTION
I'm building a tauri app using sn_api and came across a conflict in dependencies that prevented the tauri build from completing:

```text
error: failed to select a version for `tokio`.
    ... required by package `tauri v1.0.5`                                                                                                  
    ... which satisfies dependency `tauri = "^1.0.5"` of package `app v0.1.0 (/home/ian/code/tauri-app/src-tauri)`                          
versions that meet the requirements `^1.19` are: 1.20.1, 1.20.0, 1.19.2, 1.19.1, 1.19.0
                                   
all possible versions conflict with previously selected packages.
                                   
  previously selected package `tokio v1.17.0`
    ... which satisfies dependency `tokio = "~1.17.0"` of package `sn_interface v0.9.0`
    ... which satisfies dependency `sn_interface = "^0.9.0"` of package `sn_api v0.67.0`
    ... which satisfies dependency `sn_api = "^0.67.0"` of package `app v0.1.0 (/home/ian/code/tauri-app/src-tauri)`
                                   
failed to select a version for `tokio` which could resolve this conflict
```

This PR resolves the conflict by updating tokio from 1.17 to 1.19

The version in tauri is 1.19, see [tauri/Cargo.toml L51](https://github.com/tauri-apps/tauri/blob/28a1ec34a47d441965ae2e9af57ff3c5dcf4b18c/core/tauri/Cargo.toml#L51)