### PR TITLE
Remove bootstrap node from join process; remove unneeded error handling in Comms

### DIFF
--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -105,11 +105,8 @@ impl SectionTree {
     fn insert(&mut self, sap: SectionAuth<SectionAuthorityProvider>) -> bool {
         let prefix = sap.prefix();
         // Don't insert if any descendant is already present in the map.
-        if self
-            .sections
-            .iter()
-            .any(|(p, _)| p.is_extension_of(&prefix))
-        {
+        if let Some(extension_p) = self.sections.keys().find(|p| p.is_extension_of(&prefix)) {
+            info!("Dropping update since we have a prefix '{extension_p}' that is an extension of '{prefix}'");
             return false;
         }
 
@@ -237,6 +234,7 @@ impl SectionTree {
         match self.get_signed(incoming_prefix) {
             Some(sap) if sap == &signed_sap => {
                 // It's the same SAP we are already aware of
+                info!("Dropping SectionTree update since the SAP we have for prefix '{incoming_prefix}' is not new");
                 return Ok(false);
             }
             Some(sap) => {

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -8,8 +8,6 @@
 
 use super::Link;
 
-use crate::node::Result;
-
 use qp2p::RetryConfig;
 use qp2p::UsrMsgBytes;
 use sn_interface::messaging::MsgId;
@@ -71,7 +69,7 @@ impl PeerSession {
     }
 
     #[instrument(skip(self, bytes))]
-    pub(crate) async fn send(&self, msg_id: MsgId, bytes: UsrMsgBytes) -> Result<SendWatcher> {
+    pub(crate) async fn send(&self, msg_id: MsgId, bytes: UsrMsgBytes) -> SendWatcher {
         let (watcher, reporter) = status_watching();
 
         let job = SendJob {
@@ -85,7 +83,7 @@ impl PeerSession {
             error!("Error while sending Send command {e:?}");
         }
 
-        Ok(watcher)
+        watcher
     }
 
     pub(crate) async fn disconnect(self) {

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -48,7 +48,7 @@ pub(crate) async fn join_network(
     network_contacts: SectionTree,
     join_timeout: Duration,
 ) -> Result<(NodeInfo, NetworkKnowledge)> {
-    let (outgoing_msgs_sender, outgoing_msgs_receiver) = mpsc::channel(1);
+    let (outgoing_msgs_sender, outgoing_msgs_receiver) = mpsc::channel(100);
 
     let span = trace_span!("bootstrap");
     let joiner = Joiner::new(node, outgoing_msgs_sender, incoming_msgs, network_contacts);
@@ -486,9 +486,6 @@ async fn send_messages(
             let bytes = msg.serialize()?;
             match comm.send(peer, msg_id, bytes).await {
                 Ok(()) => trace!("Msg {msg_id:?} sent on {dst:?}"),
-                Err(Error::FailedSend(peer)) => {
-                    error!("Failed to send message {msg_id:?} to {peer:?}")
-                }
                 Err(error) => {
                     warn!("Error in comms when sending msg {msg_id:?} to peer {peer:?}: {error}")
                 }

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -863,7 +863,7 @@ async fn msg_to_self() -> Result<()> {
         let info = network_utils::gen_info(MIN_ADULT_AGE, None);
         let (event_sender, _) = event_channel::new(network_utils::TEST_EVENT_CHANNEL_SIZE);
         let (comm_tx, mut comm_rx) = mpsc::channel(network_utils::TEST_EVENT_CHANNEL_SIZE);
-        let comm = Comm::first_node(
+        let comm = Comm::new(
             (Ipv4Addr::LOCALHOST, 0).into(),
             Default::default(),
             comm_tx,

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -376,7 +376,7 @@ pub(crate) fn gen_info(age: u8, prefix: Option<Prefix>) -> NodeInfo {
 
 pub(crate) async fn create_comm() -> Result<Comm> {
     let (tx, _rx) = mpsc::channel(TEST_EVENT_CHANNEL_SIZE);
-    Ok(Comm::first_node((Ipv4Addr::LOCALHOST, 0).into(), Default::default(), tx).await?)
+    Ok(Comm::new((Ipv4Addr::LOCALHOST, 0).into(), Default::default(), tx).await?)
 }
 
 /// Create a `Proposal::Online` whose agreement handling triggers relocation of a node with the

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -164,7 +164,7 @@ async fn bootstrap_node(
             std::process::id()
         );
 
-        let comm = Comm::first_node(
+        let comm = Comm::new(
             local_addr,
             config.network_config().clone(),
             connection_event_tx,
@@ -223,7 +223,7 @@ async fn bootstrap_node(
             Error::Configuration("Could not obtain network contacts file path".to_string())
         })?;
         let network_contacts = SectionTree::from_disk(&path).await?;
-        let comm = Comm::bootstrap(
+        let comm = Comm::new(
             local_addr,
             config.network_config().clone(),
             connection_event_tx,


### PR DESCRIPTION
Two changes
1. remove some unnecessary error handling in Comm
2. Remove the `bootstrap_node` argument to the join process.

The `bootstrap_node: SocketAddr` was there as a backup in case we did not have any peer entries in our SectionTree, but if you trace the logic all the way through, you can see that the `bootstrap_node` was being pulled from our `SectionTree`! So the fallback address is a fallback to itself?