### PR TITLE
feat(node): return error to client when it cannot accept a query

### DIFF
--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -250,19 +250,17 @@ impl QueryResponse {
     /// Returns true if the result returned is DataNotFound
     pub fn is_data_not_found(&self) -> bool {
         use QueryResponse::*;
-        match self {
-            GetChunk(result) => matches!(result, Err(Error::DataNotFound(_))),
-            GetRegister((result, _op_id)) => matches!(result, Err(Error::DataNotFound(_))),
-            GetRegisterEntry((result, _op_id)) => matches!(result, Err(Error::DataNotFound(_))),
-            GetRegisterOwner((result, _op_id)) => matches!(result, Err(Error::DataNotFound(_))),
-            ReadRegister((result, _op_id)) => matches!(result, Err(Error::DataNotFound(_))),
-            GetRegisterPolicy((result, _op_id)) => matches!(result, Err(Error::DataNotFound(_))),
-            GetRegisterUserPermissions((result, _op_id)) => {
-                matches!(result, Err(Error::DataNotFound(_)))
-            }
-            SpentProofShares((result, _op_id)) => matches!(result, Err(Error::DataNotFound(_))),
-            FailedToCreateOperationId => false,
-        }
+        matches!(
+            self,
+            GetChunk(Err(Error::DataNotFound(_)))
+                | GetRegister((Err(Error::DataNotFound(_)), _))
+                | GetRegisterEntry((Err(Error::DataNotFound(_)), _))
+                | GetRegisterOwner((Err(Error::DataNotFound(_)), _))
+                | ReadRegister((Err(Error::DataNotFound(_)), _))
+                | GetRegisterPolicy((Err(Error::DataNotFound(_)), _))
+                | GetRegisterUserPermissions((Err(Error::DataNotFound(_)), _))
+                | SpentProofShares((Err(Error::DataNotFound(_)), _))
+        )
     }
 
     /// Retrieves the operation identifier for this response, use in tracking node liveness

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -162,15 +162,6 @@ pub enum SystemMsg {
     },
     /// Events are facts about something that happened on a node.
     NodeEvent(NodeEvent),
-    /// The returned error, from any msg handling on recipient node.
-    NodeMsgError {
-        /// The error.
-        // TODO: return node::Error instead
-        error: crate::messaging::data::Error,
-        /// ID of causing cmd.
-        correlation_id: MsgId,
-    },
-
     #[cfg(any(feature = "chunks", feature = "registers"))]
     /// Cmds are orders to perform some operation, only sent internally in the network.
     NodeCmd(NodeCmd),
@@ -230,8 +221,6 @@ impl SystemMsg {
             // Inter-node comms for backpressure
             Self::BackPressure(_) => BACKPRESSURE_MSG_PRIORITY,
 
-            Self::NodeMsgError { .. } => NODE_DATA_MSG_PRIORITY,
-
             #[cfg(any(feature = "chunks", feature = "registers"))]
             // Inter-node comms related to processing client requests
             Self::NodeCmd(_)
@@ -265,7 +254,6 @@ impl SystemMsg {
             Self::HandoverAE(_) => State::Handover,
             Self::Propose { .. } => State::Propose,
             Self::NodeEvent(_) => State::Node,
-            Self::NodeMsgError { .. } => State::Node,
             Self::NodeCmd(_) => State::Node,
             Self::NodeQuery(_) => State::Node,
             Self::NodeQueryResponse { .. } => State::Node,
@@ -306,7 +294,6 @@ impl Display for SystemMsg {
             Self::HandoverAE { .. } => write!(f, "SystemMsg::HandoverAE"),
             Self::Propose { .. } => write!(f, "SystemMsg::Propose"),
             Self::NodeEvent { .. } => write!(f, "SystemMsg::NodeEvent"),
-            Self::NodeMsgError { .. } => write!(f, "SystemMsg::NodeMsgError"),
             #[cfg(any(feature = "chunks", feature = "registers"))]
             Self::NodeCmd { .. } => write!(f, "SystemMsg::NodeCmd"),
             #[cfg(any(feature = "chunks", feature = "registers"))]

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -9,7 +9,7 @@
 #![recursion_limit = "256"]
 
 use sn_interface::{
-    messaging::{data::Error::FailedToWriteFile, system::SystemMsg, MsgId},
+    messaging::system::{NodeCmd, SystemMsg},
     types::Cache,
 };
 use sn_node::node::{
@@ -436,10 +436,7 @@ impl Network {
         // section health to appear lower than it actually is.
 
         // just some valid message
-        let msg = SystemMsg::NodeMsgError {
-            error: FailedToWriteFile,
-            correlation_id: MsgId::new(),
-        };
+        let msg = SystemMsg::NodeCmd(NodeCmd::ReplicateData(vec![]));
 
         let recipients = node.our_elders().await;
 

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -12,7 +12,7 @@ use crate::node::handover::Error as HandoverError;
 
 use sn_dbc::Error as DbcError;
 use sn_interface::{
-    messaging::data::Error as ErrorMsg,
+    messaging::data::{DataQuery, Error as ErrorMsg},
     types::{convert_dt_error_to_error_msg, DataAddress, Peer},
 };
 
@@ -169,6 +169,9 @@ pub enum Error {
     /// Error thrown by DBC public API
     #[error("DbcError: {0}")]
     DbcError(#[from] DbcError),
+    /// Cannot handle more queries at this point
+    #[error("Cannot handle more queries at this point: {0:?}")]
+    CannotHandleQuery(DataQuery),
 }
 
 impl From<qp2p::ClientEndpointError> for Error {

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -34,7 +34,7 @@ use sn_interface::{
     messaging::{
         data::{DataCmd, Error as MessagingDataError, RegisterCmd, ServiceMsg, SpentbookCmd},
         system::{
-            JoinAsRelocatedRequest, JoinRequest, JoinResponse, KeyedSig, MembershipState,
+            JoinAsRelocatedRequest, JoinRequest, JoinResponse, KeyedSig, MembershipState, NodeCmd,
             NodeMsgAuthorityUtils, NodeState as NodeStateMsg, RelocateDetails, ResourceProof,
             SectionAuth, SystemMsg,
         },
@@ -875,10 +875,7 @@ async fn msg_to_self() -> Result<()> {
         let info = node.info();
         let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)), comm);
 
-        let node_msg = SystemMsg::NodeMsgError {
-            error: sn_interface::messaging::data::Error::FailedToWriteFile,
-            correlation_id: MsgId::new(),
-        };
+        let node_msg = SystemMsg::NodeCmd(NodeCmd::ReplicateData(vec![]));
 
         // don't use the cmd collection fn, as it skips Cmd::SendMsg
         let cmds = dispatcher

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -21,8 +21,8 @@ use sn_interface::{
     data_copy_count,
     messaging::{
         data::{
-            CmdError, DataCmd, DataQueryVariant, EditRegister, ServiceMsg, SignedRegisterEdit,
-            SpentbookCmd,
+            CmdError, DataCmd, DataQueryVariant, EditRegister, OperationId, ServiceMsg,
+            SignedRegisterEdit, SpentbookCmd,
         },
         system::{NodeQueryResponse, SystemMsg},
         AuthorityProof, EndUser, MsgId, ServiceAuth,
@@ -134,18 +134,9 @@ impl Node {
         response: NodeQueryResponse,
         user: EndUser,
         sending_node_pk: PublicKey,
+        op_id: OperationId,
         #[cfg(feature = "traceroute")] traceroute: Traceroute,
     ) -> Option<Cmd> {
-        let op_id = if let Ok(op_id) = response.operation_id() {
-            op_id
-        } else {
-            warn!(
-                "There is no operation id. Dropping chunk query response from Adult {}, to user: {}.",
-                sending_node_pk, user.0
-            );
-            return None;
-        };
-
         debug!(
             "Handling data read @ elders, received from {:?}, op id: {:?}",
             sending_node_pk, op_id


### PR DESCRIPTION
Also:
- Avoiding unnecessary operation id generation upon query response at elder since it's expensive (serialisation involved)
- Removing unused `SystemMsg::NodeMsgError` msg type