### PR TITLE
feat: use err result to send errors back to client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,14 +152,23 @@ upload-sn_node-musl-to-s3:
 	)
 
 .ONESHELL:
-run-local-baby-fleming:
+run-baby-fleming-clean-build:
 	pgrep sn_node | xargs kill -9
 	rm -rf ~/.safe
 	mkdir -p ~/.safe/node
 	cargo clean
-	cargo build --release --bin sn_node
-	cp target/release/sn_node ~/.safe/node
-	cargo run --release node run-baby-fleming
+	cargo build --bin sn_node
+	cp target/debug/sn_node ~/.safe/node
+	RUST_LOG=sn_node=debug cargo run node run-baby-fleming
+
+.ONESHELL:
+run-baby-fleming:
+	pgrep sn_node | xargs kill -9
+	rm -rf ~/.safe
+	mkdir -p ~/.safe/node
+	cargo build --bin sn_node
+	cp target/debug/sn_node ~/.safe/node
+	RUST_LOG=sn_node=debug cargo run node run-baby-fleming
 
 ci-unit-tests:
 	cargo test --no-run --release --package sn_interface --package sn_dysfunction --package sn_node

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -53,7 +53,7 @@ pub(crate) struct Comm {
 /// Commands for interacting with Comm.
 #[allow(unused)]
 #[derive(Debug, Clone)]
-pub(crate) enum Cmd {
+pub enum Cmd {
     #[cfg(feature = "back-pressure")]
     /// Set message rate for peer to the desired msgs per second
     Regulate { peer: Peer, msgs_per_s: f64 },

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -13,7 +13,7 @@ use crate::node::{flow_ctrl::cmds::Cmd, handover::Error as HandoverError};
 use sn_dbc::Error as DbcError;
 use sn_interface::{
     messaging::data::Error as ErrorMsg,
-    types::{convert_dt_error_to_error_msg, Peer, PublicKey, ReplicatedDataAddress as DataAddress},
+    types::{convert_dt_error_to_error_msg, DataAddress, Peer, PublicKey},
 };
 
 use secured_linked_list::error::Error as SecuredLinkedListError;

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -8,12 +8,12 @@
 
 use super::Prefix;
 
-use crate::node::handover::Error as HandoverError;
+use crate::node::{flow_ctrl::cmds::Cmd, handover::Error as HandoverError};
 
 use sn_dbc::Error as DbcError;
 use sn_interface::{
     messaging::data::Error as ErrorMsg,
-    types::{convert_dt_error_to_error_msg, DataAddress, Peer, PublicKey},
+    types::{convert_dt_error_to_error_msg, Peer, PublicKey, ReplicatedDataAddress as DataAddress},
 };
 
 use secured_linked_list::error::Error as SecuredLinkedListError;
@@ -203,6 +203,15 @@ pub enum Error {
     GenesisDbcError(String),
     #[error("DbcError: {0}")]
     DbcError(#[from] DbcError),
+    /// An error occurred while processing a command and we want to send a response back to the
+    /// client.
+    ///
+    /// It's not really a type of error as such, but rather a marker for the command processing
+    /// code that we want to send an acknowledgement back to the client. It enables command
+    /// processing (or message handling) to return errors for more robust unit testing. Previously
+    /// if there was an error we would return back an `Ok` result with an empty list of commands.
+    #[error("Error processing command. Response will be sent back to client.")]
+    CmdProcessingClientRespondError(Vec<Cmd>),
 }
 
 impl From<qp2p::ClientEndpointError> for Error {

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -186,8 +186,11 @@ impl CmdCtrl {
                         .await;
                 }
                 Err(error) => {
+                    debug!("Error processing command");
                     if let Error::CmdProcessingClientRespondError(ref cmds) = error {
+                        debug!("Will send error response back to client");
                         for cmd in cmds.clone() {
+                            trace!("Sending cmd to client: {:?}", cmd);
                             match cmd_process_api.send((cmd, Some(id))).await {
                                 Ok(_) => {
                                     //no issues

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -102,7 +102,7 @@ impl CmdJob {
     }
 }
 
-/// Internal cmds for a node.
+/// Commands for a node.
 ///
 /// Cmds are used to connect different modules, allowing
 /// for a better modularization of the code base.
@@ -111,7 +111,7 @@ impl CmdJob {
 /// In other words, it enables enhanced flow control.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
-pub(crate) enum Cmd {
+pub enum Cmd {
     /// Cleanup node's PeerLinks, removing any unsused, unconnected peers
     CleanupPeerLinks,
     /// Validate `wire_msg` from `sender`.

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -88,7 +88,10 @@ pub(crate) async fn handle_online_cmd(
     Ok(status)
 }
 
-pub(crate) async fn run_and_collect_cmds(cmd: Cmd, dispatcher: &Dispatcher) -> Result<Vec<Cmd>> {
+pub(crate) async fn run_and_collect_cmds(
+    cmd: Cmd,
+    dispatcher: &Dispatcher,
+) -> crate::node::error::Result<Vec<Cmd>> {
     let mut all_cmds = vec![];
 
     let mut cmds = dispatcher.process_cmd(cmd).await?;

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -35,14 +35,14 @@ use std::collections::BTreeSet;
 
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
-pub(crate) enum OutgoingMsg {
+pub enum OutgoingMsg {
     System(SystemMsg),
     Service(ServiceMsg),
     DstAggregated((BlsShareAuth, Bytes)),
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum Peers {
+pub enum Peers {
     Single(Peer),
     Multiple(BTreeSet<Peer>),
 }

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -14,8 +14,8 @@ use sn_interface::{
 };
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) enum Proposal {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Proposal {
     VoteNodeOffline(NodeState),
     SectionInfo(SectionAuthorityProvider),
     NewElders(SectionAuth<SectionAuthorityProvider>),


### PR DESCRIPTION
- 6c6efb5c1 **feat: use err result to send errors back to client**

  Previously the mechanism for handling errors in `handle_valid_service_msg` was to return an `Ok`
  result with an empty list of commands, or if you wanted to send an error response back to the
  client, to include a command in that `Ok` result.

  A new `CmdProcessingClientRespondError` variant is added to `Error` to enable returning an `Err`
  result when we want to return an error back to the client. When the command processing code
  encounters this error variant, it will process the commands included in the error, which will be the
  information to send back to the client.

  The intention is also to return `Err` results from `handle_valid_service_msg` when any errors are
  encountered, not just for the limited few we want to send back to the client.

- b601edaf6 **refactor: err result from gen spent proof share**

  The spent proof share generation function now returns `SpentProofShare` directly rather than an
  `Option`, and we return `Err` results rather than `Ok(None)`. The unit tests were then updated to
  check for specific kinds of errors. The calling code is also a bit cleaner since it can just use the
  `?` operator.

  Note the use of an `allow` attribute to suppress a clippy warning about this function having too
  many arguments. The additional arguments are just required for the composition of the error that
  gets sent back to the client, which I consider justified. Otherwise this error will need to be
  handled in a special way outside the function, which is an unnecessary complication.

- f37c4d876 **chore: makefile targets for easier local network use**

  There are now two targets for running a local network, one that does a clean build and one that
  doesn't. The nodes have debug logging set and also use a debug build for speed.

  Also added some additional logging output to the command processing code to indicate the return of
  an error to the client.

## Test for Error Handling

To test the command processing change for sending an error back to the client with the new error
type, I created a client a test that sent an invalid spent proof. The code in the message handler
for this case was temporarily modified to return `Err(CmdProcessingClientRespondError)`. The case
where we do actually send back an error to the client is when the spent proof is signed with a
section key we are not aware of, so it would have been ideal to use this case, but we don't know how
to setup the conditions for an automated test for this.

In this contrived case, things worked as expected.

Node log output:
```
[2022-08-29T20:43:40.295898Z DEBUG sn_node::node::flow_ctrl::cmd_ctrl] Error processing command
[2022-08-29T20:43:40.295982Z DEBUG sn_node::node::flow_ctrl::cmd_ctrl] Sending error response back to client
[2022-08-29T20:43:40.296073Z DEBUG sn_node::node::flow_ctrl::cmd_ctrl] Sending cmd to client: SendMsg { msg: Service(CmdError { error: Data(SpentProofUnknownSectionKey), correlation_id: MsgId(6d26..9a92) }), msg_id: MsgId(971f..d0bb), recipients: Single(Peer { name: 221c12(00100010).., addr: 127.0.0.1:42144 }), traceroute: Traceroute: Client(Ed25519(PublicKey(221c..37b7))) }
```
Client log output:
```
[2022-08-29T20:44:08.491579Z TRACE sn_client::api::cmds/spend_dbc/client-api send cmd/send_cmd_with_retry_count] Failed response on Spentbook(<snipped>) attempt #5: Err(ErrorCmd { source: SpentProofUnknownSectionKey, msg_id: MsgId(b31a..9770) })
[2022-08-29T20:44:08.492153Z DEBUG sn_client::api::spentbook_apis::tests] error: Error received from the network: SpentProofUnknownSectionKey for cmd: MsgId(b31a..9770)
```
The temporary testing code has been removed.