### PR TITLE
feat(node): report any error occurred when handling a service msg back to the client

### DIFF
--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -71,8 +71,9 @@ pub enum Error {
     /// Destination is either outdated or incorrect
     #[error("Destination is either outdated or wrong")]
     WrongDestination,
-    #[error("Spent proof was signed with unknown section key")]
-    SpentProofUnknownSectionKey,
+    /// Failed to verify a spent proof since it's signed by unknown section key
+    #[error("Spent proof was signed with unknown section key: {0:?}")]
+    SpentProofUnknownSectionKey(bls::PublicKey),
     /// Failed to seriliase the Cmd for hashing
     #[error("Cmd could not be serialised")]
     CouldNotSerialiseCmd,

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -6,11 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::types::{register::User, DataAddress, PublicKey};
+use crate::types::{register::User, DataAddress};
 use serde::{Deserialize, Serialize};
 use std::result;
 use thiserror::Error;
-use xor_name::{Prefix, XorName};
+use xor_name::Prefix;
 
 /// A specialised `Result` type.
 pub type Result<T, E = Error> = result::Result<T, E>;
@@ -18,14 +18,10 @@ pub type Result<T, E = Error> = result::Result<T, E>;
 /// Errors that can occur when interactive with client messaging APIs.
 #[derive(Error, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(clippy::large_enum_variant)]
 pub enum Error {
     /// Access denied for user
     #[error("Access denied for user: {0:?}")]
     AccessDenied(User),
-    /// Requested data not found
-    #[error("Requested chunk not found: {0:?}")]
-    ChunkNotFound(XorName),
     /// Requested data not found
     #[error("Requested data not found: {0:?}")]
     DataNotFound(DataAddress),
@@ -48,33 +44,16 @@ pub enum Error {
     /// Entry could not be found on the data
     #[error("Requested entry not found")]
     NoSuchEntry,
-    /// Key does not exist
-    #[error("Key does not exist")]
-    NoSuchKey,
-    /// The list of owner keys is invalid
-    #[error("Invalid owner key: {0}")]
-    InvalidOwner(PublicKey),
     /// Invalid Operation such as a POST on ImmutableData
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
     /// There was an error forming the OperationId
     #[error("Operation id could not be derived.")]
     NoOperationId,
-    /// Node failed to delete the requested data for some reason.
-    #[error("Failed to delete requested data")]
-    FailedToDelete,
     /// Error is not valid for operation id generation. This should not absolve a pending (and thus far unfulfilled) operation
-    #[error(
-        "Could not generation operation id for chunk retrieval. Error was not 'DataNotFound'."
-    )]
+    #[error("Could not generate operation id for chunk retrieval. Error was not 'DataNotFound'.")]
     InvalidQueryResponseErrorForOperationId,
-    /// Destination is either outdated or incorrect
-    #[error("Destination is either outdated or wrong")]
-    WrongDestination,
     /// Failed to verify a spent proof since it's signed by unknown section key
     #[error("Spent proof was signed with unknown section key: {0:?}")]
     SpentProofUnknownSectionKey(bls::PublicKey),
-    /// Failed to seriliase the Cmd for hashing
-    #[error("Cmd could not be serialised")]
-    CouldNotSerialiseCmd,
 }

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -251,41 +251,17 @@ impl QueryResponse {
     pub fn failed_with_data_not_found(&self) -> bool {
         use QueryResponse::*;
 
-        match self {
-            GetChunk(result) => match result {
-                Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMsg::ChunkNotFound(_)),
-            },
-            GetRegister((result, _op_id)) => match result {
-                Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
-            },
-            GetRegisterEntry((result, _op_id)) => match result {
-                Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
-            },
-            GetRegisterOwner((result, _op_id)) => match result {
-                Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
-            },
-            ReadRegister((result, _op_id)) => match result {
-                Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
-            },
-            GetRegisterPolicy((result, _op_id)) => match result {
-                Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
-            },
-            GetRegisterUserPermissions((result, _op_id)) => match result {
-                Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
-            },
-            SpentProofShares((result, _op_id)) => match result {
-                Ok(_) => false,
-                Err(error) => matches!(*error, ErrorMsg::DataNotFound(_)),
-            },
-            FailedToCreateOperationId => false,
-        }
+        matches!(
+            self,
+            GetChunk(Err(ErrorMsg::DataNotFound(_)))
+                | GetRegister((Err(ErrorMsg::DataNotFound(_)), _))
+                | GetRegisterEntry((Err(ErrorMsg::DataNotFound(_)), _))
+                | GetRegisterOwner((Err(ErrorMsg::DataNotFound(_)), _))
+                | ReadRegister((Err(ErrorMsg::DataNotFound(_)), _))
+                | GetRegisterPolicy((Err(ErrorMsg::DataNotFound(_)), _))
+                | GetRegisterUserPermissions((Err(ErrorMsg::DataNotFound(_)), _))
+                | SpentProofShares((Err(ErrorMsg::DataNotFound(_)), _))
+        )
     }
 
     /// Retrieves the operation identifier for this response, use in tracking node liveness
@@ -297,10 +273,7 @@ impl QueryResponse {
         match self {
             GetChunk(result) => match result {
                 Ok(chunk) => chunk_operation_id(chunk.address()),
-                Err(ErrorMsg::ChunkNotFound(name)) => chunk_operation_id(&ChunkAddress(*name)),
-                Err(ErrorMsg::DataNotFound(DataAddress::Bytes(address))) => {
-                    chunk_operation_id(address)
-                }
+                Err(ErrorMsg::DataNotFound(DataAddress::Bytes(name))) => chunk_operation_id(name),
                 Err(ErrorMsg::DataNotFound(another_address)) => {
                     error!(
                         "{:?} address returned when we were expecting a ChunkAddress",

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -51,9 +51,8 @@ pub(crate) struct Comm {
 }
 
 /// Commands for interacting with Comm.
-#[allow(unused)]
 #[derive(Debug, Clone)]
-pub enum Cmd {
+pub(crate) enum Cmd {
     #[cfg(feature = "back-pressure")]
     /// Set message rate for peer to the desired msgs per second
     Regulate { peer: Peer, msgs_per_s: f64 },

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -189,6 +189,7 @@ impl From<qp2p::SendError> for Error {
     }
 }
 
+// Convert node error to messaging error message for sending over the network.
 impl From<Error> for ErrorMsg {
     fn from(error: Error) -> ErrorMsg {
         match error {

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -13,12 +13,11 @@ use crate::node::{
         dispatcher::Dispatcher,
         event_channel::EventSender,
     },
-    CmdProcessEvent, Error, Event, RateLimits,
+    CmdProcessEvent, Event, RateLimits,
 };
 
 use custom_debug::Debug;
 use priority_queue::PriorityQueue;
-
 use std::time::SystemTime;
 use std::{
     sync::{
@@ -167,21 +166,7 @@ impl CmdCtrl {
                         .await;
                 }
                 Err(error) => {
-                    debug!("Error processing command");
-                    if let Error::CmdProcessingClientRespondError(ref cmds) = error {
-                        debug!("Will send error response back to client");
-                        for cmd in cmds.clone() {
-                            trace!("Sending cmd to client: {:?}", cmd);
-                            match cmd_process_api.send((cmd, Some(id))).await {
-                                Ok(_) => {
-                                    //no issues
-                                }
-                                Err(error) => {
-                                    error!("Could not enqueue child Cmd: {:?}", error);
-                                }
-                            }
-                        }
-                    }
+                    debug!("Error when processing command: {:?}", error);
                     node_event_sender
                         .send(Event::CmdProcessing(CmdProcessEvent::Failed {
                             id,

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -111,7 +111,7 @@ impl CmdJob {
 /// In other words, it enables enhanced flow control.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
-pub enum Cmd {
+pub(crate) enum Cmd {
     /// Cleanup node's PeerLinks, removing any unsused, unconnected peers
     CleanupPeerLinks,
     /// Validate `wire_msg` from `sender`.

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -1308,25 +1308,26 @@ async fn spentbook_spend_spent_proof_with_invalid_pk_should_return_spentbook_err
             )
             .await;
 
-            match result {
-                Ok(cmds) => {
-                    assert_eq!(cmds.len(), 1);
-                    let cmd_err = cmds[0].get_error()?;
-                    assert_eq!(
-                        cmd_err,
-                        MessagingDataError::InvalidOperation(format!(
-                            "Failed to perform operation: SpentbookError(\"Spent proof \
-                            signature {:?} is invalid\")",
-                            pk
-                        ))
-                    );
-                    Ok(())
-                }
-                Err(err) => Err(eyre!(
+            let cmds = result.map_err(|err| {
+                eyre!(
                     "A cmd to send the error to the client was expected for this case: {:?}",
                     err
+                )
+            })?;
+
+            assert_eq!(cmds.len(), 1);
+            let cmd_err = cmds[0].get_error()?;
+            assert_eq!(
+                cmd_err,
+                MessagingDataError::InvalidOperation(format!(
+                    "Failed to perform operation: SpentbookError(\"Spent proof \
+                    signature {:?} is invalid\")",
+                    pk
                 )),
-            }
+                "A different error was expected for this case: {:?}",
+                cmd_err
+            );
+            Ok(())
         })
         .await
 }
@@ -1365,22 +1366,23 @@ async fn spentbook_spend_spent_proof_with_key_not_in_section_chain_should_return
             )
             .await;
 
-            match result {
-                Ok(cmds) => {
-                    assert_eq!(cmds.len(), 1);
-                    let cmd_err = cmds[0].get_error()?;
-                    let section_key = sk_set.public_keys().public_key();
-                    assert_eq!(
-                        cmd_err,
-                        MessagingDataError::SpentProofUnknownSectionKey(section_key)
-                    );
-                    Ok(())
-                }
-                Err(err) => Err(eyre!(
+            let cmds = result.map_err(|err| {
+                eyre!(
                     "A cmd to send the error to the client was expected for this case: {:?}",
                     err
-                )),
-            }
+                )
+            })?;
+
+            assert_eq!(cmds.len(), 1);
+            let cmd_err = cmds[0].get_error()?;
+            let section_key = sk_set.public_keys().public_key();
+            assert_eq!(
+                cmd_err,
+                MessagingDataError::SpentProofUnknownSectionKey(section_key),
+                "A different error was expected for this case: {:?}",
+                cmd_err
+            );
+            Ok(())
         })
         .await
 }
@@ -1434,26 +1436,27 @@ async fn spentbook_spend_spent_proofs_do_not_relate_to_input_dbcs_should_return_
             )
             .await;
 
-            match result {
-                Ok(cmds) => {
-                    assert_eq!(cmds.len(), 1);
-                    let cmd_err = cmds[0].get_error()?;
-                    assert_eq!(
-                        cmd_err,
-                        MessagingDataError::InvalidOperation(
-                            "Failed to perform operation: SpentbookError(\"The number of \
-                            spent proofs (0) does not match the number of input \
-                            public keys (1)\")"
-                                .to_string()
-                        )
-                    );
-                    Ok(())
-                }
-                Err(err) => Err(eyre!(
+            let cmds = result.map_err(|err| {
+                eyre!(
                     "A cmd to send the error to the client was expected for this case: {:?}",
                     err
-                )),
-            }
+                )
+            })?;
+
+            assert_eq!(cmds.len(), 1);
+            let cmd_err = cmds[0].get_error()?;
+            assert_eq!(
+                cmd_err,
+                MessagingDataError::InvalidOperation(
+                    "Failed to perform operation: SpentbookError(\"The number of \
+                            spent proofs (0) does not match the number of input \
+                            public keys (1)\")"
+                        .to_string()
+                ),
+                "A different error was expected for this case: {:?}",
+                cmd_err
+            );
+            Ok(())
         })
         .await
 }
@@ -1502,25 +1505,26 @@ async fn spentbook_spend_transaction_with_no_inputs_should_return_spentbook_erro
             )
             .await;
 
-            match result {
-                Ok(cmds) => {
-                    assert_eq!(cmds.len(), 1);
-                    let cmd_err = cmds[0].get_error()?;
-                    assert_eq!(
-                        cmd_err,
-                        MessagingDataError::InvalidOperation(
-                            "Failed to perform operation: SpentbookError(\"The DBC \
-                            transaction must have at least one input\")"
-                                .to_string()
-                        )
-                    );
-                    Ok(())
-                }
-                Err(err) => Err(eyre!(
+            let cmds = result.map_err(|err| {
+                eyre!(
                     "A cmd to send the error to the client was expected for this case: {:?}",
                     err
-                )),
-            }
+                )
+            })?;
+
+            assert_eq!(cmds.len(), 1);
+            let cmd_err = cmds[0].get_error()?;
+            assert_eq!(
+                cmd_err,
+                MessagingDataError::InvalidOperation(
+                    "Failed to perform operation: SpentbookError(\"The DBC \
+                            transaction must have at least one input\")"
+                        .to_string()
+                ),
+                "A different error was expected for this case: {:?}",
+                cmd_err
+            );
+            Ok(())
         })
         .await
 }
@@ -1568,25 +1572,26 @@ async fn spentbook_spend_with_random_key_image_should_return_spentbook_error() -
             )
             .await;
 
-            match result {
-                Ok(cmds) => {
-                    assert_eq!(cmds.len(), 1);
-                    let cmd_err = cmds[0].get_error()?;
-                    assert_eq!(
-                        cmd_err,
-                        MessagingDataError::InvalidOperation(format!(
-                            "Failed to perform operation: SpentbookError(\"There are no \
-                            commitments for the given key image {:?}\")",
-                            pk
-                        ))
-                    );
-                    Ok(())
-                }
-                Err(err) => Err(eyre!(
+            let cmds = result.map_err(|err| {
+                eyre!(
                     "A cmd to send the error to the client was expected for this case: {:?}",
                     err
+                )
+            })?;
+
+            assert_eq!(cmds.len(), 1);
+            let cmd_err = cmds[0].get_error()?;
+            assert_eq!(
+                cmd_err,
+                MessagingDataError::InvalidOperation(format!(
+                    "Failed to perform operation: SpentbookError(\"There are no \
+                            commitments for the given key image {:?}\")",
+                    pk
                 )),
-            }
+                "A different error was expected for this case: {:?}",
+                cmd_err
+            );
+            Ok(())
         })
         .await
 }

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -1307,15 +1307,25 @@ async fn spentbook_spend_spent_proof_with_invalid_pk_should_return_spentbook_err
                 &dispatcher,
             )
             .await;
+
             match result {
-                Err(error) => match error {
-                    Error::SpentbookError(msg) => {
-                        assert_eq!(msg, format!("Spent proof signature {:?} is invalid", pk));
-                        Ok(())
-                    }
-                    _ => Err(eyre!("A `Error::SpentbookError` variant was expected")),
-                },
-                Ok(_) => Err(eyre!("An error result was expected for this case")),
+                Ok(cmds) => {
+                    assert_eq!(cmds.len(), 1);
+                    let cmd_err = cmds[0].get_error()?;
+                    assert_eq!(
+                        cmd_err,
+                        MessagingDataError::InvalidOperation(format!(
+                            "Failed to perform operation: SpentbookError(\"Spent proof \
+                            signature {:?} is invalid\")",
+                            pk
+                        ))
+                    );
+                    Ok(())
+                }
+                Err(err) => Err(eyre!(
+                    "A cmd to send the error to the client was expected for this case: {:?}",
+                    err
+                )),
             }
         })
         .await
@@ -1354,20 +1364,22 @@ async fn spentbook_spend_spent_proof_with_key_not_in_section_chain_should_return
                 &dispatcher,
             )
             .await;
+
             match result {
-                Err(error) => match error {
-                    Error::CmdProcessingClientRespondError(cmds) => {
-                        assert_eq!(cmds.len(), 1);
-                        let cmd = cmds[0].clone();
-                        let cmd_err = cmd.get_error()?;
-                        assert_matches!(cmd_err, MessagingDataError::SpentProofUnknownSectionKey);
-                        Ok(())
-                    }
-                    _ => Err(eyre!(
-                        "A `Error::CmdProcessingClientRespondError` variant was expected"
-                    )),
-                },
-                Ok(_) => Err(eyre!("An error result was expected for this case")),
+                Ok(cmds) => {
+                    assert_eq!(cmds.len(), 1);
+                    let cmd_err = cmds[0].get_error()?;
+                    let section_key = sk_set.public_keys().public_key();
+                    assert_eq!(
+                        cmd_err,
+                        MessagingDataError::SpentProofUnknownSectionKey(section_key)
+                    );
+                    Ok(())
+                }
+                Err(err) => Err(eyre!(
+                    "A cmd to send the error to the client was expected for this case: {:?}",
+                    err
+                )),
             }
         })
         .await
@@ -1421,19 +1433,26 @@ async fn spentbook_spend_spent_proofs_do_not_relate_to_input_dbcs_should_return_
                 &dispatcher,
             )
             .await;
+
             match result {
-                Err(error) => match error {
-                    Error::SpentbookError(msg) => {
-                        assert_eq!(
-                            msg,
-                            "The number of spent proofs (0) does not match the number of input \
-                            public keys (1)"
-                        );
-                        Ok(())
-                    }
-                    _ => Err(eyre!("A `Error::SpentbookError` variant was expected")),
-                },
-                Ok(_) => Err(eyre!("An error result was expected for this case")),
+                Ok(cmds) => {
+                    assert_eq!(cmds.len(), 1);
+                    let cmd_err = cmds[0].get_error()?;
+                    assert_eq!(
+                        cmd_err,
+                        MessagingDataError::InvalidOperation(
+                            "Failed to perform operation: SpentbookError(\"The number of \
+                            spent proofs (0) does not match the number of input \
+                            public keys (1)\")"
+                                .to_string()
+                        )
+                    );
+                    Ok(())
+                }
+                Err(err) => Err(eyre!(
+                    "A cmd to send the error to the client was expected for this case: {:?}",
+                    err
+                )),
             }
         })
         .await
@@ -1482,15 +1501,25 @@ async fn spentbook_spend_transaction_with_no_inputs_should_return_spentbook_erro
                 &dispatcher,
             )
             .await;
+
             match result {
-                Err(error) => match error {
-                    Error::SpentbookError(msg) => {
-                        assert_eq!(msg, "The DBC transaction must have at least one input");
-                        Ok(())
-                    }
-                    _ => Err(eyre!("A `Error::SpentbookError` variant was expected")),
-                },
-                Ok(_) => Err(eyre!("An error result was expected for this case")),
+                Ok(cmds) => {
+                    assert_eq!(cmds.len(), 1);
+                    let cmd_err = cmds[0].get_error()?;
+                    assert_eq!(
+                        cmd_err,
+                        MessagingDataError::InvalidOperation(
+                            "Failed to perform operation: SpentbookError(\"The DBC \
+                            transaction must have at least one input\")"
+                                .to_string()
+                        )
+                    );
+                    Ok(())
+                }
+                Err(err) => Err(eyre!(
+                    "A cmd to send the error to the client was expected for this case: {:?}",
+                    err
+                )),
             }
         })
         .await
@@ -1538,18 +1567,25 @@ async fn spentbook_spend_with_random_key_image_should_return_spentbook_error() -
                 &dispatcher,
             )
             .await;
+
             match result {
-                Err(error) => match error {
-                    Error::SpentbookError(msg) => {
-                        assert_eq!(
-                            msg,
-                            format!("There are no commitments for the given key image {:?}", pk)
-                        );
-                        Ok(())
-                    }
-                    _ => Err(eyre!("A `Error::SpentbookError` variant was expected")),
-                },
-                Ok(_) => Err(eyre!("An error result was expected for this case")),
+                Ok(cmds) => {
+                    assert_eq!(cmds.len(), 1);
+                    let cmd_err = cmds[0].get_error()?;
+                    assert_eq!(
+                        cmd_err,
+                        MessagingDataError::InvalidOperation(format!(
+                            "Failed to perform operation: SpentbookError(\"There are no \
+                            commitments for the given key image {:?}\")",
+                            pk
+                        ))
+                    );
+                    Ok(())
+                }
+                Err(err) => Err(eyre!(
+                    "A cmd to send the error to the client was expected for this case: {:?}",
+                    err
+                )),
             }
         })
         .await

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -35,14 +35,14 @@ use std::collections::BTreeSet;
 
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
-pub enum OutgoingMsg {
+pub(crate) enum OutgoingMsg {
     System(SystemMsg),
     Service(ServiceMsg),
     DstAggregated((BlsShareAuth, Bytes)),
 }
 
 #[derive(Debug, Clone)]
-pub enum Peers {
+pub(crate) enum Peers {
     Single(Peer),
     Multiple(BTreeSet<Peer>),
 }

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -15,7 +15,7 @@ use sn_interface::{
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Proposal {
+pub(crate) enum Proposal {
     VoteNodeOffline(NodeState),
     SectionInfo(SectionAuthorityProvider),
     NewElders(SectionAuth<SectionAuthorityProvider>),

--- a/sn_node/src/storage/chunks.rs
+++ b/sn_node/src/storage/chunks.rs
@@ -6,9 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{
-    errors::convert_to_error_msg, list_files_in, prefix_tree_path, Error, Result, UsedSpace,
-};
+use super::{list_files_in, prefix_tree_path, Error, Result, UsedSpace};
 
 use sn_interface::{
     messaging::system::NodeQueryResponse,
@@ -104,7 +102,7 @@ impl ChunkStorage {
     // Read chunk from local store and return NodeQueryResponse
     pub(super) async fn get(&self, address: &ChunkAddress) -> NodeQueryResponse {
         trace!("{:?}", LogMarker::ChunkQueryReceviedAtAdult);
-        NodeQueryResponse::GetChunk(self.get_chunk(address).await.map_err(convert_to_error_msg))
+        NodeQueryResponse::GetChunk(self.get_chunk(address).await.map_err(|error| error.into()))
     }
 
     /// Store a chunk in the local disk store

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -185,7 +185,7 @@ impl DataStorage {
                     .await
                     .map(ReplicatedData::SpentbookLog)
             }
-            DataAddress::SafeKey(xorname) => Err(Error::UnsupportedDataType(*xorname)),
+            other => Err(Error::UnsupportedDataType(*other)),
         }
     }
 
@@ -198,7 +198,7 @@ impl DataStorage {
                 let reg_addr = RegisterAddress::new(*addr.name(), SPENTBOOK_TYPE_TAG);
                 self.registers.remove_register(&reg_addr).await
             }
-            DataAddress::SafeKey(xorname) => Err(Error::UnsupportedDataType(*xorname)),
+            other => Err(Error::UnsupportedDataType(*other)),
         }
     }
 

--- a/sn_node/src/storage/registers.rs
+++ b/sn_node/src/storage/registers.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{
-    errors::convert_to_error_msg,
     register_store::{RegisterStore, StoredRegister},
     Error, Result,
 };
@@ -178,7 +177,7 @@ impl RegisterStorage {
             Ok(register) => Ok(register),
             Err(error) => {
                 error!("Error reading register from disk {error:?}");
-                Err(convert_to_error_msg(error))
+                Err(error.into())
             }
         };
 
@@ -196,7 +195,7 @@ impl RegisterStorage {
             Err(error) => Err(error),
         };
 
-        NodeQueryResponse::ReadRegister((result.map_err(convert_to_error_msg), operation_id))
+        NodeQueryResponse::ReadRegister((result.map_err(|error| error.into()), operation_id))
     }
 
     async fn get_owner(
@@ -207,7 +206,7 @@ impl RegisterStorage {
     ) -> NodeQueryResponse {
         let result = match self.get_register(&address, Action::Read, requester).await {
             Ok(res) => Ok(res.owner()),
-            Err(error) => Err(convert_to_error_msg(error)),
+            Err(error) => Err(error.into()),
         };
 
         NodeQueryResponse::GetRegisterOwner((result, operation_id))
@@ -226,7 +225,7 @@ impl RegisterStorage {
             .and_then(|register| register.get(hash).map(|c| c.clone()).map_err(Error::from))
         {
             Ok(res) => Ok(res),
-            Err(error) => Err(convert_to_error_msg(error)),
+            Err(error) => Err(error.into()),
         };
 
         NodeQueryResponse::GetRegisterEntry((result, operation_id))
@@ -245,7 +244,7 @@ impl RegisterStorage {
             .and_then(|register| register.permissions(user).map_err(Error::from))
         {
             Ok(res) => Ok(res),
-            Err(error) => Err(convert_to_error_msg(error)),
+            Err(error) => Err(error.into()),
         };
 
         NodeQueryResponse::GetRegisterUserPermissions((result, operation_id))
@@ -263,7 +262,7 @@ impl RegisterStorage {
             .map(|register| register.policy().clone())
         {
             Ok(res) => Ok(res),
-            Err(error) => Err(convert_to_error_msg(error)),
+            Err(error) => Err(error.into()),
         };
 
         NodeQueryResponse::GetRegisterPolicy((result, operation_id))


### PR DESCRIPTION
- Removing several unused sn_node::Error types.
- Adapting sn_api wallet and sn_node spentbook unit tests for new error msgs/cmds.
- Removing some unused sn_interface Error types.
- Minor refactor to how we convert sn_node modules Error types to sn_interface::Error types.
