### PR TITLE
change DEFAULT_MAX_QUERY_CMD_RETRIES:

### DIFF
--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -43,7 +43,7 @@ pub const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(30);
 /// Max retries to be attempted in the DEFAULT_QUERY_CMD_TIMEOUT; DEFAULT_QUERY_CMD_TIMEOUT / DEFAULT_MAX_QUERY_CMD_RETRIES ~ tries per second
 /// (though exponential backoff exists)
-pub const DEFAULT_MAX_QUERY_CMD_RETRIES: usize = 15;
+pub const DEFAULT_MAX_QUERY_CMD_RETRIES: usize = 5;
 /// Default timeout for waiting for potential Anti-Entropy messages
 pub const DEFAULT_ACK_WAIT: Duration = Duration::from_secs(10);
 


### PR DESCRIPTION
change line 46 pub const DEFAULT_MAX_QUERY_CMD_RETRIES: usize = 15;    to 5

https://safenetforum.org/t/pre-dev-update-thread-yay-d/6203/4896?u=southside

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
