### PR TITLE
fix: always resend query to adults

### DIFF
--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -103,10 +103,6 @@ impl Node {
             if peers.len() > MAX_WAITING_PEERS_PER_QUERY {
                 warn!("Dropping query from {source_client:?}, there are more than {MAX_WAITING_PEERS_PER_QUERY} waiting already");
                 return Ok(vec![]);
-            } else {
-                // we don't respond to the actual query, as we're still within data query timeout
-                // we rely on the data query cache timeout to decide as/when we'll be re-sending a query to adults
-                return Ok(cmds);
             }
         }
 


### PR DESCRIPTION
Remove a potential source of errors. We _always_ send on queries now. Regardless if the client already exists in `pending_queries`. There's a reason they're re-requesting.

When we have cache implemented at elders we can short circuit this there... but otherwise we should treat each request equally.