### PR TITLE
[WIP-DON'T MERGE] refactor(node): using explicit chunk/register addr types in file store mod api

### DIFF
--- a/sn_interface/src/messaging/data/data_exchange.rs
+++ b/sn_interface/src/messaging/data/data_exchange.rs
@@ -6,11 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::RegisterCmd;
-use crate::{
-    messaging::SectionAuth,
-    types::{Error, RegisterAddress, Result, SpentbookAddress},
-};
+use crate::types::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use xor_name::XorName;
@@ -20,37 +16,6 @@ use xor_name::XorName;
 pub struct MetadataExchange {
     /// Adult storage levels.
     pub adult_levels: BTreeMap<XorName, StorageLevel>,
-}
-
-/// Data to be exchanged between Register stores.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RegisterStoreExport(pub Vec<ReplicatedRegisterLog>);
-
-/// Register data exchange.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ReplicatedRegisterLog {
-    ///
-    pub address: RegisterAddress,
-    /// This is a duplicated entry as it should exist in first cmd
-    pub section_auth: SectionAuth,
-    ///
-    pub op_log: Vec<RegisterCmd>,
-}
-
-/// Data to be exchanged between Spentbook stores.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SpentbookStoreExport(pub Vec<ReplicatedSpentbookLog>);
-
-/// Register data exchange.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ReplicatedSpentbookLog {
-    ///
-    pub address: SpentbookAddress,
-    /// section sig over address.id()
-    /// This is a duplicated entry as it should exist in first cmd
-    pub section_auth: SectionAuth,
-    ///
-    pub op_log: Vec<RegisterCmd>,
 }
 
 /// The degree to which storage has been used.

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -17,10 +17,7 @@ mod spentbook;
 
 pub use self::{
     cmd::DataCmd,
-    data_exchange::{
-        MetadataExchange, RegisterStoreExport, ReplicatedRegisterLog, ReplicatedSpentbookLog,
-        SpentbookStoreExport, StorageLevel,
-    },
+    data_exchange::{MetadataExchange, StorageLevel},
     errors::{Error, Result},
     query::DataQuery,
     query::DataQueryVariant,

--- a/sn_interface/src/types/address/mod.rs
+++ b/sn_interface/src/types/address/mod.rs
@@ -42,16 +42,6 @@ impl DataAddress {
         }
     }
 
-    /// Returns the Address serialised and encoded in z-base-32.
-    pub fn encode_to_zbase32(&self) -> Result<String> {
-        utils::encode(&self)
-    }
-
-    /// Creates from z-base-32 encoded string.
-    pub fn decode_from_zbase32<T: AsRef<str>>(encoded: T) -> Result<Self> {
-        utils::decode(encoded)
-    }
-
     ///
     pub fn register(name: XorName, tag: u64) -> DataAddress {
         DataAddress::Register(RegisterAddress::new(name, tag))
@@ -93,16 +83,6 @@ impl ReplicatedDataAddress {
             Self::Spentbook(address) => address.name(),
         }
     }
-
-    /// Returns the Address serialised and encoded in z-base-32.
-    pub fn encode_to_zbase32(&self) -> Result<String> {
-        utils::encode(&self)
-    }
-
-    /// Creates from z-base-32 encoded string.
-    pub fn decode_from_zbase32<T: AsRef<str>>(encoded: T) -> Result<Self> {
-        utils::decode(encoded)
-    }
 }
 
 /// Address of a Chunk.
@@ -128,19 +108,9 @@ impl ChunkAddress {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{ChunkAddress, DataAddress, Result};
+    use super::ChunkAddress;
+    use crate::types::Result;
     use xor_name::XorName;
-
-    #[test]
-    fn zbase32_encode_decode_data_address() -> Result<()> {
-        let name: XorName = xor_name::rand::random();
-        let chunk_addr = ChunkAddress(name);
-        let address = DataAddress::Bytes(chunk_addr);
-        let encoded = address.encode_to_zbase32()?;
-        let decoded = DataAddress::decode_from_zbase32(&encoded)?;
-        assert_eq!(address, decoded);
-        Ok(())
-    }
 
     #[test]
     fn zbase32_encode_decode_chunk_address() -> Result<()> {

--- a/sn_interface/src/types/address/register.rs
+++ b/sn_interface/src/types/address/register.rs
@@ -6,8 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::super::{Result, XorName};
-use super::DataAddress;
+use super::super::{utils, Result, XorName};
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
@@ -27,12 +26,6 @@ impl RegisterAddress {
         Self { name, tag }
     }
 
-    /// This is a unique identifier of the Register,
-    /// since it also encodes the tag of the Address.
-    pub fn id(&self) -> Result<XorName> {
-        Ok(XorName::from_content(self.encode_to_zbase32()?.as_bytes()))
-    }
-
     /// Returns the name.
     /// This is not a unique identifier.
     pub fn name(&self) -> &XorName {
@@ -46,6 +39,28 @@ impl RegisterAddress {
 
     /// Returns the Address serialised and encoded in z-base-32.
     pub fn encode_to_zbase32(&self) -> Result<String> {
-        DataAddress::Register(*self).encode_to_zbase32()
+        utils::encode(&self)
+    }
+
+    /// Creates from z-base-32 encoded string.
+    pub fn decode_from_zbase32<T: AsRef<str>>(encoded: T) -> Result<Self> {
+        utils::decode(encoded)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RegisterAddress;
+    use crate::types::Result;
+    use xor_name::XorName;
+
+    #[test]
+    fn zbase32_encode_decode_register_address() -> Result<()> {
+        let name: XorName = xor_name::rand::random();
+        let address = RegisterAddress::new(name, rand::random());
+        let encoded = address.encode_to_zbase32()?;
+        let decoded = RegisterAddress::decode_from_zbase32(&encoded)?;
+        assert_eq!(address, decoded);
+        Ok(())
     }
 }

--- a/sn_interface/src/types/address/spentbook.rs
+++ b/sn_interface/src/types/address/spentbook.rs
@@ -6,8 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::super::{Result, XorName};
-use super::DataAddress;
+use super::super::XorName;
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
@@ -25,10 +24,5 @@ impl SpentbookAddress {
     /// This is a unique identifier.
     pub fn name(&self) -> &XorName {
         &self.0
-    }
-
-    /// Returns the Address serialised and encoded in z-base-32.
-    pub fn encode_to_zbase32(&self) -> Result<String> {
-        DataAddress::Spentbook(*self).encode_to_zbase32()
     }
 }

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -25,8 +25,9 @@ mod chunk;
 mod errors;
 mod peer;
 
-pub use crate::messaging::data::{
-    RegisterCmd, RegisterCmdId, ReplicatedRegisterLog, ReplicatedSpentbookLog,
+pub use crate::messaging::{
+    data::{RegisterCmd, RegisterCmdId},
+    SectionAuth,
 };
 
 pub use address::{
@@ -54,6 +55,17 @@ pub use keys::secret_key::test_utils::{keyed_signed, SecretKeySet};
 // TODO: temporary type tag for spentbook since its underlying data type is
 // still not implemented, it uses a Public Register for now.
 pub const SPENTBOOK_TYPE_TAG: u64 = 0;
+
+/// Register data exchange.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplicatedRegisterLog {
+    ///
+    pub address: RegisterAddress,
+    /// This is a duplicated entry as it should exist in first cmd
+    pub section_auth: SectionAuth,
+    ///
+    pub op_log: Vec<RegisterCmd>,
+}
 
 ///
 #[allow(clippy::large_enum_variant)]

--- a/sn_node/src/storage/errors.rs
+++ b/sn_node/src/storage/errors.rs
@@ -11,7 +11,7 @@ use sn_interface::{
     types::{convert_dt_error_to_error_msg, PublicKey, ReplicatedDataAddress as DataAddress},
 };
 
-use std::io;
+use std::{io, path::PathBuf};
 use thiserror::Error;
 use xor_name::XorName;
 
@@ -26,9 +26,9 @@ pub enum Error {
     /// Not enough space to store the value.
     #[error("Not enough space")]
     NotEnoughSpace,
-    /// Key not found.
-    #[error("Key not found: {0:?}")]
-    KeyNotFound(String),
+    /// Register not found in local storage.
+    #[error("Rgister not found in storage, expected location: {0}")]
+    RegisterNotFound(PathBuf),
     /// Data not found.
     #[error("No such data: {0:?}")]
     NoSuchData(DataAddress),


### PR DESCRIPTION
- Moving functionality to generate Register log folder name to storage mod, as it doesn't belong to the RegisterAddress type but just to the node's storage implementation.
- Removing some unnecessary type definitions used only within the storage impl.
- Storage paths for Chunks are now calculated by encoding the ChunkAdddress instead of a DataAddress::Bytes(ChunkAddress).