### PR TITLE
feat: return error to client on unknown section key

### DIFF
--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -708,7 +708,7 @@ mod tests {
         let elders_len = 5;
 
         let prefix = prefix("0")?;
-        let (section_auth, _, secret_key_set) = random_sap(prefix, elders_len);
+        let (section_auth, _, secret_key_set) = random_sap(prefix, elders_len, 0, None);
         let sap0 = section_signed(secret_key_set.secret_key(), section_auth)?;
         let (mut network_contacts, _genesis_sk, _) = new_network_network_contacts();
         assert!(network_contacts.insert_without_chain(sap0));

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -71,6 +71,8 @@ pub enum Error {
     /// Destination is either outdated or incorrect
     #[error("Destination is either outdated or wrong")]
     WrongDestination,
+    #[error("Spent proof was signed with unknown section key")]
+    SpentProofUnknownSectionKey,
     /// Failed to seriliase the Cmd for hashing
     #[error("Cmd could not be serialised")]
     CouldNotSerialiseCmd,

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -321,21 +321,28 @@ pub mod test_utils {
             .collect()
     }
 
-    // Generate random `SectionAuthorityProvider` for testing purposes.
+    /// Generate a random `SectionAuthorityProvider` for testing.
+    ///
+    /// The total number of members in the section will be `elder_count` + `adult_count`. A lot of
+    /// tests don't require adults in the section, so zero is an acceptable value for
+    /// `adult_count`.
+    ///
+    /// An optional `sk_threshold_size` can be passed to specify the threshold when the secret key
+    /// set is generated for the section key. Some tests require a low threshold.
     pub fn random_sap(
         prefix: Prefix,
-        count: usize,
+        elder_count: usize,
+        adult_count: usize,
+        sk_threshold_size: Option<usize>,
     ) -> (SectionAuthorityProvider, Vec<NodeInfo>, SecretKeySet) {
-        let elder_nodes = gen_sorted_nodes(&prefix, count, false);
-        let elders = elder_nodes.iter().map(NodeInfo::peer);
-        let members = elder_nodes
-            .iter()
-            .map(|i| NodeState::joined(i.peer(), None));
-        let secret_key_set = SecretKeySet::random();
+        let nodes = gen_sorted_nodes(&prefix, elder_count + adult_count, false);
+        let elders = nodes.iter().map(NodeInfo::peer).take(elder_count);
+        let members = nodes.iter().map(|i| NodeState::joined(i.peer(), None));
+        let secret_key_set = SecretKeySet::random(sk_threshold_size);
         let section_auth =
             SectionAuthorityProvider::new(elders, prefix, members, secret_key_set.public_keys(), 0);
 
-        (section_auth, elder_nodes, secret_key_set)
+        (section_auth, nodes, secret_key_set)
     }
 
     // Create signature for the given payload using the given secret key.

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -812,7 +812,7 @@ mod tests {
     }
 
     fn gen_section_auth(prefix: Prefix) -> Result<SectionAuth<SectionAuthorityProvider>> {
-        let (section_auth, _, secret_key_set) = random_sap(prefix, 5);
+        let (section_auth, _, secret_key_set) = random_sap(prefix, 5, 0, None);
         section_signed(secret_key_set.secret_key(), section_auth)
             .context(format!("Failed to generate SAP for prefix {:?}", prefix))
     }
@@ -867,7 +867,7 @@ mod tests {
             Rc::new(RefCell::new(BTreeMap::new()));
 
         // genesis section; inserted at the end
-        let (gen_sap, _, gen_sk) = random_sap(Prefix::default(), 0);
+        let (gen_sap, _, gen_sk) = random_sap(Prefix::default(), 0, 0, None);
         let gen_sap_signed = section_signed(gen_sk.secret_key(), gen_sap.clone())?;
         let mut chain = SecuredLinkedList::new(gen_sap.section_key());
 
@@ -886,7 +886,7 @@ mod tests {
 
         // insert a new section
         let mut insert = |prefix: Prefix, parent_sk: &bls::SecretKey| -> Result<()> {
-            let (sap, _, sk) = random_sap(prefix, 0);
+            let (sap, _, sk) = random_sap(prefix, 0, 0, None);
             let section_key_signed =
                 bincode::serialize(&sap.section_key()).map(|bytes| parent_sk.sign(&bytes))?;
             let sap_signed = section_signed(sk.secret_key(), sap.clone())?;

--- a/sn_interface/src/types/keys/secret_key.rs
+++ b/sn_interface/src/types/keys/secret_key.rs
@@ -105,8 +105,9 @@ pub mod test_utils {
     }
 
     impl SecretKeySet {
-        pub fn random() -> Self {
-            let poly = bls::poly::Poly::random(threshold(), &mut rand::thread_rng());
+        pub fn random(threshold_size: Option<usize>) -> Self {
+            let threshold_size = threshold_size.unwrap_or_else(threshold);
+            let poly = bls::poly::Poly::random(threshold_size, &mut rand::thread_rng());
             let key = bls::SecretKey::from_mut(&mut poly.evaluate(0));
             let set = bls::SecretKeySet::from(poly);
 

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -145,7 +145,7 @@ impl Node {
 }
 
 // Helper to generate the (currently bearer) genesis DBC to be owned by the provided key.
-fn gen_genesis_dbc(input_sk_set: &bls::SecretKeySet) -> Result<Dbc> {
+pub(crate) fn gen_genesis_dbc(input_sk_set: &bls::SecretKeySet) -> Result<Dbc> {
     // Use the same key as the input and output of Genesis Tx.
     let output_sk = input_sk_set.secret_key();
     let output_owner = OwnerOnce::from_owner_base(Owner::from(output_sk), &mut rng::thread_rng());

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -548,7 +548,8 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (section_auth, mut nodes, sk_set) = random_sap(Prefix::default(), elder_count());
+        let (section_auth, mut nodes, sk_set) =
+            random_sap(Prefix::default(), elder_count(), 0, None);
         let bootstrap_node = nodes.remove(0);
         let bootstrap_addr = bootstrap_node.addr;
         let sk = sk_set.secret_key();
@@ -664,7 +665,7 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (_, mut nodes, sk_set) = random_sap(Prefix::default(), elder_count());
+        let (_, mut nodes, sk_set) = random_sap(Prefix::default(), elder_count(), 0, None);
         let bootstrap_node = nodes.remove(0);
         let genesis_key = sk_set.secret_key().public_key();
 
@@ -698,7 +699,8 @@ mod tests {
                 .map(|_| (xor_name::rand::random(), gen_addr()))
                 .collect();
 
-            let (new_section_auth, _, new_sk_set) = random_sap(Prefix::default(), elder_count());
+            let (new_section_auth, _, new_sk_set) =
+                random_sap(Prefix::default(), elder_count(), 0, None);
             let new_pk_set = new_sk_set.public_keys();
 
             send_response(
@@ -761,7 +763,7 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (_, mut nodes, sk_set) = random_sap(Prefix::default(), elder_count());
+        let (_, mut nodes, sk_set) = random_sap(Prefix::default(), elder_count(), 0, None);
         let bootstrap_node = nodes.remove(0);
 
         let node = NodeInfo::new(
@@ -781,7 +783,8 @@ mod tests {
             assert_matches!(wire_msg.into_msg(), Ok(MsgType::System { msg, .. }) =>
             assert_matches!(msg, SystemMsg::JoinRequest{..}));
 
-            let (new_section_auth, _, new_sk_set) = random_sap(Prefix::default(), elder_count());
+            let (new_section_auth, _, new_sk_set) =
+                random_sap(Prefix::default(), elder_count(), 0, None);
             let new_pk_set = new_sk_set.public_keys();
 
             send_response(
@@ -842,7 +845,8 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (section_auth, mut nodes, sk_set) = random_sap(Prefix::default(), elder_count());
+        let (section_auth, mut nodes, sk_set) =
+            random_sap(Prefix::default(), elder_count(), 0, None);
         let bootstrap_node = nodes.remove(0);
 
         let node = NodeInfo::new(
@@ -913,7 +917,7 @@ mod tests {
             }
         };
 
-        let (section_auth, _, sk_set) = random_sap(good_prefix, elder_count());
+        let (section_auth, _, sk_set) = random_sap(good_prefix, elder_count(), 0, None);
         let section_key = sk_set.public_keys().public_key();
 
         let state = Joiner::new(node, send_tx, &mut recv_rx, SectionTree::new(section_key));
@@ -948,7 +952,7 @@ mod tests {
             send_response(
                 &recv_tx,
                 JoinResponse::Retry {
-                    section_auth: random_sap(bad_prefix, elder_count()).0.to_msg(),
+                    section_auth: random_sap(bad_prefix, elder_count(), 0, None).0.to_msg(),
                     section_signed: signed_sap.sig.clone(),
                     proof_chain: section_chain.clone(),
                     expected_age: MIN_ADULT_AGE,

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -239,6 +239,7 @@ impl Node {
     /// Used to fetch the list of holders for given name of data. Excludes full nodes
     pub(crate) fn target_data_holders(&self, target: XorName) -> BTreeSet<Peer> {
         let full_adults = self.full_adults();
+        trace!("full_adults = {}", full_adults.len());
         // TODO: reuse our_adults_sorted_by_distance_to API when core is merged into upper layer
         let adults = self.network_knowledge().adults();
 

--- a/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
@@ -1,0 +1,181 @@
+use crate::node::{api::gen_genesis_dbc, flow_ctrl::dispatcher::Dispatcher};
+use eyre::{eyre, Result};
+use sn_dbc::{
+    Commitment, Dbc, Hash, IndexedSignatureShare, KeyImage, Owner, OwnerOnce, PublicKey,
+    RingCtTransaction, Signature, SpentProof, SpentProofContent, SpentProofShare, Token,
+    TransactionBuilder,
+};
+use sn_interface::{
+    messaging::data::{DataCmd, RegisterCmd, ServiceMsg, SpentbookCmd},
+    network_knowledge::{SectionAuthorityProvider, SectionKeysProvider},
+    types::{Peer, ReplicatedData},
+};
+use std::collections::BTreeSet;
+use std::str::FromStr;
+
+struct FakeProofKeyVerifier {}
+impl sn_dbc::SpentProofKeyVerifier for FakeProofKeyVerifier {
+    type Error = crate::node::Error;
+
+    fn verify_known_key(&self, _key: &PublicKey) -> std::result::Result<(), crate::node::Error> {
+        Ok(())
+    }
+}
+
+/// Get the spent proof share that's packaged inside the data that's to be replicated to the adults
+/// in the section.
+pub(crate) fn get_spent_proof_share_from_replicated_data(
+    replicated_data: ReplicatedData,
+) -> Result<SpentProofShare> {
+    match replicated_data {
+        ReplicatedData::SpentbookWrite(reg_cmd) => match reg_cmd {
+            RegisterCmd::Edit(signed_edit) => {
+                let entry = signed_edit.op.edit.crdt_op.value;
+                let spent_proof_share: SpentProofShare = rmp_serde::from_slice(&entry)?;
+                Ok(spent_proof_share)
+            }
+            _ => Err(eyre!("A RegisterCmd::Edit variant was expected")),
+        },
+        _ => Err(eyre!(
+            "A ReplicatedData::SpentbookWrite variant was expected"
+        )),
+    }
+}
+
+/// Returns the info necessary to populate the `SpentbookCmd::Spend` message to be handled.
+///
+/// The genesis DBC is used, but that doesn't really matter; for testing the code in the message
+/// handler we could use any DBC.
+///
+/// The `gen_genesis_dbc` function returns the DBC itself. To put it through the spending message
+/// handler, it needs to have a transaction, which is what we provide here before we return it
+/// back for use in tests.
+pub(crate) fn get_genesis_dbc_spend_info(
+    sk_set: &bls::SecretKeySet,
+) -> Result<(
+    KeyImage,
+    RingCtTransaction,
+    BTreeSet<SpentProof>,
+    BTreeSet<RingCtTransaction>,
+)> {
+    let genesis_dbc = gen_genesis_dbc(sk_set)?;
+    let dbc_owner = genesis_dbc.owner_base().clone();
+    let output_owner = OwnerOnce::from_owner_base(dbc_owner, &mut rand::thread_rng());
+    let tx_builder = TransactionBuilder::default()
+        .set_decoys_per_input(0)
+        .set_require_all_decoys(false)
+        .add_input_dbc_bearer(&genesis_dbc)?;
+    let inputs_amount_sum = tx_builder.inputs_amount_sum();
+    let dbc_builder = tx_builder
+        .add_output_by_amount(inputs_amount_sum, output_owner)
+        .build(&mut rand::thread_rng())?;
+    let (key_image, tx) = &dbc_builder.inputs()[0];
+    Ok((
+        *key_image,
+        tx.clone(),
+        genesis_dbc.spent_proofs.clone(),
+        genesis_dbc.spent_transactions,
+    ))
+}
+
+/// Reissue a new DBC (at a particular amount) from a given input DBC.
+///
+/// The change DBC will be discarded.
+///
+/// A spent proof share is generated for the input DBC, but it doesn't go through the complete
+/// spending validation process. This should be OK for the testing process.
+///
+/// This function was originally setup to use the dispatcher to send a `SpentbookCmd::Spend`
+/// message to avoid duplication of code, but unfortunately this causes a stack overflow during the
+/// test run. Thus, some functions in the `Node` type were scoped at `pub(crate)` and these are
+/// called here.
+pub(crate) fn reissue_dbc(
+    input: &Dbc,
+    amount: u64,
+    output_owner_sk: &bls::SecretKey,
+    sap: &SectionAuthorityProvider,
+    section_keys_provider: &SectionKeysProvider,
+) -> Result<Dbc> {
+    let output_amount = Token::from_nano(amount);
+    let input_amount = input.amount_secrets_bearer()?.amount();
+    let change_amount = input_amount
+        .checked_sub(output_amount)
+        .ok_or_else(|| eyre!("The input amount minus the amount must evaluate to a valid value"))?;
+
+    let mut rng = rand::thread_rng();
+    let output_owner = Owner::from(output_owner_sk.clone());
+    let mut dbc_builder = TransactionBuilder::default()
+        .set_decoys_per_input(0)
+        .set_require_all_decoys(false)
+        .add_input_dbc_bearer(input)?
+        .add_output_by_amount(
+            output_amount,
+            OwnerOnce::from_owner_base(output_owner, &mut rng),
+        )
+        .add_output_by_amount(
+            change_amount,
+            OwnerOnce::from_owner_base(input.owner_base().clone(), &mut rng),
+        )
+        .build(rng)?;
+    for (key_image, tx) in dbc_builder.inputs() {
+        let public_commitments = crate::node::Node::get_public_commitments_from_transaction(
+            &tx,
+            &input.spent_proofs,
+            &input.spent_transactions,
+        )?;
+        let public_commitments: Vec<Commitment> = public_commitments
+            .into_iter()
+            .flat_map(|(k, v)| if k == key_image { v } else { vec![] })
+            .collect();
+        let spent_proof_share = crate::node::Node::build_spent_proof_share(
+            &key_image,
+            &tx,
+            sap,
+            section_keys_provider,
+            public_commitments,
+        )?;
+        dbc_builder = dbc_builder
+            .add_spent_proof_share(spent_proof_share)
+            .add_spent_transaction(tx);
+    }
+    let verifier = FakeProofKeyVerifier {};
+    let output_dbcs = dbc_builder.build(&verifier)?;
+    let (output_dbc, ..) = output_dbcs
+        .into_iter()
+        .next()
+        .ok_or_else(|| eyre!("At least one output DBC should have been generated"))?;
+    Ok(output_dbc)
+}
+
+pub(crate) fn reissue_invalid_dbc_with_no_inputs(
+    input: &Dbc,
+    amount: u64,
+    output_owner_sk: &bls::SecretKey,
+) -> Result<Dbc> {
+    let output_amount = Token::from_nano(amount);
+    let input_amount = input.amount_secrets_bearer()?.amount();
+    let change_amount = input_amount
+        .checked_sub(output_amount)
+        .ok_or_else(|| eyre!("The input amount minus the amount must evaluate to a valid value"))?;
+
+    let mut rng = rand::thread_rng();
+    let output_owner = Owner::from(output_owner_sk.clone());
+    let dbc_builder = TransactionBuilder::default()
+        .set_decoys_per_input(0)
+        .set_require_all_decoys(false)
+        .add_output_by_amount(
+            output_amount,
+            OwnerOnce::from_owner_base(output_owner, &mut rng),
+        )
+        .add_output_by_amount(
+            change_amount,
+            OwnerOnce::from_owner_base(input.owner_base().clone(), &mut rng),
+        )
+        .build(rng)?;
+    let output_dbcs = dbc_builder.build_without_verifying()?;
+    let (output_dbc, ..) = output_dbcs
+        .into_iter()
+        .next()
+        .ok_or_else(|| eyre!("At least one output DBC should have been generated"))?;
+    Ok(output_dbc)
+}

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -32,7 +32,7 @@ use sn_interface::messaging::Traceroute;
 use sn_interface::{
     elder_count, init_logger,
     messaging::{
-        data::{DataCmd, RegisterCmd, ServiceMsg, SpentbookCmd},
+        data::{DataCmd, Error as MessagingDataError, RegisterCmd, ServiceMsg, SpentbookCmd},
         system::{
             JoinAsRelocatedRequest, JoinRequest, JoinResponse, KeyedSig, MembershipState,
             NodeMsgAuthorityUtils, NodeState as NodeStateMsg, RelocateDetails, ResourceProof,
@@ -1331,7 +1331,7 @@ async fn spentbook_spend_spentproof_with_invalid_pk_should_return_no_commands() 
 }
 
 #[tokio::test]
-async fn spentbook_spend_spentproof_with_key_not_in_section_chain_should_return_no_commands(
+async fn spentbook_spend_spentproof_with_key_not_in_section_chain_should_return_cmd_error_response(
 ) -> Result<()> {
     let local = tokio::task::LocalSet::new();
     local
@@ -1364,7 +1364,10 @@ async fn spentbook_spend_spentproof_with_key_not_in_section_chain_should_return_
             )
             .await?;
 
-            assert_eq!(cmds.len(), 0);
+            assert_eq!(cmds.len(), 1);
+            let cmd = cmds[0].clone();
+            let cmd_err = cmd.get_error()?;
+            assert_matches!(cmd_err, MessagingDataError::SpentProofUnknownSectionKey);
 
             Result::<()>::Ok(())
         })

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -668,7 +668,8 @@ mod tests {
             let prefix1 = Prefix::default().pushed(true);
 
             // generate a SAP for prefix0
-            let (section_auth, mut nodes, secret_key_set) = random_sap(prefix0, elder_count());
+            let (section_auth, mut nodes, secret_key_set) =
+                random_sap(prefix0, elder_count(), 0, None);
             let info = nodes.remove(0);
             let sap_sk = secret_key_set.secret_key();
             let signed_sap = section_signed(sap_sk, section_auth)?;
@@ -707,7 +708,7 @@ mod tests {
             );
 
             // generate other SAP for prefix1
-            let (other_sap, _, secret_key_set) = random_sap(prefix1, elder_count());
+            let (other_sap, _, secret_key_set) = random_sap(prefix1, elder_count(), 0, None);
             let other_sap_sk = secret_key_set.secret_key();
             let other_sap = section_signed(other_sap_sk, other_sap)?;
             // generate a proof chain for this other SAP

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn serialize_for_signing() -> Result<()> {
         // Proposal::SectionInfo
-        let (section_auth, _, _) = random_sap(Prefix::default(), 4);
+        let (section_auth, _, _) = random_sap(Prefix::default(), 4, 0, None);
         let proposal = Proposal::SectionInfo(section_auth.clone());
         verify_serialize_for_signing(&proposal, &section_auth)?;
 

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -161,7 +161,7 @@ mod tests {
     }
 
     fn proptest_actions_impl(peers: Vec<Peer>, signature_trailing_zeros: u8) -> Result<()> {
-        let sk_set = SecretKeySet::random();
+        let sk_set = SecretKeySet::random(None);
         let sk = sk_set.secret_key();
         let genesis_pk = sk.public_key();
 


### PR DESCRIPTION
- 50f3d94f3 **tests(messaging): unit tests for spentbook handler**

  Provide unit test coverage for the `SpentbookCmd::Spent` message handler.

  It's important to note that at this point, the failure cases only assert that no commands were
  returned from the handler, because this is the way we deal with failures at the moment.
  Unfortunately this means it's easy for there to be false positives because you can't check the error
  type or message. I will look into changing this as a separate PR.

  Most of the changes here are related to testing infrastructure:
  * Support setting a threshold when a secret key set is generated for the section. For use with the
    genesis DBC generation, the threshold had to be set to 0.
  * Support adults in the test section. The spent message generates data to be replicated on adults,
    so the mechanisms for creating a test section were extended for this. There are now
    `create_section` and `create_section_with_elders` functions, because some existing tests require
    the condition where only elders have been marked as members.
  * The genesis DBC is needed for these tests, so the scope of the function for generating it was
    changed to `pub(crate)`.
  * The `Cmd` struct was extended in the test module to provide utils to get at the content of
    messages, which are used for test verification.
  * Provide util function for wrapping a `ServiceMsg` inside a `WireMsg` and so on. Keeps the testing
    code cleaner.
  * Provide util function for extracting the spent proof share from the replicated data so that we can
    verify the message handler assigned the correct values to its fields.
  * Various util functions related to the use of DBCs were provided in a `dbc_utils` module. The doc
    comments on the functions should hopefully make clear what they are for.

  A couple of superficial changes were also made to the message handler code:
  * The key image sent by the client is validated (along with a test case for that).
  * Change the format of debugging messages and comments to be more uniform.
  * Move some code into functions scoped at `pub(crate)`. This is so they can be shared for use with
    test setup. For further explanation, see the doc comments on these functions in the diff.

- fdcb0f5b0 **feat: return error to client on unknown section key**

  If one of the spent proofs sent by the client have been signed with a key this section is not
  currently aware of, return an error back to the client.

  This introduces a new SpentProofUnknownSectionKey variant to the messaging data errors, because none
  of the existing variants seemed appropriate for this scenario.