### PR TITLE
feat: retry dbc spend on unknown section key

### DIFF
--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -12,7 +12,10 @@ use crate::Error;
 
 use sn_dbc::{KeyImage, RingCtTransaction, SpentProof, SpentProofShare};
 use sn_interface::{
-    messaging::data::{DataCmd, DataQueryVariant, QueryResponse, SpentbookCmd, SpentbookQuery},
+    messaging::data::{
+        DataCmd, DataQueryVariant, Error as NetworkDataError, QueryResponse, SpentbookCmd,
+        SpentbookQuery,
+    },
     types::SpentbookAddress,
 };
 
@@ -25,6 +28,15 @@ impl Client {
     //---------------------
 
     /// Spend a DBC's key image.
+    ///
+    /// It's possible that the section processing the spend request will not be aware of the
+    /// section keys used to sign the spent proofs. If this is the case, the network will return a
+    /// particular error and we will retry. There are several retries because there could be
+    /// several keys the section is not aware of, but it only returns back the first one it
+    /// encounters.
+    ///
+    /// When the request is resubmitted, it gets sent along with a proof chain and a signed SAP
+    /// that the section can use to update itself.
     #[instrument(skip(self), level = "debug")]
     pub async fn spend_dbc(
         &self,
@@ -33,13 +45,66 @@ impl Client {
         spent_proofs: BTreeSet<SpentProof>,
         spent_transactions: BTreeSet<RingCtTransaction>,
     ) -> Result<(), Error> {
-        let cmd = SpentbookCmd::Spend {
+        let mut cmd = SpentbookCmd::Spend {
             key_image,
-            tx,
-            spent_proofs,
-            spent_transactions,
+            tx: tx.clone(),
+            spent_proofs: spent_proofs.clone(),
+            spent_transactions: spent_transactions.clone(),
+            network_knowledge: None,
         };
-        self.send_cmd(DataCmd::Spentbook(cmd)).await
+        let mut attempts = 1;
+        debug!("Attempting DBC spend request.");
+        debug!(
+            "Will reattempt if spent proof was signed with a section key that is unknown to the \
+            processing section."
+        );
+        loop {
+            let result = self.send_cmd(DataCmd::Spentbook(cmd)).await;
+            match result {
+                Ok(()) => {
+                    return Ok(());
+                }
+                Err(err) => match err {
+                    Error::ErrorCmd {
+                        source:
+                            NetworkDataError::SpentProofUnknownSectionKey(
+                                current_section_key,
+                                unknown_section_key,
+                            ),
+                        ..
+                    } => {
+                        debug!("Encountered unknown section key during spend request.");
+                        debug!(
+                            "Will obtain updated network knowledge and retry. \
+                                Attempts made: {attempts}"
+                        );
+                        attempts += 1;
+                        if attempts > 5 {
+                            error!("DBC spend request failed after 5 retry attempts");
+                            return Err(Error::DbcSpendRetryAttemptsExceeded);
+                        }
+                        let network = self.session.network.read().await;
+                        let proof_chain = network
+                            .get_sections_dag()
+                            .get_proof_chain(&current_section_key, &unknown_section_key)?;
+                        let signed_sap = network
+                            .get_signed_by_key(&unknown_section_key)
+                            .ok_or(Error::SignedSapNotFound(unknown_section_key))?;
+                        cmd = SpentbookCmd::Spend {
+                            key_image,
+                            tx: tx.clone(),
+                            spent_proofs: spent_proofs.clone(),
+                            spent_transactions: spent_transactions.clone(),
+                            network_knowledge: Some((proof_chain, signed_sap.clone())),
+                        };
+                        continue;
+                    }
+                    _ => {
+                        return Err(err);
+                    }
+                },
+            }
+        }
     }
 
     //----------------------

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -689,7 +689,7 @@ mod tests {
 
         let prefix = prefix("0")?;
         let (section_auth, _, secret_key_set) = random_sap(prefix, elders_len, 0, None);
-        let sap0 = section_signed(secret_key_set.secret_key(), section_auth)?;
+        let sap0 = section_signed(&secret_key_set.secret_key(), section_auth)?;
         let (mut network_contacts, _genesis_sk, _) = new_network_network_contacts();
         assert!(network_contacts.insert_without_chain(sap0));
 

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -181,9 +181,6 @@ pub enum Error {
         /// Number of Chunks generated
         chunked: usize,
     },
-    /// Errors from the secured linked list crate.
-    #[error(transparent)]
-    SecuredLinkedList(#[from] secured_linked_list::error::Error),
     /// Occurs if a signed SAP cannot be obtained for a section key.
     #[error("A signed section authority provider was not found for section key {0:?}")]
     SignedSapNotFound(PublicKey),

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -181,4 +181,13 @@ pub enum Error {
         /// Number of Chunks generated
         chunked: usize,
     },
+    /// Errors from the secured linked list crate.
+    #[error(transparent)]
+    SecuredLinkedList(#[from] secured_linked_list::error::Error),
+    /// Occurs if a signed SAP cannot be obtained for a section key.
+    #[error("A signed section authority provider was not found for section key {0:?}")]
+    SignedSapNotFound(PublicKey),
+    /// Occurs if a DBC spend command eventually fails after a number of retry attempts.
+    #[error("The DBC spend request failed after several retry attempts")]
+    DbcSpendRetryAttemptsExceeded,
 }

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -53,7 +53,10 @@ pub enum Error {
     /// Error is not valid for operation id generation. This should not absolve a pending (and thus far unfulfilled) operation
     #[error("Could not generate operation id for chunk retrieval. Error was not 'DataNotFound'.")]
     InvalidQueryResponseErrorForOperationId,
-    /// Failed to verify a spent proof since it's signed by unknown section key
-    #[error("Spent proof was signed with unknown section key: {0:?}")]
-    SpentProofUnknownSectionKey(bls::PublicKey),
+    /// A DBC spend request could not be processed because the processing section was unaware of
+    /// the section that signed one of the input spent proofs.
+    #[error(
+        "Spent proof is signed by section key {0:?} that is unknown to the current section {1:?}"
+    )]
+    SpentProofUnknownSectionKey(bls::PublicKey, bls::PublicKey),
 }

--- a/sn_interface/src/messaging/data/spentbook.rs
+++ b/sn_interface/src/messaging/data/spentbook.rs
@@ -10,11 +10,10 @@ use super::{Error, QueryResponse, Result};
 
 use crate::messaging::data::OperationId;
 use crate::messaging::system::SectionAuth;
-use crate::network_knowledge::SectionAuthorityProvider;
+use crate::network_knowledge::{SectionAuthorityProvider, SectionsDAG};
 use crate::types::{utils, SpentbookAddress};
 use tiny_keccak::{Hasher, Sha3};
 
-use secured_linked_list::SecuredLinkedList;
 use serde::{Deserialize, Serialize};
 use sn_dbc::{KeyImage, RingCtTransaction, SpentProof};
 use std::collections::BTreeSet;
@@ -44,7 +43,7 @@ pub enum SpentbookCmd {
         tx: RingCtTransaction,
         spent_proofs: BTreeSet<SpentProof>,
         spent_transactions: BTreeSet<RingCtTransaction>,
-        network_knowledge: Option<(SecuredLinkedList, SectionAuth<SectionAuthorityProvider>)>,
+        network_knowledge: Option<(SectionsDAG, SectionAuth<SectionAuthorityProvider>)>,
     },
 }
 

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -339,7 +339,7 @@ pub mod test_utils {
         elder_count: usize,
         adult_count: usize,
         sk_threshold_size: Option<usize>,
-    ) -> (SectionAuthorityProvider, Vec<NodeInfo>, SecretKeySet) {
+    ) -> (SectionAuthorityProvider, Vec<NodeInfo>, bls::SecretKeySet) {
         let nodes = gen_sorted_nodes(&prefix, elder_count + adult_count, false);
         let elders = nodes.iter().map(NodeInfo::peer).take(elder_count);
         let members = nodes.iter().map(|i| NodeState::joined(i.peer(), None));
@@ -364,6 +364,25 @@ pub mod test_utils {
             sk_threshold_size,
         )
     }
+
+    /// Generate a random `SectionAuthorityProvider` for testing.
+    ///
+    /// The same as `random_sap`, but instead the secret key is provided. This can be useful for
+    /// creating a section to share the same genesis key as another one.
+    pub fn random_sap_with_key(
+        prefix: Prefix,
+        elder_count: usize,
+        adult_count: usize,
+        sk_set: &bls::SecretKeySet,
+    ) -> (SectionAuthorityProvider, Vec<NodeInfo>) {
+        let nodes = gen_sorted_nodes(&prefix, elder_count + adult_count, false);
+        let elders = nodes.iter().map(NodeInfo::peer).take(elder_count);
+        let members = nodes.iter().map(|i| NodeState::joined(i.peer(), None));
+        let section_auth =
+            SectionAuthorityProvider::new(elders, prefix, members, sk_set.public_keys(), 0);
+        (section_auth, nodes)
+    }
+
 
     // Create signature for the given payload using the given secret key.
     pub fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<KeyedSig> {

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -271,25 +271,6 @@ impl SectionTree {
             }
         }
 
-        // Make sure the proof chain can be trusted,
-        // i.e. check each key is signed by its parent/predecessor key.
-        if !proof_chain.self_verify() {
-            return Err(Error::UntrustedProofChain(format!(
-                "invalid proof chain: {:?}",
-                proof_chain
-            )));
-        }
-
-        // Check the SAP's key is the last key of the proof chain
-        if *proof_chain.last_key() != signed_sap.section_key() {
-            return Err(Error::UntrustedSectionAuthProvider(format!(
-                "section key ({:?}, from prefix {:?}) isn't in the last key in the proof chain provided. (Which ends with ({:?}))",
-                signed_sap.section_key(),
-                signed_sap.prefix(),
-                proof_chain.last_key()
-            )));
-        }
-
         // We can now update our knowledge of the remote section's SAP.
         // Note: we don't expect the same SAP to be found in our records
         // for the prefix since we've already checked that above.
@@ -794,7 +775,7 @@ pub(crate) mod tests {
     // Test helpers
     fn gen_section_auth(prefix: Prefix) -> Result<SectionAuth<SectionAuthorityProvider>> {
         let (section_auth, _, secret_key_set) = random_sap(prefix, 5, 0, None);
-        section_signed(secret_key_set.secret_key(), section_auth)
+        section_signed(&secret_key_set.secret_key(), section_auth)
             .context(format!("Failed to generate SAP for prefix {:?}", prefix))
     }
 

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -161,6 +161,19 @@ impl SectionTree {
         self.sections.get(prefix)
     }
 
+    /// Get signed `SectionAuthorityProvider` of a known section with the given section key.
+    pub fn get_signed_by_key(
+        &self,
+        section_key: &bls::PublicKey,
+    ) -> Option<&SectionAuth<SectionAuthorityProvider>> {
+        for (_, signed_sap) in self.sections.iter() {
+            if signed_sap.public_key_set().public_key() == *section_key {
+                return Some(signed_sap);
+            }
+        }
+        None
+    }
+
     /// Update our `SectionTree` if the provided update can be verified
     /// Returns true if an update was made
     pub fn update(&mut self, section_tree_update: SectionTreeUpdate) -> Result<bool> {

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -271,6 +271,25 @@ impl SectionTree {
             }
         }
 
+        // Make sure the proof chain can be trusted,
+        // i.e. check each key is signed by its parent/predecessor key.
+        if !proof_chain.self_verify() {
+            return Err(Error::UntrustedProofChain(format!(
+                "invalid proof chain: {:?}",
+                proof_chain
+            )));
+        }
+
+        // Check the SAP's key is the last key of the proof chain
+        if *proof_chain.last_key() != signed_sap.section_key() {
+            return Err(Error::UntrustedSectionAuthProvider(format!(
+                "section key ({:?}, from prefix {:?}) isn't in the last key in the proof chain provided. (Which ends with ({:?}))",
+                signed_sap.section_key(),
+                signed_sap.prefix(),
+                proof_chain.last_key()
+            )));
+        }
+
         // We can now update our knowledge of the remote section's SAP.
         // Note: we don't expect the same SAP to be found in our records
         // for the prefix since we've already checked that above.

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -1191,7 +1191,7 @@ pub(crate) mod tests {
 
         let (sap_gen, _, sk_gen) = random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None);
         let sk_gen = sk_gen.secret_key();
-        let sap_gen = section_signed(sk_gen, sap_gen)?;
+        let sap_gen = section_signed(&sk_gen, sap_gen)?;
         let pk_gen = sap_gen.public_key_set().public_key();
 
         let mut dag = SectionsDAG::new(pk_gen);
@@ -1218,17 +1218,17 @@ pub(crate) mod tests {
             dag: &mut SectionsDAG,
         ) -> Result<()> {
             let (sap, _, sk_set) = random_sap_with_rng(rng, prefix, 0, 0, None);
-            let sap = section_signed(sk_set.secret_key(), sap)?;
+            let sap = section_signed(&sk_set.secret_key(), sap)?;
             let key = sap.public_key_set().public_key();
             let sig = sign(parent_sk, &key);
             dag.insert(&parent_sk.public_key(), sap.section_key(), sig)?;
-            sections_map.insert(sap.section_key(), (sk_set.secret_key().clone(), sap));
+            sections_map.insert(sap.section_key(), (sk_set.secret_key(), sap));
             Ok(())
         }
 
         // insert prefix 0,1
-        insert(prefix("0")?, sk_gen, &mut rng, &mut sections_map, &mut dag)?;
-        insert(prefix("1")?, sk_gen, &mut rng, &mut sections_map, &mut dag)?;
+        insert(prefix("0")?, &sk_gen, &mut rng, &mut sections_map, &mut dag)?;
+        insert(prefix("1")?, &sk_gen, &mut rng, &mut sections_map, &mut dag)?;
 
         while count < n_sections {
             let leaves: Vec<_> = dag.leaf_keys().into_iter().collect();

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -614,7 +614,7 @@ mod tests {
             });
 
             // Send JoinResponse::Approved
-            let signed_sap = section_signed(sk, section_auth.clone())?;
+            let section_auth = section_signed(&sk, section_auth.clone())?;
             let decision = section_decision(&sk_set, NodeState::joined(peer, None).to_msg())?;
             let section_pk = signed_sap.section_key();
             let section_tree_update = {

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -583,7 +583,7 @@ mod tests {
             );
 
             // Send JoinResponse::Retry with section auth provider info
-            let signed_sap = section_signed(sk, section_auth.clone())?;
+            let signed_sap = section_signed(&sk, section_auth.clone())?;
             let section_tree_update = {
                 let proof_chain = SectionsDAG::new(original_section_key);
                 SectionTreeUpdate::new(signed_sap, proof_chain)
@@ -614,7 +614,7 @@ mod tests {
             });
 
             // Send JoinResponse::Approved
-            let section_auth = section_signed(&sk, section_auth.clone())?;
+            let signed_sap = section_signed(&sk, section_auth.clone())?;
             let decision = section_decision(&sk_set, NodeState::joined(peer, None).to_msg())?;
             let section_pk = signed_sap.section_key();
             let section_tree_update = {
@@ -931,7 +931,7 @@ mod tests {
             );
 
             let proof_chain = SectionsDAG::new(section_key);
-            let signed_sap = section_signed(sk_set.secret_key(), section_auth.clone())?;
+            let signed_sap = section_signed(&sk_set.secret_key(), section_auth.clone())?;
 
             // Send `Retry` with bad prefix
             let bad_section_tree_update = {

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -160,9 +160,12 @@ pub enum Error {
     /// Spentbook error
     #[error("Spentbook Error: {0}")]
     SpentbookError(String),
-    /// Failed to verify a spent proof since it's signed by an unknown section key
-    #[error("Spent proof is signed by unknown section key: {0:?}")]
-    SpentProofUnknownSectionKey(bls::PublicKey),
+    /// A DBC spend request could not be processed because the processing section was unaware of
+    /// the section that signed one of the input spent proofs.
+    #[error(
+        "Spent proof is signed by section key {0:?} that is unknown to the current section {1:?}"
+    )]
+    SpentProofUnknownSectionKey(bls::PublicKey, bls::PublicKey),
     /// Error occurred when minting the Genesis DBC.
     #[error("Genesis DBC error:: {0}")]
     GenesisDbcError(String),
@@ -206,7 +209,9 @@ impl From<Error> for ErrorMsg {
                 found,
             },
             Error::DataExists(address) => ErrorMsg::DataExists(address),
-            Error::SpentProofUnknownSectionKey(pk) => ErrorMsg::SpentProofUnknownSectionKey(pk),
+            Error::SpentProofUnknownSectionKey(unknown_section_key, current_section_key) => {
+                ErrorMsg::SpentProofUnknownSectionKey(unknown_section_key, current_section_key)
+            }
             Error::NetworkData(error) => convert_dt_error_to_error_msg(error),
             other => {
                 ErrorMsg::InvalidOperation(format!("Failed to perform operation: {:?}", other))

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -21,7 +21,7 @@ use sn_interface::{
         system::{DkgFailureSigSet, KeyedSig, NodeState, SectionAuth, SystemMsg},
         AuthorityProof, MsgId, NodeMsgAuthority, ServiceAuth, WireMsg,
     },
-    network_knowledge::{SectionAuthorityProvider, SectionKeyShare},
+    network_knowledge::{SectionAuthorityProvider, SectionKeyShare, SectionsDAG},
     types::{DataAddress, Peer},
 };
 
@@ -146,7 +146,7 @@ pub(crate) enum Cmd {
         traceroute: Traceroute,
     },
     UpdateNetworkAndHandleValidServiceMsg {
-        proof_chain: SecuredLinkedList,
+        proof_chain: SectionsDAG,
         signed_sap: SectionAuth<SectionAuthorityProvider>,
         msg_id: MsgId,
         msg: ServiceMsg,

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -145,6 +145,17 @@ pub(crate) enum Cmd {
         #[cfg(feature = "traceroute")]
         traceroute: Traceroute,
     },
+    UpdateNetworkAndHandleValidServiceMsg {
+        proof_chain: SecuredLinkedList,
+        signed_sap: SectionAuth<SectionAuthorityProvider>,
+        msg_id: MsgId,
+        msg: ServiceMsg,
+        origin: Peer,
+        /// Requester's authority over this message
+        auth: AuthorityProof<ServiceAuth>,
+        #[cfg(feature = "traceroute")]
+        traceroute: Traceroute,
+    },
     /// Handle a timeout previously scheduled with `ScheduleDkgTimeout`.
     HandleDkgTimeout(u64),
     /// Handle peer that's been detected as lost.
@@ -243,6 +254,7 @@ impl Cmd {
             // See [`MsgType`] for the priority constants and the range of possible values.
             HandleValidSystemMsg { msg, .. } => msg.priority(),
             HandleValidServiceMsg { msg, .. } => msg.priority(),
+            UpdateNetworkAndHandleValidServiceMsg { msg, .. } => msg.priority(),
 
             ValidateMsg { .. } => -9, // before it's validated, we cannot give it high prio, as it would be a spam vector
         }
@@ -257,6 +269,7 @@ impl Cmd {
             Cmd::ValidateMsg { .. } => State::Validation,
             Cmd::HandleValidSystemMsg { msg, .. } => msg.statemap_states(),
             Cmd::HandleValidServiceMsg { .. } => State::ServiceMsg,
+            Cmd::UpdateNetworkAndHandleValidServiceMsg { .. } => State::ServiceMsg,
             Cmd::TrackNodeIssueInDysfunction { .. } => State::Dysfunction,
             Cmd::AddToPendingQueries { .. } => State::Dysfunction,
             Cmd::HandleAgreement { .. } => State::Agreement,
@@ -298,6 +311,9 @@ impl fmt::Display for Cmd {
             }
             Cmd::HandleValidServiceMsg { msg_id, msg, .. } => {
                 write!(f, "HandleValidServiceMsg {:?}: {:?}", msg_id, msg)
+            }
+            Cmd::UpdateNetworkAndHandleValidServiceMsg { msg_id, msg, .. } => {
+                write!(f, "UpdateAndHandleValidServiceMsg {:?}: {:?}", msg_id, msg)
             }
             Cmd::HandleFailedSendToNode { peer, msg_id } => {
                 write!(f, "HandlePeerFailedSend({:?}, {:?})", peer.name(), msg_id)

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -178,6 +178,38 @@ impl Dispatcher {
                     }
                 }
             }
+            Cmd::UpdateNetworkAndHandleValidServiceMsg {
+                proof_chain,
+                signed_sap,
+                msg_id,
+                msg,
+                origin,
+                auth,
+                #[cfg(feature = "traceroute")]
+                traceroute,
+            } => {
+                debug!("Updating network knowledge before handling message");
+                let mut node = self.node.write().await;
+                let name = node.name();
+                let skp = node.section_keys_provider.clone();
+                let updated = node.network_knowledge.update_knowledge_if_valid(
+                    signed_sap,
+                    &proof_chain,
+                    None,
+                    &name,
+                    &skp,
+                )?;
+                debug!("Network knowledge was updated: {updated}");
+                node.handle_valid_service_msg(
+                    msg_id,
+                    msg,
+                    auth,
+                    origin,
+                    #[cfg(feature = "traceroute")]
+                    traceroute,
+                )
+                .await
+            }
             Cmd::HandleValidSystemMsg {
                 origin,
                 msg_id,

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -16,7 +16,7 @@ use crate::node::{
 #[cfg(feature = "traceroute")]
 use sn_interface::{messaging::Entity, messaging::Traceroute};
 use sn_interface::{
-    messaging::{AuthKind, Dst, MsgId, WireMsg},
+    messaging::{AuthKind, Dst, MsgId, SectionTreeUpdate, WireMsg},
     types::Peer,
 };
 
@@ -191,13 +191,10 @@ impl Dispatcher {
                 debug!("Updating network knowledge before handling message");
                 let mut node = self.node.write().await;
                 let name = node.name();
-                let skp = node.section_keys_provider.clone();
                 let updated = node.network_knowledge.update_knowledge_if_valid(
-                    signed_sap,
-                    &proof_chain,
+                    SectionTreeUpdate::new(signed_sap, proof_chain),
                     None,
                     &name,
-                    &skp,
                 )?;
                 debug!("Network knowledge was updated: {updated}");
                 node.handle_valid_service_msg(

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -28,7 +28,7 @@ pub(crate) struct HandleOnlineStatus {
 
 pub(crate) async fn handle_online_cmd(
     peer: &Peer,
-    sk_set: &SecretKeySet,
+    sk_set: &bls::SecretKeySet,
     dispatcher: &Dispatcher,
     section_auth: &SectionAuthorityProvider,
 ) -> Result<HandleOnlineStatus> {

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -1237,8 +1237,7 @@ async fn spentbook_spend_service_message_should_replicate_to_adults_and_send_ack
                         tx: tx.clone(),
                         spent_proofs,
                         spent_transactions,
-                        updated_proof_chain: None,
-                        signed_sap: None,
+                        network_knowledge: None,
                     })),
                     peer,
                 )?,
@@ -1305,8 +1304,7 @@ async fn spentbook_spend_spent_proof_with_invalid_pk_should_return_spentbook_err
                         tx,
                         spent_proofs,
                         spent_transactions,
-                        updated_proof_chain: None,
-                        signed_sap: None,
+                        network_knowledge: None,
                     })),
                     peer,
                 )?,
@@ -1365,8 +1363,7 @@ async fn spentbook_spend_spent_proof_with_key_not_in_section_chain_should_return
                         tx,
                         spent_proofs,
                         spent_transactions,
-                        updated_proof_chain: None,
-                        signed_sap: None,
+                        network_knowledge: None,
                     })),
                     peer,
                 )?,
@@ -1438,8 +1435,7 @@ async fn spentbook_spend_spent_proofs_do_not_relate_to_input_dbcs_should_return_
                         tx: new_dbc2.transaction.clone(),
                         spent_proofs: genesis_dbc.spent_proofs.clone(),
                         spent_transactions: genesis_dbc.spent_transactions.clone(),
-                        updated_proof_chain: None,
-                        signed_sap: None,
+                        network_knowledge: None,
                     })),
                     peer,
                 )?,
@@ -1509,8 +1505,7 @@ async fn spentbook_spend_transaction_with_no_inputs_should_return_spentbook_erro
                         tx: new_dbc2.transaction.clone(),
                         spent_proofs: new_dbc.spent_proofs.clone(),
                         spent_transactions: new_dbc.spent_transactions.clone(),
-                        updated_proof_chain: None,
-                        signed_sap: None,
+                        network_knowledge: None,
                     })),
                     peer,
                 )?,
@@ -1578,8 +1573,7 @@ async fn spentbook_spend_with_random_key_image_should_return_spentbook_error() -
                         tx: new_dbc2.transaction.clone(),
                         spent_proofs: new_dbc.spent_proofs.clone(),
                         spent_transactions: new_dbc.spent_transactions.clone(),
-                        updated_proof_chain: None,
-                        signed_sap: None,
+                        network_knowledge: None,
                     })),
                     peer,
                 )?,
@@ -1654,8 +1648,7 @@ async fn spentbook_spend_with_updated_proof_chain_network_knowledge_should_be_up
                         tx: tx.clone(),
                         spent_proofs,
                         spent_transactions,
-                        updated_proof_chain: Some(proof_chain),
-                        signed_sap: Some(other_signed_sap),
+                        network_knowledge: Some((proof_chain, other_signed_sap)),
                     })),
                     peer,
                 )?,
@@ -1676,7 +1669,6 @@ async fn spentbook_spend_with_updated_proof_chain_network_knowledge_should_be_up
                 .await
                 .network_knowledge()
                 .our_section_dag();
-            debug!("proof chain = {:?}", proof_chain);
             assert_eq!(proof_chain.len(), 2);
 
             Result::<()>::Ok(())

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -213,6 +213,14 @@ impl TestNodeBuilder {
     }
 }
 
+pub(crate) fn create_section_with_random_sap(
+    prefix: Prefix,
+) -> Result<(NetworkKnowledge, SectionAuthorityProvider, SecretKeySet)> {
+    let (sap, _, sk_set) = random_sap(prefix, elder_count(), 0, Some(0));
+    let (section, _) = create_section(&sk_set, &sap)?;
+    Ok((section, sap, sk_set))
+}
+
 /// Creates a section where all elders and adults are marked as joined members.
 ///
 /// Can be used for tests requiring adults to be members of the section, e.g., when you expect

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -19,7 +19,7 @@ use sn_interface::{
     messaging::{system::NodeState as NodeStateMsg, SectionTreeUpdate},
     network_knowledge::{
         test_utils::*, NetworkKnowledge, NodeInfo, NodeState, SectionAuthorityProvider,
-        SectionKeyShare, SectionsDAG, MIN_ADULT_AGE,
+        SectionKeyShare, SectionsDAG, SectionTree, MIN_ADULT_AGE,
     },
     types::{keys::ed25519, Peer, SecretKeySet},
 };
@@ -42,9 +42,11 @@ pub(crate) struct TestNodeBuilder {
     pub(crate) node_event_sender: EventSender,
     pub(crate) section: Option<NetworkKnowledge>,
     pub(crate) first_node: Option<NodeInfo>,
-    pub(crate) sk_set: Option<SecretKeySet>,
+    pub(crate) genesis_sk_set: Option<bls::SecretKeySet>,
     pub(crate) sap: Option<SectionAuthorityProvider>,
     pub(crate) custom_peer: Option<Peer>,
+    pub(crate) other_section_keys: Option<Vec<bls::SecretKey>>,
+    pub(crate) parent_section_tree: Option<SectionTree>,
 }
 
 impl TestNodeBuilder {
@@ -69,10 +71,37 @@ impl TestNodeBuilder {
             node_event_sender: event_sender,
             section: None,
             first_node: None,
-            sk_set: None,
+            genesis_sk_set: None,
             sap: None,
             custom_peer: None,
+            other_section_keys: None,
+            parent_section_tree: None,
         }
+    }
+
+    /// Provide a the genesis key set for the section to be created with.
+    pub(crate) fn genesis_sk_set(mut self, sk_set: bls::SecretKeySet) -> TestNodeBuilder {
+        self.genesis_sk_set = Some(sk_set);
+        self
+    }
+
+    /// Provide other keys for the section chain.
+    ///
+    /// This list should *not* include the genesis key.
+    pub(crate) fn other_section_keys(mut self, other_keys: Vec<bls::SecretKey>) -> TestNodeBuilder {
+        self.other_section_keys = Some(other_keys);
+        self
+    }
+
+    /// Provide the parent section tree.
+    ///
+    /// Use this when creating section that's supposed to be related to another one.
+    pub(crate) fn parent_section_tree(
+        mut self,
+        parent_section_tree: SectionTree,
+    ) -> TestNodeBuilder {
+        self.parent_section_tree = Some(parent_section_tree);
+        self
     }
 
     /// Set the number of adults for the section.
@@ -130,11 +159,11 @@ impl TestNodeBuilder {
     pub(crate) fn section(
         mut self,
         section: NetworkKnowledge,
-        sk_set: SecretKeySet,
+        sk_set: bls::SecretKeySet,
         first_node: NodeInfo,
     ) -> TestNodeBuilder {
         self.section = Some(section);
-        self.sk_set = Some(sk_set);
+        self.genesis_sk_set = Some(sk_set);
         self.first_node = Some(first_node);
         self
     }
@@ -145,6 +174,46 @@ impl TestNodeBuilder {
     pub(crate) fn custom_peer(mut self, peer: Peer) -> TestNodeBuilder {
         self.custom_peer = Some(peer);
         self
+    }
+
+    /// Build a mock network section using the values provided.
+    ///
+    /// This is to avoid creating another node and dispatcher when they are not needed. It's
+    /// simpler to have two separate functions rather than `build` returning options and so on.
+    ///
+    /// Note that this function is *not* compatible with the use of a custom section.
+    pub(crate) async fn build_section(
+        self,
+    ) -> Result<(NetworkKnowledge, bls::SecretKeySet, SectionKeyShare)> {
+        let section_key_set = if let Some(ref section_keys) = self.other_section_keys {
+            let last_key = section_keys
+                .last()
+                .ok_or_else(|| eyre!("The section keys list must be populated"))?;
+            bls::SecretKeySet::from_bytes(last_key.to_bytes().to_vec())?
+        } else if let Some(ref genesis_sk_set) = self.genesis_sk_set {
+            genesis_sk_set.clone()
+        } else {
+            bls::SecretKeySet::random(self.section_sk_threshold, &mut rand::thread_rng())
+        };
+
+        let (sap, _) = random_sap_with_key(
+            self.prefix,
+            self.elder_count,
+            self.adult_count,
+            &section_key_set,
+        );
+        let genesis_key_set = if let Some(ref genesis_sk_set) = self.genesis_sk_set {
+            genesis_sk_set.clone()
+        } else {
+            bls::SecretKeySet::random(self.section_sk_threshold, &mut rand::thread_rng())
+        };
+        let (section, section_key_share) = create_section(
+            &genesis_key_set,
+            &sap,
+            self.other_section_keys,
+            self.parent_section_tree,
+        )?;
+        Ok((section, section_key_set, section_key_share))
     }
 
     /// Build a `Node` with mock network section using the values provided.
@@ -158,40 +227,54 @@ impl TestNodeBuilder {
     /// which can be provided via the section (NetworkKnowledge).
     ///
     /// A node will be created with a mock section and it will be wrapped inside the dispatcher.
-    pub(crate) async fn build(self) -> Result<(Dispatcher, NetworkKnowledge, Peer, SecretKeySet)> {
+    pub(crate) async fn build(
+        self,
+    ) -> Result<(Dispatcher, NetworkKnowledge, Peer, bls::SecretKeySet)> {
         std::env::set_var("SN_DATA_COPY_COUNT", self.data_copy_count.to_string());
-        let (section, section_key_share, keypair, peer, sk_set) =
-            if let Some(custom_section) = self.section {
-                let first_node = self.first_node.ok_or_else(|| {
-                    eyre!("The first node must be provided when providing a custom section")
-                })?;
-                let sk_set = self.sk_set.ok_or_else(|| {
-                    eyre!("The secret key set must be supplied when providing a custom section")
-                })?;
-                let section_key_share = create_section_key_share(&sk_set, 0);
-                (
-                    custom_section,
-                    section_key_share,
-                    first_node.keypair.clone(),
-                    first_node.peer(),
-                    sk_set,
-                )
+        let (section, section_key_share, keypair, peer, sk_set) = if let Some(custom_section) =
+            self.section
+        {
+            let first_node = self.first_node.ok_or_else(|| {
+                eyre!("The first node must be provided when providing a custom section")
+            })?;
+            let sk_set = self.genesis_sk_set.ok_or_else(|| {
+                eyre!("The secret key set must be supplied when providing a custom section")
+            })?;
+            let section_key_share = create_section_key_share(&sk_set, 0);
+            (
+                custom_section,
+                section_key_share,
+                first_node.keypair.clone(),
+                first_node.peer(),
+                sk_set,
+            )
+        } else {
+            let (sap, mut nodes, sk_set) = if let Some(sk_set) = self.genesis_sk_set {
+                let (sap, nodes) =
+                    random_sap_with_key(self.prefix, self.elder_count, self.adult_count, &sk_set);
+                (sap, nodes, sk_set)
             } else {
-                let (sap, mut nodes, sk_set) = random_sap(
+                random_sap(
                     self.prefix,
                     self.elder_count,
                     self.adult_count,
                     Some(self.section_sk_threshold),
-                );
-                let (section, section_key_share) = create_section(&sk_set, &sap)?;
-                let node = nodes.remove(0);
-                let keypair = node.keypair.clone();
-                (section, section_key_share, keypair, node.peer(), sk_set)
+                )
             };
+            let (section, section_key_share) = create_section(
+                &sk_set,
+                &sap,
+                self.other_section_keys,
+                self.parent_section_tree,
+            )?;
+            let node = nodes.remove(0);
+            let keypair = node.keypair.clone();
+            (section, section_key_share, keypair, node.peer(), sk_set)
+        };
 
         if let Some(custom_peer) = self.custom_peer {
             let node_state = NodeState::joined(custom_peer, None);
-            let node_state = section_signed(sk_set.secret_key(), node_state)?;
+            let node_state = section_signed(&sk_set.secret_key(), node_state)?;
             let _updated = section.update_member(node_state);
         }
 
@@ -213,12 +296,13 @@ impl TestNodeBuilder {
     }
 }
 
-pub(crate) fn create_section_with_random_sap(
+pub(crate) fn create_section_with_key(
     prefix: Prefix,
-) -> Result<(NetworkKnowledge, SectionAuthorityProvider, SecretKeySet)> {
-    let (sap, _, sk_set) = random_sap(prefix, elder_count(), 0, Some(0));
-    let (section, _) = create_section(&sk_set, &sap)?;
-    Ok((section, sap, sk_set))
+    sk_set: &SecretKeySet,
+) -> Result<(NetworkKnowledge, SectionAuthorityProvider)> {
+    let (sap, _) = random_sap_with_key(prefix, elder_count(), 0, sk_set);
+    let (section, _) = create_section(sk_set, &sap, None, None)?;
+    Ok((section, sap))
 }
 
 /// Creates a section where all elders and adults are marked as joined members.
@@ -226,24 +310,17 @@ pub(crate) fn create_section_with_random_sap(
 /// Can be used for tests requiring adults to be members of the section, e.g., when you expect
 /// replication to occur after handling a message.
 pub(crate) fn create_section(
-    sk_set: &SecretKeySet,
-    section_auth: &SectionAuthorityProvider,
+    genesis_sk_set: &bls::SecretKeySet,
+    sap: &SectionAuthorityProvider,
+    other_keys: Option<Vec<bls::SecretKey>>,
+    parent_section_tree: Option<SectionTree>,
 ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
-    let genesis_key = sk_set.public_keys().public_key();
-    let section_tree_update = {
-        let section_chain = SectionsDAG::new(genesis_key);
-        let signed_sap = section_signed(sk_set.secret_key(), section_auth.clone())?;
-        SectionTreeUpdate::new(signed_sap, section_chain)
-    };
-    let section = NetworkKnowledge::new(SectionTree::new(genesis_key), section_tree_update)?;
-
-    for ns in section_auth.members() {
-        let auth_ns = section_signed(sk_set.secret_key(), ns.clone())?;
+    let (section, section_key_share) =
+        do_create_section(sap, genesis_sk_set, other_keys, parent_section_tree)?;
+    for ns in sap.members() {
+        let auth_ns = section_signed(&genesis_sk_set.secret_key(), ns.clone())?;
         let _updated = section.update_member(auth_ns);
     }
-
-    let section_key_share = create_section_key_share(sk_set, 0);
-
     Ok((section, section_key_share))
 }
 
@@ -252,25 +329,14 @@ pub(crate) fn create_section(
 /// Some tests require the condition where only the elders were marked as joined members.
 pub(crate) fn create_section_with_elders(
     sk_set: &SecretKeySet,
-    section_auth: &SectionAuthorityProvider,
+    sap: &SectionAuthorityProvider,
 ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
-    let genesis_key = sk_set.public_keys().public_key();
-    let section_tree_update = {
-        let section_chain = SectionsDAG::new(genesis_key);
-        let signed_sap = section_signed(sk_set.secret_key(), section_auth.clone())?;
-        SectionTreeUpdate::new(signed_sap, section_chain)
-    };
-
-    let section = NetworkKnowledge::new(SectionTree::new(genesis_key), section_tree_update)?;
-
-    for peer in section_auth.elders() {
+    let (section, section_key_share) = do_create_section(sap, sk_set, None, None)?;
+    for peer in sap.elders() {
         let node_state = NodeState::joined(*peer, None);
         let node_state = section_signed(sk_set.secret_key(), node_state)?;
         let _updated = section.update_member(node_state);
     }
-
-    let section_key_share = create_section_key_share(sk_set, 0);
-
     Ok((section, section_key_share))
 }
 
@@ -285,7 +351,8 @@ pub(crate) fn create_section_key_share(
     }
 }
 
-pub(crate) fn create_section_auth() -> (SectionAuthorityProvider, Vec<NodeInfo>, SecretKeySet) {
+pub(crate) fn create_section_auth() -> (SectionAuthorityProvider, Vec<NodeInfo>, bls::SecretKeySet)
+{
     let (section_auth, elders, secret_key_set) =
         random_sap(Prefix::default(), elder_count(), 0, None);
     (section_auth, elders, secret_key_set)
@@ -335,4 +402,53 @@ pub(crate) fn create_relocation_trigger(
             return Ok(decision);
         }
     }
+}
+
+///
+/// Private helpers
+///
+
+fn do_create_section(
+    section_auth: &SectionAuthorityProvider,
+    genesis_ks: &bls::SecretKeySet,
+    other_section_keys: Option<Vec<bls::SecretKey>>,
+    parent_section_tree: Option<SectionTree>,
+) -> Result<(NetworkKnowledge, SectionKeyShare)> {
+    let (section_chain, last_sk, share_index) = if let Some(other_section_keys) = other_section_keys
+    {
+        let section_chain = make_section_chain(&genesis_ks.secret_key(), &other_section_keys)?;
+        let last_key = other_section_keys
+            .last()
+            .ok_or_else(|| eyre!("The section keys list must be populated"))?;
+        let share_index = section_chain.len() - 1;
+        (section_chain, last_key.clone(), share_index)
+    } else {
+        let section_chain = SecuredLinkedList::new(genesis_ks.public_keys().public_key());
+        (section_chain, genesis_ks.secret_key(), 0)
+    };
+    let signed_sap = section_signed(&last_sk, section_auth.clone())?;
+    let section = NetworkKnowledge::new(
+        *section_chain.root_key(),
+        section_chain,
+        signed_sap,
+        parent_section_tree,
+    )?;
+
+    let sks = bls::SecretKeySet::from_bytes(last_sk.to_bytes().to_vec())?;
+    let section_key_share = create_section_key_share(&sks, share_index);
+    Ok((section, section_key_share))
+}
+
+fn make_section_chain(
+    genesis_key: &bls::SecretKey,
+    other_keys: &Vec<bls::SecretKey>,
+) -> Result<SecuredLinkedList> {
+    let mut section_chain = SecuredLinkedList::new(genesis_key.public_key());
+    let mut parent = genesis_key.clone();
+    for key in other_keys {
+        let sig = parent.sign(key.public_key().to_bytes());
+        section_chain.insert(&parent.public_key(), key.public_key(), sig)?;
+        parent = key.clone();
+    }
+    Ok(section_chain)
 }

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -702,7 +702,7 @@ mod tests {
                 random_sap(prefix0, elder_count(), 0, None);
             let info = nodes.remove(0);
             let sap_sk = secret_key_set.secret_key();
-            let signed_sap = section_signed(sap_sk, section_auth)?;
+            let signed_sap = section_signed(&sap_sk, section_auth)?;
 
             let (proof_chain, genesis_sk_set) = create_proof_chain(signed_sap.section_key())
                 .context("failed to create section chain")?;
@@ -735,7 +735,7 @@ mod tests {
             // generate other SAP for prefix1
             let (other_sap, _, secret_key_set) = random_sap(prefix1, elder_count(), 0, None);
             let other_sap_sk = secret_key_set.secret_key();
-            let other_sap = section_signed(other_sap_sk, other_sap)?;
+            let other_sap = section_signed(&other_sap_sk, other_sap)?;
             // generate a proof chain for this other SAP
             let mut proof_chain = SectionsDAG::new(genesis_pk);
             let signature = bincode::serialize(&other_sap_sk.public_key())

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -216,8 +216,8 @@ impl Node {
                 info!("Processing spend request for key image: {:?}", key_image);
                 if let Some((proof_chain, signed_sap)) = network_knowledge {
                     debug!(
-                        "Received updated proof chain with the request. Will return new command \
-                        to update the network knowledge before processing the spend."
+                        "Received updated network knowledge with the request. Will return new command \
+                        to update the node network knowledge before processing the spend."
                     );
                     // To avoid a loop, recompose the message without the updated proof_chain.
                     let updated_service_msg =

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -211,11 +211,10 @@ impl Node {
                 tx,
                 spent_proofs,
                 spent_transactions,
-                updated_proof_chain,
-                signed_sap,
+                network_knowledge,
             })) => {
                 info!("Processing spend request for key image: {:?}", key_image);
-                if let Some(proof_chain) = updated_proof_chain {
+                if let Some((proof_chain, signed_sap)) = network_knowledge {
                     debug!(
                         "Received updated proof chain with the request. Will return new command \
                         to update the network knowledge before processing the spend."
@@ -227,16 +226,11 @@ impl Node {
                             tx,
                             spent_proofs,
                             spent_transactions,
-                            updated_proof_chain: None,
-                            signed_sap: None,
+                            network_knowledge: None,
                         }));
                     let update_command = Cmd::UpdateNetworkAndHandleValidServiceMsg {
                         proof_chain,
-                        signed_sap: signed_sap.ok_or_else(|| {
-                            Error::SpentbookError(
-                                "A signed section authority provider must also be provided with an \
-                                updated proof chain".to_string())
-                        })?,
+                        signed_sap,
                         msg_id,
                         msg: updated_service_msg,
                         origin,


### PR DESCRIPTION
- bdcbeefd6 **feat: dbc spend can update network knowledge**

  When a DBC is submitted for spending, there are a set of spent proofs sent along with the request,
  one for each input for the DBC being spent. It's possible that these proofs were signed with a
  section key that the section processing the request is not aware of. In this case, the request
  processing section needs to be updated with new network knowledge. Therefore, we add a couple of
  fields to the spend command to give it the option to send new network knowledge, namely the updated
  proof chain and the signed section authority provider.

  If the node detects the spend command has been sent with these, it will create a new type of
  internal command, `UpdateNetworkAndHandleValidServiceMsg` which will be returned for processing.
  This command will contain the original spend request, which will be run after the network knowledge
  is updated. The reason for issuing the new command is because the original `HandleValidServiceMsg`
  command does not have mutable access to the node.

- 14c82ca14 **feat: retry dbc spend on unknown section key**

  This is the client side for the scenario where the spent proofs are signed by section keys that the
  processing section is not aware of.

  Several retries will be attempted because it's possible for there to be multiple section keys that
  are not known, but the network will only return back one key at a time.

- 9e8bcae5d **tests: spend with updated network knowledge**

  Previously I had a placeholder in for this case, but now have something working.

  The test requires having two network sections and one of the input DBCs for a transaction being
  signed by the other section key.

  The `TestNodeBuilder` was extended with a function that creates a section without a creating a node,
  and this included being able to provide a section chain and tree.

- 8422307a7 **chore: remove spend retry on client**

  The spend retry depends on providing new network knowledge. We will be using another mechanism to
  obtain this knowledge, which is not available at the moment. Once it's available, we'll add the
  retry again.

  For now we decided it's best to remove it and only merge the node-side changes.