### PR TITLE
ci: dont change default QUERY_TIMEOUT on ci

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -285,7 +285,6 @@ jobs:
           test-threads: 10
         timeout-minutes: 60
         env:
-          SN_QUERY_TIMEOUT: 10
           TEST_ENV_GENESIS_DBC_PATH: /tmp/genesis_dbc
 
   cli:
@@ -342,7 +341,6 @@ jobs:
           test-threads: 10
         timeout-minutes: 60
         env:
-          SN_QUERY_TIMEOUT: 10
           TEST_ENV_GENESIS_DBC_PATH: /tmp/genesis_dbc
 
   kill-testnet:

--- a/resources/scripts/cli_tests.sh
+++ b/resources/scripts/cli_tests.sh
@@ -8,8 +8,7 @@ exit=0
 # The tests parse output from the CLI process and they are expecting it to be in a certain form, so
 # any additional logging needs to be disabled.
 unset RUST_LOG
-# The default timeout value is 120 seconds, which causes NRS to run extremely slow.
-export SN_QUERY_TIMEOUT=10
+
 export RUST_BACKTRACE=full
 
 cd sn_cli


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
