### PR TITLE
chore: sn_interface lints and fixes

### DIFF
--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -570,7 +570,7 @@ impl Session {
                 let mut retries = 0;
 
                 let send_and_retry = || async {
-                    match link.send_with(msg_bytes_clone.clone(), None, listen).await {
+                    match link.send(msg_bytes_clone.clone(), listen).await {
                         Ok(()) => Ok(()),
                         Err(SendToOneError::Connection(err)) => {
                             Err(Error::QuicP2pConnection { peer, error: err })

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -6,7 +6,23 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#![warn(clippy::unwrap_used)]
+#![forbid(
+    arithmetic_overflow,
+    mutable_transmutes,
+    no_mangle_const_items,
+    unknown_crate_types,
+    unsafe_code
+)]
+#![warn(
+    trivial_casts,
+    trivial_numeric_casts,
+    unreachable_pub,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    clippy::unicode_not_nfc,
+    clippy::unwrap_used
+)]
 
 //! SAFE network data types.
 

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -393,7 +393,7 @@ mod tests {
         ]
     }
 
-    pub fn gen_keys() -> Vec<PublicKey> {
+    fn gen_keys() -> Vec<PublicKey> {
         gen_keypairs().iter().map(PublicKey::from).collect()
     }
 

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -97,7 +97,7 @@ impl Display for SectionAuthorityProvider {
     }
 }
 
-impl serde::Serialize for SectionAuthorityProvider {
+impl Serialize for SectionAuthorityProvider {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -111,7 +111,7 @@ impl serde::Serialize for SectionAuthorityProvider {
 // at the system's boundaries when we receive it and verify it.
 // This way we can make sure that this type means that the data can always be considered verified.
 // To achieve this, we will also need to get rid of the `into_state` (from `messaging`) below.
-impl<'de> serde::Deserialize<'de> for SectionAuthorityProvider {
+impl<'de> Deserialize<'de> for SectionAuthorityProvider {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -146,11 +146,8 @@ impl SectionTree {
     }
 
     /// Returns all known sections SAP.
-    pub fn all(&self) -> Vec<SectionAuthorityProvider> {
-        self.sections
-            .iter()
-            .map(|(_, sap)| sap.value.clone())
-            .collect()
+    pub fn all(&self) -> Vec<&SectionAuthorityProvider> {
+        self.sections.iter().map(|(_, sap)| &sap.value).collect()
     }
 
     /// Get `SectionAuthorityProvider` of a known section with the given prefix.
@@ -732,7 +729,7 @@ mod tests {
         ),
     > {
         (any::<u64>(), 0..max_sections).prop_map(move |(seed, size)| {
-            let (map, main_chain) = generate_random_section_tree(Some(seed as u64), size).unwrap();
+            let (map, main_chain) = generate_random_section_tree(Some(seed), size).unwrap();
             let mut rng = SmallRng::seed_from_u64(seed);
             let mut update_variations_list = Vec::new();
 

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -23,7 +23,7 @@ use std::{
 use tiny_keccak::{Hasher, Sha3};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
-pub struct SectionInfo {
+pub(crate) struct SectionInfo {
     key: bls::PublicKey,
     sig: bls::Signature,
 }
@@ -794,7 +794,7 @@ mod tests {
         (any::<u64>(), 2..=max_sections).prop_map(move |(seed, size)| {
             // size is [2, max_sections] size of 0,1 will give us back only the genesis_key and
             // hence we cannot obtain the partial dag
-            let main_dag = gen_random_sections_dag(Some(seed as u64), size).unwrap();
+            let main_dag = gen_random_sections_dag(Some(seed), size).unwrap();
             let mut rng = SmallRng::seed_from_u64(seed);
             let mut update_variations_list = Vec::new();
 

--- a/sn_interface/src/types/cache/item.rs
+++ b/sn_interface/src/types/cache/item.rs
@@ -16,8 +16,8 @@ pub struct Item<T> {
 
 #[derive(Clone, Copy, Debug)]
 struct Time {
-    pub start: Instant,
-    pub expiry: Instant,
+    start: Instant,
+    expiry: Instant,
 }
 
 impl<T> Item<T> {

--- a/sn_interface/src/types/connections/link.rs
+++ b/sn_interface/src/types/connections/link.rs
@@ -142,10 +142,10 @@ impl Link {
                 // clean up failing connections at once, no nead to leak it outside of here
                 // next send (e.g. when retrying) will use/create a new connection
                 let id = &conn.id();
+
+                // We could write just `self.queue.remove(id)`, but the library warns for `unused_results`.
                 {
                     let _ = self.connections.write().await.remove(id);
-                }
-                {
                     let _ = self.queue.write().await.remove(id);
                 }
                 conn.close(Some(format!("{:?}", error)));

--- a/sn_interface/src/types/errors.rs
+++ b/sn_interface/src/types/errors.rs
@@ -117,7 +117,7 @@ pub enum Error {
     BlsError(#[from] BlsError),
 }
 
-pub fn convert_bincode_error(err: bincode::Error) -> Error {
+pub(crate) fn convert_bincode_error(err: bincode::Error) -> Error {
     Error::Serialisation(err.as_ref().to_string())
 }
 

--- a/sn_interface/src/types/keys/public_key.rs
+++ b/sn_interface/src/types/keys/public_key.rs
@@ -234,7 +234,7 @@ impl UpperHex for PublicKey {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use super::utils;
     use super::*;
     use bls;
@@ -252,7 +252,7 @@ pub mod tests {
         ]
     }
 
-    pub fn gen_keys() -> Vec<PublicKey> {
+    fn gen_keys() -> Vec<PublicKey> {
         gen_keypairs().iter().map(PublicKey::from).collect()
     }
 

--- a/sn_interface/src/types/keys/secret_key.rs
+++ b/sn_interface/src/types/keys/secret_key.rs
@@ -86,7 +86,7 @@ impl Display for SecretKey {
 }
 
 #[cfg(any(test, feature = "test-utils"))]
-pub mod test_utils {
+pub(crate) mod test_utils {
     use crate::messaging::system::KeyedSig;
     use crate::network_knowledge::{elder_count, supermajority};
     use std::ops::Deref;

--- a/sn_node/src/comm/link.rs
+++ b/sn_node/src/comm/link.rs
@@ -137,8 +137,11 @@ impl Link {
                 // clean up failing connections at once, no nead to leak it outside of here
                 // next send (e.g. when retrying) will use/create a new connection
                 let id = &conn.id();
-                let _ = self.connections.remove(id);
-                let _ = self.queue.remove(id);
+                // We could write just `self.queue.remove(id)`, but the library warns for `unused_results`.
+                {
+                    let _ = self.connections.remove(id);
+                    let _ = self.queue.remove(id);
+                }
                 conn.close(Some(format!("{:?}", error)));
                 Err(SendToOneError::Send(error))
             }

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -756,7 +756,7 @@ async fn untrusted_ae_msg_errors() -> Result<()> {
                     .network_knowledge()
                     .section_tree()
                     .all(),
-                vec![signed_sap.value]
+                vec![&signed_sap.value]
             );
             Result::<()>::Ok(())
         })


### PR DESCRIPTION
Apply lints used in other crates, as far as they can easily be applied.
The `unused_results` lint has been left out, as that is too much
cleaning up to do, just like adding documentation to all the public
interfaces.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
