### PR TITLE
chore: switch on clippy::unwrap_used as a warning

### DIFF
--- a/sn_api/src/app/wallet.rs
+++ b/sn_api/src/app/wallet.rs
@@ -320,7 +320,15 @@ impl Safe {
                     "Output amount to reissue needs to be larger than zero (0).".to_string(),
                 ));
             }
-            total_output_amount = total_output_amount.checked_add(output_amount).unwrap();
+            total_output_amount =
+                total_output_amount
+                    .checked_add(output_amount)
+                    .ok_or_else(|| {
+                        Error::DbcReissueError(
+                        "Overflow occurred while calculating the total amount for the output DBC"
+                            .to_string(),
+                    )
+                    })?;
 
             let output_owner = if let Some(pk) = owner_pk {
                 let owner = Owner::from(pk);

--- a/sn_api/src/lib.rs
+++ b/sn_api/src/lib.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#![warn(clippy::unwrap_used)]
+
 #[cfg(feature = "app")]
 mod app;
 #[cfg(any(feature = "app", feature = "authd_client"))]

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 #![recursion_limit = "256"]
+#![warn(clippy::unwrap_used)]
 
 mod cli;
 mod operations;

--- a/sn_cli/src/operations/config.rs
+++ b/sn_cli/src/operations/config.rs
@@ -729,7 +729,13 @@ pub mod test_utils {
             )
             .await?;
             // set one as default
-            let default_network_contacts = dummy_network_contacts.clone().pop().unwrap();
+            let default_network_contacts =
+                dummy_network_contacts.clone().pop().ok_or_else(|| {
+                    eyre!(
+                        "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                    )
+                })?;
             self.set_default_network_contacts(default_network_contacts.genesis_key())
                 .await?;
             Ok(dummy_network_contacts)
@@ -926,7 +932,7 @@ mod constructor {
 #[cfg(test)]
 mod read_network_contacts {
     use super::Config;
-    use color_eyre::Result;
+    use color_eyre::{eyre::eyre, Result};
     use sn_api::DEFAULT_NETWORK_CONTACTS_FILE_NAME;
     use tokio::fs;
 
@@ -938,7 +944,12 @@ mod read_network_contacts {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
 
         let (retrieved_network_contacts, _) = config.read_default_network_contacts().await?;
         assert_eq!(retrieved_network_contacts, network_contacts);
@@ -1129,7 +1140,12 @@ mod sync_network_contacts_and_settings {
         let network_contacts = store_dummy_network_contacts(&tmp_dir, None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let network_contacts_path = tmp_dir
             .path()
             .join(format!("{:?}", network_contacts.genesis_key()));
@@ -1159,7 +1175,12 @@ mod sync_network_contacts_and_settings {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
 
         config.sync().await?;
 
@@ -1236,7 +1257,12 @@ mod networks {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let path = config
             .network_contacts_dir
             .join(format!("{:?}", network_contacts.genesis_key()));
@@ -1255,7 +1281,12 @@ mod networks {
         let network_contacts = store_dummy_network_contacts(&tmp_dir, None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let network_contacts_path = tmp_dir
             .path()
             .join(format!("{:?}", network_contacts.genesis_key()));
@@ -1282,14 +1313,24 @@ mod networks {
         let mut network_contacts = store_dummy_network_contacts(&tmp_dir, None, 2).await?;
         let mut config = Config::create_config(&tmp_dir, None).await?;
 
-        let network_contacts_1 = network_contacts.pop().unwrap();
+        let network_contacts_1 = network_contacts.pop().ok_or_else(|| {
+            eyre!(
+                "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+            )
+        })?;
         let network_1 = NetworkInfo::Local(
             tmp_dir
                 .path()
                 .join(format!("{:?}", network_contacts_1.genesis_key())),
             None,
         );
-        let network_contacts_2 = network_contacts.pop().unwrap();
+        let network_contacts_2 = network_contacts.pop().ok_or_else(|| {
+            eyre!(
+                "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+            )
+        })?;
         let network_2 = NetworkInfo::Local(
             tmp_dir
                 .path()

--- a/sn_cli/src/subcommands/node.rs
+++ b/sn_cli/src/subcommands/node.rs
@@ -572,7 +572,7 @@ mod join_command {
     use crate::operations::config::{Config, NetworkInfo};
     use crate::operations::node::SN_NODE_EXECUTABLE;
     use assert_fs::prelude::*;
-    use color_eyre::Result;
+    use color_eyre::{eyre::eyre, Result};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::path::PathBuf;
 
@@ -587,7 +587,12 @@ mod join_command {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let baby_fleming = NetworkInfo::Local(
             config
                 .network_contacts_dir
@@ -632,7 +637,12 @@ mod join_command {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let baby_fleming = NetworkInfo::Local(
             config
                 .network_contacts_dir
@@ -679,7 +689,12 @@ mod join_command {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let baby_fleming = NetworkInfo::Local(
             config
                 .network_contacts_dir
@@ -727,7 +742,12 @@ mod join_command {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let baby_fleming = NetworkInfo::Local(
             config
                 .network_contacts_dir
@@ -774,7 +794,12 @@ mod join_command {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let baby_fleming = NetworkInfo::Local(
             config
                 .network_contacts_dir
@@ -820,7 +845,12 @@ mod join_command {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let baby_fleming = NetworkInfo::Local(
             config
                 .network_contacts_dir
@@ -864,7 +894,12 @@ mod join_command {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let baby_fleming = NetworkInfo::Local(
             config
                 .network_contacts_dir
@@ -911,7 +946,12 @@ mod join_command {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let baby_fleming = NetworkInfo::Local(
             config
                 .network_contacts_dir
@@ -954,7 +994,12 @@ mod join_command {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let baby_fleming = NetworkInfo::Local(
             config
                 .network_contacts_dir
@@ -998,7 +1043,12 @@ mod join_command {
             .store_dummy_network_contacts_and_set_default(None, 1)
             .await?
             .pop()
-            .unwrap();
+            .ok_or_else(|| {
+                eyre!(
+                    "There must be at least one set of contacts in the dummy_network_contacts \
+                        list"
+                )
+            })?;
         let baby_fleming = NetworkInfo::Local(
             config
                 .network_contacts_dir

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -44,7 +44,8 @@
     unused_import_braces,
     unused_qualifications,
     unused_results,
-    clippy::unicode_not_nfc
+    clippy::unicode_not_nfc,
+    clippy::unwrap_used
 )]
 
 #[macro_use]

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -477,6 +477,7 @@ mod tests {
 
     proptest! {
         #[test]
+        #[allow(clippy::unwrap_used)]
         fn pt_calculate_scores_should_include_all_nodes_in_score_map(
             node_count in 4..50usize, issue_type in generate_no_churn_normal_use_msg_issues())
         {
@@ -511,6 +512,7 @@ mod tests {
         }
 
         #[test]
+        #[allow(clippy::unwrap_used)]
         fn pt_calculate_scores_one_node_with_issues_should_have_higher_score_and_others_should_have_zero(
             node_count in 4..50usize, issue_count in 1..50, issue_type in generate_no_churn_normal_use_msg_issues())
         {
@@ -561,6 +563,7 @@ mod tests {
 
 
         #[test]
+        #[allow(clippy::unwrap_used)]
         /// Test that gives a range of nodes and a few bad nodes,
         /// we then check that we can reliably detect those nodes
         ///
@@ -656,6 +659,7 @@ mod tests {
 
 
         #[test]
+        #[allow(clippy::unwrap_used)]
         /// Test to check if we have more DKG messages, that bad nodes are found, within our expected issue count
         /// we then check that we can reliably detect those nodes
         ///
@@ -746,7 +750,9 @@ mod tests {
                 Ok(())
             });
         }
+
         #[test]
+        #[allow(clippy::unwrap_used)]
         /// Test to check if we have unresponded to AeProbe msgs
         ///
         /// "Nodes" are just random xornames,
@@ -832,6 +838,7 @@ mod tests {
         }
 
         #[test]
+        #[allow(clippy::unwrap_used)]
         fn pt_calculate_scores_when_all_nodes_have_the_same_number_of_issues_scores_should_all_be_zero(
             node_count in 4..50, issue_count in 0..50, issue_type in generate_no_churn_normal_use_msg_issues())
         {

--- a/sn_dysfunction/src/lib.rs
+++ b/sn_dysfunction/src/lib.rs
@@ -37,7 +37,8 @@
     unused_import_braces,
     unused_qualifications,
     unused_results,
-    clippy::unicode_not_nfc
+    clippy::unicode_not_nfc,
+    clippy::unwrap_used
 )]
 
 #[macro_use]

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#![warn(clippy::unwrap_used)]
+
 //! SAFE network data types.
 
 // Standardised messaging interface

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -372,7 +372,7 @@ mod tests {
             public_key: src_client_keypair.public_key(),
             signature: src_client_keypair.sign(&payload),
         };
-        let auth_proof = AuthorityProof::verify(auth.clone(), &payload).unwrap();
+        let auth_proof = AuthorityProof::verify(auth.clone(), &payload)?;
 
         let auth = AuthKind::Service(auth);
 

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -706,6 +706,7 @@ mod tests {
             cases: 20, .. ProptestConfig::default()
         })]
         #[test]
+        #[allow(clippy::unwrap_used)]
         fn proptest_section_tree_fields_should_stay_in_sync((main_chain, update_variations_list) in arb_sll_and_proof_chains(25, 3)) {
             for variation in update_variations_list {
                 let mut section_tree = SectionTree::new(*main_chain.root_key());
@@ -720,6 +721,7 @@ mod tests {
 
     // Generate an arbitrary sized SecuredLinkedList and a List<list of proof_chains which inserted in
     // that order gives back the main_chain>; i.e., multiple variations of <list of proof_chains>
+    #[allow(clippy::unwrap_used)]
     fn arb_sll_and_proof_chains(
         max_sections: usize,
         update_variations: usize,

--- a/sn_interface/src/types/keys/ed25519.rs
+++ b/sn_interface/src/types/keys/ed25519.rs
@@ -55,6 +55,7 @@ pub fn gen_keypair(range: &RangeInclusive<XorName>, age: u8) -> Keypair {
 }
 
 #[cfg(feature = "proptest")]
+#[allow(clippy::unwrap_used)]
 pub mod proptesting {
 
     pub use ed25519_dalek::{Keypair, PublicKey, Signature, Verifier};

--- a/sn_interface/src/types/keys/signature.rs
+++ b/sn_interface/src/types/keys/signature.rs
@@ -92,10 +92,11 @@ impl From<(usize, bls::SignatureShare)> for Signature {
 #[cfg(test)]
 mod tests {
     use super::Signature;
+    use eyre::Result;
 
     #[test]
-    fn ed25519_rmp_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
-        let signature = gen_ed25519_sig();
+    fn ed25519_rmp_roundtrip() -> Result<()> {
+        let signature = gen_ed25519_sig()?;
         let serialized = rmp_serde::to_vec(&signature)?;
 
         assert_eq!(
@@ -110,7 +111,7 @@ mod tests {
     /// in the array passed in, and does a bitwise and operation on it. If that operation doesn't
     /// result in 0, an error is returned. The only thing that makes sense to me is to keep trying
     /// until you get a value it accepts. It doesn't seem to take very long.
-    fn gen_ed25519_sig() -> Signature {
+    fn gen_ed25519_sig() -> Result<Signature> {
         let random_bytes: Vec<u8> = (0..ed25519::Signature::BYTE_SIZE)
             .map(|_| rand::random::<u8>())
             .collect();
@@ -121,6 +122,6 @@ mod tests {
                 .collect();
             result = ed25519::Signature::from_bytes(&random_bytes);
         }
-        Signature::Ed25519(result.unwrap())
+        Ok(Signature::Ed25519(result?))
     }
 }

--- a/sn_node/src/bin/sn_node/main.rs
+++ b/sn_node/src/bin/sn_node/main.rs
@@ -24,7 +24,8 @@
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
-    unused_results
+    unused_results,
+    clippy::unwrap_used
 )]
 
 use sn_node::node::{start_node, Config, Error as NodeError, Event, MembershipEvent};

--- a/sn_node/src/lib.rs
+++ b/sn_node/src/lib.rs
@@ -35,7 +35,8 @@
     unused_import_braces,
     unused_qualifications,
     unused_results,
-    clippy::unicode_not_nfc
+    clippy::unicode_not_nfc,
+    clippy::unwrap_used
 )]
 
 #[macro_use]

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -10,6 +10,7 @@ use super::Prefix;
 
 use crate::node::handover::Error as HandoverError;
 
+use sn_dbc::Error as DbcError;
 use sn_interface::{
     messaging::data::Error as ErrorMsg,
     types::{convert_dt_error_to_error_msg, Peer, PublicKey, ReplicatedDataAddress as DataAddress},
@@ -200,6 +201,8 @@ pub enum Error {
     /// Error occurred when minting the Genesis DBC.
     #[error("Genesis DBC error:: {0}")]
     GenesisDbcError(String),
+    #[error("DbcError: {0}")]
+    DbcError(#[from] DbcError),
 }
 
 impl From<qp2p::ClientEndpointError> for Error {

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -188,7 +188,7 @@ async fn membership_churn_starts_on_join_request_with_resource_proof() -> Result
                 .await
                 .membership
                 .as_ref()
-                .unwrap()
+                .ok_or_else(|| eyre!("Membership for the node must be set"))?
                 .is_churn_in_progress());
             // makes sure that the nonce signature is always valid
             let random_peer = Peer::new(xor_name::rand::random(), gen_addr());
@@ -272,7 +272,7 @@ async fn membership_churn_starts_on_join_request_from_relocated_node() -> Result
                 .await
                 .membership
                 .as_ref()
-                .unwrap()
+                .ok_or_else(|| eyre!("Membership for the node must be set"))?
                 .is_churn_in_progress());
 
             Result::<()>::Ok(())
@@ -375,7 +375,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
                 .await
                 .membership
                 .as_mut()
-                .unwrap()
+                .ok_or_else(|| eyre!("Membership for the node must be set"))?
                 .force_bootstrap(node_state.to_msg());
 
             let cmds = run_and_collect_cmds(
@@ -447,7 +447,7 @@ async fn handle_join_request_of_rejoined_node() -> Result<()> {
                 .await
                 .membership
                 .as_mut()
-                .unwrap()
+                .ok_or_else(|| eyre!("Membership for the node must be set"))?
                 .force_bootstrap(NodeState::left(peer, None).to_msg());
 
             // Simulate the same peer rejoining
@@ -466,7 +466,7 @@ async fn handle_join_request_of_rejoined_node() -> Result<()> {
                 .await
                 .membership
                 .as_ref()
-                .unwrap()
+                .ok_or_else(|| eyre!("Membership for the node must be set"))?
                 .is_churn_in_progress());
             Ok(())
         })
@@ -550,7 +550,7 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
                 .await
                 .membership
                 .as_ref()
-                .unwrap()
+                .ok_or_else(|| eyre!("Membership for the node must be set"))?
                 .is_churn_in_progress());
             Result::<()>::Ok(())
         })
@@ -781,7 +781,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async move {
-            let prefix: Prefix = "0".parse().unwrap();
+            let prefix: Prefix = "0".parse().map_err(|_| eyre!("Failed to parse integer to Prefix"))?;
             let section_size = match relocated_peer_role {
                 RelocatedPeerRole::Elder => elder_count(),
                 RelocatedPeerRole::NonElder => recommended_section_size(),

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -188,7 +188,7 @@ async fn bootstrap_node(
 
         // Write the genesis DBC to disk
         let path = root_storage_dir.join(GENESIS_DBC_FILENAME);
-        fs::write(path, genesis_dbc.to_hex().unwrap()).await?;
+        fs::write(path, genesis_dbc.to_hex()?).await?;
 
         let network_knowledge = node.network_knowledge();
 

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -152,6 +152,7 @@ mod tests {
 
     proptest! {
         #[test]
+        #[allow(clippy::unwrap_used)]
         fn proptest_actions(
             peers in arbitrary_unique_peers(2..(recommended_section_size() + elder_count()), MIN_ADULT_AGE..MAX_AGE),
             signature_trailing_zeros in 0..MAX_AGE)

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -435,6 +435,7 @@ mod tests {
     // a hashmap. The behaviour of both the models should be identical.
     proptest! {
         #[test]
+        #[allow(clippy::unwrap_used)]
         fn model_based_test(ops in arbitrary_ops(0..MAX_N_OPS)){
             model_based_test_imp(ops).unwrap();
         }

--- a/sn_node/src/storage/registers.rs
+++ b/sn_node/src/storage/registers.rs
@@ -573,8 +573,8 @@ fn section_auth() -> SectionAuth {
 mod test {
     use super::{create_reg_w_policy, RegisterStorage};
 
-    use crate::node::{Error, Result};
     use crate::UsedSpace;
+    use eyre::{eyre, Result};
 
     use sn_interface::{
         messaging::{
@@ -612,18 +612,16 @@ mod test {
             e => panic!("Could not read! {:?}", e),
         }
 
-        // try to create the register again
-        // (should fail)
-
-        let res = store.write(cmd).await;
-
-        assert_eq!(
-            res.err().unwrap().to_string(),
-            Error::DataExists.to_string(),
-            "Should not be able to create twice!"
-        );
-
-        Ok(())
+        match store.write(cmd).await {
+            Ok(_) => Err(eyre!("An error should occur for this test case")),
+            Err(error) => match error {
+                crate::storage::Error::DataExists => {
+                    assert_eq!(error.to_string(), "Data already exists at this node");
+                    Ok(())
+                }
+                _ => Err(eyre!("A Error::DataExists variant was expected")),
+            },
+        }
     }
 
     #[tokio::test]
@@ -648,13 +646,19 @@ mod test {
         // assert the same tests hold as for the first db
 
         // should fail to write same register again, also on this new store
-        let res = new_store.write(cmd).await;
-
-        assert_eq!(
-            res.err().unwrap().to_string(),
-            Error::DataExists.to_string(),
-            "Should not be able to create twice!"
-        );
+        match new_store.write(cmd).await {
+            Ok(_) => {
+                return Err(eyre!("An error should occur for this test case"));
+            }
+            Err(error) => match error {
+                crate::storage::Error::DataExists => {
+                    assert_eq!(error.to_string(), "Data already exists at this node");
+                }
+                _ => {
+                    return Err(eyre!("A Error::DataExists variant was expected"));
+                }
+            },
+        }
 
         // should be able to read the same value from this new store also
         let res = new_store


### PR DESCRIPTION
sn_interface:
All usages were in testing code. They were either removed in favour of using the `?` operator or an
`ok_or_else` with an error message. The `allow` attribute was applied for a couple of cases where
the usage was in a `proptest!` macro. This was agreed to be preferable to using `except`.

sn_dysfunction:
All usages were in `proptest!` macros and therefore the `allow` attribute was applied.

sn_node:
A conversion from `sn_dbc::Error` to `sn_node::storage::Error` was added to remove an unwrap in
the bootstrapping process. The remainder were in test cases, with one `allow` added for use in a
`proptest!` macro.

sn_client:
A couple of usages were found in little pattern matching functions. They were changed to return an
IO error, which is the error type in the `Result`, the return type of the closure the code is called
in. It wasn't possible to use the `eyre!` macro here because there was no conversion between the IO
error and the `eyre` error type.

sn_api:
One usage was found while calculating the total amount for DBC reissues. The arithmetic for the
`Token` type returns an `Option` with `None` in the case of an overflow. The unwrap was replaced
with an error.

sn_cli:
Removed several usages from testing code. All usages were the unwrapping of an `Option`, which was
replaced with `ok_or_else` and an error message.