### PR TITLE
feat(statemaps): some minimal infrastructure for generating statemaps

### DIFF
--- a/resources/scripts/statemap-preprocess.sh
+++ b/resources/scripts/statemap-preprocess.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -x
+
+if ! command -v rg &> /dev/null
+then
+    echo "ripgrep could not be found and is required"
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null
+then
+    echo "jq could not be found and is required"
+    exit 1
+fi
+
+log_dir="$HOME/.safe/node/local-test-network"
+genesis_log_dir="$HOME/.safe/node/local-test-network/sn-node-genesis"
+out_file="safe_states.out"
+
+# Extract statemap metadata
+rg -IN ".*STATEMAP_METADATA: " "$genesis_log_dir" --replace "" > "$out_file"
+rg -IN ".*STATEMAP_ENTRY: " "$log_dir" --replace "" | jq -s 'sort_by(.time|tonumber)' | jq -c '.[]' >> "$out_file"
+
+echo "Generated statemap data at $out_file"
+echo "Render the statemap SVG with"
+echo "    statemap -c 10000 $out_file > safe.svg"

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -31,6 +31,7 @@ traceroute = ["sn_interface/traceroute"]
 # Needs to be built with RUSTFLAGS="--cfg tokio_unstable"
 tokio-console = ["console-subscriber"]
 otlp = [ "opentelemetry", "opentelemetry-otlp", "opentelemetry-semantic-conventions", "tracing-opentelemetry" ]
+statemap = []
 
 [dependencies]
 backoff = { version = "~0.4.0", features = [ "tokio" ] }

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::log_sleep;
+use crate::node::statemap;
 use crate::node::{
     flow_ctrl::{
         cmds::{Cmd, CmdJob},
@@ -162,7 +163,12 @@ impl CmdCtrl {
 
         let dispatcher = self.dispatcher.clone();
         let _ = tokio::task::spawn_local(async move {
-            dispatcher.node().read().await.log_statemap(1);
+            dispatcher
+                .node()
+                .read()
+                .await
+                .statemap_log_state(cmd.statemap_state());
+
             match dispatcher.process_cmd(cmd).await {
                 Ok(cmds) => {
                     monitoring.increment_cmds().await;
@@ -199,7 +205,11 @@ impl CmdCtrl {
                 }
             }
             throughpout.increment(); // both on fail and success
-            dispatcher.node().read().await.log_statemap(0);
+            dispatcher
+                .node()
+                .read()
+                .await
+                .statemap_log_state(statemap::State::Idle);
         });
         Ok(())
     }

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -162,6 +162,7 @@ impl CmdCtrl {
 
         let dispatcher = self.dispatcher.clone();
         let _ = tokio::task::spawn_local(async move {
+            dispatcher.node().read().await.log_statemap(1);
             match dispatcher.process_cmd(cmd).await {
                 Ok(cmds) => {
                     monitoring.increment_cmds().await;
@@ -198,6 +199,7 @@ impl CmdCtrl {
                 }
             }
             throughpout.increment(); // both on fail and success
+            dispatcher.node().read().await.log_statemap(0);
         });
         Ok(())
     }

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -8,7 +8,7 @@
 
 use crate::node::{
     messaging::{OutgoingMsg, Peers},
-    Proposal, XorName,
+    statemap, Proposal, XorName,
 };
 
 use sn_consensus::Decision;
@@ -256,6 +256,30 @@ impl Cmd {
             HandleValidServiceMsg { msg, .. } => msg.priority(),
 
             ValidateMsg { .. } => -9, // before it's validated, we cannot give it high prio, as it would be a spam vector
+        }
+    }
+
+    pub(crate) fn statemap_state(&self) -> statemap::State {
+        use statemap::State;
+        match self {
+            Cmd::CleanupPeerLinks => State::Comms,
+            Cmd::SendMsg { .. } => State::Comms,
+            Cmd::Comm(_) => State::Comms,
+            Cmd::HandlePeerFailedSend(_) => State::Comms,
+            Cmd::ValidateMsg { .. } => State::ProcessCmd,
+            Cmd::HandleValidSystemMsg { .. } => State::SystemMsg,
+            Cmd::HandleValidServiceMsg { .. } => State::ServiceMsg,
+            Cmd::TrackNodeIssueInDysfunction { .. } => State::Dysfunction,
+            Cmd::AddToPendingQueries { .. } => State::Dysfunction,
+            Cmd::HandleAgreement { .. } => State::Agreement,
+            Cmd::HandleMembershipDecision(_) => State::Membership,
+            Cmd::ProposeVoteNodesOffline(_) => State::Membership,
+            Cmd::HandleNewEldersAgreement { .. } => State::Handover,
+            Cmd::HandleDkgTimeout(_) => State::Dkg,
+            Cmd::HandleDkgOutcome { .. } => State::Dkg,
+            Cmd::HandleDkgFailure(_) => State::Dkg,
+            Cmd::ScheduleDkgTimeout { .. } => State::Dkg,
+            Cmd::EnqueueDataForReplication { .. } => State::Replication,
         }
     }
 }

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -159,6 +159,7 @@ mod core {
     pub(crate) type AeBackoffCache = LRUCache<(Peer, ExponentialBackoff), BACKOFF_CACHE_LIMIT>;
 
     pub(crate) struct Node {
+        #[allow(unused)]
         pub(crate) start_time: SystemTime,
         pub(crate) addr: SocketAddr, // does this change? if so... when? only at node start atm?
         pub(crate) event_sender: EventSender,

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -29,6 +29,7 @@ mod node_test_api;
 mod proposal;
 mod relocation;
 mod split_barrier;
+mod statemap;
 
 use self::{
     bootstrap::join_network,
@@ -85,7 +86,6 @@ mod core {
         },
         UsedSpace,
     };
-    use serde_json::json;
     use sn_dysfunction::{DysfunctionDetection, IssueType};
     #[cfg(feature = "traceroute")]
     use sn_interface::messaging::Entity;
@@ -113,7 +113,7 @@ mod core {
         net::SocketAddr,
         path::PathBuf,
         sync::Arc,
-        time::{Duration, SystemTime, UNIX_EPOCH},
+        time::{Duration, SystemTime},
     };
     use uluru::LRUCache;
 
@@ -288,7 +288,7 @@ mod core {
                 membership,
             };
 
-            node.log_statemap_metadata();
+            node.statemap_log_metadata();
 
             // Write the section tree to this node's root storage directory
             node.write_section_tree().await;
@@ -777,50 +777,6 @@ mod core {
             } else {
                 Entity::Adult(self.info().public_key())
             }
-        }
-
-        pub(crate) fn log_statemap_metadata(&self) {
-            let start_dur = match self.start_time.duration_since(UNIX_EPOCH) {
-                Ok(dur) => dur,
-                Err(e) => {
-                    error!("STATEMAP: failed to calculate start time {e:?}");
-                    return;
-                }
-            };
-            let secs = start_dur.as_secs();
-            let nanos = start_dur.subsec_nanos();
-            let name = self.name();
-            let states = json!({
-                "waiting-for-cmd": { "value": 0, "color": "#f9f9f9" },
-                "processing-cmd": { "value": 1, "color": "#850101" },
-            });
-
-            let metadata = json!({
-                "title": format!("States of {name}"),
-                "start": [secs, nanos],
-                "host": name,
-                "states": states
-            });
-
-            trace!("STATEMAP_METADATA: {metadata}");
-        }
-
-        pub(crate) fn log_statemap(&self, state: usize) {
-            // { "time": "1579579142", "entity": "<xorname>", "state": 6 }
-            let time = match SystemTime::now().duration_since(self.start_time) {
-                Ok(t) => t.as_nanos(),
-                Err(e) => {
-                    error!("STATEMAP: failed to read system time: {e:?}");
-                    return;
-                }
-            };
-            let name = self.name();
-            let entry = json!({
-                "time": format!("{}", time),
-                "entity": name,
-                "state": state,
-            });
-            info!("STATEMAP_ENTRY: {entry}")
         }
     }
 

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -791,8 +791,8 @@ mod core {
             let nanos = start_dur.subsec_nanos();
             let name = self.name();
             let states = json!({
-                "waiting-for-cmd": { "value": 0, "color": "#DAF7A6" },
-                "processing-cmd": { "value": 1, "color": "#f9f9f9" },
+                "waiting-for-cmd": { "value": 0, "color": "#f9f9f9" },
+                "processing-cmd": { "value": 1, "color": "#850101" },
             });
 
             let metadata = json!({

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -85,6 +85,7 @@ mod core {
         },
         UsedSpace,
     };
+    use serde_json::json;
     use sn_dysfunction::{DysfunctionDetection, IssueType};
     #[cfg(feature = "traceroute")]
     use sn_interface::messaging::Entity;
@@ -112,7 +113,7 @@ mod core {
         net::SocketAddr,
         path::PathBuf,
         sync::Arc,
-        time::Duration,
+        time::{Duration, SystemTime, UNIX_EPOCH},
     };
     use uluru::LRUCache;
 
@@ -158,6 +159,7 @@ mod core {
     pub(crate) type AeBackoffCache = LRUCache<(Peer, ExponentialBackoff), BACKOFF_CACHE_LIMIT>;
 
     pub(crate) struct Node {
+        pub(crate) start_time: SystemTime,
         pub(crate) addr: SocketAddr, // does this change? if so... when? only at node start atm?
         pub(crate) event_sender: EventSender,
         root_storage_dir: PathBuf,
@@ -258,6 +260,7 @@ mod core {
             };
 
             let node = Self {
+                start_time: SystemTime::now(),
                 addr,
                 keypair,
                 network_knowledge,
@@ -284,6 +287,8 @@ mod core {
                 ae_backoff_cache: AeBackoffCache::default(),
                 membership,
             };
+
+            node.log_statemap_metadata();
 
             // Write the section tree to this node's root storage directory
             node.write_section_tree().await;
@@ -772,6 +777,50 @@ mod core {
             } else {
                 Entity::Adult(self.info().public_key())
             }
+        }
+
+        pub(crate) fn log_statemap_metadata(&self) {
+            let start_dur = match self.start_time.duration_since(UNIX_EPOCH) {
+                Ok(dur) => dur,
+                Err(e) => {
+                    error!("STATEMAP: failed to calculate start time {e:?}");
+                    return;
+                }
+            };
+            let secs = start_dur.as_secs();
+            let nanos = start_dur.subsec_nanos();
+            let name = self.name();
+            let states = json!({
+                "waiting-for-cmd": { "value": 0, "color": "#DAF7A6" },
+                "processing-cmd": { "value": 1, "color": "#f9f9f9" },
+            });
+
+            let metadata = json!({
+                "title": format!("States of {name}"),
+                "start": [secs, nanos],
+                "host": name,
+                "states": states
+            });
+
+            trace!("STATEMAP_METADATA: {metadata}");
+        }
+
+        pub(crate) fn log_statemap(&self, state: usize) {
+            // { "time": "1579579142", "entity": "<xorname>", "state": 6 }
+            let time = match SystemTime::now().duration_since(self.start_time) {
+                Ok(t) => t.as_nanos(),
+                Err(e) => {
+                    error!("STATEMAP: failed to read system time: {e:?}");
+                    return;
+                }
+            };
+            let name = self.name();
+            let entry = json!({
+                "time": format!("{}", time),
+                "entity": name,
+                "state": state,
+            });
+            info!("STATEMAP_ENTRY: {entry}")
         }
     }
 

--- a/sn_node/src/node/statemap.rs
+++ b/sn_node/src/node/statemap.rs
@@ -1,0 +1,87 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! Instrumentation for statemaps: https://github.com/TritonDataCenter/statemap
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::json;
+
+use super::core::Node;
+
+pub(crate) enum State {
+    Idle,
+    ProcessCmd,
+    Comms,
+    Validation,
+    Dysfunction,
+    SystemMsg,
+    ServiceMsg,
+    Dkg,
+    Agreement,
+    Membership,
+    Handover,
+    Replication,
+}
+
+impl Node {
+    pub(crate) fn statemap_log_metadata(&self) {
+        let start_dur = match self.start_time.duration_since(UNIX_EPOCH) {
+            Ok(dur) => dur,
+            Err(e) => {
+                error!("STATEMAP: failed to calculate start time {e:?}");
+                return;
+            }
+        };
+        let secs = start_dur.as_secs();
+        let nanos = start_dur.subsec_nanos();
+        let name = self.name();
+        let states = json!({
+            "Idle": {"value": State::Idle as usize, "color": "#f9f9f9"},
+            "ProcessCmd": {"value": State::ProcessCmd as usize, "color": "#a0522d"},
+            "Comms": {"value": State::Comms as usize, "color": "#008000"},
+            "Validation": {"value": State::Validation as usize, "color": "#4b0082"},
+            "Dysfunction": {"value": State::Dysfunction as usize, "color": "#ff0000"},
+            "SystemMsg": {"value": State::SystemMsg as usize, "color": "#ffd700"},
+            "ServiceMsg": {"value": State::ServiceMsg as usize, "color": "#7fff00"},
+            "Dkg": {"value": State::Dkg as usize, "color": "#00ffff"},
+            "Agreement": {"value": State::Agreement as usize, "color": "#0000ff"},
+            "Membership": {"value": State::Membership as usize, "color": "#ff00ff"},
+            "Handover": {"value": State::Handover as usize, "color": "#6495ed"},
+            "Replication": {"value": State::Replication as usize, "color": "#ff69b4"},
+        });
+
+        let metadata = json!({
+            "title": format!("The various states safe_network"),
+            "start": [secs, nanos],
+            "host": name,
+            "states": states
+        });
+
+        trace!("STATEMAP_METADATA: {metadata}");
+    }
+
+    pub(crate) fn statemap_log_state(&self, state: State) {
+        // { "time": "1579579142", "entity": "<xorname>", "state": 6 }
+        let time = match SystemTime::now().duration_since(self.start_time) {
+            Ok(t) => t.as_nanos(),
+            Err(e) => {
+                error!("STATEMAP: failed to read system time: {e:?}");
+                return;
+            }
+        };
+        let name = self.name();
+        let entry = json!({
+            "time": format!("{}", time),
+            "entity": name,
+            "state": state as usize,
+        });
+
+        info!("STATEMAP_ENTRY: {entry}")
+    }
+}

--- a/sn_node/src/node/statemap.rs
+++ b/sn_node/src/node/statemap.rs
@@ -8,17 +8,12 @@
 
 //! Instrumentation for statemaps: https://github.com/TritonDataCenter/statemap
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use serde_json::json;
-
 use super::core::Node;
 
 pub(crate) enum State {
     Idle,
     ProcessCmd,
     Comms,
-    Validation,
     Dysfunction,
     SystemMsg,
     ServiceMsg,
@@ -31,57 +26,61 @@ pub(crate) enum State {
 
 impl Node {
     pub(crate) fn statemap_log_metadata(&self) {
-        let start_dur = match self.start_time.duration_since(UNIX_EPOCH) {
-            Ok(dur) => dur,
-            Err(e) => {
-                error!("STATEMAP: failed to calculate start time {e:?}");
-                return;
-            }
-        };
-        let secs = start_dur.as_secs();
-        let nanos = start_dur.subsec_nanos();
-        let name = self.name();
-        let states = json!({
-            "Idle": {"value": State::Idle as usize, "color": "#f9f9f9"},
-            "ProcessCmd": {"value": State::ProcessCmd as usize, "color": "#a0522d"},
-            "Comms": {"value": State::Comms as usize, "color": "#008000"},
-            "Validation": {"value": State::Validation as usize, "color": "#4b0082"},
-            "Dysfunction": {"value": State::Dysfunction as usize, "color": "#ff0000"},
-            "SystemMsg": {"value": State::SystemMsg as usize, "color": "#ffd700"},
-            "ServiceMsg": {"value": State::ServiceMsg as usize, "color": "#7fff00"},
-            "Dkg": {"value": State::Dkg as usize, "color": "#00ffff"},
-            "Agreement": {"value": State::Agreement as usize, "color": "#0000ff"},
-            "Membership": {"value": State::Membership as usize, "color": "#ff00ff"},
-            "Handover": {"value": State::Handover as usize, "color": "#6495ed"},
-            "Replication": {"value": State::Replication as usize, "color": "#ff69b4"},
-        });
+        #[cfg(feature = "statemap")]
+        {
+            let start_dur = match self.start_time.duration_since(std::time::UNIX_EPOCH) {
+                Ok(dur) => dur,
+                Err(e) => {
+                    error!("STATEMAP: failed to calculate start time {e:?}");
+                    return;
+                }
+            };
+            let secs = start_dur.as_secs();
+            let nanos = start_dur.subsec_nanos();
+            let name = self.name();
+            let states = serde_json::json!({
+                "Idle": {"value": State::Idle as usize, "color": "#f9f9f9"},
+                "ProcessCmd": {"value": State::ProcessCmd as usize, "color": "#a0522d"},
+                "Comms": {"value": State::Comms as usize, "color": "#008000"},
+                "Dysfunction": {"value": State::Dysfunction as usize, "color": "#ff0000"},
+                "SystemMsg": {"value": State::SystemMsg as usize, "color": "#ffd700"},
+                "ServiceMsg": {"value": State::ServiceMsg as usize, "color": "#7fff00"},
+                "Dkg": {"value": State::Dkg as usize, "color": "#00ffff"},
+                "Agreement": {"value": State::Agreement as usize, "color": "#0000ff"},
+                "Membership": {"value": State::Membership as usize, "color": "#ff00ff"},
+                "Handover": {"value": State::Handover as usize, "color": "#6495ed"},
+                "Replication": {"value": State::Replication as usize, "color": "#ff69b4"},
+            });
 
-        let metadata = json!({
-            "title": format!("The various states safe_network"),
-            "start": [secs, nanos],
-            "host": name,
-            "states": states
-        });
-
-        trace!("STATEMAP_METADATA: {metadata}");
+            let metadata = serde_json::json!({
+                "title": format!("The various states safe_network"),
+                "start": [secs, nanos],
+                "host": name,
+                "states": states
+            });
+            trace!("STATEMAP_METADATA: {metadata}");
+        }
     }
 
-    pub(crate) fn statemap_log_state(&self, state: State) {
-        // { "time": "1579579142", "entity": "<xorname>", "state": 6 }
-        let time = match SystemTime::now().duration_since(self.start_time) {
-            Ok(t) => t.as_nanos(),
-            Err(e) => {
-                error!("STATEMAP: failed to read system time: {e:?}");
-                return;
-            }
-        };
-        let name = self.name();
-        let entry = json!({
-            "time": format!("{}", time),
-            "entity": name,
-            "state": state as usize,
-        });
+    pub(crate) fn statemap_log_state(&self, #[allow(unused)] state: State) {
+        #[cfg(feature = "statemap")]
+        {
+            // { "time": "1579579142", "entity": "<xorname>", "state": 6 }
+            let time = match std::time::SystemTime::now().duration_since(self.start_time) {
+                Ok(t) => t.as_nanos(),
+                Err(e) => {
+                    error!("STATEMAP: failed to read system time: {e:?}");
+                    return;
+                }
+            };
+            let name = self.name();
+            let entry = serde_json::json!({
+                "time": format!("{}", time),
+                "entity": name,
+                "state": state as usize,
+            });
 
-        info!("STATEMAP_ENTRY: {entry}")
+            info!("STATEMAP_ENTRY: {entry}")
+        }
     }
 }

--- a/sn_node/src/node/statemap.rs
+++ b/sn_node/src/node/statemap.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-//! Instrumentation for statemaps: https://github.com/TritonDataCenter/statemap
+//! Instrumentation for statemaps: <https://github.com/TritonDataCenter/statemap>
 
 use super::core::Node;
 

--- a/testnet/Cargo.toml
+++ b/testnet/Cargo.toml
@@ -12,10 +12,11 @@ version = "0.1.0"
 
 
 [features]
-default = ["traceroute"]
+default = ["traceroute", "statemap"]
 # required to pass on flag to node builds
 chaos = []
 traceroute = []
+statemap = []
 
 [[bin]]
 path="bin.rs"

--- a/testnet/bin.rs
+++ b/testnet/bin.rs
@@ -115,14 +115,16 @@ async fn main() -> Result<()> {
 
         // Keep features consistent to avoid recompiling when possible
         if cfg!(feature = "traceroute") {
-            println!("*** Building testnet with TRACEROUTE enabled. Watch out for traces. ***");
-            build_args.push("--features");
-            build_args.push("traceroute");
+            build_args.extend(["--features", "traceroute"]);
+        }
+
+        // Keep features consistent to avoid recompiling when possible
+        if cfg!(feature = "statemap") {
+            build_args.extend(["--features", "statemap"]);
         }
 
         if cfg!(feature = "unstable-wiremsg-debuginfo") {
-            build_args.push("--features");
-            build_args.push("unstable-wiremsg-debuginfo");
+            build_args.extend(["--features", "unstable-wiremsg-debuginfo"]);
         }
 
         if cmd_args.flame {


### PR DESCRIPTION
usage:

0. install `statemap`

       git clone git@github.com:TritonDataCenter/statemap.git
       cd statemap
       cargo install --path .

2. startup a network as usual
3. extract the states file from a log using:

        ./resources/scripts/statemap-preprocess.sh

4. run `statemap` on the generated `safe_states.out` file:

        # vary -c to change the fidelity (max-number of rectangles) larger produces larger SVG's
        statemap -c 300000 safe_states.out > safe.svg

5. open `safe.svg` in a browser

issues with this approach:
  - `statemap` wants all state entry timestamps to be monotonically increasing, my method of extracting states from logs can mess that up when you combine logs form multiple nodes and/or log rotation kicks in
  - would be nicer if we have some state constants instead of using magic numbers throughout the code.