### PR TITLE
chore: change throughput measure

### DIFF
--- a/sn_client/benches/serialize.rs
+++ b/sn_client/benches/serialize.rs
@@ -105,9 +105,8 @@ fn criterion_benchmark(c: &mut Criterion) {
         Err(_error) => panic!("Could not serialize the msg bytes"),
     };
 
-    group.throughput(Throughput::Bytes(
-        (std::mem::size_of_val(&msg_bytes) * dsts.len()) as u64,
-    ));
+    group.throughput(Throughput::Bytes((&msg_bytes.len() * dsts.len()) as u64));
+
     // upload and read
     group.bench_with_input(
         "generating bytes to send the same msg to various Dsts",


### PR DESCRIPTION
use Bytes.len, not the size of the Bytes struct!

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
