### PR TITLE
Refactor op id in elders from msg payload bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,7 +3881,7 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "sn_api"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "sn_cli"
-version = "0.66.0"
+version = "0.67.0"
 dependencies = [
  "ansi_term",
  "assert_cmd",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "sn_client"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "backoff 0.4.0",
  "base64",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "sn_dysfunction"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "dashmap",
  "eyre",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "sn_interface"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "base64",
  "bincode",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "assert_matches",
  "backoff 0.4.0",

--- a/log_cmds_inspector/Cargo.toml
+++ b/log_cmds_inspector/Cargo.toml
@@ -27,4 +27,4 @@ clap = { version = "3.0.0", features = ["derive", "env"] }
 strum = "~0.23.0"
 strum_macros = "~0.23.1"
 walkdir = "2"
-sn_interface = { path = "../sn_interface", version = "^0.14.0" }
+sn_interface = { path = "../sn_interface", version = "^0.15.0" }

--- a/sn_api/CHANGELOG.md
+++ b/sn_api/CHANGELOG.md
@@ -5,9 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.74.0 (2022-09-19)
+
 ## v0.73.0 (2022-09-09)
 
+### Chore
+
+ - <csr-id-448694176dd3b40a12bd8ecc16d9bb66fd171a37/> sn_interface-0.14.0/sn_dysfunction-0.13.0/sn_client-0.75.0/sn_node-0.70.0/sn_api-0.73.0/sn_cli-0.66.0
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 1 commit contributed to the release.
+ - 1 day passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' where seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - sn_interface-0.14.0/sn_dysfunction-0.13.0/sn_client-0.75.0/sn_node-0.70.0/sn_api-0.73.0/sn_cli-0.66.0 ([`4486941`](https://github.com/maidsafe/safe_network/commit/448694176dd3b40a12bd8ecc16d9bb66fd171a37))
+</details>
+
 ## v0.72.0 (2022-09-07)
+
+<csr-id-fe659c5685289fe0071b54298dcac394e83c0dce/>
 
 ### Chore
 
@@ -17,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - <csr-id-d671f4ee4c76b42187d266aee99351114acf6cd7/> report any error occurred when handling a service msg back to the client
    - Removing several unused sn_node::Error types.
-   - Adapting sn_api wallet and sn_node spentbook unit tests for new error msgs/cmds.
+- Adapting sn_api wallet and sn_node spentbook unit tests for new error msgs/cmds.
 
 ### Commit Statistics
 
@@ -45,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-id-dd89cac97da96ffe26ae78c4b7b62aa952ec53fc/>
 <csr-id-921438659ccaf65b2ea8cc00efb61d8146ef71ef/>
 <csr-id-3a718d8c0957957a75250b044c9d1ad1b5874ab0/>
+<csr-id-1b9e0a6564e9564201ef3a3e04adb0bfbef6ac14/>
 
 ### Chore
 

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sn_api"
-version = "0.73.0"
+version = "0.74.0"
 description = "Safe API"
 authors = [
   "bochaco <gabrielviganotti@gmail.com>",
@@ -41,9 +41,9 @@ pbkdf2 = { version = "~0.7", default-features = false }
 serde = "1.0.123"
 serde_json = "1.0.62"
 sha3 = "~0.9"
-sn_client = { path = "../sn_client", version = "^0.75.0" }
+sn_client = { path = "../sn_client", version = "^0.76.0" }
 sn_dbc = { version = "8.0.0", features = ["serdes"] }
-sn_interface = { path = "../sn_interface", version = "^0.14.0" }
+sn_interface = { path = "../sn_interface", version = "^0.15.0" }
 thiserror = "1.0.23"
 time = { version = "~0.3.4", features = ["formatting"] }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
@@ -71,6 +71,6 @@ async_once = "~0.2.6"
 hex = "~0.4"
 predicates = "2.0"
 proptest = "1.0.0"
-sn_client = { path = "../sn_client", version = "^0.75.0", features = ["test-utils"] }
+sn_client = { path = "../sn_client", version = "^0.76.0", features = ["test-utils"] }
 tokio = { version = "1.6.0", features = ["macros"] }
 tracing-subscriber = "~0.3.1"

--- a/sn_cli/CHANGELOG.md
+++ b/sn_cli/CHANGELOG.md
@@ -4,9 +4,37 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## v0.67.0 (2022-09-19)
+
 ## v0.66.0 (2022-09-09)
 
+### Chore
+
+ - <csr-id-448694176dd3b40a12bd8ecc16d9bb66fd171a37/> sn_interface-0.14.0/sn_dysfunction-0.13.0/sn_client-0.75.0/sn_node-0.70.0/sn_api-0.73.0/sn_cli-0.66.0
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 1 commit contributed to the release.
+ - 1 day passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' where seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - sn_interface-0.14.0/sn_dysfunction-0.13.0/sn_client-0.75.0/sn_node-0.70.0/sn_api-0.73.0/sn_cli-0.66.0 ([`4486941`](https://github.com/maidsafe/safe_network/commit/448694176dd3b40a12bd8ecc16d9bb66fd171a37))
+</details>
+
 ## v0.65.0 (2022-09-07)
+
+<csr-id-fe659c5685289fe0071b54298dcac394e83c0dce/>
+<csr-id-638bcdfea4cbc713d8a4faecec7ed8538317fa29/>
 
 ### Chore
 
@@ -51,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 <csr-id-f5d436fba99e0e9c258c7ab3c3a256be3be58f84/>
 <csr-id-3a718d8c0957957a75250b044c9d1ad1b5874ab0/>
 <csr-id-39dd5a043c75492e416bb9371015a1365b06fa01/>
+<csr-id-1b9e0a6564e9564201ef3a3e04adb0bfbef6ac14/>
 
 ### Chore
 

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sn_cli"
-version = "0.66.0"
+version = "0.67.0"
 description = "Safe CLI"
 authors = [
   "bochaco <gabrielviganotti@gmail.com>",
@@ -37,7 +37,7 @@ rcgen = "~0.9"
 relative-path = "1.3.2"
 reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls"] }
 rmp-serde = "1.0.0"
-sn_api = { path = "../sn_api", version = "^0.73.0", default-features = false, features = ["app"] }
+sn_api = { path = "../sn_api", version = "^0.74.0", default-features = false, features = ["app"] }
 sn_dbc = { version = "8.0.0", features = ["serdes"] }
 sn_launch_tool = "~0.12.0"
 serde = "1.0.123"
@@ -78,7 +78,7 @@ walkdir = "2.3.1"
 multibase = "~0.9.1"
 xor_name = "~5.0.0"
 futures = "0.3.21"
-sn_api = { path = "../sn_api", version = "^0.73.0", features = ["app", "test-utils"] }
+sn_api = { path = "../sn_api", version = "^0.74.0", features = ["app", "test-utils"] }
 httpmock = "~0.6.6"
 
 [dev-dependencies.sn_cmd_test_utilities]

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_client"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.75.0"
+version = "0.76.0"
 
 [[bench]]
 name = "upload_bytes"
@@ -75,7 +75,7 @@ serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
 sn_dbc = { version = "8.0.0", features = ["serdes"] }
-sn_interface = { path = "../sn_interface", version = "^0.14.0" }
+sn_interface = { path = "../sn_interface", version = "^0.15.0" }
 strum = "~0.23.0"
 strum_macros = "~0.23.1"
 tempfile = "3.2.0"
@@ -103,7 +103,7 @@ sn_launch_tool = "~0.12.0"
 termcolor="1.1.2"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 walkdir = "2"
-sn_interface = { path = "../sn_interface", version = "^0.14.0", features= ["test-utils"] }
+sn_interface = { path = "../sn_interface", version = "^0.15.0", features= ["test-utils"] }
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -149,7 +149,7 @@ impl Client {
             .await
     }
 
-    /// Send a DataCmd to the network without awaiting for a response.
+    /// Send a DataCmd to the network and await a response.
     /// Cmds are automatically retried using exponential backoff if an error is returned.
     /// This function is a helper private to this module.
     #[instrument(skip_all, level = "debug", name = "client-api send cmd")]

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -97,8 +97,8 @@ impl Client {
         let res = self.send_query(query.clone()).await?;
 
         let chunk: Chunk = match res.response {
-            QueryResponse::GetChunk((result, op_id)) => {
-                result.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetChunk(result) => {
+                result.map_err(|err| Error::ErrorMsg { source: err })
             }
             response => return Err(Error::UnexpectedQueryResponse { query, response }),
         }?;

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -96,9 +96,8 @@ impl Client {
         let query = DataQueryVariant::GetChunk(ChunkAddress(*name));
         let res = self.send_query(query.clone()).await?;
 
-        let op_id = res.operation_id;
         let chunk: Chunk = match res.response {
-            QueryResponse::GetChunk(result) => {
+            QueryResponse::GetChunk((result, op_id)) => {
                 result.map_err(|err| Error::ErrorMsg { source: err, op_id })
             }
             response => return Err(Error::UnexpectedQueryResponse { query, response }),

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -188,10 +188,10 @@ impl Client {
                 query,
                 auth,
                 serialised_query,
-                #[cfg(feature = "traceroute")]
-                self.public_key(),
                 dst_section_info,
                 force_new_link,
+                #[cfg(feature = "traceroute")]
+                self.public_key(),
             )
             .await
     }

--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -137,9 +137,7 @@ impl Client {
 
         debug!("get_register result is; {query_result:?}");
         match query_result.response {
-            QueryResponse::GetRegister((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
-            }
+            QueryResponse::GetRegister(res) => res.map_err(|err| Error::ErrorMsg { source: err }),
             other => Err(Error::UnexpectedQueryResponse {
                 query,
                 response: other,
@@ -156,9 +154,7 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::Read(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::ReadRegister((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
-            }
+            QueryResponse::ReadRegister(res) => res.map_err(|err| Error::ErrorMsg { source: err }),
             other => Err(Error::UnexpectedQueryResponse {
                 query,
                 response: other,
@@ -176,8 +172,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetEntry { address, hash });
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterEntry((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterEntry(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -196,8 +192,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetOwner(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterOwner((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterOwner(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -220,8 +216,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetUserPermissions { address, user });
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterUserPermissions((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterUserPermissions(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -236,8 +232,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetPolicy(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterPolicy((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterPolicy(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -56,8 +56,8 @@ impl Client {
         let query = DataQueryVariant::Spentbook(SpentbookQuery::SpentProofShares(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::SpentProofShares((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::SpentProofShares(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,

--- a/sn_client/src/bin/query-adult/main.rs
+++ b/sn_client/src/bin/query-adult/main.rs
@@ -117,7 +117,7 @@ async fn query_chunk(client: &Client, adult_index: usize, address: XorName) -> R
     };
     let query_response = send_query(client, query).await?;
     match query_response {
-        QueryResponse::GetChunk(result) => result.map_err(|e| e.into()),
+        QueryResponse::GetChunk((result, _)) => result.map_err(|e| e.into()),
         response => Err(Error::UnexpectedQueryResponse {
             query: variant,
             response,

--- a/sn_client/src/bin/query-adult/main.rs
+++ b/sn_client/src/bin/query-adult/main.rs
@@ -117,7 +117,7 @@ async fn query_chunk(client: &Client, adult_index: usize, address: XorName) -> R
     };
     let query_response = send_query(client, query).await?;
     match query_response {
-        QueryResponse::GetChunk((result, _)) => result.map_err(|e| e.into()),
+        QueryResponse::GetChunk(result) => result.map_err(|e| e.into()),
         response => Err(Error::UnexpectedQueryResponse {
             query: variant,
             response,

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -238,16 +238,14 @@ impl Session {
                     correlation_id,
                 } => {
                     trace!(
-                    "ServiceMsg with id {:?} is QueryResponse regarding {:?} with response {:?}",
-                    msg_id,
-                    correlation_id,
-                    response,
-                );
+                        "ServiceMsg with id {:?} is QueryResponse regarding {:?} with response {:?}",
+                        msg_id,
+                        correlation_id,
+                        response,
+                    );
 
-                    let op_id = response.operation_id();
-                    debug!("OpId of {msg_id:?} is {op_id:?}");
-                    if let Some(entry) = queries.get_mut(&op_id) {
-                        debug!("op id: {op_id:?} exists in pending queries...");
+                    if let Some(entry) = queries.get_mut(&correlation_id) {
+                        debug!("correlation_id: {correlation_id:?} exists in pending queries...");
                         let received = entry.value();
 
                         debug!("inserting response : {response:?}");
@@ -257,10 +255,10 @@ impl Session {
 
                         debug!("received now looks like: {:?}", received);
                     } else {
-                        debug!("op id: {op_id:?} does not exist in pending queries...");
+                        debug!("correlation_id: {correlation_id:?} does not exist in pending queries...");
                         let received = DashSet::new();
                         let _prior = received.insert((src_peer.addr(), response));
-                        let _prev = queries.insert(op_id, Arc::new(received));
+                        let _prev = queries.insert(correlation_id, Arc::new(received));
                     }
                 }
                 ServiceMsg::CmdError {
@@ -272,7 +270,7 @@ impl Session {
                 }
                 ServiceMsg::CmdAck { correlation_id } => {
                     debug!(
-                        "CmdAck was received for Message{:?} w/ID: {:?} from {:?}",
+                        "CmdAck was received with id {:?} regarding {:?} from {:?}",
                         msg_id,
                         correlation_id,
                         src_peer.addr()

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -244,30 +244,23 @@ impl Session {
                     response,
                 );
 
-                    if let Ok(op_id) = response.operation_id() {
-                        debug!("OpId of {msg_id:?} is {op_id:?}");
-                        if let Some(entry) = queries.get_mut(&op_id) {
-                            debug!("op id: {op_id:?} exists in pending queries...");
-                            let received = entry.value();
+                    let op_id = response.operation_id();
+                    debug!("OpId of {msg_id:?} is {op_id:?}");
+                    if let Some(entry) = queries.get_mut(&op_id) {
+                        debug!("op id: {op_id:?} exists in pending queries...");
+                        let received = entry.value();
 
-                            debug!("inserting response : {response:?}");
-                            // we can acutally have many responses per peer if they're different
-                            // this could be a fail, and then an Ok aftewards from a different adult.
-                            let _prior = received.insert((src_peer.addr(), response));
+                        debug!("inserting response : {response:?}");
+                        // we can acutally have many responses per peer if they're different
+                        // this could be a fail, and then an Ok aftewards from a different adult.
+                        let _prior = received.insert((src_peer.addr(), response));
 
-                            debug!("received now looks like: {:?}", received);
-                        } else {
-                            debug!("op id: {op_id:?} does not exist in pending queries...");
-                            let received = DashSet::new();
-                            let _prior = received.insert((src_peer.addr(), response));
-                            let _prev = queries.insert(op_id, Arc::new(received));
-                            debug!("op_id added :{op_id:?}")
-                        }
+                        debug!("received now looks like: {:?}", received);
                     } else {
-                        warn!(
-                            "Ignoring query response without operation id: {:?} {:?}",
-                            msg_id, response
-                        );
+                        debug!("op id: {op_id:?} does not exist in pending queries...");
+                        let received = DashSet::new();
+                        let _prior = received.insert((src_peer.addr(), response));
+                        let _prev = queries.insert(op_id, Arc::new(received));
                     }
                 }
                 ServiceMsg::CmdError {

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -12,7 +12,7 @@ mod messaging;
 use crate::Result;
 use sn_interface::{
     messaging::{
-        data::{Error as ErrorMsg, OperationId, QueryResponse},
+        data::{Error as ErrorMsg, QueryResponse},
         MsgId,
     },
     network_knowledge::SectionTree,
@@ -25,7 +25,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::RwLock;
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
-type PendingQueryResponses = Arc<DashMap<OperationId, Arc<DashSet<(SocketAddr, QueryResponse)>>>>;
+type PendingQueryResponses = Arc<DashMap<MsgId, Arc<DashSet<(SocketAddr, QueryResponse)>>>>;
 
 type CmdResponse = (SocketAddr, Option<ErrorMsg>);
 

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -36,7 +36,6 @@ type PendingCmdAcks = Arc<DashMap<MsgId, Arc<DashSet<CmdResponse>>>>;
 #[derive(Debug)]
 pub struct QueryResult {
     pub response: QueryResponse,
-    pub operation_id: OperationId,
 }
 
 impl QueryResult {

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -8,7 +8,7 @@
 
 use sn_interface::{
     messaging::{
-        data::{DataQuery, DataQueryVariant, Error as ErrorMsg, OperationId, QueryResponse},
+        data::{DataQuery, DataQueryVariant, Error as ErrorMsg, QueryResponse},
         Error as MessagingError, MsgId,
     },
     types::{Error as DtError, Peer},
@@ -119,12 +119,10 @@ pub enum Error {
     #[error(transparent)]
     NetworkDataError(#[from] DtError),
     /// Errors received from the network via sn_messaging
-    #[error("Error received from the network: {source:?} Operationid: {op_id:?}")]
+    #[error("Error received from the network: {source:?}")]
     ErrorMsg {
         /// The source of an error msg
         source: ErrorMsg,
-        /// operation ID that was used to send the query
-        op_id: OperationId,
     },
     /// Error response received for a client cmd sent to the network
     #[error("Error received from the network: {source:?} for cmd: {msg_id:?}")]

--- a/sn_cmd_test_utilities/Cargo.toml
+++ b/sn_cmd_test_utilities/Cargo.toml
@@ -17,7 +17,7 @@ dirs-next = "2.0.0"
 rand = "~0.8"
 serde = "1.0.123"
 serde_json = "1.0.62"
-sn_api = { path = "../sn_api", version = "^0.73.0", default-features=false, features = ["app", "authd_client"] }
+sn_api = { path = "../sn_api", version = "^0.74.0", default-features=false, features = ["app", "authd_client"] }
 walkdir = "2.3.1"
 multibase = "~0.9.1"
 

--- a/sn_dysfunction/CHANGELOG.md
+++ b/sn_dysfunction/CHANGELOG.md
@@ -5,9 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.14.0 (2022-09-19)
+
 ## v0.13.0 (2022-09-09)
 
+### Chore
+
+ - <csr-id-448694176dd3b40a12bd8ecc16d9bb66fd171a37/> sn_interface-0.14.0/sn_dysfunction-0.13.0/sn_client-0.75.0/sn_node-0.70.0/sn_api-0.73.0/sn_cli-0.66.0
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 1 commit contributed to the release.
+ - 1 day passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' where seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - sn_interface-0.14.0/sn_dysfunction-0.13.0/sn_client-0.75.0/sn_node-0.70.0/sn_api-0.73.0/sn_cli-0.66.0 ([`4486941`](https://github.com/maidsafe/safe_network/commit/448694176dd3b40a12bd8ecc16d9bb66fd171a37))
+</details>
+
 ## v0.12.0 (2022-09-07)
+
+<csr-id-fe659c5685289fe0071b54298dcac394e83c0dce/>
 
 ### Chore
 

--- a/sn_dysfunction/Cargo.toml
+++ b/sn_dysfunction/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_dysfunction"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.13.0"
+version = "0.14.0"
 
 [features]
 default = []
@@ -21,7 +21,7 @@ thiserror = "1.0.23"
 tokio = { version = "1.0.23", features = [ "sync" ] }
 tracing = "~0.1.26"
 xor_name = "~5.0.0"
-sn_interface = { path = "../sn_interface", version = "^0.14.0" }
+sn_interface = { path = "../sn_interface", version = "^0.15.0" }
 
 [dev-dependencies]
 proptest = "~1.0.0"

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -91,7 +91,7 @@ impl DysfunctionDetection {
                 *node,
                 self.calculate_node_score_for_type(
                     node,
-                    &IssueType::PendingRequestOperation(rand_op_id()),
+                    &IssueType::PendingRequestOperation(OperationId::random()),
                 ),
             );
         }
@@ -279,12 +279,6 @@ impl DysfunctionDetection {
 
         Ok(dysfunctional_nodes)
     }
-}
-
-fn rand_op_id() -> OperationId {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    OperationId(rng.gen())
 }
 
 #[cfg(test)]
@@ -898,7 +892,7 @@ mod ops_tests {
         let mut pending_operations = Vec::new();
         for node in &nodes {
             for _ in 0..NORMAL_OPERATIONS_ISSUES {
-                let op_id = rand_op_id();
+                let op_id = OperationId::random();
                 pending_operations.push((node, op_id));
                 dysfunctional_detection
                     .track_issue(*node, IssueType::PendingRequestOperation(op_id));
@@ -917,7 +911,7 @@ mod ops_tests {
 
         // adding more issues though, and we should see some dysfunction
         for _ in 0..300 {
-            let op_id = rand_op_id();
+            let op_id = OperationId::random();
             dysfunctional_detection
                 .track_issue(nodes[0], IssueType::PendingRequestOperation(op_id));
         }

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -286,7 +286,7 @@ mod tests {
     use itertools::Itertools;
 
     use crate::{detection::IssueType, tests::init_test_logger, DysfunctionDetection};
-    use sn_interface::messaging::data::OperationId;
+    use sn_interface::messaging::system::OperationId;
 
     use eyre::bail;
     use proptest::prelude::*;

--- a/sn_dysfunction/src/lib.rs
+++ b/sn_dysfunction/src/lib.rs
@@ -50,7 +50,7 @@ mod error;
 pub use detection::IssueType;
 
 pub use crate::error::Error;
-use sn_interface::messaging::data::OperationId;
+use sn_interface::messaging::system::OperationId;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     time::Instant,
@@ -279,7 +279,7 @@ fn std_deviation(data: &[f32]) -> Option<f32> {
 #[cfg(test)]
 mod tests {
     use super::{DysfunctionDetection, IssueType};
-    use sn_interface::messaging::data::OperationId;
+    use sn_interface::messaging::system::OperationId;
 
     use eyre::Error;
     use std::{collections::BTreeSet, sync::Once};

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_interface"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.14.0"
+version = "0.15.0"
 
 [features]
 default = ["chunks", "registers", "spentbook", "traceroute"]

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -47,12 +47,6 @@ pub enum Error {
     /// Invalid Operation such as a POST on ImmutableData
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
-    /// There was an error forming the OperationId
-    #[error("Operation id could not be derived.")]
-    NoOperationId,
-    /// Error is not valid for operation id generation. This should not absolve a pending (and thus far unfulfilled) operation
-    #[error("Could not generate operation id for chunk retrieval. Error was not 'DataNotFound'.")]
-    InvalidQueryResponseErrorForOperationId,
     /// Failed to verify a spent proof since it's signed by unknown section key
     #[error("Spent proof was signed with unknown section key: {0:?}")]
     SpentProofUnknownSectionKey(bls::PublicKey),

--- a/sn_interface/src/messaging/data/query.rs
+++ b/sn_interface/src/messaging/data/query.rs
@@ -6,9 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{
-    register::RegisterQuery, spentbook::SpentbookQuery, Error, OperationId, QueryResponse,
-};
+use super::{register::RegisterQuery, spentbook::SpentbookQuery, Error, QueryResponse};
 use crate::types::{ChunkAddress, DataAddress, SpentbookAddress};
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
@@ -52,15 +50,15 @@ pub enum DataQueryVariant {
 impl DataQueryVariant {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error, op_id: OperationId) -> QueryResponse {
+    pub fn error(&self, error: Error) -> QueryResponse {
         use DataQueryVariant::*;
         match self {
             #[cfg(feature = "chunks")]
-            GetChunk(_) => QueryResponse::GetChunk((Err(error), op_id)),
+            GetChunk(_) => QueryResponse::GetChunk(Err(error)),
             #[cfg(feature = "registers")]
-            Register(q) => q.error(error, op_id),
+            Register(q) => q.error(error),
             #[cfg(feature = "spentbook")]
-            Spentbook(q) => q.error(error, op_id),
+            Spentbook(q) => q.error(error),
         }
     }
 

--- a/sn_interface/src/messaging/data/register.rs
+++ b/sn_interface/src/messaging/data/register.rs
@@ -8,7 +8,7 @@
 
 use super::{Error, QueryResponse};
 
-use crate::messaging::{data::OperationId, SectionAuth, ServiceAuth};
+use crate::messaging::{SectionAuth, ServiceAuth};
 #[allow(unused_imports)] // needed by rustdocs links
 use crate::types::register::Register;
 use crate::types::{
@@ -163,16 +163,16 @@ impl SignedRegisterEdit {
 impl RegisterQuery {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error, op_id: OperationId) -> QueryResponse {
+    pub fn error(&self, error: Error) -> QueryResponse {
         match self {
-            Self::Get(_) => QueryResponse::GetRegister((Err(error), op_id)),
-            Self::Read(_) => QueryResponse::ReadRegister((Err(error), op_id)),
-            Self::GetPolicy(_) => QueryResponse::GetRegisterPolicy((Err(error), op_id)),
+            Self::Get(_) => QueryResponse::GetRegister(Err(error)),
+            Self::Read(_) => QueryResponse::ReadRegister(Err(error)),
+            Self::GetPolicy(_) => QueryResponse::GetRegisterPolicy(Err(error)),
             Self::GetUserPermissions { .. } => {
-                QueryResponse::GetRegisterUserPermissions((Err(error), op_id))
+                QueryResponse::GetRegisterUserPermissions(Err(error))
             }
-            Self::GetEntry { .. } => QueryResponse::GetRegisterEntry((Err(error), op_id)),
-            Self::GetOwner(_) => QueryResponse::GetRegisterOwner((Err(error), op_id)),
+            Self::GetEntry { .. } => QueryResponse::GetRegisterEntry(Err(error)),
+            Self::GetOwner(_) => QueryResponse::GetRegisterOwner(Err(error)),
         }
     }
 

--- a/sn_interface/src/messaging/data/register.rs
+++ b/sn_interface/src/messaging/data/register.rs
@@ -6,16 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{Error, QueryResponse, Result};
+use super::{Error, QueryResponse};
 
 use crate::messaging::{data::OperationId, SectionAuth, ServiceAuth};
 #[allow(unused_imports)] // needed by rustdocs links
 use crate::types::register::Register;
 use crate::types::{
     register::{Entry, EntryHash, Policy, RegisterOp, User},
-    utils, RegisterAddress,
+    RegisterAddress,
 };
-use tiny_keccak::{Hasher, Sha3};
 
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
@@ -164,18 +163,16 @@ impl SignedRegisterEdit {
 impl RegisterQuery {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error) -> Result<QueryResponse> {
-        let op_id = self.operation_id()?;
-        match *self {
-            Self::Get(_) => Ok(QueryResponse::GetRegister((Err(error), op_id))),
-            Self::Read(_) => Ok(QueryResponse::ReadRegister((Err(error), op_id))),
-            Self::GetPolicy(_) => Ok(QueryResponse::GetRegisterPolicy((Err(error), op_id))),
-            Self::GetUserPermissions { .. } => Ok(QueryResponse::GetRegisterUserPermissions((
-                Err(error),
-                op_id,
-            ))),
-            Self::GetEntry { .. } => Ok(QueryResponse::GetRegisterEntry((Err(error), op_id))),
-            Self::GetOwner(_) => Ok(QueryResponse::GetRegisterOwner((Err(error), op_id))),
+    pub fn error(&self, error: Error, op_id: OperationId) -> QueryResponse {
+        match self {
+            Self::Get(_) => QueryResponse::GetRegister((Err(error), op_id)),
+            Self::Read(_) => QueryResponse::ReadRegister((Err(error), op_id)),
+            Self::GetPolicy(_) => QueryResponse::GetRegisterPolicy((Err(error), op_id)),
+            Self::GetUserPermissions { .. } => {
+                QueryResponse::GetRegisterUserPermissions((Err(error), op_id))
+            }
+            Self::GetEntry { .. } => QueryResponse::GetRegisterEntry((Err(error), op_id)),
+            Self::GetOwner(_) => QueryResponse::GetRegisterOwner((Err(error), op_id)),
         }
     }
 
@@ -201,18 +198,6 @@ impl RegisterQuery {
             | Self::GetEntry { ref address, .. }
             | Self::GetOwner(ref address) => *address.name(),
         }
-    }
-
-    /// Retrieves the operation identifier for this response, use in tracking node liveness
-    /// and responses at clients.
-    /// Must be the same as the query response
-    pub fn operation_id(&self) -> Result<OperationId> {
-        let bytes = utils::serialise(&self).map_err(|_| Error::NoOperationId)?;
-        let mut hasher = Sha3::v256();
-        let mut output = [0; 32];
-        hasher.update(&bytes);
-        hasher.finalize(&mut output);
-        Ok(OperationId(output))
     }
 }
 

--- a/sn_interface/src/messaging/data/spentbook.rs
+++ b/sn_interface/src/messaging/data/spentbook.rs
@@ -8,7 +8,6 @@
 
 use super::{Error, QueryResponse};
 
-use crate::messaging::data::OperationId;
 use crate::types::SpentbookAddress;
 
 use serde::{Deserialize, Serialize};
@@ -41,9 +40,9 @@ pub enum SpentbookCmd {
 impl SpentbookQuery {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error, op_id: OperationId) -> QueryResponse {
+    pub fn error(&self, error: Error) -> QueryResponse {
         match self {
-            Self::SpentProofShares(_) => QueryResponse::SpentProofShares((Err(error), op_id)),
+            Self::SpentProofShares(_) => QueryResponse::SpentProofShares(Err(error)),
         }
     }
 

--- a/sn_interface/src/messaging/data/spentbook.rs
+++ b/sn_interface/src/messaging/data/spentbook.rs
@@ -6,11 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{Error, QueryResponse, Result};
+use super::{Error, QueryResponse};
 
 use crate::messaging::data::OperationId;
-use crate::types::{utils, SpentbookAddress};
-use tiny_keccak::{Hasher, Sha3};
+use crate::types::SpentbookAddress;
 
 use serde::{Deserialize, Serialize};
 use sn_dbc::{KeyImage, RingCtTransaction, SpentProof};
@@ -42,12 +41,9 @@ pub enum SpentbookCmd {
 impl SpentbookQuery {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error) -> Result<QueryResponse> {
-        match *self {
-            Self::SpentProofShares(_) => Ok(QueryResponse::SpentProofShares((
-                Err(error),
-                self.operation_id()?,
-            ))),
+    pub fn error(&self, error: Error, op_id: OperationId) -> QueryResponse {
+        match self {
+            Self::SpentProofShares(_) => QueryResponse::SpentProofShares((Err(error), op_id)),
         }
     }
 
@@ -61,18 +57,6 @@ impl SpentbookQuery {
     /// Returns the xorname of the data for request.
     pub fn dst_name(&self) -> XorName {
         *self.dst_address().name()
-    }
-
-    /// Retrieves the operation identifier for this request, use in tracking node liveness
-    /// and responses at clients.
-    /// Must be the same as the query response
-    pub fn operation_id(&self) -> Result<OperationId> {
-        let bytes = utils::serialise(&self).map_err(|_| Error::NoOperationId)?;
-        let mut hasher = Sha3::v256();
-        let mut output = [0; 32];
-        hasher.update(&bytes);
-        hasher.finalize(&mut output);
-        Ok(OperationId(output))
     }
 }
 

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -8,8 +8,8 @@
 
 use super::wire_msg_header::WireMsgHeader;
 use crate::messaging::{
-    data::{OperationId, ServiceMsg},
-    system::SystemMsg,
+    data::ServiceMsg,
+    system::{OperationId, SystemMsg},
     AuthKind, AuthorityProof, Dst, Error, MsgId, MsgType, NodeMsgAuthority, Result, ServiceAuth,
 };
 

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -8,21 +8,22 @@
 
 use super::wire_msg_header::WireMsgHeader;
 use crate::messaging::{
-    data::ServiceMsg, system::SystemMsg, AuthKind, AuthorityProof, Dst, Error, MsgId, MsgType,
-    NodeMsgAuthority, Result, ServiceAuth,
+    data::{OperationId, ServiceMsg},
+    system::SystemMsg,
+    AuthKind, AuthorityProof, Dst, Error, MsgId, MsgType, NodeMsgAuthority, Result, ServiceAuth,
 };
+
 use bytes::Bytes;
 use custom_debug::Debug;
+use qp2p::UsrMsgBytes;
 use serde::Serialize;
 
 #[cfg(feature = "traceroute")]
 use crate::types::PublicKey;
 #[cfg(feature = "traceroute")]
-use serde::Deserialize;
-
-#[cfg(feature = "traceroute")]
 use itertools::Itertools;
-use qp2p::UsrMsgBytes;
+#[cfg(feature = "traceroute")]
+use serde::Deserialize;
 #[cfg(feature = "traceroute")]
 use std::fmt::{Debug as StdDebug, Display, Formatter};
 
@@ -298,6 +299,11 @@ impl WireMsg {
     /// Return the message id of this message
     pub fn msg_id(&self) -> MsgId {
         self.header.msg_envelope.msg_id
+    }
+
+    /// Return the operation id of this message based on the payload bytes
+    pub fn operation_id(&self) -> OperationId {
+        OperationId::from(&self.payload)
     }
 
     /// Return the auth of this message

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -28,7 +28,7 @@ pub use signed::{KeyedSig, SigShare};
 use super::{authority::SectionAuth as SectionAuthProof, AuthorityProof};
 use qp2p::UsrMsgBytes;
 
-use crate::messaging::{MsgId, SectionAuthorityProvider};
+use crate::messaging::SectionAuthorityProvider;
 use crate::network_knowledge::SapCandidate;
 
 use sn_consensus::{Generation, SignedVote};
@@ -171,8 +171,6 @@ pub enum SystemMsg {
     NodeQueryResponse {
         /// QueryResponse.
         response: NodeQueryResponse,
-        /// ID of causing query.
-        correlation_id: MsgId,
         /// ID of the requested operation.
         operation_id: OperationId,
     },

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -12,6 +12,7 @@ mod join_as_relocated;
 mod msg_authority;
 mod node_msgs;
 mod node_state;
+mod op_id;
 mod signed;
 use bls::PublicKey as BlsPublicKey;
 
@@ -21,12 +22,13 @@ pub use join_as_relocated::{JoinAsRelocatedRequest, JoinAsRelocatedResponse};
 pub use msg_authority::NodeMsgAuthorityUtils;
 pub use node_msgs::{NodeCmd, NodeEvent, NodeQuery, NodeQueryResponse};
 pub use node_state::{MembershipState, NodeState, RelocateDetails};
+pub use op_id::OperationId;
 pub use signed::{KeyedSig, SigShare};
 
 use super::{authority::SectionAuth as SectionAuthProof, AuthorityProof};
 use qp2p::UsrMsgBytes;
 
-use crate::messaging::{EndUser, MsgId, SectionAuthorityProvider};
+use crate::messaging::{MsgId, SectionAuthorityProvider};
 use crate::network_knowledge::SapCandidate;
 
 use sn_consensus::{Generation, SignedVote};
@@ -171,8 +173,8 @@ pub enum SystemMsg {
         response: NodeQueryResponse,
         /// ID of causing query.
         correlation_id: MsgId,
-        /// TEMP: Add user here as part of return flow. Remove this as we have chunk routing etc
-        user: EndUser,
+        /// ID of the requested operation.
+        operation_id: OperationId,
     },
 }
 

--- a/sn_interface/src/messaging/system/node_msgs.rs
+++ b/sn_interface/src/messaging/system/node_msgs.rs
@@ -9,7 +9,7 @@
 use super::OperationId;
 use crate::messaging::{
     data::{DataQueryVariant, MetadataExchange, QueryResponse, StorageLevel},
-    MsgId, ServiceAuth,
+    ServiceAuth,
 };
 use crate::types::{DataAddress, PublicKey, ReplicatedData};
 
@@ -67,8 +67,6 @@ pub enum NodeQuery {
         query: DataQueryVariant,
         /// Client signature
         auth: ServiceAuth,
-        /// The correlation id that recorded in Elders for this query
-        correlation_id: MsgId,
         /// The operation id that recorded in Elders for this query
         operation_id: OperationId,
     },

--- a/sn_interface/src/messaging/system/node_msgs.rs
+++ b/sn_interface/src/messaging/system/node_msgs.rs
@@ -6,9 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::OperationId;
 use crate::messaging::{
-    data::{DataQueryVariant, MetadataExchange, OperationId, QueryResponse, StorageLevel},
-    EndUser, MsgId, ServiceAuth,
+    data::{DataQueryVariant, MetadataExchange, QueryResponse, StorageLevel},
+    MsgId, ServiceAuth,
 };
 use crate::types::{DataAddress, PublicKey, ReplicatedData};
 
@@ -66,8 +67,6 @@ pub enum NodeQuery {
         query: DataQueryVariant,
         /// Client signature
         auth: ServiceAuth,
-        /// The user that has initiated this query
-        origin: EndUser,
         /// The correlation id that recorded in Elders for this query
         correlation_id: MsgId,
         /// The operation id that recorded in Elders for this query

--- a/sn_interface/src/messaging/system/node_msgs.rs
+++ b/sn_interface/src/messaging/system/node_msgs.rs
@@ -7,17 +7,12 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::{
-    data::{DataQueryVariant, MetadataExchange, OperationId, QueryResponse, Result, StorageLevel},
+    data::{DataQueryVariant, MetadataExchange, OperationId, QueryResponse, StorageLevel},
     EndUser, MsgId, ServiceAuth,
 };
-use crate::types::{
-    register::{Entry, EntryHash, Permissions, Policy, Register, User},
-    Chunk, DataAddress, PublicKey, ReplicatedData,
-};
+use crate::types::{DataAddress, PublicKey, ReplicatedData};
 
 use serde::{Deserialize, Serialize};
-use sn_dbc::SpentProofShare;
-use std::collections::BTreeSet;
 use xor_name::XorName;
 
 /// cmd message sent among nodes
@@ -75,80 +70,12 @@ pub enum NodeQuery {
         origin: EndUser,
         /// The correlation id that recorded in Elders for this query
         correlation_id: MsgId,
+        /// The operation id that recorded in Elders for this query
+        operation_id: OperationId,
     },
 }
 
-/// Responses to queries from Elders to Adults.
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub enum NodeQueryResponse {
-    //
-    // ===== Chunk =====
-    //
-    #[cfg(feature = "chunks")]
-    /// Response to [`GetChunk`]
-    ///
-    /// [`GetChunk`]: crate::messaging::data::DataQueryVariant::GetChunk
-    GetChunk(Result<Chunk>),
-    //
-    // ===== Register Data =====
-    //
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::Get`].
-    GetRegister((Result<Register>, OperationId)),
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::GetOwner`].
-    GetRegisterOwner((Result<User>, OperationId)),
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::GetEntry`].
-    GetRegisterEntry((Result<Entry>, OperationId)),
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::GetPolicy`].
-    GetRegisterPolicy((Result<Policy>, OperationId)),
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::Read`].
-    ReadRegister((Result<BTreeSet<(EntryHash, Entry)>>, OperationId)),
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::GetUserPermissions`].
-    GetRegisterUserPermissions((Result<Permissions>, OperationId)),
-    //
-    // ===== Spentbook Data =====
-    //
-    #[cfg(feature = "spentbook")]
-    /// Response to [`crate::messaging::data::SpentbookQuery::SpentProofShares`].
-    SpentProofShares((Result<Vec<SpentProofShare>>, OperationId)),
-    //
-    // ===== Other =====
-    //
-    /// Failed to create id generation
-    FailedToCreateOperationId,
-}
-
-impl NodeQueryResponse {
-    pub fn convert(self) -> QueryResponse {
-        use NodeQueryResponse::*;
-        match self {
-            #[cfg(feature = "chunks")]
-            GetChunk(res) => QueryResponse::GetChunk(res),
-            #[cfg(feature = "registers")]
-            GetRegister(res) => QueryResponse::GetRegister(res),
-            #[cfg(feature = "registers")]
-            GetRegisterEntry(res) => QueryResponse::GetRegisterEntry(res),
-            #[cfg(feature = "registers")]
-            GetRegisterOwner(res) => QueryResponse::GetRegisterOwner(res),
-            #[cfg(feature = "registers")]
-            ReadRegister(res) => QueryResponse::ReadRegister(res),
-            #[cfg(feature = "registers")]
-            GetRegisterPolicy(res) => QueryResponse::GetRegisterPolicy(res),
-            #[cfg(feature = "registers")]
-            GetRegisterUserPermissions(res) => QueryResponse::GetRegisterUserPermissions(res),
-            #[cfg(feature = "spentbook")]
-            SpentProofShares(res) => QueryResponse::SpentProofShares(res),
-            FailedToCreateOperationId => QueryResponse::FailedToCreateOperationId,
-        }
-    }
-
-    pub fn operation_id(&self) -> Result<OperationId> {
-        self.clone().convert().operation_id()
-    }
-}
+/// Responses to queries sent from Elders to Adults.
+/// We define it as an alias to `QueryResponse` type, but we keep it as
+/// a separate system message type for more clarity in logs and messaging tracking/debugging.
+pub type NodeQueryResponse = QueryResponse;

--- a/sn_interface/src/messaging/system/op_id.rs
+++ b/sn_interface/src/messaging/system/op_id.rs
@@ -1,0 +1,52 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use bytes::Bytes;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Debug, Display, Formatter};
+use tiny_keccak::{Hasher, Sha3};
+
+/// Id of an operation. Node to node query/response should return the same id for simple
+/// nodes tracking purposes.
+#[derive(Deserialize, Serialize, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct OperationId(pub [u8; 32]);
+
+impl Display for OperationId {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "OpId-{:02x}{:02x}{:02x}..",
+            self.0[0], self.0[1], self.0[2]
+        )
+    }
+}
+
+impl Debug for OperationId {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{}", self)
+    }
+}
+
+impl OperationId {
+    /// Creates an operation id by hashing the provided bytes
+    pub fn from(bytes: &Bytes) -> Self {
+        let mut hasher = Sha3::v256();
+        let mut output = [0; 32];
+        hasher.update(bytes);
+        hasher.finalize(&mut output);
+
+        Self(output)
+    }
+
+    /// Creates a random operation id
+    pub fn random() -> Self {
+        let mut rng = rand::thread_rng();
+        Self(rng.gen())
+    }
+}

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_node"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.70.0"
+version = "0.71.0"
 
 
 
@@ -71,8 +71,8 @@ secured_linked_list = "~0.5.3"
 self_encryption = "~0.27.5"
 sn_consensus = "3.1.2"
 sn_dbc = { version = "8.0.0", features = ["serdes"] }
-sn_dysfunction = { path = "../sn_dysfunction", version = "^0.13.0" }
-sn_interface = { path = "../sn_interface", version = "^0.14.0" }
+sn_dysfunction = { path = "../sn_dysfunction", version = "^0.14.0" }
+sn_interface = { path = "../sn_interface", version = "^0.15.0" }
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
@@ -113,7 +113,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 tokio-util = { version = "~0.6.7", features = ["time"] }
 walkdir = "2"
 yansi = "~0.5.0"
-sn_interface = { path = "../sn_interface", version = "^0.14.0", features= ["test-utils", "proptest"] }
+sn_interface = { path = "../sn_interface", version = "^0.15.0", features= ["test-utils", "proptest"] }
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -82,6 +82,7 @@ impl Node {
         };
 
         let mut cmds = vec![Cmd::AddToPendingQueries {
+            msg_id,
             origin: source_client,
             operation_id,
             target_adult: target.name(),
@@ -93,7 +94,14 @@ impl Node {
         {
             if peers.len() > MAX_WAITING_PEERS_PER_QUERY {
                 warn!("Dropping query from {source_client:?}, there are more than {MAX_WAITING_PEERS_PER_QUERY} waiting already");
-                return Ok(vec![]);
+                let cmd = self.cmd_error_response(
+                    Error::CannotHandleQuery(query),
+                    source_client,
+                    msg_id,
+                    #[cfg(feature = "traceroute")]
+                    traceroute,
+                );
+                return Ok(vec![cmd]);
             }
         }
 
@@ -107,7 +115,6 @@ impl Node {
         let msg = SystemMsg::NodeQuery(NodeQuery::Data {
             query: query.variant,
             auth: auth.into_inner(),
-            correlation_id: msg_id,
             operation_id,
         });
 

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -16,7 +16,7 @@ use sn_interface::messaging::Traceroute;
 use sn_interface::{
     data_copy_count,
     messaging::{
-        data::{DataQuery, MetadataExchange, StorageLevel},
+        data::{DataQuery, MetadataExchange, OperationId, StorageLevel},
         system::{NodeCmd, NodeQuery, SystemMsg},
         AuthorityProof, EndUser, MsgId, ServiceAuth,
     },
@@ -54,12 +54,12 @@ impl Node {
         &self,
         query: DataQuery,
         msg_id: MsgId,
+        operation_id: OperationId,
         auth: AuthorityProof<ServiceAuth>,
         source_client: Peer,
         #[cfg(feature = "traceroute")] traceroute: Traceroute,
     ) -> Result<Vec<Cmd>> {
         let address = query.variant.address();
-        let operation_id = query.variant.operation_id()?;
         trace!(
             "{:?} preparing to query adults for data at {:?} with op_id: {:?}",
             LogMarker::DataQueryReceviedAtElder,
@@ -109,6 +109,7 @@ impl Node {
             auth: auth.into_inner(),
             origin: EndUser(source_client.name()),
             correlation_id: msg_id,
+            operation_id,
         });
 
         cmds.push(self.trace_system_msg(

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -16,9 +16,9 @@ use sn_interface::messaging::Traceroute;
 use sn_interface::{
     data_copy_count,
     messaging::{
-        data::{DataQuery, MetadataExchange, OperationId, StorageLevel},
-        system::{NodeCmd, NodeQuery, SystemMsg},
-        AuthorityProof, EndUser, MsgId, ServiceAuth,
+        data::{DataQuery, MetadataExchange, StorageLevel},
+        system::{NodeCmd, NodeQuery, OperationId, SystemMsg},
+        AuthorityProof, MsgId, ServiceAuth,
     },
     types::{log_markers::LogMarker, Peer, PublicKey, ReplicatedData},
 };
@@ -107,7 +107,6 @@ impl Node {
         let msg = SystemMsg::NodeQuery(NodeQuery::Data {
             query: query.variant,
             auth: auth.into_inner(),
-            origin: EndUser(source_client.name()),
             correlation_id: msg_id,
             operation_id,
         });

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -17,8 +17,8 @@ use sn_dysfunction::IssueType;
 use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
-        data::{OperationId, ServiceMsg},
-        system::{DkgFailureSigSet, KeyedSig, NodeState, SectionAuth, SystemMsg},
+        data::ServiceMsg,
+        system::{DkgFailureSigSet, KeyedSig, NodeState, OperationId, SectionAuth, SystemMsg},
         AuthorityProof, MsgId, NodeMsgAuthority, ServiceAuth, WireMsg,
     },
     network_knowledge::{SectionAuthorityProvider, SectionKeyShare},

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -127,6 +127,7 @@ pub(crate) enum Cmd {
     /// Adds peer to set of recipients of an already pending query,
     /// or adds a pending query if it didn't already exist.
     AddToPendingQueries {
+        msg_id: MsgId,
         operation_id: OperationId,
         origin: Peer,
         target_adult: XorName,

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -143,6 +143,7 @@ pub(crate) enum Cmd {
     },
     HandleValidServiceMsg {
         msg_id: MsgId,
+        op_id: OperationId,
         msg: ServiceMsg,
         origin: Peer,
         /// Requester's authority over this message

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -115,6 +115,7 @@ impl Dispatcher {
                 Ok(vec![])
             }
             Cmd::AddToPendingQueries {
+                msg_id,
                 operation_id,
                 origin,
                 target_adult,
@@ -131,11 +132,11 @@ impl Dispatcher {
                         "Adding to pending data queries for op id: {:?}",
                         operation_id
                     );
-                    let _ = peers.insert(origin);
+                    let _ = peers.insert((msg_id, origin));
                 } else {
                     let _prior_value = node.pending_data_queries.set(
                         (operation_id, target_adult),
-                        BTreeSet::from([origin]),
+                        BTreeSet::from([(msg_id, origin)]),
                         None,
                     );
                 };

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -148,6 +148,7 @@ impl Dispatcher {
             }
             Cmd::HandleValidServiceMsg {
                 msg_id,
+                op_id,
                 msg,
                 origin,
                 auth,
@@ -158,6 +159,7 @@ impl Dispatcher {
                 match node
                     .handle_valid_service_msg(
                         msg_id,
+                        op_id,
                         msg,
                         auth,
                         origin,

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -15,8 +15,8 @@ use ed25519_dalek::Signer;
 use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
-        data::{DataQuery, DataQueryVariant, OperationId, ServiceMsg},
-        system::{NodeCmd, SystemMsg},
+        data::{DataQuery, DataQueryVariant, ServiceMsg},
+        system::{NodeCmd, OperationId, SystemMsg},
         AuthorityProof, MsgId, ServiceAuth, WireMsg,
     },
     types::log_markers::LogMarker,

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -15,7 +15,7 @@ use ed25519_dalek::Signer;
 use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
-        data::{DataQuery, DataQueryVariant, ServiceMsg},
+        data::{DataQuery, DataQueryVariant, OperationId, ServiceMsg},
         system::{NodeCmd, SystemMsg},
         AuthorityProof, MsgId, ServiceAuth, WireMsg,
     },
@@ -171,6 +171,7 @@ impl FlowCtrl {
         });
 
         let msg_id = MsgId::new();
+        let op_id = OperationId::random();
         let our_info = node.info();
         let origin = our_info.peer();
 
@@ -179,6 +180,7 @@ impl FlowCtrl {
         // generate the cmds, and ensure we go through dysfunction tracking
         node.handle_valid_service_msg(
             msg_id,
+            op_id,
             msg,
             auth,
             origin,

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -11,9 +11,9 @@ use eyre::Result;
 use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
-        data::{Error as MessagingDataError, OperationId, ServiceMsg},
+        data::{Error as MessagingDataError, ServiceMsg},
         serialisation::WireMsg,
-        system::{JoinResponse, MembershipState, NodeCmd, RelocateDetails, SystemMsg},
+        system::{JoinResponse, MembershipState, NodeCmd, OperationId, RelocateDetails, SystemMsg},
         AuthorityProof, MsgId, MsgType, ServiceAuth,
     },
     network_knowledge::{test_utils::*, NodeState, SectionAuthorityProvider},

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -11,7 +11,7 @@ use eyre::Result;
 use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
-        data::{Error as MessagingDataError, ServiceMsg},
+        data::{Error as MessagingDataError, OperationId, ServiceMsg},
         serialisation::WireMsg,
         system::{JoinResponse, MembershipState, NodeCmd, RelocateDetails, SystemMsg},
         AuthorityProof, MsgId, MsgType, ServiceAuth,
@@ -120,6 +120,7 @@ pub(crate) fn wrap_service_msg_for_handling(msg: ServiceMsg, peer: Peer) -> Resu
     let auth_proof = AuthorityProof::verify(auth, &payload)?;
     Ok(HandleValidServiceMsg {
         msg_id: MsgId::new(),
+        op_id: OperationId::random(),
         msg,
         origin: peer,
         auth: auth_proof,

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -65,6 +65,7 @@ impl Node {
         let msg_id = wire_msg.msg_id();
         // payload needed for aggregation
         let wire_msg_payload = wire_msg.payload.clone();
+        let op_id = wire_msg.operation_id();
 
         let msg_type = match wire_msg.into_msg() {
             Ok(msg_type) => msg_type,
@@ -168,6 +169,7 @@ impl Node {
 
                 Ok(vec![Cmd::HandleValidServiceMsg {
                     msg_id,
+                    op_id,
                     msg,
                     origin,
                     auth,

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -21,11 +21,10 @@ use sn_interface::{
     data_copy_count,
     messaging::{
         data::{
-            DataCmd, DataQueryVariant, EditRegister, OperationId, ServiceMsg, SignedRegisterEdit,
-            SpentbookCmd,
+            DataCmd, DataQueryVariant, EditRegister, ServiceMsg, SignedRegisterEdit, SpentbookCmd,
         },
-        system::{NodeQueryResponse, SystemMsg},
-        AuthorityProof, EndUser, MsgId, ServiceAuth,
+        system::{NodeQueryResponse, OperationId, SystemMsg},
+        AuthorityProof, MsgId, ServiceAuth,
     },
     network_knowledge::{SectionAuthorityProvider, SectionKeysProvider},
     types::{
@@ -103,23 +102,22 @@ impl Node {
     pub(crate) async fn handle_data_query_at_adult(
         &self,
         correlation_id: MsgId,
-        op_id: OperationId,
+        operation_id: OperationId,
         query: &DataQueryVariant,
         auth: ServiceAuth,
-        user: EndUser,
         requesting_elder: Peer,
         #[cfg(feature = "traceroute")] traceroute: Traceroute,
     ) -> Cmd {
         let response = self
             .data_storage
-            .query(query, User::Key(auth.public_key), op_id)
+            .query(query, User::Key(auth.public_key))
             .await;
 
         trace!("data query response at adult is: {:?}", response);
         let msg = SystemMsg::NodeQueryResponse {
             response,
             correlation_id,
-            user,
+            operation_id,
         };
 
         self.trace_system_msg(
@@ -135,13 +133,12 @@ impl Node {
     /// Forms a response to send to the requester
     pub(crate) async fn handle_data_query_response_at_elder(
         &mut self,
+        op_id: OperationId,
         correlation_id: MsgId,
         response: NodeQueryResponse,
-        user: EndUser,
         sending_node_pk: PublicKey,
         #[cfg(feature = "traceroute")] traceroute: Traceroute,
     ) -> Option<Cmd> {
-        let op_id = response.operation_id();
         debug!(
             "Handling data read @ elders, received from {:?}, op id: {:?}",
             sending_node_pk, op_id
@@ -165,7 +162,7 @@ impl Node {
         } else {
             warn!(
                 "Dropping chunk query response from Adult {}. We might have already forwarded this chunk to the requesting client or the client connection cache has expired: {}",
-                sending_node_pk, user.0
+                sending_node_pk, op_id
             );
             return None;
         };

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -101,7 +101,6 @@ impl Node {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn handle_data_query_at_adult(
         &self,
-        correlation_id: MsgId,
         operation_id: OperationId,
         query: &DataQueryVariant,
         auth: ServiceAuth,
@@ -116,7 +115,6 @@ impl Node {
         trace!("data query response at adult is: {:?}", response);
         let msg = SystemMsg::NodeQueryResponse {
             response,
-            correlation_id,
             operation_id,
         };
 
@@ -134,11 +132,10 @@ impl Node {
     pub(crate) async fn handle_data_query_response_at_elder(
         &mut self,
         op_id: OperationId,
-        correlation_id: MsgId,
         response: NodeQueryResponse,
         sending_node_pk: PublicKey,
         #[cfg(feature = "traceroute")] traceroute: Traceroute,
-    ) -> Option<Cmd> {
+    ) -> Vec<Cmd> {
         debug!(
             "Handling data read @ elders, received from {:?}, op id: {:?}",
             sending_node_pk, op_id
@@ -156,7 +153,7 @@ impl Node {
             if peers.is_empty() {
                 warn!("No waiting peers to send {op_id:?} to....");
                 // nothing to do
-                return None;
+                return vec![];
             }
             peers.clone()
         } else {
@@ -164,7 +161,7 @@ impl Node {
                 "Dropping chunk query response from Adult {}. We might have already forwarded this chunk to the requesting client or the client connection cache has expired: {}",
                 sending_node_pk, op_id
             );
-            return None;
+            return vec![];
         };
 
         let pending_removed = self
@@ -173,23 +170,28 @@ impl Node {
 
         if !pending_removed {
             trace!("Ignoring un-expected response");
-            return None;
+            return vec![];
         }
 
-        let msg = ServiceMsg::QueryResponse {
-            response,
-            correlation_id,
-        };
+        let mut cmds = vec![];
+        for (correlation_id, peer) in waiting_peers.into_iter() {
+            let msg = ServiceMsg::QueryResponse {
+                response: response.clone(),
+                correlation_id,
+            };
+
+            cmds.push(self.send_service_msg(
+                msg,
+                Peers::Single(peer),
+                #[cfg(feature = "traceroute")]
+                traceroute.clone(),
+            ));
+        }
 
         // Clear expired queries from the cache.
         self.pending_data_queries.remove_expired();
 
-        Some(self.send_service_msg(
-            msg,
-            Peers::Multiple(waiting_peers),
-            #[cfg(feature = "traceroute")]
-            traceroute,
-        ))
+        cmds
     }
 
     /// Handle incoming service msgs. Though NOT queries, as this requires

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -491,7 +491,6 @@ impl Node {
             SystemMsg::NodeQuery(NodeQuery::Data {
                 query,
                 auth,
-                origin,
                 correlation_id,
                 operation_id,
             }) => {
@@ -508,7 +507,6 @@ impl Node {
                         operation_id,
                         &query,
                         auth,
-                        origin,
                         sender,
                         #[cfg(feature = "traceroute")]
                         traceroute,
@@ -519,11 +517,11 @@ impl Node {
             SystemMsg::NodeQueryResponse {
                 response,
                 correlation_id,
-                user,
+                operation_id,
             } => {
                 debug!(
                     "{:?}: op_id {}, correlation_id: {correlation_id:?}, sender: {sender} origin msg_id: {msg_id:?}",
-                    LogMarker::ChunkQueryResponseReceviedFromAdult, response.operation_id()
+                    LogMarker::ChunkQueryResponseReceviedFromAdult, operation_id
                 );
 
                 match msg_authority {
@@ -531,9 +529,9 @@ impl Node {
                         let sending_nodes_pk = PublicKey::from(auth.into_inner().node_ed_pk);
                         Ok(self
                             .handle_data_query_response_at_elder(
+                                operation_id,
                                 correlation_id,
                                 response,
-                                user,
                                 sending_nodes_pk,
                                 #[cfg(feature = "traceroute")]
                                 traceroute,

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -491,19 +491,17 @@ impl Node {
             SystemMsg::NodeQuery(NodeQuery::Data {
                 query,
                 auth,
-                correlation_id,
                 operation_id,
             }) => {
                 // A request from EndUser - via elders - for locally stored data
                 debug!(
-                    "Handle NodeQuery with msg_id {:?}, correlation_id {:?}, operation_id {}",
-                    msg_id, correlation_id, operation_id
+                    "Handle NodeQuery with msg_id {:?}, operation_id {}",
+                    msg_id, operation_id
                 );
                 // There is no point in verifying a sig from a sender A or B here.
                 // Send back response to the sending elder
                 Ok(vec![
                     self.handle_data_query_at_adult(
-                        correlation_id,
                         operation_id,
                         &query,
                         auth,
@@ -516,12 +514,12 @@ impl Node {
             }
             SystemMsg::NodeQueryResponse {
                 response,
-                correlation_id,
                 operation_id,
             } => {
                 debug!(
-                    "{:?}: op_id {}, correlation_id: {correlation_id:?}, sender: {sender} origin msg_id: {msg_id:?}",
-                    LogMarker::ChunkQueryResponseReceviedFromAdult, operation_id
+                    "{:?}: op_id {}, sender: {sender} origin msg_id: {msg_id:?}",
+                    LogMarker::ChunkQueryResponseReceviedFromAdult,
+                    operation_id
                 );
 
                 match msg_authority {
@@ -530,7 +528,6 @@ impl Node {
                         Ok(self
                             .handle_data_query_response_at_elder(
                                 operation_id,
-                                correlation_id,
                                 response,
                                 sending_nodes_pk,
                                 #[cfg(feature = "traceroute")]

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -107,7 +107,6 @@ impl Node {
 
     // Handler for data messages which have successfully
     // passed all signature checks and msg verifications
-    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn handle_valid_system_msg(
         &mut self,
         msg_id: MsgId,
@@ -494,17 +493,19 @@ impl Node {
                 auth,
                 origin,
                 correlation_id,
+                operation_id,
             }) => {
                 // A request from EndUser - via elders - for locally stored data
                 debug!(
-                    "Handle NodeQuery with msg_id {:?} and correlation_id {:?}",
-                    msg_id, correlation_id,
+                    "Handle NodeQuery with msg_id {:?}, correlation_id {:?}, operation_id {}",
+                    msg_id, correlation_id, operation_id
                 );
                 // There is no point in verifying a sig from a sender A or B here.
                 // Send back response to the sending elder
                 Ok(vec![
                     self.handle_data_query_at_adult(
                         correlation_id,
+                        operation_id,
                         &query,
                         auth,
                         origin,
@@ -520,23 +521,9 @@ impl Node {
                 correlation_id,
                 user,
             } => {
-                let op_id = if let Ok(op_id) = response.operation_id() {
-                    op_id
-                } else {
-                    debug!(
-                        "{:?}: op_id None, correlation_id: {correlation_id:?}, sender: {sender} origin msg_id: {msg_id:?}",
-                        LogMarker::ChunkQueryResponseReceviedFromAdult,
-                    );
-                    warn!(
-                        "There is no operation id. Dropping chunk query response from Adult {sender}, for user: {}.",
-                        user.0
-                    );
-                    return Ok(vec![]);
-                };
-
                 debug!(
-                    "{:?}: op_id {op_id:?}, correlation_id: {correlation_id:?}, sender: {sender} origin msg_id: {msg_id:?}",
-                    LogMarker::ChunkQueryResponseReceviedFromAdult,
+                    "{:?}: op_id {}, correlation_id: {correlation_id:?}, sender: {sender} origin msg_id: {msg_id:?}",
+                    LogMarker::ChunkQueryResponseReceviedFromAdult, response.operation_id()
                 );
 
                 match msg_authority {
@@ -548,7 +535,6 @@ impl Node {
                                 response,
                                 user,
                                 sending_nodes_pk,
-                                op_id,
                                 #[cfg(feature = "traceroute")]
                                 traceroute,
                             )

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -92,7 +92,7 @@ mod core {
         messaging::{
             signature_aggregator::SignatureAggregator,
             system::{DkgSessionId, NodeState, OperationId},
-            AuthorityProof, SectionAuth, SectionAuthorityProvider,
+            AuthorityProof, MsgId, SectionAuth, SectionAuthorityProvider,
         },
         network_knowledge::{
             supermajority, NetworkKnowledge, NodeInfo, SectionKeyShare, SectionKeysProvider,
@@ -185,7 +185,7 @@ mod core {
         pub(crate) capacity: Capacity,
         pub(crate) dysfunction_tracking: DysfunctionDetection,
         /// Cache the request combo,  (OperationId -> An adult xorname), to waiting Clients peers for that combo
-        pub(crate) pending_data_queries: Cache<(OperationId, XorName), BTreeSet<Peer>>,
+        pub(crate) pending_data_queries: Cache<(OperationId, XorName), BTreeSet<(MsgId, Peer)>>,
         // Caches
         pub(crate) ae_backoff_cache: AeBackoffCache,
     }

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -90,9 +90,8 @@ mod core {
     use sn_interface::messaging::Entity;
     use sn_interface::{
         messaging::{
-            data::OperationId,
             signature_aggregator::SignatureAggregator,
-            system::{DkgSessionId, NodeState},
+            system::{DkgSessionId, NodeState, OperationId},
             AuthorityProof, SectionAuth, SectionAuthorityProvider,
         },
         network_knowledge::{

--- a/sn_node/src/storage/chunks.rs
+++ b/sn_node/src/storage/chunks.rs
@@ -9,7 +9,7 @@
 use super::{list_files_in, prefix_tree_path, Error, Result, UsedSpace};
 
 use sn_interface::{
-    messaging::system::NodeQueryResponse,
+    messaging::{data::OperationId, system::NodeQueryResponse},
     types::{log_markers::LogMarker, Chunk, ChunkAddress, DataAddress},
 };
 
@@ -100,9 +100,16 @@ impl ChunkStorage {
     }
 
     // Read chunk from local store and return NodeQueryResponse
-    pub(super) async fn get(&self, address: &ChunkAddress) -> NodeQueryResponse {
+    pub(super) async fn get(
+        &self,
+        address: &ChunkAddress,
+        op_id: OperationId,
+    ) -> NodeQueryResponse {
         trace!("{:?}", LogMarker::ChunkQueryReceviedAtAdult);
-        NodeQueryResponse::GetChunk(self.get_chunk(address).await.map_err(|error| error.into()))
+        NodeQueryResponse::GetChunk((
+            self.get_chunk(address).await.map_err(|error| error.into()),
+            op_id,
+        ))
     }
 
     /// Store a chunk in the local disk store

--- a/sn_node/src/storage/chunks.rs
+++ b/sn_node/src/storage/chunks.rs
@@ -9,7 +9,7 @@
 use super::{list_files_in, prefix_tree_path, Error, Result, UsedSpace};
 
 use sn_interface::{
-    messaging::{data::OperationId, system::NodeQueryResponse},
+    messaging::system::NodeQueryResponse,
     types::{log_markers::LogMarker, Chunk, ChunkAddress, DataAddress},
 };
 
@@ -100,16 +100,9 @@ impl ChunkStorage {
     }
 
     // Read chunk from local store and return NodeQueryResponse
-    pub(super) async fn get(
-        &self,
-        address: &ChunkAddress,
-        op_id: OperationId,
-    ) -> NodeQueryResponse {
+    pub(super) async fn get(&self, address: &ChunkAddress) -> NodeQueryResponse {
         trace!("{:?}", LogMarker::ChunkQueryReceviedAtAdult);
-        NodeQueryResponse::GetChunk((
-            self.get_chunk(address).await.map_err(|error| error.into()),
-            op_id,
-        ))
+        NodeQueryResponse::GetChunk(self.get_chunk(address).await.map_err(|error| error.into()))
     }
 
     /// Store a chunk in the local disk store

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -22,7 +22,9 @@ use registers::RegisterStorage;
 use sn_dbc::SpentProofShare;
 use sn_interface::{
     messaging::{
-        data::{DataQueryVariant, Error as MessagingError, RegisterQuery, StorageLevel},
+        data::{
+            DataQueryVariant, Error as MessagingError, OperationId, RegisterQuery, StorageLevel,
+        },
         system::NodeQueryResponse,
     },
     types::{
@@ -107,29 +109,23 @@ impl DataStorage {
         &self,
         query: &DataQueryVariant,
         requester: User,
+        op_id: OperationId,
     ) -> NodeQueryResponse {
         match query {
-            DataQueryVariant::GetChunk(addr) => self.chunks.get(addr).await,
-            DataQueryVariant::Register(read) => self.registers.read(read, requester).await,
+            DataQueryVariant::GetChunk(addr) => self.chunks.get(addr, op_id).await,
+            DataQueryVariant::Register(read) => self.registers.read(read, requester, op_id).await,
             DataQueryVariant::Spentbook(read) => {
                 // TODO: this is temporary till spentbook native data type is implemented,
                 // we read from the Register where we store the spentbook data
-                let spentbook_op_id = match read.operation_id() {
-                    Ok(id) => id,
-                    Err(_e) => {
-                        return NodeQueryResponse::FailedToCreateOperationId;
-                    }
-                };
-
                 let reg_addr = RegisterAddress::new(read.dst_name(), SPENTBOOK_TYPE_TAG);
 
                 match self
                     .registers
-                    .read(&RegisterQuery::Get(reg_addr), requester)
+                    .read(&RegisterQuery::Get(reg_addr), requester, op_id)
                     .await
                 {
                     NodeQueryResponse::GetRegister((Err(MessagingError::DataNotFound(_)), _)) => {
-                        NodeQueryResponse::SpentProofShares((Ok(Vec::new()), spentbook_op_id))
+                        NodeQueryResponse::SpentProofShares((Ok(Vec::new()), op_id))
                     }
                     NodeQueryResponse::GetRegister((result, _)) => {
                         let proof_shares_result = result.map(|reg| {
@@ -150,7 +146,7 @@ impl DataStorage {
                             proof_shares
                         });
 
-                        NodeQueryResponse::SpentProofShares((proof_shares_result, spentbook_op_id))
+                        NodeQueryResponse::SpentProofShares((proof_shares_result, op_id))
                     }
                     other => {
                         // TODO: this is temporary till spentbook native data type is implemented,
@@ -257,7 +253,7 @@ mod tests {
     use sn_interface::{
         init_logger,
         messaging::{
-            data::{CreateRegister, DataQueryVariant, SignedRegisterCreate},
+            data::{CreateRegister, DataQueryVariant, OperationId, SignedRegisterCreate},
             system::NodeQueryResponse,
         },
         types::{
@@ -314,10 +310,13 @@ mod tests {
         // Test client fetch
         let query = DataQueryVariant::GetChunk(*chunk.address());
         let user = User::Anyone;
+        let op_id = OperationId::random();
+        let query_response = storage.query(&query, user, op_id).await;
 
-        let query_response = storage.query(&query, user).await;
-
-        assert_eq!(query_response, NodeQueryResponse::GetChunk(Ok(chunk)));
+        assert_eq!(
+            query_response,
+            NodeQueryResponse::GetChunk((Ok(chunk), op_id))
+        );
 
         // Remove from storage
         storage.remove(&replicated_data.address()).await?;
@@ -543,21 +542,23 @@ mod tests {
                     let addr = ChunkAddress(key);
                     let query = DataQueryVariant::GetChunk(addr);
                     let user = User::Anyone;
-                    let stored_res = runtime.block_on(storage.query(&query, user));
+                    let op_id = OperationId::random();
+                    let stored_res = runtime.block_on(storage.query(&query, user, op_id));
                     let model_res = model.get(&key);
 
                     match model_res {
                         Some(m_res) => {
-                            if let NodeQueryResponse::GetChunk(Ok(s_chunk)) = stored_res {
+                            if let NodeQueryResponse::GetChunk((Ok(s_chunk), id)) = stored_res {
                                 if let ReplicatedData::Chunk(m_chunk) = m_res {
                                     assert_eq!(*m_chunk, s_chunk);
+                                    assert_eq!(id, op_id);
                                 }
                             } else {
                                 return Err(Error::ChunkNotFound(key));
                             }
                         }
                         None => {
-                            if let NodeQueryResponse::GetChunk(Ok(_)) = stored_res {
+                            if let NodeQueryResponse::GetChunk((Ok(_), _)) = stored_res {
                                 return Err(Error::DataExists(DataAddress::Bytes(addr)));
                             }
                         }


### PR DESCRIPTION
- Generate query/cmd `OperationId` from the msg serialised payload at Elders
- Redefine system::NodeQueryResponse type just as an alias to data::QueryResponse
- Removing `OperationId` from `ServiceMsg` msgs
- Removing `OperationId` from sn_client queries/responses tracker
- Removing `correlation_id` from `SystemMsg` node query/response msgs
- Returning error to client when an Elder reaches a maximum number of waiting peers (currently 100) for the same query response