### PR TITLE
chore: refactor client ACK receipt

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -271,6 +271,8 @@ jobs:
 
       - name: Run client tests
         uses: maidsafe/cargo-nextest@main
+        env:
+          RUST_LOG: "sn_client=trace"
         with:
           test-run-name: e2e-client-${{ matrix.os }}
           profile: ci
@@ -596,6 +598,8 @@ jobs:
 
       - name: Run API tests
         uses: maidsafe/cargo-nextest@main
+        env:
+          RUST_LOG: "sn_client=trace"
         with:
           test-run-name: api-${{ matrix.os }}
           profile: ci
@@ -720,6 +724,8 @@ jobs:
 
       - name: Run CLI tests
         uses: maidsafe/cargo-nextest@main
+        env:
+          RUST_LOG: "sn_client=trace"
         with:
           test-run-name: cli-${{ matrix.os }}
           profile: ci

--- a/resources/scripts/statemap-preprocess.sh
+++ b/resources/scripts/statemap-preprocess.sh
@@ -39,5 +39,5 @@ else
 
     echo "Render the statemap SVG with"
     echo ""
-    echo "    $statemap_cmd > save.svg"
+    echo "    $statemap_cmd > safe.svg"
 fi

--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -156,7 +156,6 @@ impl ClientBuilder {
         let max_retries = self.max_retries.unwrap_or(DEFAULT_MAX_QUERY_CMD_RETRIES);
         let query_timeout = self.query_timeout.unwrap_or(DEFAULT_QUERY_CMD_TIMEOUT);
         let cmd_timeout = self.cmd_timeout.unwrap_or(DEFAULT_QUERY_CMD_TIMEOUT);
-        let cmd_ack_wait = self.cmd_ack_wait.unwrap_or(DEFAULT_ACK_WAIT);
 
         let network_contacts = match self.network_contacts {
             Some(pm) => pm,
@@ -178,7 +177,6 @@ impl ClientBuilder {
             qp2p,
             self.local_addr
                 .unwrap_or_else(|| SocketAddr::from(DEFAULT_LOCAL_ADDR)),
-            cmd_ack_wait,
             network_contacts,
         )?;
 

--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -40,7 +40,7 @@ pub const ENV_AE_WAIT: &str = "SN_AE_WAIT";
 /// Bind by default to all network interfaces on a OS assigned port
 pub const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 /// Default timeout to use before timing out queries and commands
-pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(30);
+pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(45);
 /// Max retries to be attempted in the DEFAULT_QUERY_CMD_TIMEOUT; DEFAULT_QUERY_CMD_TIMEOUT / DEFAULT_MAX_QUERY_CMD_RETRIES ~ tries per second
 /// (though exponential backoff exists)
 pub const DEFAULT_MAX_QUERY_CMD_RETRIES: usize = 15;

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -58,10 +58,10 @@ impl Client {
         let op_limit = self.cmd_timeout;
 
         let mut backoff = ExponentialBackoff {
-            initial_interval: Duration::from_secs(3),
-            max_interval: Duration::from_secs(60),
+            initial_interval: Duration::from_millis(500),
+            max_interval: Duration::from_secs(20),
             max_elapsed_time: Some(op_limit),
-            // randomization_factor: 0.5,
+            randomization_factor: 0.5,
             ..Default::default()
         };
 

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -69,6 +69,8 @@ impl Client {
         let _ = span.enter();
         let mut attempts = 1;
         let dst = query.variant.dst_name();
+        let mut data_not_found_count = BTreeSet::default();
+
         loop {
             let msg = ServiceMsg::Query(query.clone());
             let serialised_query = WireMsg::serialize_msg_payload(&msg)?;

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -69,13 +69,10 @@ impl Client {
         let _ = span.enter();
         let mut attempts = 1;
         let dst = query.variant.dst_name();
-
-        let mut data_not_found_count = BTreeSet::default();
         loop {
             let msg = ServiceMsg::Query(query.clone());
             let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
             let signature = self.keypair.sign(&serialised_query);
-
             debug!(
                 "Attempting {:?} (attempt #{}) with a query timeout of {:?}",
                 query, attempts, attempt_timeout

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -18,7 +18,7 @@ use qp2p::UsrMsgBytes;
 use sn_interface::{
     at_least_one_correct_elder,
     messaging::{
-        data::{CmdError, ServiceMsg},
+        data::{CmdError, DataCmdId, ServiceMsg},
         system::{AntiEntropyKind, KeyedSig, NodeMsgAuthorityUtils, SectionAuth, SystemMsg},
         AuthKind, AuthorityProof, Dst, MsgId, MsgType, NodeMsgAuthority, ServiceAuth, WireMsg,
     },
@@ -195,7 +195,7 @@ impl Session {
     #[instrument(skip(cmds), level = "debug")]
     fn send_cmd_response(
         cmds: PendingCmdAcks,
-        correlation_id: MsgId,
+        correlation_id: Option<DataCmdId>,
         src: SocketAddr,
         error: Option<CmdError>,
     ) {
@@ -203,14 +203,18 @@ impl Session {
             debug!("CmdError was received for {correlation_id:?}: {:?}", error);
         }
 
-        if let Some(mut received_acks) = cmds.get_mut(&correlation_id) {
-            let acks = received_acks.value_mut();
+        if let Some(cmd_id) = correlation_id {
+            if let Some(mut received_acks) = cmds.get_mut(&cmd_id) {
+                let acks = received_acks.value_mut();
 
-            let _prior = acks.insert((src, error));
+                let _prior = acks.insert((src, error));
+            } else {
+                let received = DashSet::new();
+                let _nonexistent = received.insert((src, error));
+                let _non_prior = cmds.insert(cmd_id, Arc::new(received));
+            }
         } else {
-            let received = DashSet::new();
-            let _nonexistent = received.insert((src, error));
-            let _non_prior = cmds.insert(correlation_id, Arc::new(received));
+            warn!("No correlating DataCmdId returned");
         }
     }
 
@@ -276,21 +280,23 @@ impl Session {
                         warn!("Ignoring query response without operation id");
                     }
                 }
-                ServiceMsg::CmdError {
-                    error,
-                    correlation_id,
-                    ..
+                ServiceMsg::Error {
+                    error, msg_id: _, ..
                 } => {
-                    Self::send_cmd_response(cmds, correlation_id, src_peer.addr(), Some(error));
+                    let (_error, data_cmd_id) = match error.clone() {
+                        CmdError::Data { error, data_cmd_id } => (error, data_cmd_id),
+                    };
+
+                    Self::send_cmd_response(cmds, data_cmd_id, src_peer.addr(), Some(error));
                 }
-                ServiceMsg::CmdAck { correlation_id } => {
+                ServiceMsg::CmdAck { data_cmd_id } => {
                     debug!(
-                        "CmdAck was received for Message{:?} w/ID: {:?} from {:?}",
+                        "CmdAck was received for Message{:?} w/CmdId: {:?} from {:?}",
                         msg_id,
-                        correlation_id,
+                        data_cmd_id,
                         src_peer.addr()
                     );
-                    Self::send_cmd_response(cmds, correlation_id, src_peer.addr(), None);
+                    Self::send_cmd_response(cmds, Some(data_cmd_id), src_peer.addr(), None);
                 }
                 _ => {
                     warn!("Ignoring unexpected msg type received: {:?}", msg);

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -8,7 +8,7 @@
 
 use super::{QueryResult, Session};
 
-use crate::{connections::CmdResponse, Error, Result};
+use crate::{Error, Result};
 
 #[cfg(feature = "traceroute")]
 use sn_interface::{
@@ -88,68 +88,78 @@ impl Session {
         wire_msg.append_trace(&mut Traceroute(vec![Entity::Client(client_pk)]));
 
         // The insertion of channel will be executed AFTER the completion of the `send_message`.
-        let (sender, mut receiver) = channel::<CmdResponse>(elders_len);
-        let _ = self.pending_cmds.insert(msg_id, sender);
-        trace!("Inserted channel for cmd {:?}", msg_id);
-
         self.send_msg(elders, wire_msg, msg_id).await?;
+        trace!("Cmd msg {:?} sent", msg_id);
 
-        let expected_acks = elders_len * 2 / 3 + 1;
+        let expected_acks = elders_len;
 
         // We are not wait for the receive of majority of cmd Acks.
         // This could be further strict to wait for ALL the Acks get received.
         // The period is expected to have AE completed, hence no extra wait is required.
-        let mut received_ack = 0;
-        let mut received_err = 0;
-        let mut attempts = 0;
-        let interval = Duration::from_millis(50);
-        let expected_cmd_ack_wait_attempts =
-            std::cmp::max(200, self.cmd_ack_wait.as_millis() / interval.as_millis());
-        loop {
-            match receiver.try_recv() {
-                Ok((src, None)) => {
-                    received_ack += 1;
-                    trace!("received CmdAck of {msg_id:?} from {src:?}, so far {received_ack} / {expected_acks}");
 
-                    if received_ack >= expected_acks {
-                        let _ = self.pending_cmds.remove(&msg_id);
-                        break;
+        let mut ack_checks = 0;
+        let max_ack_checks = 100;
+        let interval = Duration::from_millis(50);
+
+        loop {
+            if let Some(acks_we_have) = self.pending_cmds.get(&msg_id) {
+                let acks = acks_we_have.value();
+
+                let received_response_count = acks.len();
+
+                let mut error_count = 0;
+                let mut return_error = None;
+
+                // track received errors
+                for refmulti in acks.iter() {
+                    let (ack_src, error) = refmulti.key();
+                    if return_error.is_none() {
+                        return_error = error.clone();
+                    }
+
+                    if error.is_some() {
+                        error!(
+                            "received error response {:?} of cmd {:?} from {:?}, so far {} respones and {} of them are errors",
+                            error, msg_id, ack_src, received_response_count, error_count
+                        );
+                        error_count += 1;
                     }
                 }
-                Ok((src, Some(error))) => {
-                    received_err += 1;
+
+                // first exit if too many errors:
+                if error_count >= expected_acks {
                     error!(
-                        "received error response {:?} of cmd {:?} from {:?}, so far {} acks vs. {} errors",
-                        error, msg_id, src, received_ack, received_err
+                        "Received majority of error response for cmd {:?}: {:?}",
+                        msg_id, return_error
                     );
-                    if received_err >= expected_acks {
-                        error!("Received majority of error response for cmd {:?}", msg_id);
-                        let _ = self.pending_cmds.remove(&msg_id);
-                        let CmdError::Data(source) = error;
+                    // attempt to cleanup... though more acks may come in..
+                    let _ = self.pending_cmds.remove(&msg_id);
+
+                    if let Some(CmdError::Data(source)) = return_error {
                         return Err(Error::ErrorCmd { source, msg_id });
                     }
                 }
-                Err(_err) => {
-                    // this is not an error..the channel is just empty atm
+
+                let actual_ack_count = received_response_count - error_count;
+
+                if actual_ack_count >= expected_acks {
+                    break;
                 }
+
+                debug!("insufficient acks returned so far: {actual_ack_count}/{expected_acks}");
             }
-            attempts += 1;
-            if attempts >= expected_cmd_ack_wait_attempts {
-                warn!(
-                    "Terminated with insufficient CmdAcks for {:?}, {} / {} acks received",
-                    msg_id, received_ack, expected_acks
-                );
-                break;
+
+            if ack_checks >= max_ack_checks {
+                return Err(Error::InsufficientAcksReceived);
             }
-            trace!(
-                "current ack waiting loop count {}/{}",
-                attempts,
-                expected_cmd_ack_wait_attempts
-            );
+
+            ack_checks += 1;
+
+            trace!("{:?} current ack waiting loop count {}", msg_id, ack_checks,);
             tokio::time::sleep(interval).await;
         }
 
-        trace!("Wait for any cmd response/reaction (AE msgs eg), is over)");
+        trace!("Wait for any cmd response/reaction (AE msgs eg), is over. We've had sufficient success.)");
         Ok(())
     }
 
@@ -520,14 +530,12 @@ impl Session {
     pub(super) async fn send_msg(
         &self,
         nodes: Vec<Peer>,
-        mut wire_msg: WireMsg,
+        wire_msg: WireMsg,
         msg_id: MsgId,
     ) -> Result<()> {
-        let bytes = wire_msg.serialize_and_cache_bytes()?;
+        let bytes = wire_msg.serialize()?;
 
         let mut last_error = None;
-        drop(wire_msg);
-
         // Send message to all Elders concurrently
         let mut tasks = Vec::default();
 
@@ -640,7 +648,11 @@ impl Session {
         }
 
         if failures > successful_sends {
-            warn!("More errors when sending a message than successes");
+            warn!(
+                "More errors when sending a message than successes, last_error: {:?}",
+                last_error
+            );
+
             if let Some(error) = last_error {
                 warn!("The relevant error is: {error}");
                 return Err(error);
@@ -661,10 +673,7 @@ mod tests {
 
     use eyre::{eyre, Result};
     use qp2p::Config;
-    use std::{
-        net::{Ipv4Addr, SocketAddr},
-        time::Duration,
-    };
+    use std::net::{Ipv4Addr, SocketAddr};
     use xor_name::Prefix;
 
     fn prefix(s: &str) -> Result<Prefix> {
@@ -694,7 +703,6 @@ mod tests {
         let session = Session::new(
             Config::default(),
             SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
-            Duration::from_secs(10),
             network_contacts,
         )?;
 

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -19,9 +19,9 @@ use sn_interface::{
     types::PeerLinks,
 };
 
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use qp2p::{Config as QuicP2pConfig, Endpoint};
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::{mpsc::Sender, RwLock};
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
@@ -29,7 +29,10 @@ type PendingQueryResponses = Arc<DashMap<OperationId, Vec<(MsgId, QueryResponseS
 type QueryResponseSender = Sender<QueryResponse>;
 
 type CmdResponse = (SocketAddr, Option<CmdError>);
-type PendingCmdAcks = Arc<DashMap<MsgId, Sender<CmdResponse>>>;
+
+/// As we receive ACKs, we write the ACKd peer here for checking.
+/// TODO: This could be a mem leak for long running clients.
+type PendingCmdAcks = Arc<DashMap<MsgId, Arc<DashSet<CmdResponse>>>>;
 
 #[derive(Debug)]
 pub struct QueryResult {
@@ -54,8 +57,6 @@ pub(super) struct Session {
     pending_cmds: PendingCmdAcks,
     /// All elders we know about from AE messages
     pub(super) network: Arc<RwLock<SectionTree>>,
-    /// Standard time to await potential AE messages:
-    cmd_ack_wait: Duration,
     /// Links to nodes
     peer_links: PeerLinks,
 }
@@ -66,7 +67,6 @@ impl Session {
     pub(crate) fn new(
         qp2p_config: QuicP2pConfig,
         local_addr: SocketAddr,
-        cmd_ack_wait: Duration,
         network_contacts: SectionTree,
     ) -> Result<Self> {
         let endpoint = Endpoint::new_client(local_addr, qp2p_config)?;
@@ -77,7 +77,6 @@ impl Session {
             pending_cmds: Arc::new(DashMap::default()),
             endpoint,
             network: Arc::new(RwLock::new(network_contacts)),
-            cmd_ack_wait,
             peer_links,
         };
 

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -13,7 +13,7 @@ use crate::Result;
 use sn_interface::{
     messaging::{
         data::{CmdError, OperationId, QueryResponse},
-        MsgId,
+        DataCmdId, MsgId,
     },
     network_knowledge::SectionTree,
     types::PeerLinks,
@@ -32,7 +32,7 @@ type CmdResponse = (SocketAddr, Option<CmdError>);
 
 /// As we receive ACKs, we write the ACKd peer here for checking.
 /// TODO: This could be a mem leak for long running clients.
-type PendingCmdAcks = Arc<DashMap<MsgId, Arc<DashSet<CmdResponse>>>>;
+type PendingCmdAcks = Arc<DashMap<DataCmdId, Arc<DashSet<CmdResponse>>>>;
 
 #[derive(Debug)]
 pub struct QueryResult {

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -30,6 +30,9 @@ pub enum Error {
     /// Failed to obtain network contacts to bootstrap to
     #[error("Failed to obtain network contacts to bootstrap to: {0}")]
     NetworkContacts(String),
+    /// InsufficientAcksReceived
+    #[error("Did not receive sufficient ACK messages from elders to be sure this cmd passed.")]
+    InsufficientAcksReceived,
     /// Message auth checks failed
     #[error("Message's authority could not be trusted, unknown section key: {0:?}.")]
     UntrustedMessage(PublicKey),

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -30,6 +30,9 @@ pub enum Error {
     /// Failed to obtain network contacts to bootstrap to
     #[error("Failed to obtain network contacts to bootstrap to: {0}")]
     NetworkContacts(String),
+    /// Serialization error while trying to generate DataCmdId
+    #[error("Failed to serialize DataCmd.")]
+    CouldNotSerializeDataCmd,
     /// InsufficientAcksReceived
     #[error("Did not receive sufficient ACK messages from elders to be sure this cmd passed.")]
     InsufficientAcksReceived,

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -56,4 +56,7 @@ pub enum Error {
     /// Failed to verify a spent proof since it's signed by unknown section key
     #[error("Spent proof was signed with unknown section key: {0:?}")]
     SpentProofUnknownSectionKey(bls::PublicKey),
+    /// DataCmd could not be serialised
+    #[error("DataCmd could not be serialised")]
+    DataCmdSerialisation,
 }

--- a/sn_interface/src/messaging/data/register.rs
+++ b/sn_interface/src/messaging/data/register.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{CmdError, Error, QueryResponse, Result};
+use super::{CmdError, DataCmdId, Error, QueryResponse, Result};
 
 use crate::messaging::{data::OperationId, SectionAuth};
 #[allow(unused_imports)] // needed by rustdocs links
@@ -233,8 +233,11 @@ impl RegisterQuery {
 impl RegisterCmd {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error) -> CmdError {
-        CmdError::Data(error)
+    pub fn error(&self, error: Error, cmd_id: DataCmdId) -> CmdError {
+        CmdError::Data {
+            error,
+            data_cmd_id: Some(cmd_id),
+        }
     }
 
     /// Returns the name of the register.

--- a/sn_interface/src/messaging/data/spentbook.rs
+++ b/sn_interface/src/messaging/data/spentbook.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{CmdError, Error, QueryResponse, Result};
+use super::{CmdError, DataCmdId, Error, QueryResponse, Result};
 
 use crate::messaging::data::OperationId;
 use crate::types::SpentbookAddress;
@@ -79,8 +79,11 @@ impl SpentbookQuery {
 impl SpentbookCmd {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error) -> CmdError {
-        CmdError::Data(error)
+    pub fn error(&self, error: Error, cmd_id: DataCmdId) -> CmdError {
+        CmdError::Data {
+            error,
+            data_cmd_id: Some(cmd_id),
+        }
     }
 
     /// Returns the name of the register.

--- a/sn_interface/src/messaging/mod.rs
+++ b/sn_interface/src/messaging/mod.rs
@@ -48,6 +48,7 @@ pub use self::{
     authority::{
         AuthorityProof, BlsShareAuth, NodeAuth, SectionAuth, ServiceAuth, VerifyAuthority,
     },
+    data::DataCmdId,
     dst::Dst,
     errors::{Error, Result},
     msg_id::{MsgId, MESSAGE_ID_LEN},

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -54,7 +54,7 @@ pub(crate) struct PeerSession {
 
 impl PeerSession {
     pub(crate) fn new(link: Link) -> PeerSession {
-        let (sender, receiver) = mpsc::channel(1000);
+        let (sender, receiver) = mpsc::channel(10_000);
 
         let _ =
             tokio::task::spawn_local(PeerSessionWorker::new(link, sender.clone()).run(receiver));

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -87,7 +87,6 @@ impl Node {
             target_adult: target.name(),
         }];
 
-        // here we conflate adults targetted!!
         if let Some(peers) = self
             .pending_data_queries
             .get(&(operation_id, target.name()))

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -117,6 +117,8 @@ impl CmdCtrl {
         let id = job.id();
         let cmd = job.clone().into_cmd();
 
+        trace!("Processing cmd: {cmd:?}");
+
         let cmd_string = cmd.clone().to_string();
         let priority = job.priority();
 
@@ -134,6 +136,7 @@ impl CmdCtrl {
             }))
             .await;
 
+        trace!("about to spawn for processing cmd: {cmd:?}");
         let dispatcher = self.dispatcher.clone();
         let _ = tokio::task::spawn_local(async move {
             dispatcher
@@ -144,9 +147,8 @@ impl CmdCtrl {
 
             match dispatcher.process_cmd(cmd).await {
                 Ok(cmds) => {
-                    monitoring.increment_cmds().await;
-
                     for cmd in cmds {
+                        monitoring.increment_cmds().await;
                         match cmd_process_api.send((cmd, Some(id))).await {
                             Ok(_) => {
                                 //no issues

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -221,11 +221,7 @@ impl Cmd {
     pub(crate) fn priority(&self) -> i32 {
         use Cmd::*;
         match self {
-            SendMsg { msg, .. } => match msg {
-                OutgoingMsg::System(_) => 20,
-                _ => 19,
-            },
-
+            SendMsg { .. } => 20,
             HandleAgreement { .. } => 10,
             HandleNewEldersAgreement { .. } => 10,
             HandleDkgOutcome { .. } => 10,

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -60,6 +60,8 @@ impl Dispatcher {
 
     /// Handles a single cmd.
     pub(crate) async fn process_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
+        trace!("doing actual processing cmd: {cmd:?}");
+
         match cmd {
             Cmd::CleanupPeerLinks => {
                 let members = { self.node.read().await.network_knowledge.section_members() };

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -13,6 +13,7 @@ use crate::node::{
     Cmd, Error, Node, Result,
 };
 
+use sn_interface::messaging::data::ServiceMsg;
 #[cfg(feature = "traceroute")]
 use sn_interface::{messaging::Entity, messaging::Traceroute};
 use sn_interface::{
@@ -160,6 +161,11 @@ impl Dispatcher {
                 #[cfg(feature = "traceroute")]
                 traceroute,
             } => {
+                let data_cmd_id = match &msg {
+                    ServiceMsg::Cmd(cmd) => Some(cmd.data_cmd_id()?),
+                    _ => None,
+                };
+
                 let node = self.node.read().await;
                 match node
                     .handle_valid_service_msg(
@@ -177,6 +183,7 @@ impl Dispatcher {
                         debug!("Will send error response back to client");
                         let cmd = node.cmd_error_response(
                             err,
+                            data_cmd_id,
                             origin,
                             msg_id,
                             #[cfg(feature = "traceroute")]
@@ -309,6 +316,31 @@ impl Dispatcher {
 async fn sleep_facility(duration: Duration) {
     log_sleep!(Duration::from_millis(duration.as_millis() as u64));
 }
+
+// /// Forms a `CmdError` msg to send back to the client
+// fn service_msg_error_response(
+//     error: Error,
+//     data_cmd_id: Option<DataCmdId>,
+//     target: Peer,
+//     msg_id: MsgId,
+//     #[cfg(feature = "traceroute")] traceroute: Traceroute,
+// ) -> Cmd {
+//     let the_error_msg = ServiceMsg::Error {
+//         error: CmdError::Data {
+//             error: error.into(),
+//             data_cmd_id,
+//         },
+//         msg_id: msg_id,
+//     };
+
+//     Cmd::SendMsg {
+//         msg: OutgoingMsg::Service(the_error_msg),
+//         msg_id: MsgId::new(),
+//         recipients: Peers::Single(target),
+//         #[cfg(feature = "traceroute")]
+//         traceroute,
+//     }
+// }
 
 // Serializes and signs the msg,
 // and produces one [`WireMsg`] instance per recipient -

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -186,7 +186,7 @@ impl Cmd {
         match self {
             Cmd::SendMsg { msg, .. } => match msg {
                 OutgoingMsg::Service(service_msg) => match service_msg {
-                    ServiceMsg::CmdError { error, .. } => match error {
+                    ServiceMsg::Error { error, .. } => match error {
                         CmdError::Data(err) => Ok(err.clone()),
                     },
                     _ => Err(eyre!("A ServiceMsg::CmdError variant was expected")),

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -147,6 +147,7 @@ impl Node {
                         warn!("Pending queries length exceeded, dropping query {msg:?}");
                         let cmd = self.cmd_error_response(
                             Error::CannotHandleQuery(query.clone()),
+                            None,
                             origin,
                             msg_id,
                             #[cfg(feature = "traceroute")]

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -86,6 +86,9 @@ impl Node {
         #[cfg(feature = "traceroute")]
         traceroute.0.push(self.identity());
 
+        let new_msg_id = MsgId::new();
+
+        debug!("SendMSg formed for {:?}", new_msg_id);
         Cmd::SendMsg {
             msg: OutgoingMsg::Service(msg),
             msg_id: MsgId::new(),


### PR DESCRIPTION
moves to write to a map on ack receipt, regardless of when it come sin.
Previously we could miss ACKs if they were in before our DashMap was updated

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
