### PR TITLE
fix(client): always send_msg_in_bg and log error

### DIFF
--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -343,7 +343,7 @@ impl Session {
 
                 debug!("Resending original message on AE-Redirect with updated details. Expecting an AE-Retry next");
 
-                self.send_msg(vec![elder], wire_msg, msg_id).await?;
+                Self::send_msg_in_bg(self.clone(), vec![elder], wire_msg, msg_id)?;
             } else {
                 error!("No elder determined for resending AE message");
             }


### PR DESCRIPTION
never use send_msg directly as it can bubble up errors
unexpectedly. ANy send, should be retrying over errors anyway,
so this should not be an issue

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
