### PR TITLE
refactor(messaging)!: removing op id from query response

### DIFF
--- a/sn_api/src/app/nrs/mod.rs
+++ b/sn_api/src/app/nrs/mod.rs
@@ -430,7 +430,7 @@ mod tests {
 
         assert_eq!(url.public_name(), site_name);
         assert!(url.content_version().is_some());
-        let nrs_map = retry_loop_for_pattern!(safe.nrs_get_subnames_map(&site_name, None), Ok(nrs_map) if nrs_map.map.len() > 0)?;
+        let nrs_map = retry_loop_for_pattern!(safe.nrs_get_subnames_map(&site_name, None), Ok(nrs_map) if !nrs_map.map.is_empty())?;
         assert_eq!(nrs_map.map.len(), 1);
         assert_eq!(
             *nrs_map.map.get(&site_name).ok_or_else(|| anyhow!(format!(
@@ -638,7 +638,7 @@ mod tests {
         assert!(topname_registered);
 
         // we're retrying until an adult returns with the data we've just put.
-        let nrs_map = retry_loop_for_pattern!(safe.nrs_get_subnames_map(&site_name, None), Ok(nrs_map) if nrs_map.map.len() > 0)?;
+        let nrs_map = retry_loop_for_pattern!(safe.nrs_get_subnames_map(&site_name, None), Ok(nrs_map) if !nrs_map.map.is_empty())?;
 
         assert_eq!(nrs_map.map.len(), 1, "nrs map has len 1");
         assert_eq!(
@@ -681,7 +681,7 @@ mod tests {
         assert_eq!(url.public_name(), &format!("another.{site_name}"));
         assert!(url.content_version().is_some());
 
-        let nrs_map = retry_loop_for_pattern!(safe.nrs_get_subnames_map(&site_name, None), Ok(nrs_map) if nrs_map.map.len()> 0)?;
+        let nrs_map = retry_loop_for_pattern!(safe.nrs_get_subnames_map(&site_name, None), Ok(nrs_map) if !nrs_map.map.is_empty())?;
         assert_eq!(nrs_map.map.len(), 1);
         assert_eq!(
             *nrs_map
@@ -706,7 +706,7 @@ mod tests {
         safe.nrs_associate(&site_name, &files_container.url).await?;
 
         // we're retrying until an adult returns with the data we've just put.
-        let nrs_map = retry_loop_for_pattern!(safe.nrs_get_subnames_map(&site_name, None), Ok(nrs_map) if nrs_map.map.len() > 0)?;
+        let nrs_map = retry_loop_for_pattern!(safe.nrs_get_subnames_map(&site_name, None), Ok(nrs_map) if !nrs_map.map.is_empty())?;
         assert_eq!(nrs_map.map.len(), 1);
 
         let url = safe.nrs_remove(&site_name).await?;
@@ -714,7 +714,7 @@ mod tests {
         assert_eq!(url.public_name(), site_name);
         assert!(url.content_version().is_some());
         // we're retrying until an adult returns with the data we've just put.
-        let nrs_map = retry_loop_for_pattern!(safe.nrs_get_subnames_map(&site_name, None), Ok(nrs_map) if nrs_map.map.len() < 1)?;
+        let nrs_map = retry_loop_for_pattern!(safe.nrs_get_subnames_map(&site_name, None), Ok(nrs_map) if nrs_map.map.is_empty())?;
         assert_eq!(nrs_map.map.len(), 0);
         Ok(())
     }

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -149,7 +149,7 @@ impl Client {
             .await
     }
 
-    /// Send a DataCmd to the network without awaiting for a response.
+    /// Send a DataCmd to the network and await a response.
     /// Cmds are automatically retried using exponential backoff if an error is returned.
     /// This function is a helper private to this module.
     #[instrument(skip_all, level = "debug", name = "client-api send cmd")]

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -96,10 +96,9 @@ impl Client {
         let query = DataQueryVariant::GetChunk(ChunkAddress(*name));
         let res = self.send_query(query.clone()).await?;
 
-        let op_id = res.operation_id;
         let chunk: Chunk = match res.response {
             QueryResponse::GetChunk(result) => {
-                result.map_err(|err| Error::ErrorMsg { source: err, op_id })
+                result.map_err(|err| Error::ErrorMsg { source: err })
             }
             response => return Err(Error::UnexpectedQueryResponse { query, response }),
         }?;

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -188,10 +188,10 @@ impl Client {
                 query,
                 auth,
                 serialised_query,
-                #[cfg(feature = "traceroute")]
-                self.public_key(),
                 dst_section_info,
                 force_new_link,
+                #[cfg(feature = "traceroute")]
+                self.public_key(),
             )
             .await
     }

--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -137,9 +137,7 @@ impl Client {
 
         debug!("get_register result is; {query_result:?}");
         match query_result.response {
-            QueryResponse::GetRegister((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
-            }
+            QueryResponse::GetRegister(res) => res.map_err(|err| Error::ErrorMsg { source: err }),
             other => Err(Error::UnexpectedQueryResponse {
                 query,
                 response: other,
@@ -156,9 +154,7 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::Read(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::ReadRegister((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
-            }
+            QueryResponse::ReadRegister(res) => res.map_err(|err| Error::ErrorMsg { source: err }),
             other => Err(Error::UnexpectedQueryResponse {
                 query,
                 response: other,
@@ -176,8 +172,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetEntry { address, hash });
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterEntry((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterEntry(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -196,8 +192,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetOwner(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterOwner((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterOwner(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -220,8 +216,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetUserPermissions { address, user });
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterUserPermissions((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterUserPermissions(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -236,8 +232,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetPolicy(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterPolicy((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterPolicy(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -507,7 +503,7 @@ mod tests {
 
         // Different entries written to the same rigister from root shall giving different hash
         let (value1_hash, _batch) = client
-            .write_to_register(address, value_1.clone(), BTreeSet::new())
+            .write_to_local_register(address, value_1.clone(), BTreeSet::new())
             .await?;
 
         let value_2 = random_register_entry();
@@ -516,7 +512,7 @@ mod tests {
             tracing::info_span!("test__register_write_without_publish__second_write").entered();
 
         let (value2_hash, _batch) = client
-            .write_to_register(address, value_2.clone(), BTreeSet::new())
+            .write_to_local_register(address, value_2.clone(), BTreeSet::new())
             .await?;
 
         assert!(value1_hash != value2_hash);
@@ -531,10 +527,10 @@ mod tests {
             tracing::info_span!("test__register_write_without_publish__third_write").entered();
 
         let (value1_3_hash, _batch) = client
-            .write_to_register(address, value_3.clone(), children.clone())
+            .write_to_local_register(address, value_3.clone(), children.clone())
             .await?;
         let (value1_2_hash, _batch) = client
-            .write_to_register(address, value_2.clone(), children.clone())
+            .write_to_local_register(address, value_2.clone(), children.clone())
             .await?;
         assert!(value1_2_hash != value1_3_hash);
 

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -56,8 +56,8 @@ impl Client {
         let query = DataQueryVariant::Spentbook(SpentbookQuery::SpentProofShares(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::SpentProofShares((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::SpentProofShares(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -237,36 +237,27 @@ impl Session {
                     correlation_id,
                 } => {
                     trace!(
-                    "ServiceMsg with id {:?} is QueryResponse regarding {:?} with response {:?}",
-                    msg_id,
-                    correlation_id,
-                    response,
-                );
+                        "ServiceMsg with id {:?} is QueryResponse regarding {:?} with response {:?}",
+                        msg_id,
+                        correlation_id,
+                        response,
+                    );
 
-                    if let Ok(op_id) = response.operation_id() {
-                        debug!("OpId of {msg_id:?} is {op_id:?}");
-                        if let Some(entry) = queries.get_mut(&op_id) {
-                            debug!("op id: {op_id:?} exists in pending queries...");
-                            let received = entry.value();
+                    if let Some(entry) = queries.get_mut(&correlation_id) {
+                        debug!("correlation_id: {correlation_id:?} exists in pending queries...");
+                        let received = entry.value();
 
-                            debug!("inserting response : {response:?}");
-                            // we can acutally have many responses per peer if they're different
-                            // this could be a fail, and then an Ok aftewards from a different adult.
-                            let _prior = received.insert((src_peer.addr(), response));
+                        debug!("inserting response : {response:?}");
+                        // we can acutally have many responses per peer if they're different
+                        // this could be a fail, and then an Ok aftewards from a different adult.
+                        let _prior = received.insert((src_peer.addr(), response));
 
-                            debug!("received now looks like: {:?}", received);
-                        } else {
-                            debug!("op id: {op_id:?} does not exist in pending queries...");
-                            let received = DashSet::new();
-                            let _prior = received.insert((src_peer.addr(), response));
-                            let _prev = queries.insert(op_id, Arc::new(received));
-                            debug!("op_id added :{op_id:?}")
-                        }
+                        debug!("received now looks like: {:?}", received);
                     } else {
-                        warn!(
-                            "Ignoring query response without operation id: {:?} {:?}",
-                            msg_id, response
-                        );
+                        debug!("correlation_id: {correlation_id:?} does not exist in pending queries...");
+                        let received = DashSet::new();
+                        let _prior = received.insert((src_peer.addr(), response));
+                        let _prev = queries.insert(correlation_id, Arc::new(received));
                     }
                 }
                 ServiceMsg::CmdError {
@@ -278,7 +269,7 @@ impl Session {
                 }
                 ServiceMsg::CmdAck { correlation_id } => {
                     debug!(
-                        "CmdAck was received for Message{:?} w/ID: {:?} from {:?}",
+                        "CmdAck was received with id {:?} regarding {:?} from {:?}",
                         msg_id,
                         correlation_id,
                         src_peer.addr()

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -12,7 +12,7 @@ mod messaging;
 use crate::Result;
 use sn_interface::{
     messaging::{
-        data::{Error as ErrorMsg, OperationId, QueryResponse},
+        data::{Error as ErrorMsg, QueryResponse},
         MsgId,
     },
     network_knowledge::SectionTree,
@@ -25,7 +25,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::RwLock;
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
-type PendingQueryResponses = Arc<DashMap<OperationId, Arc<DashSet<(SocketAddr, QueryResponse)>>>>;
+type PendingQueryResponses = Arc<DashMap<MsgId, Arc<DashSet<(SocketAddr, QueryResponse)>>>>;
 
 type CmdResponse = (SocketAddr, Option<ErrorMsg>);
 
@@ -36,7 +36,6 @@ type PendingCmdAcks = Arc<DashMap<MsgId, Arc<DashSet<CmdResponse>>>>;
 #[derive(Debug)]
 pub struct QueryResult {
     pub response: QueryResponse,
-    pub operation_id: OperationId,
 }
 
 impl QueryResult {

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -8,7 +8,7 @@
 
 use sn_interface::{
     messaging::{
-        data::{DataQuery, DataQueryVariant, Error as ErrorMsg, OperationId, QueryResponse},
+        data::{DataQuery, DataQueryVariant, Error as ErrorMsg, QueryResponse},
         Error as MessagingError, MsgId,
     },
     types::{Error as DtError, Peer},
@@ -119,12 +119,10 @@ pub enum Error {
     #[error(transparent)]
     NetworkDataError(#[from] DtError),
     /// Errors received from the network via sn_messaging
-    #[error("Error received from the network: {source:?} Operationid: {op_id:?}")]
+    #[error("Error received from the network: {source:?}")]
     ErrorMsg {
         /// The source of an error msg
         source: ErrorMsg,
-        /// operation ID that was used to send the query
-        op_id: OperationId,
     },
     /// Error response received for a client cmd sent to the network
     #[error("Error received from the network: {source:?} for cmd: {msg_id:?}")]

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -91,7 +91,7 @@ impl DysfunctionDetection {
                 *node,
                 self.calculate_node_score_for_type(
                     node,
-                    &IssueType::PendingRequestOperation(rand_op_id()),
+                    &IssueType::PendingRequestOperation(OperationId::random()),
                 ),
             );
         }
@@ -281,18 +281,12 @@ impl DysfunctionDetection {
     }
 }
 
-fn rand_op_id() -> OperationId {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    OperationId(rng.gen())
-}
-
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;
 
     use crate::{detection::IssueType, tests::init_test_logger, DysfunctionDetection};
-    use sn_interface::messaging::data::OperationId;
+    use sn_interface::messaging::system::OperationId;
 
     use eyre::bail;
     use proptest::prelude::*;
@@ -898,7 +892,7 @@ mod ops_tests {
         let mut pending_operations = Vec::new();
         for node in &nodes {
             for _ in 0..NORMAL_OPERATIONS_ISSUES {
-                let op_id = rand_op_id();
+                let op_id = OperationId::random();
                 pending_operations.push((node, op_id));
                 dysfunctional_detection
                     .track_issue(*node, IssueType::PendingRequestOperation(op_id));
@@ -917,7 +911,7 @@ mod ops_tests {
 
         // adding more issues though, and we should see some dysfunction
         for _ in 0..300 {
-            let op_id = rand_op_id();
+            let op_id = OperationId::random();
             dysfunctional_detection
                 .track_issue(nodes[0], IssueType::PendingRequestOperation(op_id));
         }

--- a/sn_dysfunction/src/lib.rs
+++ b/sn_dysfunction/src/lib.rs
@@ -50,7 +50,7 @@ mod error;
 pub use detection::IssueType;
 
 pub use crate::error::Error;
-use sn_interface::messaging::data::OperationId;
+use sn_interface::messaging::system::OperationId;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     time::Instant,
@@ -279,7 +279,7 @@ fn std_deviation(data: &[f32]) -> Option<f32> {
 #[cfg(test)]
 mod tests {
     use super::{DysfunctionDetection, IssueType};
-    use sn_interface::messaging::data::OperationId;
+    use sn_interface::messaging::system::OperationId;
 
     use eyre::Error;
     use std::{collections::BTreeSet, sync::Once};

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -47,12 +47,6 @@ pub enum Error {
     /// Invalid Operation such as a POST on ImmutableData
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
-    /// There was an error forming the OperationId
-    #[error("Operation id could not be derived.")]
-    NoOperationId,
-    /// Error is not valid for operation id generation. This should not absolve a pending (and thus far unfulfilled) operation
-    #[error("Could not generate operation id for chunk retrieval. Error was not 'DataNotFound'.")]
-    InvalidQueryResponseErrorForOperationId,
     /// Failed to verify a spent proof since it's signed by unknown section key
     #[error("Spent proof was signed with unknown section key: {0:?}")]
     SpentProofUnknownSectionKey(bls::PublicKey),

--- a/sn_interface/src/messaging/data/query.rs
+++ b/sn_interface/src/messaging/data/query.rs
@@ -6,10 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{
-    chunk_operation_id, register::RegisterQuery, spentbook::SpentbookQuery, Error, OperationId,
-    QueryResponse, Result,
-};
+use super::{register::RegisterQuery, spentbook::SpentbookQuery, Error, QueryResponse};
 use crate::types::{ChunkAddress, DataAddress, SpentbookAddress};
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
@@ -53,11 +50,11 @@ pub enum DataQueryVariant {
 impl DataQueryVariant {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error) -> Result<QueryResponse> {
+    pub fn error(&self, error: Error) -> QueryResponse {
         use DataQueryVariant::*;
         match self {
             #[cfg(feature = "chunks")]
-            GetChunk(_) => Ok(QueryResponse::GetChunk(Err(error))),
+            GetChunk(_) => QueryResponse::GetChunk(Err(error)),
             #[cfg(feature = "registers")]
             Register(q) => q.error(error),
             #[cfg(feature = "spentbook")]
@@ -89,21 +86,6 @@ impl DataQueryVariant {
             Self::Spentbook(read) => {
                 DataAddress::Spentbook(SpentbookAddress::new(*read.dst_address().name()))
             }
-        }
-    }
-
-    /// Retrieves the operation identifier for this response, use in tracking node liveness
-    /// and responses at clients.
-    /// Must be the same as the query response
-    /// Right now returning result to fail for anything non-chunk, as that's all we're tracking from other nodes here just now.
-    pub fn operation_id(&self) -> Result<OperationId> {
-        match self {
-            #[cfg(feature = "chunks")]
-            Self::GetChunk(address) => chunk_operation_id(address),
-            #[cfg(feature = "registers")]
-            Self::Register(read) => read.operation_id(),
-            #[cfg(feature = "spentbook")]
-            Self::Spentbook(read) => read.operation_id(),
         }
     }
 }

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -11,18 +11,18 @@ use crate::messaging::{
     data::ServiceMsg, system::SystemMsg, AuthKind, AuthorityProof, Dst, Error, MsgId, MsgType,
     NodeMsgAuthority, Result, ServiceAuth,
 };
+
 use bytes::Bytes;
 use custom_debug::Debug;
+use qp2p::UsrMsgBytes;
 use serde::Serialize;
 
 #[cfg(feature = "traceroute")]
 use crate::types::PublicKey;
 #[cfg(feature = "traceroute")]
-use serde::Deserialize;
-
-#[cfg(feature = "traceroute")]
 use itertools::Itertools;
-use qp2p::UsrMsgBytes;
+#[cfg(feature = "traceroute")]
+use serde::Deserialize;
 #[cfg(feature = "traceroute")]
 use std::fmt::{Debug as StdDebug, Display, Formatter};
 

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -12,6 +12,7 @@ mod join_as_relocated;
 mod msg_authority;
 mod node_msgs;
 mod node_state;
+mod op_id;
 mod signed;
 use bls::PublicKey as BlsPublicKey;
 
@@ -21,12 +22,13 @@ pub use join_as_relocated::{JoinAsRelocatedRequest, JoinAsRelocatedResponse};
 pub use msg_authority::NodeMsgAuthorityUtils;
 pub use node_msgs::{NodeCmd, NodeEvent, NodeQuery, NodeQueryResponse};
 pub use node_state::{MembershipState, NodeState, RelocateDetails};
+pub use op_id::OperationId;
 pub use signed::{KeyedSig, SigShare};
 
 use super::{authority::SectionAuth as SectionAuthProof, AuthorityProof};
 use qp2p::UsrMsgBytes;
 
-use crate::messaging::{EndUser, MsgId, SectionAuthorityProvider};
+use crate::messaging::SectionAuthorityProvider;
 use crate::network_knowledge::{SapCandidate, SectionsDAG};
 
 use sn_consensus::{Generation, SignedVote};
@@ -168,10 +170,8 @@ pub enum SystemMsg {
     NodeQueryResponse {
         /// QueryResponse.
         response: NodeQueryResponse,
-        /// ID of causing query.
-        correlation_id: MsgId,
-        /// TEMP: Add user here as part of return flow. Remove this as we have chunk routing etc
-        user: EndUser,
+        /// ID of the requested operation.
+        operation_id: OperationId,
     },
 }
 

--- a/sn_interface/src/messaging/system/op_id.rs
+++ b/sn_interface/src/messaging/system/op_id.rs
@@ -1,0 +1,52 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use bytes::Bytes;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Debug, Display, Formatter};
+use tiny_keccak::{Hasher, Sha3};
+
+/// Id of an operation. Node to node query/response should return the same id for simple
+/// nodes tracking purposes.
+#[derive(Deserialize, Serialize, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct OperationId(pub [u8; 32]);
+
+impl Display for OperationId {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "OpId-{:02x}{:02x}{:02x}..",
+            self.0[0], self.0[1], self.0[2]
+        )
+    }
+}
+
+impl Debug for OperationId {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{}", self)
+    }
+}
+
+impl OperationId {
+    /// Creates an operation id by hashing the provided bytes
+    pub fn from(bytes: &Bytes) -> Self {
+        let mut hasher = Sha3::v256();
+        let mut output = [0; 32];
+        hasher.update(bytes);
+        hasher.finalize(&mut output);
+
+        Self(output)
+    }
+
+    /// Creates a random operation id
+    pub fn random() -> Self {
+        let mut rng = rand::thread_rng();
+        Self(rng.gen())
+    }
+}

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -17,8 +17,8 @@ use sn_dysfunction::IssueType;
 use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
-        data::{OperationId, ServiceMsg},
-        system::{DkgFailureSigSet, KeyedSig, NodeState, SectionAuth, SystemMsg},
+        data::ServiceMsg,
+        system::{DkgFailureSigSet, KeyedSig, NodeState, OperationId, SectionAuth, SystemMsg},
         AuthorityProof, MsgId, NodeMsgAuthority, ServiceAuth, WireMsg,
     },
     network_knowledge::{SectionAuthorityProvider, SectionKeyShare},
@@ -127,6 +127,7 @@ pub(crate) enum Cmd {
     /// Adds peer to set of recipients of an already pending query,
     /// or adds a pending query if it didn't already exist.
     AddToPendingQueries {
+        msg_id: MsgId,
         operation_id: OperationId,
         origin: Peer,
         target_adult: XorName,

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -115,6 +115,7 @@ impl Dispatcher {
                 Ok(vec![])
             }
             Cmd::AddToPendingQueries {
+                msg_id,
                 operation_id,
                 origin,
                 target_adult,
@@ -131,11 +132,11 @@ impl Dispatcher {
                         "Adding to pending data queries for op id: {:?}",
                         operation_id
                     );
-                    let _ = peers.insert(origin);
+                    let _ = peers.insert((msg_id, origin));
                 } else {
                     let _prior_value = node.pending_data_queries.set(
                         (operation_id, target_adult),
-                        BTreeSet::from([origin]),
+                        BTreeSet::from([(msg_id, origin)]),
                         None,
                     );
                 };

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -13,7 +13,7 @@ use sn_interface::{
     messaging::{
         data::{Error as MessagingDataError, ServiceMsg},
         serialisation::WireMsg,
-        system::{JoinResponse, MembershipState, NodeCmd, RelocateDetails, SystemMsg},
+        system::{JoinResponse, MembershipState, NodeCmd, OperationId, RelocateDetails, SystemMsg},
         AuthorityProof, MsgId, MsgType, ServiceAuth,
     },
     network_knowledge::{test_utils::*, NodeState, SectionAuthorityProvider},

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -21,11 +21,10 @@ use sn_interface::{
     data_copy_count,
     messaging::{
         data::{
-            DataCmd, DataQueryVariant, EditRegister, OperationId, ServiceMsg, SignedRegisterEdit,
-            SpentbookCmd,
+            DataCmd, DataQueryVariant, EditRegister, ServiceMsg, SignedRegisterEdit, SpentbookCmd,
         },
-        system::{NodeQueryResponse, SystemMsg},
-        AuthorityProof, EndUser, MsgId, ServiceAuth,
+        system::{NodeQueryResponse, OperationId, SystemMsg},
+        AuthorityProof, MsgId, ServiceAuth,
     },
     network_knowledge::{SectionAuthorityProvider, SectionKeysProvider},
     types::{
@@ -86,12 +85,12 @@ impl Node {
         #[cfg(feature = "traceroute")]
         traceroute.0.push(self.identity());
 
-        let new_msg_id = MsgId::new();
+        let msg_id = MsgId::new();
 
-        debug!("SendMSg formed for {:?}", new_msg_id);
+        debug!("SendMSg formed for {:?}", msg_id);
         Cmd::SendMsg {
             msg: OutgoingMsg::Service(msg),
-            msg_id: MsgId::new(),
+            msg_id,
             recipients,
             #[cfg(feature = "traceroute")]
             traceroute,
@@ -99,12 +98,12 @@ impl Node {
     }
 
     /// Handle data query
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn handle_data_query_at_adult(
         &self,
-        correlation_id: MsgId,
+        operation_id: OperationId,
         query: &DataQueryVariant,
         auth: ServiceAuth,
-        user: EndUser,
         requesting_elder: Peer,
         #[cfg(feature = "traceroute")] traceroute: Traceroute,
     ) -> Cmd {
@@ -116,8 +115,7 @@ impl Node {
         trace!("data query response at adult is: {:?}", response);
         let msg = SystemMsg::NodeQueryResponse {
             response,
-            correlation_id,
-            user,
+            operation_id,
         };
 
         self.trace_system_msg(
@@ -133,13 +131,11 @@ impl Node {
     /// Forms a response to send to the requester
     pub(crate) async fn handle_data_query_response_at_elder(
         &mut self,
-        correlation_id: MsgId,
-        response: NodeQueryResponse,
-        user: EndUser,
-        sending_node_pk: PublicKey,
         op_id: OperationId,
+        response: NodeQueryResponse,
+        sending_node_pk: PublicKey,
         #[cfg(feature = "traceroute")] traceroute: Traceroute,
-    ) -> Option<Cmd> {
+    ) -> Vec<Cmd> {
         debug!(
             "Handling data read @ elders, received from {:?}, op id: {:?}",
             sending_node_pk, op_id
@@ -147,25 +143,22 @@ impl Node {
 
         let node_id = XorName::from(sending_node_pk);
 
-        // dont remove here, leave the receipients to expire. That way any incoming reqeusts
-        // will still be forwarded on, and one NotFound reply from one adult may not bork
-        // the Operational success at another Adult (if they were queried again)
-        let query_peers = self.pending_data_queries.get(&(op_id, node_id));
+        let query_peers = self.pending_data_queries.remove(&(op_id, node_id));
 
         // First check for waiting peers. If no one is waiting, we drop the response
         let waiting_peers = if let Some(peers) = query_peers {
             if peers.is_empty() {
                 warn!("No waiting peers to send {op_id:?} to....");
                 // nothing to do
-                return None;
+                return vec![];
             }
-            peers.clone()
+            peers
         } else {
             warn!(
                 "Dropping chunk query response from Adult {}. We might have already forwarded this chunk to the requesting client or the client connection cache has expired: {}",
-                sending_node_pk, user.0
+                sending_node_pk, op_id
             );
-            return None;
+            return vec![];
         };
 
         let pending_removed = self
@@ -174,25 +167,28 @@ impl Node {
 
         if !pending_removed {
             trace!("Ignoring un-expected response");
-            return None;
+            return vec![];
         }
 
-        let query_response = response.convert();
+        let mut cmds = vec![];
+        for (correlation_id, peer) in waiting_peers.into_iter() {
+            let msg = ServiceMsg::QueryResponse {
+                response: response.clone(),
+                correlation_id,
+            };
 
-        let msg = ServiceMsg::QueryResponse {
-            response: query_response,
-            correlation_id,
-        };
+            cmds.push(self.send_service_msg(
+                msg,
+                Peers::Single(peer),
+                #[cfg(feature = "traceroute")]
+                traceroute.clone(),
+            ));
+        }
 
         // Clear expired queries from the cache.
         self.pending_data_queries.remove_expired();
 
-        Some(self.send_service_msg(
-            msg,
-            Peers::Multiple(waiting_peers),
-            #[cfg(feature = "traceroute")]
-            traceroute,
-        ))
+        cmds
     }
 
     /// Handle incoming service msgs. Though NOT queries, as this requires

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -90,10 +90,9 @@ mod core {
     use sn_interface::messaging::Entity;
     use sn_interface::{
         messaging::{
-            data::OperationId,
             signature_aggregator::SignatureAggregator,
-            system::{DkgSessionId, NodeState},
-            AuthorityProof, SectionAuth, SectionAuthorityProvider,
+            system::{DkgSessionId, NodeState, OperationId},
+            AuthorityProof, MsgId, SectionAuth, SectionAuthorityProvider,
         },
         network_knowledge::{
             supermajority, NetworkKnowledge, NodeInfo, SectionKeyShare, SectionKeysProvider,
@@ -186,7 +185,7 @@ mod core {
         pub(crate) capacity: Capacity,
         pub(crate) dysfunction_tracking: DysfunctionDetection,
         /// Cache the request combo,  (OperationId -> An adult xorname), to waiting Clients peers for that combo
-        pub(crate) pending_data_queries: Cache<(OperationId, XorName), BTreeSet<Peer>>,
+        pub(crate) pending_data_queries: Cache<(OperationId, XorName), BTreeSet<(MsgId, Peer)>>,
         // Caches
         pub(crate) ae_backoff_cache: AeBackoffCache,
     }

--- a/sn_node/src/storage/registers.rs
+++ b/sn_node/src/storage/registers.rs
@@ -14,8 +14,8 @@ use super::{
 use sn_interface::{
     messaging::{
         data::{
-            CreateRegister, EditRegister, OperationId, RegisterCmd, RegisterQuery,
-            SignedRegisterCreate, SignedRegisterEdit,
+            CreateRegister, EditRegister, RegisterCmd, RegisterQuery, SignedRegisterCreate,
+            SignedRegisterEdit,
         },
         system::NodeQueryResponse,
         SectionAuth, ServiceAuth, VerifyAuthority,
@@ -122,27 +122,16 @@ impl RegisterStorage {
     /// --- Reading ---
 
     pub(super) async fn read(&self, read: &RegisterQuery, requester: User) -> NodeQueryResponse {
-        trace!("Reading register {:?}", read.dst_address());
-        let operation_id = match read.operation_id() {
-            Ok(id) => id,
-            Err(_e) => {
-                return NodeQueryResponse::FailedToCreateOperationId;
-            }
-        };
-        trace!("Operation of register read: {:?}", operation_id);
+        trace!("Reading register: {:?}", read.dst_address());
         use RegisterQuery::*;
         match read {
-            Get(address) => self.get(*address, requester, operation_id).await,
-            Read(address) => self.read_register(*address, requester, operation_id).await,
-            GetOwner(address) => self.get_owner(*address, requester, operation_id).await,
-            GetEntry { address, hash } => {
-                self.get_entry(*address, *hash, requester, operation_id)
-                    .await
-            }
-            GetPolicy(address) => self.get_policy(*address, requester, operation_id).await,
+            Get(address) => self.get(*address, requester).await,
+            Read(address) => self.read_register(*address, requester).await,
+            GetOwner(address) => self.get_owner(*address, requester).await,
+            GetEntry { address, hash } => self.get_entry(*address, *hash, requester).await,
+            GetPolicy(address) => self.get_policy(*address, requester).await,
             GetUserPermissions { address, user } => {
-                self.get_user_permissions(*address, *user, requester, operation_id)
-                    .await
+                self.get_user_permissions(*address, *user, requester).await
             }
         }
     }
@@ -167,12 +156,7 @@ impl RegisterStorage {
     }
 
     /// Get entire Register.
-    async fn get(
-        &self,
-        address: RegisterAddress,
-        requester: User,
-        operation_id: OperationId,
-    ) -> NodeQueryResponse {
+    async fn get(&self, address: RegisterAddress, requester: User) -> NodeQueryResponse {
         let result = match self.get_register(&address, Action::Read, requester).await {
             Ok(register) => Ok(register),
             Err(error) => {
@@ -181,35 +165,25 @@ impl RegisterStorage {
             }
         };
 
-        NodeQueryResponse::GetRegister((result, operation_id))
+        NodeQueryResponse::GetRegister(result)
     }
 
-    async fn read_register(
-        &self,
-        address: RegisterAddress,
-        requester: User,
-        operation_id: OperationId,
-    ) -> NodeQueryResponse {
+    async fn read_register(&self, address: RegisterAddress, requester: User) -> NodeQueryResponse {
         let result = match self.get_register(&address, Action::Read, requester).await {
             Ok(register) => Ok(register.read()),
             Err(error) => Err(error),
         };
 
-        NodeQueryResponse::ReadRegister((result.map_err(|error| error.into()), operation_id))
+        NodeQueryResponse::ReadRegister(result.map_err(|error| error.into()))
     }
 
-    async fn get_owner(
-        &self,
-        address: RegisterAddress,
-        requester: User,
-        operation_id: OperationId,
-    ) -> NodeQueryResponse {
+    async fn get_owner(&self, address: RegisterAddress, requester: User) -> NodeQueryResponse {
         let result = match self.get_register(&address, Action::Read, requester).await {
             Ok(res) => Ok(res.owner()),
             Err(error) => Err(error.into()),
         };
 
-        NodeQueryResponse::GetRegisterOwner((result, operation_id))
+        NodeQueryResponse::GetRegisterOwner(result)
     }
 
     async fn get_entry(
@@ -217,7 +191,6 @@ impl RegisterStorage {
         address: RegisterAddress,
         hash: EntryHash,
         requester: User,
-        operation_id: OperationId,
     ) -> NodeQueryResponse {
         let result = match self
             .get_register(&address, Action::Read, requester)
@@ -228,7 +201,7 @@ impl RegisterStorage {
             Err(error) => Err(error.into()),
         };
 
-        NodeQueryResponse::GetRegisterEntry((result, operation_id))
+        NodeQueryResponse::GetRegisterEntry(result)
     }
 
     async fn get_user_permissions(
@@ -236,7 +209,6 @@ impl RegisterStorage {
         address: RegisterAddress,
         user: User,
         requester: User,
-        operation_id: OperationId,
     ) -> NodeQueryResponse {
         let result = match self
             .get_register(&address, Action::Read, requester)
@@ -247,15 +219,10 @@ impl RegisterStorage {
             Err(error) => Err(error.into()),
         };
 
-        NodeQueryResponse::GetRegisterUserPermissions((result, operation_id))
+        NodeQueryResponse::GetRegisterUserPermissions(result)
     }
 
-    async fn get_policy(
-        &self,
-        address: RegisterAddress,
-        requester_pk: User,
-        operation_id: OperationId,
-    ) -> NodeQueryResponse {
+    async fn get_policy(&self, address: RegisterAddress, requester_pk: User) -> NodeQueryResponse {
         let result = match self
             .get_register(&address, Action::Read, requester_pk)
             .await
@@ -265,7 +232,7 @@ impl RegisterStorage {
             Err(error) => Err(error.into()),
         };
 
-        NodeQueryResponse::GetRegisterPolicy((result, operation_id))
+        NodeQueryResponse::GetRegisterPolicy(result)
     }
 
     // ========================================================================
@@ -700,7 +667,7 @@ mod test {
         // get register
         let address = cmd.dst_address();
         match store.read(&RegisterQuery::Get(address), authority).await {
-            NodeQueryResponse::GetRegister((Ok(reg), _)) => {
+            NodeQueryResponse::GetRegister(Ok(reg)) => {
                 assert_eq!(reg.address(), &address, "Should have same address!");
                 assert_eq!(reg.owner(), authority, "Should have same owner!");
             }
@@ -780,7 +747,7 @@ mod test {
         let res = new_store.read(&RegisterQuery::Get(addr), authority).await;
 
         match res {
-            NodeQueryResponse::GetRegister((Ok(reg), _)) => {
+            NodeQueryResponse::GetRegister(Ok(reg)) => {
                 assert_eq!(reg.address(), &addr, "Should have same address!");
                 assert_eq!(reg.owner(), authority, "Should have same owner!");
             }
@@ -807,10 +774,10 @@ mod test {
             .read(&RegisterQuery::GetEntry { address, hash }, authority)
             .await;
         match res {
-            NodeQueryResponse::GetRegisterEntry((Err(e), _)) => {
+            NodeQueryResponse::GetRegisterEntry(Err(e)) => {
                 assert_eq!(e, sn_interface::messaging::data::Error::NoSuchEntry)
             }
-            NodeQueryResponse::GetRegisterEntry((Ok(entry), _)) => {
+            NodeQueryResponse::GetRegisterEntry(Ok(entry)) => {
                 panic!("Should not exist any entry for random hash! {:?}", entry)
             }
             e => panic!("Could not read! {:?}", e),
@@ -839,10 +806,10 @@ mod test {
             )
             .await;
         match res {
-            NodeQueryResponse::GetRegisterUserPermissions((Err(e), _)) => {
+            NodeQueryResponse::GetRegisterUserPermissions(Err(e)) => {
                 assert_eq!(e, sn_interface::messaging::data::Error::NoSuchEntry)
             }
-            NodeQueryResponse::GetRegisterUserPermissions((Ok(perms), _)) => panic!(
+            NodeQueryResponse::GetRegisterUserPermissions(Ok(perms)) => panic!(
                 "Should not exist any permissions for random user! {:?}",
                 perms
             ),


### PR DESCRIPTION
- Use the query msg id to generate the operation id to track the response from Adults
- Remove peers from pending data queries when response was obtained from Adults
- Removing correlation id from SystemMsg node query/response
- Redefine system::NodeQueryResponse type just as an alias to data::QueryResponse

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
