### PR TITLE
feat(statemap): run statemap in CI

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -327,7 +327,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          unset RUST_FLAGS
+          unset RUSTFLAGS # Disable `-D warnings` since statemap is 3rd party
           cargo install --git https://github.com/TritonDataCenter/statemap.git
           ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
 
@@ -497,7 +497,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          unset RUST_FLAGS
+          unset RUSTFLAGS # Disable `-D warnings` since statemap is 3rd party
           cargo install --git https://github.com/TritonDataCenter/statemap.git
           ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
 
@@ -626,7 +626,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          unset RUST_FLAGS
+          unset RUSTFLAGS # Disable `-D warnings` since statemap is 3rd party
           cargo install --git https://github.com/TritonDataCenter/statemap.git
           ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
 
@@ -750,7 +750,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          unset RUST_FLAGS
+          unset RUSTFLAGS # Disable `-D warnings` since statemap is 3rd party
           cargo install --git https://github.com/TritonDataCenter/statemap.git
           ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
 

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -248,7 +248,7 @@ jobs:
         run: ./target/release/testnet
         id: section-startup
         env:
-          RUST_LOG: "sn_node,sn_api,sn_consensus,sn_dysfunction=trace"
+          RUST_LOG: "sn_node,sn_api,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
 
       - name: Print Network Log Stats at start
         shell: bash
@@ -397,7 +397,7 @@ jobs:
         shell: bash
         run: cargo run --release --example churn
         env:
-          RUST_LOG: "sn_node,sn_client,sn_consensus,sn_dysfunction=trace"
+          RUST_LOG: "sn_node,sn_client,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
 
 
       - name: Print Network Stats after churn test
@@ -575,7 +575,7 @@ jobs:
         run: ./target/release/testnet
         id: section-startup
         env:
-          RUST_LOG: "sn_node,sn_consensus,sn_dysfunction=trace"
+          RUST_LOG: "sn_node,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
 
       - name: Print Network Log Stats at start
         shell: bash
@@ -702,7 +702,7 @@ jobs:
         run: ./target/release/testnet
         id: section-startup
         env:
-          RUST_LOG: "sn_node,sn_api,sn_consensus,sn_dysfunction=trace"
+          RUST_LOG: "sn_node,sn_api,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
 
       - name: Print Network Log Stats at start
         shell: bash

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -329,7 +329,7 @@ jobs:
         run: |
           unset RUSTFLAGS # Disable `-D warnings` since statemap is 3rd party
           cargo install --git https://github.com/TritonDataCenter/statemap.git
-          ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
+          ./resources/scripts/statemap-preprocess.sh --run-statemap > safe_statemap.svg
 
       - name: Upload StateMap
         uses: actions/upload-artifact@main
@@ -499,7 +499,7 @@ jobs:
         run: |
           unset RUSTFLAGS # Disable `-D warnings` since statemap is 3rd party
           cargo install --git https://github.com/TritonDataCenter/statemap.git
-          ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
+          ./resources/scripts/statemap-preprocess.sh --run-statemap > safe_statemap.svg
 
       - name: Upload StateMap
         uses: actions/upload-artifact@main
@@ -628,7 +628,7 @@ jobs:
         run: |
           unset RUSTFLAGS # Disable `-D warnings` since statemap is 3rd party
           cargo install --git https://github.com/TritonDataCenter/statemap.git
-          ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
+          ./resources/scripts/statemap-preprocess.sh --run-statemap > safe_statemap.svg
 
       - name: Upload StateMap
         uses: actions/upload-artifact@main
@@ -752,7 +752,7 @@ jobs:
         run: |
           unset RUSTFLAGS # Disable `-D warnings` since statemap is 3rd party
           cargo install --git https://github.com/TritonDataCenter/statemap.git
-          ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
+          ./resources/scripts/statemap-preprocess.sh --run-statemap > safe_statemap.svg
 
       - name: Upload StateMap
         uses: actions/upload-artifact@main

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -336,7 +336,6 @@ jobs:
         with:
           name: statemap_e2e_${{matrix.os}}.svg
           path: safe_statemap.svg
-        if: failure()
         continue-on-error: true
 
       - name: Tar log files
@@ -506,7 +505,6 @@ jobs:
         with:
           name: statemap_e2e_split_self_hosted_ubuntu.svg
           path: safe_statemap.svg
-        if: failure()
         continue-on-error: true
 
       - name: Tar log files
@@ -635,7 +633,6 @@ jobs:
         with:
           name: statemap_api_${{matrix.os}}.svg
           path: safe_statemap.svg
-        if: failure()
         continue-on-error: true
 
       - name: Print Network Log Stats
@@ -759,9 +756,7 @@ jobs:
         with:
           name: statemap_cli_${{matrix.os}}.svg
           path: safe_statemap.svg
-        if: failure()
         continue-on-error: true
-
 
       - name: Print Network Log Stats
         shell: bash

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -323,6 +323,21 @@ jobs:
         run: ./target/release/log_cmds_inspector $HOME/.safe/node/local-test-network
         if: matrix.os != 'windows-latest'
 
+      - name: Generate StateMap
+        shell: bash
+        continue-on-error: true
+        run: |
+          cargo install --git https://github.com/TritonDataCenter/statemap.git
+          ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
+
+      - name: Upload StateMap
+        uses: actions/upload-artifact@main
+        with:
+          name: statemap_e2e_${{matrix.os}}.svg
+          path: safe_statemap.svg
+        if: failure()
+        continue-on-error: true
+
       - name: Tar log files
         shell: bash
         continue-on-error: true
@@ -477,6 +492,21 @@ jobs:
         continue-on-error: true
         run: ./target/release/log_cmds_inspector $HOME/.safe/node/local-test-network
 
+      - name: Generate StateMap
+        shell: bash
+        continue-on-error: true
+        run: |
+          cargo install --git https://github.com/TritonDataCenter/statemap.git
+          ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
+
+      - name: Upload StateMap
+        uses: actions/upload-artifact@main
+        with:
+          name: statemap_e2e_split_self_hosted_ubuntu.svg
+          path: safe_statemap.svg
+        if: failure()
+        continue-on-error: true
+
       - name: Tar log files
         shell: bash
         continue-on-error: true
@@ -590,6 +620,20 @@ jobs:
         # we just want to print out the info. If there is none, an exit code of 1 is returned, so here we return true
         run: rg "Membership - decided" $HOME/.safe/node/local-test-network | rg Left || true
 
+      - name: Generate StateMap
+        shell: bash
+        continue-on-error: true
+        run: |
+          cargo install --git https://github.com/TritonDataCenter/statemap.git
+          ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
+
+      - name: Upload StateMap
+        uses: actions/upload-artifact@main
+        with:
+          name: statemap_api_${{matrix.os}}.svg
+          path: safe_statemap.svg
+        if: failure()
+        continue-on-error: true
 
       - name: Print Network Log Stats
         shell: bash
@@ -698,6 +742,22 @@ jobs:
         if: matrix.os != 'windows-latest'
         # we just want to print out the info. If there is none, an exit code of 1 is returned, so here we return true
         run: rg "Membership - decided" $HOME/.safe/node/local-test-network | rg Left || true
+
+      - name: Generate StateMap
+        shell: bash
+        continue-on-error: true
+        run: |
+          cargo install --git https://github.com/TritonDataCenter/statemap.git
+          ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
+
+      - name: Upload StateMap
+        uses: actions/upload-artifact@main
+        with:
+          name: statemap_cli_${{matrix.os}}.svg
+          path: safe_statemap.svg
+        if: failure()
+        continue-on-error: true
+
 
       - name: Print Network Log Stats
         shell: bash

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -327,6 +327,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
+          unset RUST_FLAGS
           cargo install --git https://github.com/TritonDataCenter/statemap.git
           ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
 
@@ -496,6 +497,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
+          unset RUST_FLAGS
           cargo install --git https://github.com/TritonDataCenter/statemap.git
           ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
 
@@ -624,6 +626,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
+          unset RUST_FLAGS
           cargo install --git https://github.com/TritonDataCenter/statemap.git
           ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
 
@@ -747,6 +750,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
+          unset RUST_FLAGS
           cargo install --git https://github.com/TritonDataCenter/statemap.git
           ./resources/scripts/statemap.sh --run-statemap > safe_statemap.svg
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,27 @@ Once you have your network running you can simply run `cargo test --release`. Th
 
 In general it can be useful to scope your test running, eg `cargo test --release client` will run _only_ the client tests. Or perhaps you want to ignore `proptests` as they can be quite long: `cargo test --release client --skip proptest`
 
+## Development Tools
+
+### Statemaps
+
+It's possible to generate [statemaps](https://github.com/TritonDataCenter/statemap) to get a wider view of what's going on in a network.
+
+Steps:
+
+0. Install `statemap`
+
+```
+cargo install --git https://github.com/TritonDataCenter/statemap.git
+```
+
+1. [Start a testnet](#running-a-local-testnet), make sure to have the `statemap` feature enabled.
+
+2. Run `./resources/scripts/statemap-preprocess.sh` to extract statemap states from the node logs.
+
+3. After the script completes, it will output a `statemap` command, execute the command to generate the statemap SVG.
+
+4. Open the SVG in a browser
 
 
 ## Releases

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ In general it can be useful to scope your test running, eg `cargo test --release
 
 ### Statemaps
 
-It's possible to generate [statemaps](https://github.com/TritonDataCenter/statemap) to get a wider view of what's going on in a network.
+> Note: Statemaps are automatically generated for CI integration tests
 
-Steps:
+[Statemaps](https://github.com/TritonDataCenter/statemap) can be useful to get a wider view of what's going on in a network. 
+
+Steps to generate:
 
 0. Install `statemap`
 

--- a/resources/scripts/statemap-preprocess.sh
+++ b/resources/scripts/statemap-preprocess.sh
@@ -31,13 +31,12 @@ begin_time=$(cat safe_states.out | rg 'time' | jq -sr 'min_by(.time | tonumber) 
 end_time=$(cat safe_states.out | rg 'time' | jq -sr 'max_by(.time | tonumber) | .time')
 statemap_cmd="statemap --sortby=Idle -b $begin_time -e $end_time -c 100000 $out_file"
 
-echo "Wrote statemap data to $out_file"
-
 if [[ $* == *--run-statemap* ]]
 then
-    echo "Generating statemap svg"
     $(statemap_cmd)
 else
+    echo "Wrote statemap data to $out_file"
+
     echo "Render the statemap SVG with"
     echo ""
     echo "    $statemap_cmd > save.svg"

--- a/resources/scripts/statemap-preprocess.sh
+++ b/resources/scripts/statemap-preprocess.sh
@@ -29,7 +29,7 @@ rg -IN ".*STATEMAP_ENTRY: " "$log_dir" --replace "" | jq -s 'sort_by(.time|tonum
 
 begin_time=$(cat safe_states.out | rg 'time' | jq -sr 'min_by(.time | tonumber) | .time')
 end_time=$(cat safe_states.out | rg 'time' | jq -sr 'max_by(.time | tonumber) | .time')
-statemap_cmd="statemap --sortby=Idle -b $begin_time -e $end_time -c 100000 $out_file"
+statemap_cmd="statemap --sortby=Idle -b $begin_time -e $end_time -c 300000 $out_file"
 
 if [[ $* == *--run-statemap* ]]
 then

--- a/resources/scripts/statemap-preprocess.sh
+++ b/resources/scripts/statemap-preprocess.sh
@@ -33,7 +33,7 @@ statemap_cmd="statemap --sortby=Idle -b $begin_time -e $end_time -c 100000 $out_
 
 if [[ $* == *--run-statemap* ]]
 then
-    $(statemap_cmd)
+    $statemap_cmd
 else
     echo "Wrote statemap data to $out_file"
 

--- a/sn_client/examples/churn.rs
+++ b/sn_client/examples/churn.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|_| println!("Error initializing logger"));
 
     // First lets build the network and testnet launcher, to ensure we're on the latest version
-    let args: Vec<&str> = vec!["build", "--release"];
+    let args: Vec<&str> = vec!["build", "--release", "--features", "statemap"];
 
     println!("Building current sn_node");
     let _child = Command::new("cargo")

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -23,7 +23,7 @@ name = "routing_minimal"
 name = "routing_stress"
 
 [features]
-default = ["traceroute"]
+default = ["traceroute", "statemap"]
 chaos = []
 back-pressure = ["sn_interface/back-pressure"]
 unstable-wiremsg-debuginfo = []


### PR DESCRIPTION
Statemaps are now generated for each integration test and uploaded as artifacts after the workflow completes.

Sample run, see `statemap_*.svg` artifacts on: https://github.com/maidsafe/safe_network/actions/runs/3011677860