### PR TITLE
refactor(types)!: removing unused sn_node::dbs::Error variants and RegisterExtend cmd

### DIFF
--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -64,12 +64,7 @@ impl Client {
     ) -> Result<(Address, RegisterWriteAheadLog), Error> {
         let address = Address { name, tag };
 
-        let op = CreateRegister::Empty {
-            name,
-            tag,
-            size: u16::MAX, // TODO: use argument
-            policy,
-        };
+        let op = CreateRegister::Empty { name, tag, policy };
         let signature = self.keypair.sign(&bincode::serialize(&op)?);
 
         let cmd = DataCmd::Register(RegisterCmd::Create {

--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -64,7 +64,7 @@ impl Client {
     ) -> Result<(Address, RegisterWriteAheadLog), Error> {
         let address = Address { name, tag };
 
-        let op = CreateRegister::Empty { name, tag, policy };
+        let op = CreateRegister { name, tag, policy };
         let signature = self.keypair.sign(&bincode::serialize(&op)?);
 
         let cmd = DataCmd::Register(RegisterCmd::Create {

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -25,8 +25,8 @@ pub use self::{
     query::DataQuery,
     query::DataQueryVariant,
     register::{
-        CreateRegister, EditRegister, ExtendRegister, RegisterCmd, RegisterQuery,
-        SignedRegisterCreate, SignedRegisterEdit, SignedRegisterExtend,
+        CreateRegister, EditRegister, RegisterCmd, RegisterQuery, SignedRegisterCreate,
+        SignedRegisterEdit,
     },
     spentbook::{SpentbookCmd, SpentbookQuery},
 };

--- a/sn_interface/src/messaging/data/register.rs
+++ b/sn_interface/src/messaging/data/register.rs
@@ -9,9 +9,10 @@
 use super::{CmdError, Error, QueryResponse, Result};
 
 use crate::messaging::{data::OperationId, SectionAuth};
-use crate::types::register::{EntryHash, Register};
+#[allow(unused_imports)] // needed by rustdocs links
+use crate::types::register::Register;
 use crate::types::{
-    register::{Entry, Policy, RegisterOp, User},
+    register::{Entry, EntryHash, Policy, RegisterOp, User},
     RegisterAddress,
 };
 use tiny_keccak::{Hasher, Sha3};
@@ -91,39 +92,26 @@ pub enum RegisterCmd {
 ///
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub enum CreateRegister {
-    /// Populated with entries
-    Populated(Register),
-    /// Without entries
-    Empty {
-        /// The name of the [`Register`].
-        name: XorName,
-        /// The tag on the [`Register`].
-        tag: u64,
-        /// The policy of the [`Register`].
-        policy: Policy,
-    },
+pub struct CreateRegister {
+    /// The name of the [`Register`].
+    pub name: XorName,
+    /// The tag on the [`Register`].
+    pub tag: u64,
+    /// The policy of the [`Register`].
+    pub policy: Policy,
 }
 
 impl CreateRegister {
-    ///
+    /// Returns the owner of the register.
     pub fn owner(&self) -> User {
-        use CreateRegister::*;
-        match self {
-            Populated(reg) => reg.owner(),
-            Empty { policy, .. } => *policy.owner(),
-        }
+        *self.policy.owner()
     }
 
-    ///
+    /// Returns the address of the register.
     pub fn address(&self) -> RegisterAddress {
-        use CreateRegister::*;
-        match self {
-            Populated(reg) => *reg.address(),
-            Empty { name, tag, .. } => RegisterAddress {
-                name: *name,
-                tag: *tag,
-            },
+        RegisterAddress {
+            name: self.name,
+            tag: self.tag,
         }
     }
 }

--- a/sn_node/benches/data_storage.rs
+++ b/sn_node/benches/data_storage.rs
@@ -242,12 +242,7 @@ pub fn create_random_register_replicated_data() -> ReplicatedData {
     let owner = User::Key(keypair.public_key());
     let policy = public_policy(owner);
 
-    let op = CreateRegister::Empty {
-        name,
-        tag,
-        size: u16::MAX, // TODO: use argument
-        policy,
-    };
+    let op = CreateRegister::Empty { name, tag, policy };
     let signature = keypair.sign(&bincode::serialize(&op).expect("could not serialize op"));
     let reg_cmd = RegisterCmd::Create {
         cmd: SignedRegisterCreate {

--- a/sn_node/benches/data_storage.rs
+++ b/sn_node/benches/data_storage.rs
@@ -242,7 +242,7 @@ pub fn create_random_register_replicated_data() -> ReplicatedData {
     let owner = User::Key(keypair.public_key());
     let policy = public_policy(owner);
 
-    let op = CreateRegister::Empty { name, tag, policy };
+    let op = CreateRegister { name, tag, policy };
     let signature = keypair.sign(&bincode::serialize(&op).expect("could not serialize op"));
     let reg_cmd = RegisterCmd::Create {
         cmd: SignedRegisterCreate {

--- a/sn_node/src/dbs/errors.rs
+++ b/sn_node/src/dbs/errors.rs
@@ -23,24 +23,12 @@ pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 #[non_exhaustive]
 /// Node error variants.
 pub enum Error {
-    /// Db key conversion failed
-    #[error("Could not convert the Db key")]
-    CouldNotConvertDbKey,
-    /// Db key conversion failed
-    #[error("Could not decode the Db key: {0:?}")]
-    CouldNotDecodeDbKey(String),
     /// Not enough space to store the value.
     #[error("Not enough space")]
     NotEnoughSpace,
     /// Key not found.
     #[error("Key not found: {0:?}")]
     KeyNotFound(String),
-    /// Key, Value pair not found.
-    #[error("No value found for key: {0:?}")]
-    NoSuchValue(String),
-    /// Data id not found.
-    #[error("Data id not found: {0:?}")]
-    DataIdNotFound(DataAddress),
     /// Data not found.
     #[error("No such data: {0:?}")]
     NoSuchData(DataAddress),
@@ -65,21 +53,12 @@ pub enum Error {
     /// Deserialization error
     #[error("Deserialization error: {0}")]
     Deserialize(String),
-    /// Creating temp directory failed.
-    #[error("Could not create temp store: {0}")]
-    TempDirCreationFailed(String),
     /// I/O error.
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
     /// Bincode error.
     #[error("Bincode error:: {0}")]
     Bincode(#[from] bincode::Error),
-    ///Db key parse error.
-    #[error("Could not parse key:: {0:?}")]
-    CouldNotParseDbKey(Vec<u8>),
-    ///Operation Id could not be generated
-    #[error("Operation Id could not be generated")]
-    NoOperationId,
     /// Invalid filename
     #[error("Invalid chunk filename")]
     InvalidFilename,
@@ -95,10 +74,8 @@ pub enum Error {
 pub(crate) fn convert_to_error_msg(error: Error) -> ErrorMsg {
     match error {
         Error::NotEnoughSpace => ErrorMsg::FailedToWriteFile,
-        Error::DataIdNotFound(address) => ErrorMsg::DataNotFound(address),
         Error::NoSuchData(address) => ErrorMsg::DataNotFound(address),
         Error::ChunkNotFound(xorname) => ErrorMsg::ChunkNotFound(xorname),
-        Error::TempDirCreationFailed(_) => ErrorMsg::FailedToWriteFile,
         Error::DataExists => ErrorMsg::DataExists,
         Error::NetworkData(error) => convert_dt_error_to_error_msg(error),
         other => ErrorMsg::InvalidOperation(format!("Failed to perform operation: {:?}", other)),

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -459,7 +459,6 @@ impl Node {
             XorName::from_content(&key_image.to_bytes()),
             SPENTBOOK_TYPE_TAG,
             policy,
-            u16::MAX,
         );
 
         let entry = Bytes::from(rmp_serde::to_vec_named(spent_proof_share).map_err(|err| {


### PR DESCRIPTION
- Removing some unused `sn_node::dbs::Error` variants.
- Removing `RegisterExtend` cmd and related code as it's currently not used, plus we'll need to work on a CRDT-compliant implementation of such a feature when required.
- Removing unused `CreateRegister::Populated` msg type.