### PR TITLE
refactor(node): optimise the way we apply and save replicated Register cmds on local storage

### DIFF
--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -43,8 +43,8 @@ pub enum Error {
         found: u8,
     },
     /// Provided data already exists on the network
-    #[error("Data provided already exists")]
-    DataExists,
+    #[error("Data provided already exists: {0:?}")]
+    DataExists(DataAddress),
     /// Entry could not be found on the data
     #[error("Requested entry not found")]
     NoSuchEntry,

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -56,8 +56,6 @@ pub const SPENTBOOK_TYPE_TAG: u64 = 0;
 pub struct ReplicatedRegisterLog {
     ///
     pub address: RegisterAddress,
-    /// This is a duplicated entry as it should exist in first cmd
-    pub section_auth: SectionAuth,
     ///
     pub op_log: Vec<RegisterCmd>,
 }

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -130,8 +130,8 @@ pub enum Error {
     #[error("No such data: {0:?}")]
     NoSuchData(DataAddress),
     /// Chunk already exists for this node
-    #[error("Data already exists at this node")]
-    DataExists,
+    #[error("Data already exists at this node: {0:?}")]
+    DataExists(DataAddress),
     /// I/O error.
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
@@ -236,7 +236,7 @@ pub(crate) fn convert_to_error_msg(error: Error) -> ErrorMsg {
     match error {
         Error::InvalidOwner(key) => ErrorMsg::InvalidOwner(key),
         Error::NoSuchData(address) => ErrorMsg::DataNotFound(address),
-        Error::DataExists => ErrorMsg::DataExists,
+        Error::DataExists(address) => ErrorMsg::DataExists(address),
         Error::NetworkData(error) => convert_dt_error_to_error_msg(error),
         other => ErrorMsg::InvalidOperation(format!("Failed to perform operation: {:?}", other)),
     }

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -461,7 +461,7 @@ impl Node {
                 let mut cmds = vec![];
 
                 let section_pk = PublicKey::Bls(self.network_knowledge.section_key());
-                let own_keypair = Keypair::Ed25519(self.keypair.clone());
+                let node_keypair = Keypair::Ed25519(self.keypair.clone());
 
                 for data in data_collection {
                     // We are an adult here, so just store away!
@@ -469,7 +469,7 @@ impl Node {
                     // well before this
                     match self
                         .data_storage
-                        .store(&data, section_pk, own_keypair.clone())
+                        .store(&data, section_pk, node_keypair.clone())
                         .await
                     {
                         Ok(level_report) => {

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -67,11 +67,11 @@ impl DataStorage {
         keypair_for_spent_book: Keypair,
     ) -> Result<Option<StorageLevel>> {
         debug!("Replicating {data:?}");
-        match data.clone() {
+        match data {
             ReplicatedData::Chunk(chunk) => self.chunks.store(chunk).await?,
             ReplicatedData::RegisterLog(data) => {
                 info!("Updating register: {:?}", data.address);
-                self.registers.update(vec![data]).await?
+                self.registers.update(data).await?
             }
             ReplicatedData::RegisterWrite(cmd) => self.registers.write(cmd).await?,
             ReplicatedData::SpentbookWrite(cmd) => {
@@ -88,7 +88,7 @@ impl DataStorage {
                 // We now write the cmd received
                 self.registers.write(cmd).await?
             }
-            ReplicatedData::SpentbookLog(data) => self.registers.update(vec![data]).await?,
+            ReplicatedData::SpentbookLog(data) => self.registers.update(data).await?,
         };
 
         // check if we've filled another approx. 10%-points of our storage

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -529,7 +529,7 @@ mod tests {
                                 // do nothing
                                 Ok(())
                             }
-                            Err(Error::DataExists) => {
+                            Err(Error::DataExists(_)) => {
                                 // also do nothing
                                 Ok(())
                             }
@@ -547,7 +547,8 @@ mod tests {
                 Op::Query(idx) => {
                     // +1 for a chance to get random xor_name
                     let key = get_xor_name(&model, idx % (model.len() + 1));
-                    let query = DataQueryVariant::GetChunk(ChunkAddress(key));
+                    let addr = ChunkAddress(key);
+                    let query = DataQueryVariant::GetChunk(addr);
                     let user = User::Anyone;
                     let stored_res = runtime.block_on(storage.query(&query, user));
                     let model_res = model.get(&key);
@@ -564,7 +565,7 @@ mod tests {
                         }
                         None => {
                             if let NodeQueryResponse::GetChunk(Ok(_)) = stored_res {
-                                return Err(Error::DataExists);
+                                return Err(Error::DataExists(DataAddress::Bytes(addr)));
                             }
                         }
                     }
@@ -585,7 +586,7 @@ mod tests {
                         }
                         None => {
                             if stored_data.is_ok() {
-                                return Err(Error::DataExists);
+                                return Err(Error::DataExists(addr));
                             }
                         }
                     }
@@ -603,7 +604,7 @@ mod tests {
                         }
                         None => {
                             if storage_res.is_ok() {
-                                return Err(Error::DataExists);
+                                return Err(Error::DataExists(addr));
                             }
                         }
                     }

--- a/sn_node/src/storage/register_store.rs
+++ b/sn_node/src/storage/register_store.rs
@@ -15,7 +15,7 @@ use sn_interface::{
     types::{
         register::Register,
         utils::{deserialise, serialise},
-        RegisterAddress, RegisterCmd, SectionAuth,
+        RegisterAddress, RegisterCmd,
     },
 };
 
@@ -36,7 +36,7 @@ pub(super) type RegisterLog = Vec<RegisterCmd>;
 
 #[derive(Clone, Debug)]
 pub(super) struct StoredRegister {
-    pub(super) state: Option<(Register, SectionAuth)>,
+    pub(super) state: Option<Register>,
     pub(super) op_log: RegisterLog,
     pub(super) op_log_path: PathBuf,
 }
@@ -132,7 +132,7 @@ impl RegisterStore {
 
                     if let RegisterCmd::Create {
                         cmd: SignedRegisterCreate { op, .. },
-                        section_auth,
+                        ..
                     } = reg_cmd
                     {
                         // TODO: if we already have read a RegisterCreate op, check if there
@@ -140,7 +140,7 @@ impl RegisterStore {
                         if stored_reg.state.is_none() {
                             let register =
                                 Register::new(*op.policy.owner(), op.name, op.tag, op.policy);
-                            stored_reg.state = Some((register, section_auth));
+                            stored_reg.state = Some(register);
                         }
                     }
                 }


### PR DESCRIPTION
- Changing some internal store APIs to avoid cloning some objects.
- Removing some unused storage Error types, while adding more context information to others.
- Allowing the Register storage to store register edit cmds even when the creation cmd is not found in the local replica/store yet.
- Skip Spentbook Register creation if it already exists.
- Unit tests for register storage key internal helper functions.