### PR TITLE
No client connection and refactor ack receipt

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,9 +1,7 @@
 [profile.ci]
-retries = 3
+retries = 0
 # Output failures both immediately and at the end of the run
 failure-output = "immediate-final"
-# Give all tests a chance to run
-fail-fast = false
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -270,6 +270,8 @@ jobs:
 
       - name: Run client tests
         uses: maidsafe/cargo-nextest@main
+        env:
+          RUST_LOG: "sn_client=trace"
         with:
           test-run-name: e2e-client-${{ matrix.os }}
           profile: ci
@@ -593,6 +595,8 @@ jobs:
 
       - name: Run API tests
         uses: maidsafe/cargo-nextest@main
+        env:
+          RUST_LOG: "sn_client=trace"
         with:
           test-run-name: api-${{ matrix.os }}
           profile: ci
@@ -716,6 +720,8 @@ jobs:
 
       - name: Run CLI tests
         uses: maidsafe/cargo-nextest@main
+        env:
+          RUST_LOG: "sn_client=trace"
         with:
           test-run-name: cli-${{ matrix.os }}
           profile: ci

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -602,7 +602,6 @@ jobs:
           release: true
           retries: 0
         timeout-minutes: 80
-        # NRS is slow without this change
 
       - name: Are nodes still running...?
         shell: bash

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -276,7 +276,7 @@ jobs:
           junit-path: junit.xml
           package: sn_client
           release: true
-          test-threads: 2
+          test-threads: 10
           retries: 0
         timeout-minutes: 25
 
@@ -600,6 +600,7 @@ jobs:
           junit-path: junit.xml
           package: sn_api
           release: true
+          retries: 0
         timeout-minutes: 80
         # NRS is slow without this change
 
@@ -724,6 +725,7 @@ jobs:
           junit-path: junit.xml
           package: sn_cli
           release: true
+          retries: 0
         timeout-minutes: 50
 
       - name: Are nodes still running...?

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -127,7 +127,6 @@ jobs:
     name: Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
@@ -208,7 +207,6 @@ jobs:
     name: E2E tests
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
@@ -533,7 +531,6 @@ jobs:
     name: Run API tests
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
@@ -660,7 +657,6 @@ jobs:
     name: Run CLI tests
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:

--- a/resources/scripts/statemap-preprocess.sh
+++ b/resources/scripts/statemap-preprocess.sh
@@ -38,5 +38,5 @@ else
 
     echo "Render the statemap SVG with"
     echo ""
-    echo "    $statemap_cmd > save.svg"
+    echo "    $statemap_cmd > safe.svg"
 fi

--- a/sn_api/src/app/files/mod.rs
+++ b/sn_api/src/app/files/mod.rs
@@ -120,7 +120,7 @@ impl Safe {
             let entry = files_map_xorurl.as_bytes().to_vec();
             let client = self.get_safe_client()?;
             let (entry_hash, reg_op) = client
-                .write_to_register(reg_address, entry, Default::default())
+                .write_to_local_register(reg_address, entry, Default::default())
                 .await?;
 
             client.publish_register_ops(reg_op).await?;

--- a/sn_api/src/app/files/mod.rs
+++ b/sn_api/src/app/files/mod.rs
@@ -2718,23 +2718,21 @@ mod tests {
         // we know there a change, so we wait for an udpated version here
         while version2 == version1 {
             let (version2_content, new_new_processed_files) = safe
-            .files_container_add(
-                &other_file_xorurl,
-                &url_with_path.to_string(),
-                true, // force to overwrite it with new link
-                false,
-                false,
-            )
-            .await?;
+                .files_container_add(
+                    &other_file_xorurl,
+                    &url_with_path.to_string(),
+                    true, // force to overwrite it with new link
+                    false,
+                    false,
+                )
+                .await?;
 
-            let (new_version2, new_new_files_map) =
-                version2_content.ok_or_else(|| anyhow!("files container was unexpectedly empty"))?;
+            let (new_version2, new_new_files_map) = version2_content
+                .ok_or_else(|| anyhow!("files container was unexpectedly empty"))?;
             version2 = new_version2;
             new_files_map = new_new_files_map;
             new_processed_files = new_new_processed_files;
         }
-
-
 
         assert_ne!(version2, version0);
         assert_ne!(version2, version1);

--- a/sn_api/src/app/multimap.rs
+++ b/sn_api/src/app/multimap.rs
@@ -102,7 +102,9 @@ impl Safe {
 
         let client = self.get_safe_client()?;
 
-        let (entry_hash, op_batch) = client.write_to_register(address, data, replace).await?;
+        let (entry_hash, op_batch) = client
+            .write_to_local_register(address, data, replace)
+            .await?;
 
         client.publish_register_ops(op_batch).await?;
 
@@ -138,7 +140,7 @@ impl Safe {
         let client = self.get_safe_client()?;
 
         let (entry_hash, op_batch) = client
-            .write_to_register(address, MULTIMAP_REMOVED_MARK.to_vec(), to_remove)
+            .write_to_local_register(address, MULTIMAP_REMOVED_MARK.to_vec(), to_remove)
             .await?;
 
         client.publish_register_ops(op_batch).await?;

--- a/sn_api/src/app/register.rs
+++ b/sn_api/src/app/register.rs
@@ -187,7 +187,10 @@ impl Safe {
         }
 
         let client = self.get_safe_client()?;
-        let (entry_hash, op_batch) = match client.write_to_register(address, entry, parents).await {
+        let (entry_hash, op_batch) = match client
+            .write_to_local_register(address, entry, parents)
+            .await
+        {
             Ok(data) => data,
             Err(
                 ClientError::NetworkDataError(SafeNdError::AccessDenied(_))

--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -156,7 +156,6 @@ impl ClientBuilder {
         let max_retries = self.max_retries.unwrap_or(DEFAULT_MAX_QUERY_CMD_RETRIES);
         let query_timeout = self.query_timeout.unwrap_or(DEFAULT_QUERY_CMD_TIMEOUT);
         let cmd_timeout = self.cmd_timeout.unwrap_or(DEFAULT_QUERY_CMD_TIMEOUT);
-        let cmd_ack_wait = self.cmd_ack_wait.unwrap_or(DEFAULT_ACK_WAIT);
 
         let network_contacts = match self.network_contacts {
             Some(pm) => pm,
@@ -178,7 +177,6 @@ impl ClientBuilder {
             qp2p,
             self.local_addr
                 .unwrap_or_else(|| SocketAddr::from(DEFAULT_LOCAL_ADDR)),
-            cmd_ack_wait,
             network_contacts,
         )?;
 

--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -40,12 +40,10 @@ pub const ENV_AE_WAIT: &str = "SN_AE_WAIT";
 /// Bind by default to all network interfaces on a OS assigned port
 pub const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 /// Default timeout to use before timing out queries and commands
-pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(45);
+pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(120);
 /// Max retries to be attempted in the DEFAULT_QUERY_CMD_TIMEOUT; DEFAULT_QUERY_CMD_TIMEOUT / DEFAULT_MAX_QUERY_CMD_RETRIES ~ second per try
 /// (though exponential backoff exists)
 pub const DEFAULT_MAX_QUERY_CMD_RETRIES: usize = 20;
-/// Default timeout for waiting for potential Anti-Entropy messages
-pub const DEFAULT_ACK_WAIT: Duration = Duration::from_secs(10);
 
 /// Build a [`crate::Client`]
 #[derive(Debug, Default)]

--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -40,10 +40,10 @@ pub const ENV_AE_WAIT: &str = "SN_AE_WAIT";
 /// Bind by default to all network interfaces on a OS assigned port
 pub const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 /// Default timeout to use before timing out queries and commands
-pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(30);
+pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(45);
 /// Max retries to be attempted in the DEFAULT_QUERY_CMD_TIMEOUT; DEFAULT_QUERY_CMD_TIMEOUT / DEFAULT_MAX_QUERY_CMD_RETRIES ~ second per try
 /// (though exponential backoff exists)
-pub const DEFAULT_MAX_QUERY_CMD_RETRIES: usize = 15;
+pub const DEFAULT_MAX_QUERY_CMD_RETRIES: usize = 20;
 /// Default timeout for waiting for potential Anti-Entropy messages
 pub const DEFAULT_ACK_WAIT: Duration = Duration::from_secs(10);
 

--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -41,7 +41,7 @@ pub const ENV_AE_WAIT: &str = "SN_AE_WAIT";
 pub const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 /// Default timeout to use before timing out queries and commands
 pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(30);
-/// Max retries to be attempted in the DEFAULT_QUERY_CMD_TIMEOUT; DEFAULT_QUERY_CMD_TIMEOUT / DEFAULT_MAX_QUERY_CMD_RETRIES ~ tries per second
+/// Max retries to be attempted in the DEFAULT_QUERY_CMD_TIMEOUT; DEFAULT_QUERY_CMD_TIMEOUT / DEFAULT_MAX_QUERY_CMD_RETRIES ~ second per try
 /// (though exponential backoff exists)
 pub const DEFAULT_MAX_QUERY_CMD_RETRIES: usize = 15;
 /// Default timeout for waiting for potential Anti-Entropy messages

--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -147,7 +147,6 @@ impl ClientBuilder {
     /// - `[Self::keypair]` and `[Self::dbc_owner]` are randomly generated
     /// - `[Self::query_timeout`] and `[Self::cmd_timeout]` default to [`DEFAULT_QUERY_CMD_TIMEOUT`]
     /// - `[Self::max_retries`] and `[Self::cmd_timeout]` default to [`DEFAULT_MAX_QUERY_CMD_RETRIES`]
-    /// - `[Self::cmd_ack_wait`] defaults to [`DEFAULT_ACK_WAIT`]
     /// - [`qp2p::Config`] will default to it's [`Default`] impl
     /// - Network contacts file will be read from a standard location
     pub async fn build(self) -> Result<Client, Error> {

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -12,7 +12,7 @@ use crate::Error;
 use sn_interface::{
     messaging::{
         data::{DataCmd, ServiceMsg},
-        ServiceAuth, WireMsg,
+        MsgId, ServiceAuth, WireMsg,
     },
     types::{PublicKey, Signature},
 };
@@ -65,6 +65,8 @@ impl Client {
             ..Default::default()
         };
 
+        let msg_id = MsgId::new();
+
         // this seems needed for custom settings to take effect
         backoff.reset();
 
@@ -80,6 +82,7 @@ impl Client {
                 .send_signed_cmd(
                     dst_name,
                     client_pk,
+                    msg_id,
                     serialised_cmd.clone(),
                     signature.clone(),
                     force_new_link,
@@ -117,6 +120,7 @@ impl Client {
         &self,
         dst_address: XorName,
         client_pk: PublicKey,
+        msg_id: MsgId,
         serialised_cmd: Bytes,
         signature: Signature,
         force_new_link: bool,
@@ -131,6 +135,7 @@ impl Client {
                 dst_address,
                 auth,
                 serialised_cmd,
+                msg_id,
                 force_new_link,
                 #[cfg(feature = "traceroute")]
                 self.public_key(),

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -58,10 +58,10 @@ impl Client {
         let op_limit = self.cmd_timeout;
 
         let mut backoff = ExponentialBackoff {
-            initial_interval: Duration::from_millis(500),
+            initial_interval: Duration::from_secs(1),
             max_interval: Duration::from_secs(20),
             max_elapsed_time: Some(op_limit),
-            randomization_factor: 1.5,
+            randomization_factor: 0.5,
             ..Default::default()
         };
 
@@ -110,6 +110,7 @@ impl Client {
                 debug!("Sleeping for {delay:?} before trying cmd {debug_cmd:?} again");
                 tokio::time::sleep(delay).await;
             } else {
+                debug!("backoff done affter #{:?} attempts", attempt - 1);
                 // we're done trying
                 break res;
             }

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -61,7 +61,7 @@ impl Client {
             initial_interval: Duration::from_millis(500),
             max_interval: Duration::from_secs(20),
             max_elapsed_time: Some(op_limit),
-            randomization_factor: 0.5,
+            randomization_factor: 1.5,
             ..Default::default()
         };
 
@@ -70,13 +70,16 @@ impl Client {
         // this seems needed for custom settings to take effect
         backoff.reset();
 
-        let span = info_span!("Attempting a cmd");
+        let span = info_span!("Attempting a cmd with total timeout of {op_limit:?}");
         let _ = span.enter();
 
         let mut attempt = 1;
-        let force_new_link = false;
+        let mut force_new_link = false;
         loop {
-            debug!("Attempting {:?} (attempt #{})", debug_cmd, attempt);
+            debug!(
+                "Attempting {:?} (attempt #{}), forcing new: {force_new_link}",
+                debug_cmd, attempt
+            );
 
             let res = self
                 .send_signed_cmd(
@@ -89,7 +92,7 @@ impl Client {
                 )
                 .await;
 
-            // force_new_link = true;
+            force_new_link = true;
 
             if let Ok(cmd_result) = res {
                 debug!("{debug_cmd} sent okay");

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -58,10 +58,10 @@ impl Client {
         let op_limit = self.cmd_timeout;
 
         let mut backoff = ExponentialBackoff {
-            initial_interval: Duration::from_secs(3),
-            max_interval: Duration::from_secs(60),
+            initial_interval: Duration::from_millis(500),
+            max_interval: Duration::from_secs(20),
             max_elapsed_time: Some(op_limit),
-            // randomization_factor: 0.5,
+            randomization_factor: 0.5,
             ..Default::default()
         };
 

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -89,7 +89,7 @@ impl Client {
                 )
                 .await;
 
-            force_new_link = true;
+            // force_new_link = true;
 
             if let Ok(cmd_result) = res {
                 debug!("{debug_cmd} sent okay");

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -74,7 +74,7 @@ impl Client {
         let _ = span.enter();
 
         let mut attempt = 1;
-        let mut force_new_link = false;
+        let force_new_link = false;
         loop {
             debug!("Attempting {:?} (attempt #{})", debug_cmd, attempt);
 

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -72,6 +72,7 @@ impl Client {
         let _ = span.enter();
 
         let mut attempt = 1;
+        let mut force_new_link = false;
         loop {
             debug!("Attempting {:?} (attempt #{})", debug_cmd, attempt);
 
@@ -81,8 +82,11 @@ impl Client {
                     client_pk,
                     serialised_cmd.clone(),
                     signature.clone(),
+                    force_new_link,
                 )
                 .await;
+
+            force_new_link = true;
 
             if let Ok(cmd_result) = res {
                 debug!("{debug_cmd} sent okay");
@@ -115,6 +119,7 @@ impl Client {
         client_pk: PublicKey,
         serialised_cmd: Bytes,
         signature: Signature,
+        force_new_link: bool,
     ) -> Result<(), Error> {
         let auth = ServiceAuth {
             public_key: client_pk,
@@ -126,6 +131,7 @@ impl Client {
                 dst_address,
                 auth,
                 serialised_cmd,
+                force_new_link,
                 #[cfg(feature = "traceroute")]
                 self.public_key(),
             )

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -354,6 +354,7 @@ mod tests {
         init_logger();
         let file = random_bytes(LARGE_FILE_SIZE_MIN);
 
+        panic!("nooo");
         use crate::api::data::encrypt_large;
         let (first_address, mut first_chunks) = encrypt_large(file.clone())?;
 

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -167,6 +167,7 @@ impl Client {
         let bytes = tokio::time::timeout(self.query_timeout, async {
             let mut last_response = self.read_bytes(address).await;
             while last_response.is_err() {
+                error!("Error when attempting to verify bytes were uploaded: {:?}", last_response);
                 last_response = self.read_bytes(address).await;
             }
             last_response

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -167,7 +167,10 @@ impl Client {
         let bytes = tokio::time::timeout(self.query_timeout, async {
             let mut last_response = self.read_bytes(address).await;
             while last_response.is_err() {
-                error!("Error when attempting to verify bytes were uploaded: {:?}", last_response);
+                error!(
+                    "Error when attempting to verify bytes were uploaded: {:?}",
+                    last_response
+                );
                 last_response = self.read_bytes(address).await;
             }
             last_response

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -353,8 +353,6 @@ mod tests {
     fn deterministic_chunking() -> Result<()> {
         init_logger();
         let file = random_bytes(LARGE_FILE_SIZE_MIN);
-
-        panic!("nooo");
         use crate::api::data::encrypt_large;
         let (first_address, mut first_chunks) = encrypt_large(file.clone())?;
 

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -74,12 +74,12 @@ impl Client {
         let force_new_link = false;
         // let mut data_not_found_count = BTreeSet::default();
 
-        let op_limit = self.query_timeout;
+        let max_interval = self.query_timeout.div_f32(retry_count as f32);
 
         let mut backoff = ExponentialBackoff {
-            initial_interval: Duration::from_millis(500),
-            max_interval: Duration::from_secs(20),
-            max_elapsed_time: Some(op_limit),
+            initial_interval: Duration::from_millis(1),
+            max_interval,
+            max_elapsed_time: Some(self.query_timeout),
             randomization_factor: 1.5,
             ..Default::default()
         };

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -142,7 +142,7 @@ impl Client {
                 _ => {
                     if attempts > self.max_retries / 3 {
                         // any further attempts should use fresh links in case of issues
-                        force_new_link = true;
+                        // force_new_link = true;
                     }
                 }
             }

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -76,7 +76,6 @@ impl Client {
             let msg = ServiceMsg::Query(query.clone());
             let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
             let signature = self.keypair.sign(&serialised_query);
-
             debug!(
                 "Attempting {:?} (attempt #{}) with a query timeout of {:?}",
                 query, attempts, attempt_timeout

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::collections::BTreeSet;
+// use std::collections::BTreeSet;
 
 use super::Client;
 use crate::{connections::QueryResult, errors::Error};
@@ -20,8 +20,9 @@ use sn_interface::{
     types::{Peer, PublicKey, Signature},
 };
 
+use backoff::{backoff::Backoff, ExponentialBackoff};
 use bytes::Bytes;
-use rand::Rng;
+use tokio::time::Duration;
 use tracing::{debug, info_span};
 
 impl Client {
@@ -58,12 +59,12 @@ impl Client {
             variant: query,
         };
 
-        let mut rng = rand::rngs::OsRng;
+        // let mut rng = rand::rngs::OsRng;
         // Add jitter so not all clients retry at the same rate. This divider will knock on to the overall retry window
         // and should help prevent elders from being conseceutively overwhelmed
-        let jitter = rng.gen_range(1.0..1.5);
-        let attempt_timeout = self.query_timeout.div_f32(retry_count as f32 + jitter);
-        trace!("Setting up query retry, interval is: {:?}", attempt_timeout);
+        // let jitter = rng.gen_range(1.0..1.5);
+        // let attempt_timeout = self.query_timeout.div_f32(retry_count as f32 + jitter);
+        trace!("Setting up query retry");
 
         let span = info_span!("Attempting a query");
         let _ = span.enter();
@@ -71,89 +72,63 @@ impl Client {
         let dst = query.variant.dst_name();
         // should we force a fresh connection to the nodes?
         let force_new_link = false;
-        let mut data_not_found_count = BTreeSet::default();
+        // let mut data_not_found_count = BTreeSet::default();
+
+        let op_limit = self.query_timeout;
+
+        let mut backoff = ExponentialBackoff {
+            initial_interval: Duration::from_millis(500),
+            max_interval: Duration::from_secs(20),
+            max_elapsed_time: Some(op_limit),
+            randomization_factor: 1.5,
+            ..Default::default()
+        };
+
+        // this seems needed for custom settings to take effect
+        backoff.reset();
+
         loop {
             let msg = ServiceMsg::Query(query.clone());
             let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
             let signature = self.keypair.sign(&serialised_query);
             debug!(
-                "Attempting {:?} (attempt #{}) with a query timeout of {:?}",
-                query, attempts, attempt_timeout
+                "Attempting {:?} (attempt #{}) will force new: {force_new_link}",
+                query, attempts
             );
 
             // grab up to date destination section from our local network knowledge
             let (section_pk, elders) = self.session.get_query_elders(dst).await?;
 
-            let res = tokio::time::timeout(
-                attempt_timeout,
-                self.send_signed_query_to_section(
+            let res = self
+                .send_signed_query_to_section(
                     query.clone(),
                     client_pk,
                     serialised_query.clone(),
                     signature.clone(),
                     Some((section_pk, elders.clone())),
                     force_new_link,
-                ),
-            )
-            .await;
-
-            match res {
-                Ok(Ok(query_result)) => {
-                    if query_result.is_data_not_found() {
-                        let _existed = data_not_found_count.insert(query.adult_index);
-                        // if we've received DataNotFound from each adult_index,
-                        // we can return that error
-                        if data_not_found_count.len() == data_copy_count() {
-                            return Ok(query_result);
-                        }
-                    } else {
-                        return Ok(query_result);
-                    }
-
-                    warn!(
-                        "{query:?} DataNotFound returned from adult_index: {:?}",
-                        query.adult_index
-                    )
-                }
-                Ok(Err(err)) if attempts > self.max_retries => {
-                    debug!(
-                        "Retries ({}) all failed returning no response for {:?}",
-                        self.max_retries, query
-                    );
-                    break Err(Error::NoResponseAfterRetrying {
-                        query,
-                        attempts,
-                        last_error: Box::new(err),
-                    });
-                }
-                Err(_) if attempts > self.max_retries => {
-                    // this should be due to our tokio time out, rather than an error
-                    // returned by `send_signed_query_to_section`
-                    debug!(
-                        "Retries ({}) all failed returning no response for {:?}",
-                        self.max_retries, query
-                    );
-                    break Err(Error::NoResponseAfterRetrying {
-                        query,
-                        attempts,
-                        last_error: Box::new(Error::NoResponse(elders)),
-                    });
-                }
-                _ => {
-                    if attempts > self.max_retries / 3 {
-                        // any further attempts should use fresh links in case of issues
-                        // force_new_link = true;
-                    }
-                }
-            }
+                )
+                .await;
 
             attempts += 1;
 
+            if let Ok(result) = res {
+                debug!("{query:?} sent and received okay");
+                return Ok(result);
+            }
             // In the next attempt, try the next adult, further away.
             query.adult_index += 1;
             // There should not be more than a certain amount of adults holding copies of the data. Retry the closest adult again.
             if query.adult_index >= data_copy_count() {
                 query.adult_index = 0;
+            }
+
+            if let Some(delay) = backoff.next_backoff() {
+                debug!("Sleeping for {delay:?} before trying query {query:?} again");
+                tokio::time::sleep(delay).await;
+            } else {
+                // we're done trying
+                return res;
             }
         }
     }

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -70,7 +70,7 @@ impl Client {
         let mut attempts = 1;
         let dst = query.variant.dst_name();
         // should we force a fresh connection to the nodes?
-        let mut force_new_link = false;
+        let force_new_link = false;
         let mut data_not_found_count = BTreeSet::default();
         loop {
             let msg = ServiceMsg::Query(query.clone());

--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -88,7 +88,7 @@ impl Client {
     /// Returns a write ahead log (WAL) of register operations, note that the changes are not uploaded to the
     /// network until the WAL is published with `publish_register_ops`
     #[instrument(skip(self, children), level = "debug")]
-    pub async fn write_to_register(
+    pub async fn write_to_local_register(
         &self,
         address: Address,
         entry: Entry,
@@ -134,6 +134,8 @@ impl Client {
         // Let's fetch the Register from the network
         let query = DataQueryVariant::Register(RegisterQuery::Get(address));
         let query_result = self.send_query(query.clone()).await?;
+
+        debug!("get_register result is; {query_result:?}");
         match query_result.response {
             QueryResponse::GetRegister((res, op_id)) => {
                 res.map_err(|err| Error::ErrorMsg { source: err, op_id })
@@ -384,7 +386,7 @@ mod tests {
             let now = Instant::now();
 
             let (_value1_hash, batch) = client
-                .write_to_register(address, value_1.clone(), BTreeSet::new())
+                .write_to_local_register(address, value_1.clone(), BTreeSet::new())
                 .await?;
             client.publish_register_ops(batch).await?;
 
@@ -502,7 +504,7 @@ mod tests {
         let value_1 = random_register_entry();
 
         let (value1_hash, batch) = client
-            .write_to_register(address, value_1.clone(), BTreeSet::new())
+            .write_to_local_register(address, value_1.clone(), BTreeSet::new())
             .await?;
         client.publish_register_ops(batch).await?;
 
@@ -520,8 +522,11 @@ mod tests {
 
         // write to the register
         let (value2_hash, batch) = client
-            .write_to_register(address, value_2.clone(), BTreeSet::new())
+            .write_to_local_register(address, value_2.clone(), BTreeSet::new())
             .await?;
+
+        // we get an op to publish
+        assert!(batch.len() == 1);
 
         client.publish_register_ops(batch).await?;
 

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -343,7 +343,7 @@ impl Session {
 
                 debug!("Resending original message on AE-Redirect with updated details. Expecting an AE-Retry next");
 
-                self.send_msg(vec![elder], wire_msg, msg_id).await?;
+                self.send_msg(vec![elder], wire_msg, msg_id, false).await?;
             } else {
                 error!("No elder determined for resending AE message");
             }

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -251,7 +251,8 @@ impl Session {
                             let received = entry.value();
 
                             debug!("inserting response : {response:?}");
-
+                            // we can acutally have many responses per peer if they're different
+                            // this could be a fail, and then an Ok aftewards from a different adult.
                             let _prior = received.insert((src_peer.addr(), response));
 
                             debug!("received now looks like: {:?}", received);

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -79,9 +79,9 @@ impl Session {
 
                     },
                     Err(Error::QuicP2p(qp2p_err)) => {
-                          // TODO: Can we recover here?
-                          info!("Error from Qp2p received, closing listener loop. {:?}", qp2p_err);
-                          break;
+                        // TODO: Can we recover here?
+                        info!("Error from Qp2p received, closing listener loop. {:?}", qp2p_err);
+                        break;
                     },
                     Err(error) => {
                         error!("Error while processing incoming msg: {:?}. Listening for next msg...", error);
@@ -89,6 +89,7 @@ impl Session {
                 }
             }
 
+            session.peer_links.remove(&peer).await;
             // once the msg loop breaks, we know the connection is closed
             trace!("{} to {} (id: {})", LogMarker::ConnectionClosed, addr, connection_id);
 
@@ -128,7 +129,7 @@ impl Session {
     ) -> Result<(), Error> {
         match msg.clone() {
             MsgType::Service { msg_id, msg, .. } => {
-                Self::handle_client_msg(session, msg_id, msg, src_peer)
+                Self::handle_service_msg(session, msg_id, msg, src_peer)
             }
             MsgType::System {
                 msg, msg_authority, ..
@@ -193,7 +194,7 @@ impl Session {
     }
 
     #[instrument(skip(cmds), level = "debug")]
-    fn send_cmd_response(
+    fn write_cmd_response(
         cmds: PendingCmdAcks,
         correlation_id: MsgId,
         src: SocketAddr,
@@ -216,7 +217,7 @@ impl Session {
 
     // Handle msgs intended for client consumption (re: queries + cmds)
     #[instrument(skip(session), level = "debug")]
-    fn handle_client_msg(
+    fn handle_service_msg(
         session: Self,
         msg_id: MsgId,
         msg: ServiceMsg,
@@ -237,43 +238,34 @@ impl Session {
                     correlation_id,
                 } => {
                     trace!(
-                        "ServiceMsg with id {:?} is QueryResponse regarding {:?} with response {:?}",
-                        msg_id,
-                        correlation_id,
-                        response,
-                    );
-                    // Note that this doesn't remove the sender from here since multiple
-                    // responses corresponding to the same msg ID might arrive.
-                    // Once we are satisfied with the response this is channel is discarded in
-                    // ConnectionManager::send_query
+                    "ServiceMsg with id {:?} is QueryResponse regarding {:?} with response {:?}",
+                    msg_id,
+                    correlation_id,
+                    response,
+                );
 
                     if let Ok(op_id) = response.operation_id() {
-                        if let Some(entry) = queries.get(&op_id) {
-                            let all_senders = entry.value();
-                            // Only valid response shall get broadcast to all
-                            for (ori_msg_id, sender) in all_senders {
-                                let res = if response.is_success() || ori_msg_id == &correlation_id
-                                {
-                                    sender.try_send(response.clone())
-                                } else {
-                                    continue;
-                                };
-                                if res.is_err() {
-                                    trace!("Error relaying query response internally on a channel for {:?} op_id {:?}: {:?}. (It has likely been removed)", msg_id, op_id, res)
-                                }
-                            }
+                        debug!("OpId of {msg_id:?} is {op_id:?}");
+                        if let Some(entry) = queries.get_mut(&op_id) {
+                            debug!("op id: {op_id:?} exists in pending queries...");
+                            let received = entry.value();
+
+                            debug!("inserting response : {response:?}");
+
+                            let _prior = received.insert((src_peer.addr(), response));
+
+                            debug!("received now looks like: {:?}", received);
                         } else {
-                            // TODO: The trace is only needed when we have an identified case of not finding a channel, but expecting one.
-                            // When expecting one, we can log "No channel found for operation", (and then probably at warn or error level).
-                            // But when we have received enough responses, we aren't really expecting a channel there, so there is no reason to log anything.
-                            // Right now, if we have already received enough responses for a query,
-                            // we drop the channels and drop any further responses for that query.
-                            // but we should not drop it immediately, but clean it up after a while
-                            // and then not log that "no channel was found" when we already had enough responses.
-                            //trace!("No channel found for operation {}", op_id);
+                            debug!("op id: {op_id:?} does not exist in pending queries...");
+                            let received = DashSet::new();
+                            let _prior = received.insert((src_peer.addr(), response));
+                            let _prev = queries.insert(op_id, Arc::new(received));
                         }
                     } else {
-                        warn!("Ignoring query response without operation id");
+                        warn!(
+                            "Ignoring query response without operation id: {:?} {:?}",
+                            msg_id, response
+                        );
                     }
                 }
                 ServiceMsg::CmdError {
@@ -281,7 +273,7 @@ impl Session {
                     correlation_id,
                     ..
                 } => {
-                    Self::send_cmd_response(cmds, correlation_id, src_peer.addr(), Some(error));
+                    Self::write_cmd_response(cmds, correlation_id, src_peer.addr(), Some(error));
                 }
                 ServiceMsg::CmdAck { correlation_id } => {
                     debug!(
@@ -290,7 +282,7 @@ impl Session {
                         correlation_id,
                         src_peer.addr()
                     );
-                    Self::send_cmd_response(cmds, correlation_id, src_peer.addr(), None);
+                    Self::write_cmd_response(cmds, correlation_id, src_peer.addr(), None);
                 }
                 _ => {
                     warn!("Ignoring unexpected msg type received: {:?}", msg);

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -13,6 +13,7 @@ use crate::{
     Error, Result,
 };
 
+use dashmap::DashSet;
 use qp2p::UsrMsgBytes;
 use sn_interface::{
     at_least_one_correct_elder,
@@ -31,6 +32,7 @@ use qp2p::{Close, ConnectionError, ConnectionIncoming as IncomingMsgs, SendError
 use rand::{rngs::OsRng, seq::SliceRandom};
 use secured_linked_list::SecuredLinkedList;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tracing::Instrument;
 
 impl Session {
@@ -197,19 +199,18 @@ impl Session {
         src: SocketAddr,
         error: Option<ErrorMsg>,
     ) {
-        if let Some(sender) = cmds.get(&correlation_id) {
-            trace!(
-                "Sending cmd response from {:?} for cmd w/{:?} via channel.",
-                src,
-                correlation_id
-            );
-            let result = sender.try_send((src, error));
-            if result.is_err() {
-                trace!("Error sending cmd response on a channel for cmd_id {:?}: {:?}. (It has likely been removed)", correlation_id, result)
-            }
+        if error.is_some() {
+            debug!("CmdError was received for {correlation_id:?}: {:?}", error);
+        }
+
+        if let Some(mut received_acks) = cmds.get_mut(&correlation_id) {
+            let acks = received_acks.value_mut();
+
+            let _prior = acks.insert((src, error));
         } else {
-            // Likely the channel is removed when received majority of Acks
-            trace!("No channel found for cmd Ack of {:?}", correlation_id);
+            let received = DashSet::new();
+            let _nonexistent = received.insert((src, error));
+            let _non_prior = cmds.insert(correlation_id, Arc::new(received));
         }
     }
 
@@ -280,7 +281,6 @@ impl Session {
                     correlation_id,
                     ..
                 } => {
-                    warn!("CmdError was received for {correlation_id:?}: {:?}", error);
                     Self::send_cmd_response(cmds, correlation_id, src_peer.addr(), Some(error));
                 }
                 ServiceMsg::CmdAck { correlation_id } => {

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -651,13 +651,6 @@ impl Session {
                 nodes.len(),
                 nodes,
             );
-        }
-
-        if failures > successful_sends {
-            warn!(
-                "More errors when sending a message than successes, last_error: {:?}",
-                last_error
-            );
 
             if let Some(error) = last_error {
                 warn!("The relevant error is: {error}");

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -99,7 +99,7 @@ impl Session {
         // We are not wait for the receive of majority of cmd Acks.
         // This could be further strict to wait for ALL the Acks get received.
         // The period is expected to have AE completed, hence no extra wait is required.
-        let mut received_ack = 0;
+        let mut received_acks = 0;
         let mut received_err = 0;
         let mut attempts = 0;
         let interval = Duration::from_millis(50);
@@ -108,10 +108,10 @@ impl Session {
         loop {
             match receiver.try_recv() {
                 Ok((src, None)) => {
-                    received_ack += 1;
-                    trace!("received CmdAck of {msg_id:?} from {src:?}, so far {received_ack} / {expected_acks}");
+                    received_acks += 1;
+                    trace!("received CmdAck of {msg_id:?} from {src:?}, so far {received_acks} / {expected_acks}");
 
-                    if received_ack >= expected_acks {
+                    if received_acks >= expected_acks {
                         let _ = self.pending_cmds.remove(&msg_id);
                         break;
                     }
@@ -120,7 +120,7 @@ impl Session {
                     received_err += 1;
                     error!(
                         "received error response {:?} of cmd {:?} from {:?}, so far {} acks vs. {} errors",
-                        error, msg_id, src, received_ack, received_err
+                        error, msg_id, src, received_acks, received_err
                     );
                     if received_err >= expected_acks {
                         error!("Received majority of error response for cmd {:?}", msg_id);
@@ -139,7 +139,7 @@ impl Session {
             if attempts >= expected_cmd_ack_wait_attempts {
                 warn!(
                     "Terminated with insufficient CmdAcks for {:?}, {} / {} acks received",
-                    msg_id, received_ack, expected_acks
+                    msg_id, received_acks, expected_acks
                 );
                 break;
             }

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -55,15 +55,13 @@ impl Session {
         dst_address: XorName,
         auth: ServiceAuth,
         payload: Bytes,
+        msg_id: MsgId,
         force_new_link: bool,
         #[cfg(feature = "traceroute")] client_pk: PublicKey,
     ) -> Result<()> {
         let endpoint = self.endpoint.clone();
         // TODO: Consider other approach: Keep a session per section!
-
         let (section_pk, elders) = self.get_cmd_elders(dst_address).await?;
-
-        let msg_id = MsgId::new();
 
         let elders_len = elders.len();
 
@@ -93,7 +91,7 @@ impl Session {
         self.send_msg(elders, wire_msg, msg_id, force_new_link)
             .await?;
 
-        let expected_acks = elders_len * 2 / 3 + 1;
+        let expected_acks = elders_len;
 
         // We are not wait for the receive of majority of cmd Acks.
         // This could be further strict to wait for ALL the Acks get received.

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -109,7 +109,7 @@ impl Session {
         // The period is expected to have AE completed, hence no extra wait is required.
 
         let mut ack_checks = 0;
-        let max_ack_checks = 20;
+        let max_ack_checks = 10;
         let interval = Duration::from_millis(50);
 
         loop {
@@ -287,14 +287,13 @@ impl Session {
         // so we don't need more than one valid response to prevent from accepting invalid responses
         // from byzantine nodes, however for mutable data (non-Chunk responses) we will
         // have to review the approach.
-        // let mut discarded_responses: usize = 0;
-        // let mut error_response = None;
-        // let mut valid_response = None;
 
         let mut response_checks = 0;
 
         loop {
-            debug!("looping send responses");
+            debug!(
+                "looping send responses, attempt: #{response_checks} for op_id: {operation_id:?}"
+            );
             if let Some(response) = self
                 .check_query_responses(msg_id, operation_id, elders.clone(), chunk_addr)
                 .await?
@@ -311,26 +310,6 @@ impl Session {
             }
             response_checks += 1;
         }
-
-        // debug!(
-        //     "Response obtained for query w/id {:?}: {:?}",
-        //     msg_id, response
-        // );
-
-        // match response {
-        //     Some(response) => {
-        //         trace!(
-        //             "Removing pending query map for {:?}",
-        //             (msg_id, &operation_id)
-        //         );
-        //         let _prev = self.pending_queries.remove(&operation_id);
-        //         Ok(QueryResult {
-        //             response,
-        //             operation_id,
-        //         })
-        //     }
-        //     None => Err(Error::NoResponse(elders)),
-        // }
     }
 
     async fn check_query_responses(

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -176,7 +176,7 @@ impl Session {
                 // attempt to cleanup... though more acks may come in..
                 let _ = self.pending_cmds.remove(&msg_id);
 
-                if let Some(CmdError::Data(source)) = return_error {
+                if let Some(source) = return_error {
                     return Err(Error::ErrorCmd { source, msg_id });
                 }
             }

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -397,6 +397,21 @@ impl Session {
                             valid_response = Some(response);
                         }
                     }
+                    QueryResponse::SpentProofShares((Ok(ref spentproof_set), _)) => {
+                        debug!("okay _read_ spentproofs");
+                        // TODO: properly merge all registers
+                        if let Some(QueryResponse::SpentProofShares((Ok(prior_response), _))) =
+                            &valid_response
+                        {
+                            if spentproof_set.len() > prior_response.len() {
+                                debug!("longer spentproof response retrieved");
+                                // keep this new register
+                                valid_response = Some(response);
+                            }
+                        } else {
+                            valid_response = Some(response);
+                        }
+                    }
                     response => {
                         // we got a valid response
                         valid_response = Some(response)

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -22,11 +22,10 @@ use sn_interface::{
 use dashmap::{DashMap, DashSet};
 use qp2p::{Config as QuicP2pConfig, Endpoint};
 use std::{net::SocketAddr, sync::Arc};
-use tokio::sync::{mpsc::Sender, RwLock};
+use tokio::sync::RwLock;
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
-type PendingQueryResponses = Arc<DashMap<OperationId, Vec<(MsgId, QueryResponseSender)>>>;
-type QueryResponseSender = Sender<QueryResponse>;
+type PendingQueryResponses = Arc<DashMap<OperationId, Arc<DashSet<(SocketAddr, QueryResponse)>>>>;
 
 type CmdResponse = (SocketAddr, Option<ErrorMsg>);
 
@@ -40,12 +39,12 @@ pub struct QueryResult {
     pub operation_id: OperationId,
 }
 
-impl QueryResult {
-    /// Returns true if the QueryResponse is DataNotFound
-    pub(crate) fn is_data_not_found(&self) -> bool {
-        self.response.is_data_not_found()
-    }
-}
+// impl QueryResult {
+//     /// Returns true if the QueryResponse is DataNotFound
+//     pub(crate) fn is_data_not_found(&self) -> bool {
+//         self.response.is_data_not_found()
+//     }
+// }
 
 #[derive(Clone, Debug)]
 pub(super) struct Session {

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -105,8 +105,8 @@ pub enum Error {
         last_error: Box<Self>,
     },
     /// No operation Id could be found
-    #[error("Could not retrieve the operation id of a query response: {0:?}")]
-    UnknownOperationId(QueryResponse),
+    #[error("Could not retrieve the operation id of a query or response")]
+    UnknownOperationId,
     /// Unexpected query response received
     #[error("Unexpected response received for {query:?}. Received: {response:?}")]
     UnexpectedQueryResponse {

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -30,6 +30,9 @@ pub enum Error {
     /// Failed to obtain network contacts to bootstrap to
     #[error("Failed to obtain network contacts to bootstrap to: {0}")]
     NetworkContacts(String),
+    /// InsufficientAcksReceived
+    #[error("Did not receive sufficient ACK messages from elders to be sure this cmd passed.")]
+    InsufficientAcksReceived,
     /// Message auth checks failed
     #[error("Message's authority could not be trusted, unknown section key: {0:?}.")]
     UntrustedMessage(PublicKey),

--- a/sn_client/src/utils/test_utils/mod.rs
+++ b/sn_client/src/utils/test_utils/mod.rs
@@ -44,7 +44,10 @@ macro_rules! retry_loop_for_pattern {
             let result = $async_func.await;
             match &result {
                 $pattern $(if $cond)? => break result,
-                Ok(_) | Err(_) => tokio::time::sleep(std::time::Duration::from_secs(2)).await,
+                Ok(_) | Err(_) => {
+                    debug!("waiting before retying.....");
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await}
+                    ,
             }
         }
     };

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -181,7 +181,7 @@ impl Display for ServiceMsg {
 /// The response to a query, containing the query result.
 /// Response operation id should match query `operation_id`
 #[allow(clippy::large_enum_variant, clippy::type_complexity)]
-#[derive(Eq, PartialEq, Clone, Serialize, Deserialize, Debug)]
+#[derive(Eq, PartialEq, Clone, Serialize, Deserialize, Debug, Hash)]
 pub enum QueryResponse {
     //
     // ===== Chunk =====

--- a/sn_interface/src/types/connections/mod.rs
+++ b/sn_interface/src/types/connections/mod.rs
@@ -82,7 +82,13 @@ impl PeerLinks {
 
     /// This method is tailored to the use-case of connecting on send.
     /// I.e. it will not connect here, but on calling send on the returned link.
-    pub async fn get_or_create(&self, peer: &Peer) -> Link {
+    pub async fn get_or_create_link(&self, peer: &Peer, force_new_link: bool) -> Link {
+        if force_new_link {
+            let link = Link::new(*peer, self.endpoint.clone());
+            let _ = self.links.write().await.insert(*peer, link.clone());
+            return link;
+        }
+
         if let Some(link) = self.get(peer).await {
             return link;
         }

--- a/sn_node/src/comm/link.rs
+++ b/sn_node/src/comm/link.rs
@@ -113,6 +113,7 @@ impl Link {
             self.queue.len(),
             self.peer
         );
+
         match conn.send_with(bytes, priority, retry_config).await {
             Ok(()) => Ok(()),
             Err(error) => {

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -439,9 +439,9 @@ mod tests {
                 let peer0_msg = new_test_msg(dst(peer0))?;
                 let peer1_msg = new_test_msg(dst(peer1))?;
 
-                comm.send_out_bytes(peer0, peer0_msg.msg_id(), peer0_msg.serialize()?)
+                comm.send_out_bytes(peer0, peer0_msg.msg_id(), peer0_msg.serialize()?, false)
                     .await?;
-                comm.send_out_bytes(peer1, peer1_msg.msg_id(), peer1_msg.serialize()?)
+                comm.send_out_bytes(peer1, peer1_msg.msg_id(), peer1_msg.serialize()?, false)
                     .await?;
 
                 if let Some(bytes) = rx0.recv().await {
@@ -480,7 +480,7 @@ mod tests {
                 let invalid_peer = get_invalid_peer().await?;
                 let invalid_addr = invalid_peer.addr();
                 let msg = new_test_msg(dst(invalid_peer))?;
-                let result = comm.send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?).await;
+                let result = comm.send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?, false).await;
 
                 assert_matches!(result, Err(Error::FailedSend(peer)) => assert_eq!(peer.addr(), invalid_addr));
 
@@ -508,7 +508,7 @@ mod tests {
                 let msg0 = new_test_msg(dst(peer))?;
 
                 send_comm
-                    .send_out_bytes(peer, msg0.msg_id(), msg0.serialize()?)
+                    .send_out_bytes(peer, msg0.msg_id(), msg0.serialize()?, false)
                     .await?;
 
                 let mut msg0_received = false;
@@ -527,7 +527,7 @@ mod tests {
 
                 let msg1 = new_test_msg(dst(peer))?;
                 send_comm
-                    .send_out_bytes(peer, msg1.msg_id(), msg1.serialize()?)
+                    .send_out_bytes(peer, msg1.msg_id(), msg1.serialize()?, false)
                     .await?;
 
                 let mut msg1_received = false;
@@ -564,7 +564,7 @@ mod tests {
                 let msg = new_test_msg(dst(peer))?;
                 // Send a message to establish the connection
                 comm1
-                    .send_out_bytes(peer, msg.msg_id(), msg.serialize()?)
+                    .send_out_bytes(peer, msg.msg_id(), msg.serialize()?, false)
                     .await?;
 
                 assert_matches!(rx0.recv().await, Some(MsgEvent::Received { .. }));

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -164,17 +164,29 @@ impl Comm {
     }
 
     #[tracing::instrument(skip(self, bytes))]
-    pub(crate) async fn send(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) -> Result<()> {
-        let watcher = self.send_to_one(peer, msg_id, bytes).await;
+    pub(crate) async fn send_out_bytes(
+        &self,
+        peer: Peer,
+        msg_id: MsgId,
+        bytes: UsrMsgBytes,
+        is_msg_for_client: bool,
+    ) -> Result<()> {
+        let watcher = self
+            .send_to_one(peer, msg_id, bytes, is_msg_for_client)
+            .await;
 
         match watcher {
-            Ok(watcher) => {
+            Ok(Some(watcher)) => {
                 if Self::is_sent(watcher, msg_id, peer).await {
                     trace!("Msg {msg_id:?} sent to {peer:?}");
                     Ok(())
                 } else {
                     Err(Error::FailedSend(peer))
                 }
+            }
+            Ok(None) => {
+                Ok(())
+                // no watcher......
             }
             Err(error) => {
                 // there is only one type of error returned: [`Error::InvalidState`]
@@ -186,12 +198,12 @@ impl Comm {
                     peer
                 );
                 error!(
-                    "Sending message (msg_id: {:?}) to {:?} (name {:?}) failed as we have disconnected from the peer. (Error is: {})",
-                    msg_id,
-                    peer.addr(),
-                    peer.name(),
-                    error,
-                );
+                        "Sending message (msg_id: {:?}) to {:?} (name {:?}) failed as we have disconnected from the peer. (Error is: {})",
+                        msg_id,
+                        peer.addr(),
+                        peer.name(),
+                        error,
+                    );
                 Err(Error::FailedSend(peer))
             }
         }
@@ -257,14 +269,14 @@ impl Comm {
 
     /// Get a PeerSession if it already exists, otherwise create and insert
     #[instrument(skip(self))]
-    async fn get_or_create(&self, peer: &Peer) -> PeerSession {
+    async fn get_or_create(&self, peer: &Peer) -> Option<PeerSession> {
         if let Some(entry) = self.sessions.get(peer) {
-            return entry.value().clone();
+            return Some(entry.value().clone());
         }
         let link = Link::new(*peer, self.our_endpoint.clone(), self.msg_listener.clone());
         let session = PeerSession::new(link);
         let _ = self.sessions.insert(*peer, session.clone());
-        session
+        Some(session)
     }
 
     /// Any number of incoming qp2p:Connections can be added.
@@ -294,20 +306,29 @@ impl Comm {
         recipient: Peer,
         msg_id: MsgId,
         bytes: UsrMsgBytes,
-    ) -> Result<SendWatcher> {
+        is_msg_for_client: bool,
+    ) -> Result<Option<SendWatcher>> {
         let bytes_len = {
             let (h, d, p) = bytes.clone();
             h.len() + d.len() + p.len()
         };
 
         trace!(
-            "Sending message ({} bytes) w/ {:?} to {:?}",
+            "Sending message (client?: {is_msg_for_client}) ({} bytes) w/ {:?} to {:?}",
             bytes_len,
             msg_id,
-            recipient,
+            recipient
         );
-        let peer = self.get_or_create(&recipient).await;
-        peer.send(msg_id, bytes).await
+
+        if let Some(peer) = self.get_or_create(&recipient).await {
+            Ok(Some(
+                peer.send_using_session(msg_id, bytes, is_msg_for_client)
+                    .await?,
+            ))
+        } else {
+            debug!("No client conn exists to send this msg on.... {msg_id:?}");
+            Ok(None)
+        }
     }
 }
 
@@ -418,9 +439,9 @@ mod tests {
                 let peer0_msg = new_test_msg(dst(peer0))?;
                 let peer1_msg = new_test_msg(dst(peer1))?;
 
-                comm.send(peer0, peer0_msg.msg_id(), peer0_msg.serialize()?)
+                comm.send_out_bytes(peer0, peer0_msg.msg_id(), peer0_msg.serialize()?)
                     .await?;
-                comm.send(peer1, peer1_msg.msg_id(), peer1_msg.serialize()?)
+                comm.send_out_bytes(peer1, peer1_msg.msg_id(), peer1_msg.serialize()?)
                     .await?;
 
                 if let Some(bytes) = rx0.recv().await {
@@ -459,7 +480,7 @@ mod tests {
                 let invalid_peer = get_invalid_peer().await?;
                 let invalid_addr = invalid_peer.addr();
                 let msg = new_test_msg(dst(invalid_peer))?;
-                let result = comm.send(invalid_peer, msg.msg_id(), msg.serialize()?).await;
+                let result = comm.send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?).await;
 
                 assert_matches!(result, Err(Error::FailedSend(peer)) => assert_eq!(peer.addr(), invalid_addr));
 
@@ -487,7 +508,7 @@ mod tests {
                 let msg0 = new_test_msg(dst(peer))?;
 
                 send_comm
-                    .send(peer, msg0.msg_id(), msg0.serialize()?)
+                    .send_out_bytes(peer, msg0.msg_id(), msg0.serialize()?)
                     .await?;
 
                 let mut msg0_received = false;
@@ -506,7 +527,7 @@ mod tests {
 
                 let msg1 = new_test_msg(dst(peer))?;
                 send_comm
-                    .send(peer, msg1.msg_id(), msg1.serialize()?)
+                    .send_out_bytes(peer, msg1.msg_id(), msg1.serialize()?)
                     .await?;
 
                 let mut msg1_received = false;
@@ -542,7 +563,9 @@ mod tests {
                 let peer = Peer::new(xor_name::rand::random(), addr0);
                 let msg = new_test_msg(dst(peer))?;
                 // Send a message to establish the connection
-                comm1.send(peer, msg.msg_id(), msg.serialize()?).await?;
+                comm1
+                    .send_out_bytes(peer, msg.msg_id(), msg.serialize()?)
+                    .await?;
 
                 assert_matches!(rx0.recv().await, Some(MsgEvent::Received { .. }));
 

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -8,7 +8,7 @@
 
 use super::Link;
 
-use crate::node::Result;
+use crate::node::{Result, Error};
 
 use qp2p::RetryConfig;
 use qp2p::UsrMsgBytes;
@@ -87,9 +87,10 @@ impl PeerSession {
             is_msg_for_client,
         };
 
-        if let Err(e) = self.channel.send(SessionCmd::Send(job)).await {
-            error!("Error while sending SendJob command {e:?}");
-        }
+        self.channel
+            .send(SessionCmd::Send(job))
+            .await
+            .map_err(|_| Error::PeerSessionChannel)?;
 
         trace!("Send job sent: {msg_id:?}");
         Ok(watcher)

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -8,7 +8,7 @@
 
 use super::Link;
 
-use crate::node::{Result, Error};
+use crate::node::{Error, Result};
 
 use qp2p::RetryConfig;
 use qp2p::UsrMsgBytes;

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -71,7 +71,12 @@ impl PeerSession {
     }
 
     #[instrument(skip(self, bytes))]
-    pub(crate) async fn send(&self, msg_id: MsgId, bytes: UsrMsgBytes) -> Result<SendWatcher> {
+    pub(crate) async fn send_using_session(
+        &self,
+        msg_id: MsgId,
+        bytes: UsrMsgBytes,
+        is_msg_for_client: bool,
+    ) -> Result<SendWatcher> {
         let (watcher, reporter) = status_watching();
 
         let job = SendJob {
@@ -79,10 +84,11 @@ impl PeerSession {
             bytes,
             retries: 0,
             reporter,
+            is_msg_for_client,
         };
 
         if let Err(e) = self.channel.send(SessionCmd::Send(job)).await {
-            error!("Error while sending Send command {e:?}");
+            error!("Error while sending SendJob command {e:?}");
         }
 
         Ok(watcher)
@@ -157,6 +163,10 @@ impl PeerSessionWorker {
     }
 
     async fn send(&mut self, mut job: SendJob) -> SessionStatus {
+        let id = job.msg_id;
+        let should_establish_new_connection = !job.is_msg_for_client;
+        trace!("Performing sendjob: {id:?} , should_establish_new_connection? {should_establish_new_connection}");
+
         if job.retries > MAX_SENDJOB_RETRIES {
             job.reporter.send(SendStatus::MaxRetriesReached);
             return SessionStatus::Ok;
@@ -164,7 +174,12 @@ impl PeerSessionWorker {
 
         let send_resp = self
             .link
-            .send_with(job.bytes.clone(), 0, Some(&RetryConfig::default()))
+            .send_with(
+                job.bytes.clone(),
+                0,
+                Some(&RetryConfig::default()),
+                should_establish_new_connection,
+            )
             .await;
 
         match send_resp {
@@ -201,6 +216,7 @@ pub(crate) struct SendJob {
     bytes: UsrMsgBytes,
     retries: usize, // TAI: Do we need this if we are using QP2P's retry
     reporter: StatusReporting,
+    pub(crate) is_msg_for_client: bool,
 }
 
 impl PartialEq for SendJob {

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -503,7 +503,7 @@ async fn send_messages(
             let msg_id = msg.msg_id();
 
             let bytes = msg.serialize()?;
-            match comm.send(peer, msg_id, bytes).await {
+            match comm.send_out_bytes(peer, msg_id, bytes, false).await {
                 Ok(()) => trace!("Msg {msg_id:?} sent on {dst:?}"),
                 Err(Error::FailedSend(peer)) => {
                     error!("Failed to send message {msg_id:?} to {peer:?}")

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -29,7 +29,7 @@ use tracing::info;
 use xor_name::XorName;
 
 impl Node {
-    // Locate ideal holders for this data, instruct them to store the data
+    // Instruct targets to store the data
     pub(crate) fn replicate_data(
         &self,
         data: ReplicatedData,
@@ -184,7 +184,7 @@ impl Node {
             .collect::<BTreeSet<_>>();
 
         trace!(
-            "Chunk holders of {:?} are non-full adults: {:?} and full adults: {:?}",
+            "Data holders of {:?} are non-full adults: {:?} and full adults: {:?}",
             target,
             candidates,
             full_adults

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -87,7 +87,6 @@ impl Node {
             target_adult: target.name(),
         }];
 
-        // here we conflate adults targetted!!
         if let Some(peers) = self
             .pending_data_queries
             .get(&(operation_id, target.name()))

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -26,6 +26,12 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
+    /// This Peer SendJob could not be sent. We should remove this peer
+    #[error("Peer channel errored")]
+    PeerSessionChannel,
+    /// This sendjob channel is closed, this peer needs cleaned up
+    #[error("Peer link has been dropped, and should be removed. ")]
+    PeerLinkDropped,
     /// This should not be possible as the channel is stored in node, and used to process child commands
     #[error("No more Cmds will be received or processed. CmdChannel senders have been dropped. ")]
     CmdCtrlChannelDropped,

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -100,6 +100,8 @@ impl CmdCtrl {
         let id = job.id();
         let cmd = job.clone().into_cmd();
 
+        trace!("Processing cmd: {cmd:?}");
+
         let cmd_string = cmd.clone().to_string();
         let priority = job.priority();
 
@@ -114,6 +116,7 @@ impl CmdCtrl {
             }))
             .await;
 
+        trace!("about to spawn for processing cmd: {cmd:?}");
         let dispatcher = self.dispatcher.clone();
         let _ = tokio::task::spawn_local(async move {
             dispatcher
@@ -125,6 +128,7 @@ impl CmdCtrl {
             match dispatcher.process_cmd(cmd).await {
                 Ok(cmds) => {
                     for cmd in cmds {
+                        monitoring.increment_cmds().await;
                         match cmd_process_api.send((cmd, Some(id))).await {
                             Ok(_) => {
                                 //no issues

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -128,7 +128,6 @@ impl CmdCtrl {
             match dispatcher.process_cmd(cmd).await {
                 Ok(cmds) => {
                     for cmd in cmds {
-                        monitoring.increment_cmds().await;
                         match cmd_process_api.send((cmd, Some(id))).await {
                             Ok(_) => {
                                 //no issues

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -218,11 +218,7 @@ impl Cmd {
     pub(crate) fn priority(&self) -> i32 {
         use Cmd::*;
         match self {
-            SendMsg { msg, .. } => match msg {
-                OutgoingMsg::System(_) => 20,
-                _ => 19,
-            },
-
+            SendMsg { .. } => 20,
             HandleAgreement { .. } => 10,
             HandleNewEldersAgreement { .. } => 10,
             HandleDkgOutcome { .. } => 10,

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -34,6 +34,8 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+pub(crate) const VALIDATE_MSG_PRIO: i32 = -9;
+
 /// A struct for the job of controlling the flow
 /// of a [`Cmd`] in the system.
 ///
@@ -91,6 +93,9 @@ impl CmdJob {
 
     pub(crate) fn into_cmd(self) -> Cmd {
         self.cmd
+    }
+    pub(crate) fn cmd(&self) -> &Cmd {
+        &self.cmd
     }
 
     pub(crate) fn priority(&self) -> i32 {
@@ -240,7 +245,7 @@ impl Cmd {
             HandleValidSystemMsg { msg, .. } => msg.priority(),
             HandleValidServiceMsg { msg, .. } => msg.priority(),
 
-            ValidateMsg { .. } => -9, // before it's validated, we cannot give it high prio, as it would be a spam vector
+            ValidateMsg { .. } => VALIDATE_MSG_PRIO, // before it's validated, we cannot give it high prio, as it would be a spam vector
         }
     }
 

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -54,6 +54,8 @@ impl Dispatcher {
 
     /// Handles a single cmd.
     pub(crate) async fn process_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
+        trace!("doing actual processing cmd: {cmd:?}");
+
         match cmd {
             Cmd::CleanupPeerLinks => {
                 let members = { self.node.read().await.network_knowledge.section_members() };

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -83,9 +83,10 @@ impl Dispatcher {
                     )?
                 };
 
-                let tasks = peer_msgs
-                    .into_iter()
-                    .map(|(peer, msg)| self.comm.send(peer, msg_id, msg));
+                let tasks = peer_msgs.into_iter().map(|(peer, msg)| {
+                    self.comm
+                        .send_out_bytes(peer, msg_id, msg, is_msg_for_client)
+                });
                 let results = futures::future::join_all(tasks).await;
 
                 // Any failed sends are tracked via Cmd::HandlePeerFailedSend, which will log dysfunction for any peers

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -33,7 +33,7 @@ use tokio::{
     time::Instant,
 };
 
-const PROCESS_BATCH_COUNT: usize = 5;
+// const PROCESS_BATCH_COUNT: usize = 25;
 
 /// Listens for incoming msgs and forms Cmds for each,
 /// Periodically triggers other Cmd Processes (eg health checks, dysfunction etc)
@@ -157,20 +157,13 @@ impl FlowCtrl {
                 break;
             }
 
-            let mut process_batch_count = 0;
-
-            let mut continue_with_periodics = false;
             // we go through all pending cmds in this loop
-            while self.cmd_ctrl.has_items_queued() && !continue_with_periodics {
-                process_batch_count += 1;
+            while self.cmd_ctrl.has_items_queued() {
                 self.process_next_cmd().await;
 
-                if process_batch_count > PROCESS_BATCH_COUNT {
-                    // let's start fresh,
-                    // adding any periodic check on top and
-                    // topping up the queue with any new msg that's come in
-                    // or been generated from existing cmds
-                    continue_with_periodics = true;
+                if let Err(error) = self.enqeue_new_cmds_from_channel().await {
+                    error!("{error:?}");
+                    break;
                 }
             }
 
@@ -204,6 +197,7 @@ impl FlowCtrl {
 
     /// Does not await the completion of the cmd.
     pub(crate) async fn fire_and_forget(&mut self, cmd: Cmd, parent_id: Option<usize>) {
+        trace!("Enqueuing cmd: {cmd:?}");
         self.cmd_ctrl.push(cmd, parent_id).await
     }
 

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -86,6 +86,9 @@ impl Node {
         #[cfg(feature = "traceroute")]
         traceroute.0.push(self.identity());
 
+        let new_msg_id = MsgId::new();
+
+        debug!("SendMSg formed for {:?}", new_msg_id);
         Cmd::SendMsg {
             msg: OutgoingMsg::Service(msg),
             msg_id: MsgId::new(),

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -146,17 +146,20 @@ impl Node {
         );
 
         let node_id = XorName::from(sending_node_pk);
-        let query_peers = self.pending_data_queries.remove(&(op_id, node_id));
-        // Clear expired queries from the cache.
-        self.pending_data_queries.remove_expired();
+
+        // dont remove here, leave the receipients to expire. That way any incoming reqeusts
+        // will still be forwarded on, and one NotFound reply from one adult may not bork
+        // the Operational success at another Adult (if they were queried again)
+        let query_peers = self.pending_data_queries.get(&(op_id, node_id));
 
         // First check for waiting peers. If no one is waiting, we drop the response
         let waiting_peers = if let Some(peers) = query_peers {
             if peers.is_empty() {
+                warn!("No waiting peers to send {op_id:?} to....");
                 // nothing to do
                 return None;
             }
-            peers
+            peers.clone()
         } else {
             warn!(
                 "Dropping chunk query response from Adult {}. We might have already forwarded this chunk to the requesting client or the client connection cache has expired: {}",
@@ -180,6 +183,9 @@ impl Node {
             response: query_response,
             correlation_id,
         };
+
+        // Clear expired queries from the cache.
+        self.pending_data_queries.remove_expired();
 
         Some(self.send_service_msg(
             msg,


### PR DESCRIPTION
 - Nodes do not attempt to connect to clients
 - Nodes do not clean up pending peers op-ids (other requests may be in flight to other adults)
 - Clients _can_ force new ocnnections to elders
 - Client ack and query receipt refactored to persist across tries and allow for fast responses
 - 7 responess required for cmds right now
 - improved client retry flow
 - clients remove Links if the connection is dropped
 - client Cmd acks persists across retries
 - Nodes dont enqueue the same validation command multiple times (doesnt seem like this is an issue though)
 - ci tweaks
 - Spentproof shares are checked and longest response returned