### PR TITLE
fix(statemap): allow generating statemaps from non genesis nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,4 +71,5 @@ cargo-flamegraph.stacks
 *flamegraph.svg
 
 #statemap
+safe_states.out
 safe.svg

--- a/resources/scripts/statemap-preprocess.sh
+++ b/resources/scripts/statemap-preprocess.sh
@@ -20,11 +20,10 @@ then
 fi
 
 log_dir="$HOME/.safe/node/local-test-network"
-genesis_log_dir="$HOME/.safe/node/local-test-network/sn-node-genesis"
 out_file="safe_states.out"
 
 # Extract statemap metadata
-rg -IN ".*STATEMAP_METADATA: " "$genesis_log_dir" --replace "" > "$out_file"
+rg -IN ".*STATEMAP_METADATA: " "$log_dir" --replace "" | head -n1 > "$out_file"
 rg -IN ".*STATEMAP_ENTRY: " "$log_dir" --replace "" | jq -s 'sort_by(.time|tonumber)' | jq -c '.[]' >> "$out_file"
 
 begin_time=$(cat safe_states.out | rg 'time' | jq -sr 'min_by(.time | tonumber) | .time')


### PR DESCRIPTION
This allows us to generate statemaps when we don't have a node named `genesis`