### PR TITLE
Ensure adults are probing for AE updates before first split

### DIFF
--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -312,6 +312,10 @@ impl NetworkKnowledge {
         true
     }
 
+    pub fn anti_entropy_probe(&self) -> SystemMsg {
+        SystemMsg::AntiEntropyProbe(self.section_key())
+    }
+
     /// Update our network knowledge if the provided SAP is valid and can be verified
     /// with the provided proof chain.
     /// If the '`update_sap`' flag is set to 'true', the provided SAP and chain will be

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -85,9 +85,7 @@ impl FlowCtrl {
 
         for cmd in cmds {
             // dont use sender here incase channel gets full
-            if let Err(error) = self.fire_and_forget(cmd).await {
-                error!("Error pushing node periodic cmd to controller: {error:?}");
-            }
+            self.fire_and_forget(cmd).await;
         }
     }
 
@@ -109,9 +107,7 @@ impl FlowCtrl {
 
         for cmd in cmds {
             // dont use sender here incase channel gets full
-            if let Err(error) = self.fire_and_forget(cmd).await {
-                error!("Error pushing adult node periodic cmd to controller: {error:?}");
-            }
+            self.fire_and_forget(cmd).await;
         }
     }
 
@@ -171,9 +167,7 @@ impl FlowCtrl {
 
         for cmd in cmds {
             // dont use sender here incase channel gets full
-            if let Err(error) = self.fire_and_forget(cmd).await {
-                error!("Error pushing adult node periodic cmd to controller: {error:?}");
-            }
+            self.fire_and_forget(cmd).await;
         }
     }
 

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -94,15 +94,12 @@ impl FlowCtrl {
         &mut self,
         last_section_probe: &mut Instant,
     ) {
-        let now = Instant::now();
         let mut cmds = vec![];
 
         // if we've passed enough time, section probe
         if last_section_probe.elapsed() > SECTION_PROBE_INTERVAL {
-            *last_section_probe = now;
-            if let Some(cmd) = Self::probe_the_section(self.node.clone()).await {
-                cmds.push(cmd);
-            }
+            *last_section_probe = Instant::now();
+            cmds.push(Self::probe_the_section(self.node.clone()).await);
         }
 
         for cmd in cmds {
@@ -229,20 +226,12 @@ impl FlowCtrl {
 
     /// Generates a probe msg, which goes to our elders in order to
     /// passively maintain network knowledge over time
-    async fn probe_the_section(node: Arc<RwLock<Node>>) -> Option<Cmd> {
+    async fn probe_the_section(node: Arc<RwLock<Node>>) -> Cmd {
         let node = node.read().await;
 
         // Send a probe message to an elder
         info!("Starting to probe section");
-
-        let prefix = node.network_knowledge().prefix();
-
-        // Send a probe message to an elder
-        if !prefix.is_empty() {
-            Some(node.generate_section_probe_msg())
-        } else {
-            None
-        }
+        node.generate_section_probe_msg()
     }
 
     /// Generates a probe msg, which goes to all section elders in order to


### PR DESCRIPTION
Adults were skipping AE probes before splits for some reason

Also included in this PR:
- move AE probe building to network knowledge
- remove the unused `stopped` state from cmd ctrl which removes some error cases for us.