### PR TITLE
chore: sign query msg outside of send loop

### DIFF
--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -67,11 +67,11 @@ impl Client {
         let _ = span.enter();
         let mut attempts = 1;
         let dst = query.variant.dst_name();
-        loop {
-            let msg = ServiceMsg::Query(query.clone());
-            let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
-            let signature = self.keypair.sign(&serialised_query);
+        let msg = ServiceMsg::Query(query.clone());
+        let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
+        let signature = self.keypair.sign(&serialised_query);
 
+        loop {
             debug!(
                 "Attempting {:?} (attempt #{}) with a query timeout of {:?}",
                 query, attempts, attempt_timeout


### PR DESCRIPTION
This should reduce client cpu load qhen attempting to retrieve data.
We sign only once, instead of on each attempt.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
