### PR TITLE
refactor: bundle proof chain + SAP into `SectionTreeUpdate` and code cleanup

### DIFF
--- a/sn_cli/src/subcommands/networks.rs
+++ b/sn_cli/src/subcommands/networks.rs
@@ -132,7 +132,7 @@ pub async fn networks_commander(
             println!();
 
             let sections_dag = network_contacts.get_sections_dag();
-            for sap in &network_contacts.all() {
+            for sap in network_contacts.all() {
                 let section_key = sap.section_key();
                 println!("Prefix '{}'", sap.prefix());
                 println!("----------------------------------");

--- a/sn_interface/src/messaging/mod.rs
+++ b/sn_interface/src/messaging/mod.rs
@@ -37,8 +37,8 @@ mod msg_type;
 mod auth_kind;
 // Msg dst
 mod dst;
-// SectionAuthorityProvider
-mod sap;
+// Network Knowledge
+mod network_knowledge;
 
 #[cfg(feature = "traceroute")]
 pub use self::serialisation::{Entity, Traceroute};
@@ -52,7 +52,7 @@ pub use self::{
     errors::{Error, Result},
     msg_id::{MsgId, MESSAGE_ID_LEN},
     msg_type::MsgType,
-    sap::SectionAuthorityProvider,
+    network_knowledge::{SectionAuthorityProvider, SectionInfo, SectionTreeUpdate, SectionsDAG},
     serialisation::{NodeMsgAuthority, WireMsg},
 };
 

--- a/sn_interface/src/messaging/network_knowledge.rs
+++ b/sn_interface/src/messaging/network_knowledge.rs
@@ -90,8 +90,6 @@ impl Sha3Hash for SectionInfo {
     }
 }
 
-// roland TODO, partialeq valid? even if section's order differ a bit, the resultant SectionsDAG
-// will be equal, but this SectionsDAGMsg is not equal.
 /// A Merkle DAG of BLS keys where every key is signed by its parent key, except the genesis one.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SectionsDAG {

--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{agreement::SectionAuth, KeyedSig, NodeState};
-use crate::{messaging::SectionAuthorityProvider, network_knowledge::SectionsDAG};
+use super::NodeState;
+use crate::messaging::{SectionAuthorityProvider, SectionTreeUpdate};
 use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::Signature;
 use serde::{Deserialize, Serialize};
@@ -63,12 +63,9 @@ pub enum JoinResponse {
     },
     /// Up to date section information for a joining peer to retry its join request with
     Retry {
-        /// Current `SectionAuthorityProvider` of the section.
-        section_auth: SectionAuthorityProvider,
-        /// Section signature over the `SectionAuthorityProvider`.
-        section_signed: KeyedSig,
-        /// Section chain truncated from the section key found in the join request.
-        partial_dag: SectionsDAG,
+        /// The update to our NetworkKnowledge containing the current `SectionAuthorityProvider` of
+        /// the section and the section chain truncated from the section key found in the join request.
+        section_tree_update: SectionTreeUpdate,
         /// The age of the node as expected by the section.
         expected_age: u8,
     },
@@ -79,12 +76,12 @@ pub enum JoinResponse {
     /// Message sent to joining peer containing the necessary
     /// info to become a member of the section.
     Approved {
-        /// Network genesis key (needed to validate) section_chain
+        // roland TODO is this needed since section tree update contains section chain for Approved
+        /// Network genesis key (needed to validate) section chain
         genesis_key: BlsPublicKey,
-        /// SectionAuthorityProvider Signed by (current section)
-        section_auth: SectionAuth<SectionAuthorityProvider>,
-        /// Full verifiable section chain
-        sections_dag: SectionsDAG,
+        /// The update to our NetworkKnowledge containing the `SectionAuthorityProvider` signed by
+        /// the current section and a fully verifiable section chain
+        section_tree_update: SectionTreeUpdate,
         /// Current node's state
         decision: Decision<NodeState>,
     },

--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -63,8 +63,8 @@ pub enum JoinResponse {
     },
     /// Up to date section information for a joining peer to retry its join request with
     Retry {
-        /// The update to our NetworkKnowledge containing the current `SectionAuthorityProvider` of
-        /// the section and the section chain truncated from the section key found in the join request.
+        /// The update to our NetworkKnowledge containing the current `SectionAuthorityProvider`
+        /// and the section chain truncated from the section key found in the join request.
         section_tree_update: SectionTreeUpdate,
         /// The age of the node as expected by the section.
         expected_age: u8,
@@ -76,11 +76,8 @@ pub enum JoinResponse {
     /// Message sent to joining peer containing the necessary
     /// info to become a member of the section.
     Approved {
-        // roland TODO is this needed since section tree update contains section chain for Approved
-        /// Network genesis key (needed to validate) section chain
-        genesis_key: BlsPublicKey,
-        /// The update to our NetworkKnowledge containing the `SectionAuthorityProvider` signed by
-        /// the current section and a fully verifiable section chain
+        /// The update to our NetworkKnowledge containing the current `SectionAuthorityProvider`
+        /// and a fully verifiable section chain
         section_tree_update: SectionTreeUpdate,
         /// Current node's state
         decision: Decision<NodeState>,

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -59,8 +59,8 @@ pub enum AntiEntropyKind {
 /// Message sent over the among nodes
 pub enum SystemMsg {
     AntiEntropy {
-        /// The update to our NetworkKnowledge containing our current section's `SectionAuthorityProvider`
-        /// and our section chain truncated from the triggering msg's dst section_key or genesis key
+        /// The update to our NetworkKnowledge containing the current `SectionAuthorityProvider`
+        /// and the section chain truncated from the triggering msg's dst section_key or genesis_key
         /// if the the dst section_key is not a direct ancestor to our section_key
         section_tree_update: SectionTreeUpdate,
         /// The kind of anti-entropy response.

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -26,8 +26,8 @@ pub use signed::{KeyedSig, SigShare};
 use super::{authority::SectionAuth as SectionAuthProof, AuthorityProof};
 use qp2p::UsrMsgBytes;
 
-use crate::messaging::{EndUser, MsgId, SectionAuthorityProvider};
-use crate::network_knowledge::{SapCandidate, SectionsDAG};
+use crate::messaging::{EndUser, MsgId, SectionTreeUpdate};
+use crate::network_knowledge::SapCandidate;
 
 use sn_consensus::{Generation, SignedVote};
 
@@ -59,13 +59,10 @@ pub enum AntiEntropyKind {
 /// Message sent over the among nodes
 pub enum SystemMsg {
     AntiEntropy {
-        /// Current `SectionAuthorityProvider` of our section.
-        section_auth: SectionAuthorityProvider,
-        /// Section signature over the `SectionAuthorityProvider` of our
-        /// section the bounced message shall be resent to.
-        section_signed: KeyedSig,
-        /// Our section chain truncated from the triggering msg's dst section_key (or genesis key for full proof)
-        partial_dag: SectionsDAG,
+        /// The update to our NetworkKnowledge containing our current section's `SectionAuthorityProvider`
+        /// and our section chain truncated from the triggering msg's dst section_key or genesis key
+        /// if the the dst section_key is not a direct ancestor to our section_key
+        section_tree_update: SectionTreeUpdate,
         /// The kind of anti-entropy response.
         kind: AntiEntropyKind,
     },

--- a/sn_interface/src/messaging/system/node_state.rs
+++ b/sn_interface/src/messaging/system/node_state.rs
@@ -85,7 +85,7 @@ impl RelocateDetails {
         let genesis_key = *network_knowledge.genesis_key();
 
         let dst_section_key = network_knowledge
-            .section_by_name(&dst)
+            .section_auth_by_name(&dst)
             .map_or_else(|_| genesis_key, |section_auth| section_auth.section_key());
 
         Self {

--- a/sn_interface/src/network_knowledge/errors.rs
+++ b/sn_interface/src/network_knowledge/errors.rs
@@ -27,9 +27,19 @@ pub enum Error {
     /// Failed to deserialise a section tree.
     #[error("Failed to deserialise section tree: {0}")]
     Deserialisation(String),
+    #[error("The provided signature cannot be verified while inserting into the SectionsDAG")]
+    InvalidSignature,
+    #[error("Key not found in the SectionsDAG: {0:?}")]
+    KeyNotFound(bls::PublicKey),
+    #[error("The 'to' or 'from' key is not present in the same branch of the SectionsDAG")]
+    InvalidBranch,
+    #[error("The SectionsDAG should contain a single branch")]
+    MultipleBranchError,
+    #[error("Proof chain cannot be trusted: {0}")]
+    UntrustedProofChain(String),
     #[error("Section authority provider cannot be trusted: {0}")]
     UntrustedSectionAuthProvider(String),
-    #[error("Invalid genesis key of provided in section tree: {}", hex::encode(_0.to_bytes()))]
+    #[error("The genesis key of the provided SectionTree is invalid: {0:?}")]
     InvalidGenesisKey(bls::PublicKey),
     #[error("The node is not in a state to handle the action.")]
     InvalidState,
@@ -57,14 +67,4 @@ pub enum Error {
     Consensus(#[from] sn_consensus::Error),
     #[error("An archived node attempted to rejoin the section")]
     ArchivedNodeRejoined,
-    #[error("The provided signature cannot be verified")]
-    InvalidSignature,
-    #[error("Key not found in the SectionsDAG: {0:?}")]
-    KeyNotFound(bls::PublicKey),
-    #[error("The 'to' or 'from' key is not present in the same branch")]
-    InvalidBranch,
-    #[error("Partial DAG cannot be trusted: {0}")]
-    UntrustedPartialDAG(String),
-    #[error("The Partial DAG should contain a single branch")]
-    MultipleBranchError,
 }

--- a/sn_interface/src/network_knowledge/section_peers.rs
+++ b/sn_interface/src/network_knowledge/section_peers.rs
@@ -126,10 +126,10 @@ impl SectionPeers {
     // than ELDER_CHURN_EVENTS_TO_PRUNE_ARCHIVE section keys ago from `last_key`
     pub(super) fn prune_members_archive(
         &self,
-        section_dag: &SectionsDAG,
+        proof_chain: &SectionsDAG,
         last_key: &bls::PublicKey,
     ) -> Result<()> {
-        let mut last_section_keys = section_dag.get_ancestors(last_key)?;
+        let mut last_section_keys = proof_chain.get_ancestors(last_key)?;
         last_section_keys.truncate(ELDER_CHURN_EVENTS_TO_PRUNE_ARCHIVE - 1);
         last_section_keys.push(*last_key);
         self.archive

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -146,8 +146,8 @@ impl SectionTree {
     }
 
     /// Returns all known sections SAP.
-    pub fn all(&self) -> Vec<&SectionAuthorityProvider> {
-        self.sections.iter().map(|(_, sap)| &sap.value).collect()
+    pub fn all(&self) -> impl Iterator<Item = &SectionAuthorityProvider> {
+        self.sections.iter().map(|(_, sap)| &sap.value)
     }
 
     /// Get `SectionAuthorityProvider` of a known section with the given prefix.
@@ -187,8 +187,7 @@ impl SectionTree {
         // i.e. check each key is signed by its parent/predecessor key.
         if !proof_chain.self_verify() {
             return Err(Error::UntrustedProofChain(format!(
-                "Proof chain failed self verification: {:?}",
-                proof_chain
+                "Proof chain failed self verification: {proof_chain:?}",
             )));
         }
 
@@ -214,7 +213,7 @@ impl SectionTree {
 
                     if proposed_sap_elder_count < current_sap_elder_count {
                         warn!("Proposed SAP elder count is LESS than current...\
-                        proposed: {proposed_sap_elder_count:?}, current: {current_sap_elder_count:?} (proposed is: {:?})", signed_sap);
+                        proposed: {proposed_sap_elder_count:?}, current: {current_sap_elder_count:?} (proposed is: {signed_sap:?})");
                     }
                 }
                 Err(e) => {
@@ -242,8 +241,7 @@ impl SectionTree {
                     // there is no need to bounce back here (assuming the sender is outdated) to
                     // avoid potential looping.
                     return Err(Error::UntrustedProofChain(format!(
-                        "Provided proof_chain doesn't cover the SAP's key we currently know: {:?}, {:?}",
-                        section_tree_update.proof_chain,
+                        "Provided proof_chain doesn't cover the SAP's key we currently know: {proof_chain:?}, {:?}",
                         sap.value
                     )));
                 }
@@ -713,7 +711,6 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    // roland: todo add more tests to update fn
     #[test]
     fn proof_chain_should_contain_a_single_branch_during_update() -> Result<()> {
         let (mut tree, genesis_sk, genesis_pk) = new_network_section_tree();

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -81,8 +81,8 @@ impl Node {
         &self.network_knowledge
     }
 
-    pub(crate) fn our_section_dag(&self) -> SectionsDAG {
-        self.network_knowledge.our_section_dag()
+    pub(crate) fn section_chain(&self) -> SectionsDAG {
+        self.network_knowledge.section_chain()
     }
 
     /// Is this node an elder?
@@ -102,7 +102,7 @@ impl Node {
     /// Returns the SAP of the section matching the name.
     pub(crate) fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
         self.network_knowledge
-            .section_by_name(name)
+            .section_auth_by_name(name)
             .map_err(Error::from)
     }
 

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -193,7 +193,6 @@ impl<'a> Joiner<'a> {
                     self.send(msg, &[sender], section_key, false).await?;
                 }
                 JoinResponse::Approved {
-                    genesis_key,
                     section_tree_update,
                     decision,
                 } => {
@@ -222,11 +221,9 @@ impl<'a> Joiner<'a> {
                     );
 
                     // Building our network knowledge instance will validate the section_tree_update
-                    let network_knowledge = NetworkKnowledge::new(
-                        genesis_key,
-                        section_tree_update,
-                        Some(self.network_contacts),
-                    )?;
+
+                    let network_knowledge =
+                        NetworkKnowledge::new(self.network_contacts, section_tree_update)?;
 
                     return Ok((self.node, network_knowledge));
                 }
@@ -627,7 +624,6 @@ mod tests {
             send_response(
                 &recv_tx,
                 JoinResponse::Approved {
-                    genesis_key: original_section_key,
                     section_tree_update,
                     decision,
                 },

--- a/sn_node/src/node/connectivity.rs
+++ b/sn_node/src/node/connectivity.rs
@@ -34,7 +34,7 @@ impl Node {
         // triggering a chain of further `Offline` proposals.
         let elders: Vec<_> = self
             .network_knowledge
-            .authority_provider()
+            .section_auth()
             .elders()
             .filter(|peer| !names.contains(&peer.name()))
             .cloned()

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -59,11 +59,14 @@ pub(crate) async fn handle_online_cmd(
         match msg {
             SystemMsg::JoinResponse(response) => {
                 if let JoinResponse::Approved {
-                    section_auth: signed_sap,
+                    section_tree_update,
                     ..
                 } = *response
                 {
-                    assert_eq!(signed_sap.value, section_auth.clone().to_msg());
+                    assert_eq!(
+                        section_tree_update.section_auth,
+                        section_auth.clone().to_msg()
+                    );
                     assert_matches!(recipients, Peers::Multiple(peers) => {
                         assert_eq!(peers, BTreeSet::from([*peer]));
                     });

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -168,10 +168,7 @@ impl Node {
                     _ => {}
                 }
             }
-            Err(err) => error!(
-                "Failed to generate proof chain for a newly received SAP: {:?}",
-                err
-            ),
+            Err(err) => error!("Failed to generate proof chain for a newly received SAP: {err:?}"),
         }
 
         info!(

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -420,7 +420,7 @@ impl Node {
         sender: Peer,
         bounced_msg: UsrMsgBytes,
     ) -> Result<Cmd> {
-        trace!("{:?} in ae_redirect ", LogMarker::AeSendRedirect);
+        trace!("{} in ae_redirect ", LogMarker::AeSendRedirect);
 
         let ae_msg = self.generate_ae_msg(None, AntiEntropyKind::Redirect { bounced_msg });
 

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -108,12 +108,12 @@ impl Node {
     }
 
     pub(crate) fn handle_dkg_start(&mut self, session_id: DkgSessionId) -> Result<Vec<Cmd>> {
-        let current_generation = self.network_knowledge.our_section_dag_len();
+        let current_generation = self.network_knowledge.section_chain_len();
         if session_id.section_chain_len < current_generation {
             trace!("Skipping DkgStart for older generation: {:?}", &session_id);
             return Ok(vec![]);
         }
-        let section_auth = self.network_knowledge().authority_provider();
+        let section_auth = self.network_knowledge().section_auth();
 
         let mut peers = vec![];
         for session_peer in session_id.elder_peers() {
@@ -195,7 +195,7 @@ impl Node {
         sender: Peer,
     ) -> Result<Vec<Cmd>> {
         let section_key = self.network_knowledge().section_key();
-        let current_generation = self.network_knowledge.our_section_dag_len();
+        let current_generation = self.network_knowledge.section_chain_len();
         if session_id.section_chain_len < current_generation {
             trace!(
                 "Ignoring DkgRetry for expired DKG session: {:?}",
@@ -245,7 +245,7 @@ impl Node {
             return Err(Error::InvalidDkgParticipant);
         }
 
-        let generation = self.network_knowledge.our_section_dag_len();
+        let generation = self.network_knowledge.section_chain_len();
 
         let dkg_session = if let Some(dkg_session) = self
             .promote_and_demote_elders(&BTreeSet::new())
@@ -309,7 +309,7 @@ impl Node {
             // This proposal is sent to the current set of elders to be aggregated
             // and section signed.
             let proposal = Proposal::SectionInfo(sap);
-            let recipients: Vec<_> = self.network_knowledge.authority_provider().elders_vec();
+            let recipients: Vec<_> = self.network_knowledge.section_auth().elders_vec();
             self.send_proposal_with(recipients, proposal, &key_share)
         }
     }

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -266,7 +266,6 @@ impl Node {
         info!("Section {prefix:?} has approved new peers {peers:?}.");
 
         let msg = SystemMsg::JoinResponse(Box::new(JoinResponse::Approved {
-            genesis_key: *self.network_knowledge.genesis_key(),
             section_tree_update: SectionTreeUpdate::new(
                 self.network_knowledge.signed_sap(),
                 self.network_knowledge.section_chain(),

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -14,8 +14,9 @@ use crate::node::{
 use bls::Signature;
 use sn_consensus::{Decision, Generation, SignedVote, VoteResponse};
 use sn_interface::{
-    messaging::system::{
-        JoinResponse, KeyedSig, MembershipState, NodeState, SectionAuth, SystemMsg,
+    messaging::{
+        system::{JoinResponse, KeyedSig, MembershipState, NodeState, SectionAuth, SystemMsg},
+        SectionTreeUpdate,
     },
     types::{log_markers::LogMarker, Peer},
 };
@@ -266,11 +267,10 @@ impl Node {
 
         let msg = SystemMsg::JoinResponse(Box::new(JoinResponse::Approved {
             genesis_key: *self.network_knowledge.genesis_key(),
-            section_auth: self
-                .network_knowledge
-                .section_signed_authority_provider()
-                .into_authed_msg(),
-            sections_dag: self.network_knowledge.our_section_dag(),
+            section_tree_update: SectionTreeUpdate::new(
+                self.network_knowledge.signed_sap(),
+                self.network_knowledge.section_chain(),
+            ),
             decision,
         }));
 

--- a/sn_node/src/node/messaging/proposal.rs
+++ b/sn_node/src/node/messaging/proposal.rs
@@ -21,7 +21,7 @@ use sn_interface::{
 impl Node {
     /// Send proposal to all our elders.
     pub(crate) fn propose(&mut self, proposal: Proposal) -> Result<Vec<Cmd>> {
-        let elders = self.network_knowledge.authority_provider().elders_vec();
+        let elders = self.network_knowledge.section_auth().elders_vec();
         self.send_proposal(elders, proposal)
     }
 

--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -36,7 +36,7 @@ impl Node {
         }
 
         // Do not carry out relocation when there is not enough elder nodes.
-        if self.network_knowledge.authority_provider().elder_count() < elder_count() {
+        if self.network_knowledge.section_auth().elder_count() < elder_count() {
             return Ok(vec![]);
         }
 
@@ -106,12 +106,12 @@ impl Node {
 
         // Create a new instance of JoiningAsRelocated to start the relocation
         // flow. This same instance will handle responses till relocation is complete.
-        let bootstrap_addrs = if let Ok(sap) = self.network_knowledge.section_by_name(&dst_xorname)
-        {
-            sap.addresses()
-        } else {
-            self.network_knowledge.authority_provider().addresses()
-        };
+        let bootstrap_addrs =
+            if let Ok(sap) = self.network_knowledge.section_auth_by_name(&dst_xorname) {
+                sap.addresses()
+            } else {
+                self.network_knowledge.section_auth().addresses()
+            };
         let (joining_as_relocated, cmd) = JoiningAsRelocated::start(
             node,
             relocate_proof,

--- a/sn_node/src/node/messaging/service_msgs.rs
+++ b/sn_node/src/node/messaging/service_msgs.rs
@@ -431,7 +431,7 @@ impl Node {
         let spent_proof_share = Self::build_spent_proof_share(
             key_image,
             tx,
-            &self.network_knowledge.authority_provider(),
+            &self.network_knowledge.section_auth(),
             &self.section_keys_provider,
             public_commitments,
         )?;

--- a/sn_node/src/node/messaging/system_msgs.rs
+++ b/sn_node/src/node/messaging/system_msgs.rs
@@ -211,16 +211,11 @@ impl Node {
                                 previous_name, new_name
                             );
 
-                            let genesis_key = *self.network_knowledge.genesis_key();
-                            let section_tree = self.network_knowledge.section_tree().clone();
-
                             let recipients = section_tree_update.section_auth.elders.clone();
 
-                            let new_network_knowledge = NetworkKnowledge::new(
-                                genesis_key,
-                                section_tree_update,
-                                Some(section_tree),
-                            )?;
+                            let section_tree = self.network_knowledge.section_tree().clone();
+                            let new_network_knowledge =
+                                NetworkKnowledge::new(section_tree, section_tree_update)?;
 
                             // TODO: confirm whether carry out the switch immediately here
                             //       or still using the cmd pattern.

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -694,7 +694,7 @@ mod core {
                 // key since the split) then this key would be unknown to them and they would send
                 // us back their whole section chain. However, this situation should be rare.
 
-                // section_chain produces a proof chain with only 1 leaf
+                // section_chain contains a single leaf key
                 let leaf_key = self.network_knowledge.section_chain().last_key()?;
                 match self.section_chain().get_parent_key(&leaf_key) {
                     Ok(prev_pk) => Ok(prev_pk.unwrap_or(*self.section_chain().genesis_key())),

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -194,7 +194,7 @@ async fn bootstrap_node(
             prefix: network_knowledge.prefix(),
             key: network_knowledge.section_key(),
             remaining: BTreeSet::new(),
-            added: network_knowledge.authority_provider().names(),
+            added: network_knowledge.section_auth().names(),
             removed: BTreeSet::new(),
         };
 

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -61,7 +61,7 @@ impl NodeTestApi {
 
     /// Returns the Section Signed Chain
     pub async fn section_chain(&self) -> SectionsDAG {
-        self.node.read().await.our_section_dag()
+        self.node.read().await.section_chain()
     }
 
     /// Returns the Section Chain's genesis key

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -124,6 +124,7 @@ mod tests {
 
     use sn_interface::{
         elder_count,
+        messaging::SectionTreeUpdate,
         network_knowledge::{
             test_utils::section_signed, SectionAuthorityProvider, SectionsDAG, MIN_ADULT_AGE,
         },
@@ -181,10 +182,12 @@ mod tests {
             sk_set.public_keys(),
             0,
         );
-        let section_auth = section_signed(sk, section_auth)?;
+        let section_tree_update = {
+            let signed_sap = section_signed(sk, section_auth)?;
+            SectionTreeUpdate::new(signed_sap, SectionsDAG::new(genesis_pk))
+        };
 
-        let network_knowledge =
-            NetworkKnowledge::new(genesis_pk, SectionsDAG::new(genesis_pk), section_auth, None)?;
+        let network_knowledge = NetworkKnowledge::new(genesis_pk, section_tree_update, None)?;
 
         for peer in &peers {
             let info = NodeState::joined(*peer, None);

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -135,6 +135,7 @@ mod tests {
     use itertools::Itertools;
     use proptest::{collection::SizeRange, prelude::*};
     use rand::{rngs::SmallRng, Rng, SeedableRng};
+    use sn_interface::network_knowledge::SectionTree;
     use std::net::SocketAddr;
     use xor_name::{Prefix, XOR_NAME_LEN};
 
@@ -187,7 +188,8 @@ mod tests {
             SectionTreeUpdate::new(signed_sap, SectionsDAG::new(genesis_pk))
         };
 
-        let network_knowledge = NetworkKnowledge::new(genesis_pk, section_tree_update, None)?;
+        let network_knowledge =
+            NetworkKnowledge::new(SectionTree::new(genesis_pk), section_tree_update)?;
 
         for peer in &peers {
             let info = NodeState::joined(*peer, None);


### PR DESCRIPTION
- The `SectionTree` always requires a Proof chain and a SAP to update it, hence bundle it together to make it cleaner
  - A `proof chain` is a chain of keys where each key is signed by the previous one
  - A `section chain` is a proof chain to our current section key
  - `partial dag` is used only inside `SectionsDAG` struct
- Reorderd the functions inside network knowledge  (removed a redundant fn). Order:
  1. Creating and updating network
  2. SAP related
  3. proof chain / keys related
  4. membership related
  5. misc
- Remove the redundant genesis key argument in `NetworkKnowledge::new` which removes a lot of validations

TODO: refactoring the `sn_interface::messaging` module will remove a lot of redundant conversions from msg -> actual struct. 