### PR TITLE
feat: use separate genesis dbc and section keys

### DIFF
--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -45,6 +45,12 @@ use serde::Serialize;
 use std::{collections::BTreeSet, iter, net::SocketAddr};
 use xor_name::{Prefix, XorName};
 
+/// The secret key for the genesis DBC.
+///
+/// This key is public for auditing purposes. Hard coding its value means all nodes will be able to
+/// validate it.
+pub const GENESIS_DBC_SK: &str = "0c5152498fc5b2f9ed691ef875f2c16f1f950910391f7ba1df63e9f0ce4b2780";
+
 /// The minimum age a node becomes an adult node.
 pub const MIN_ADULT_AGE: u8 = 5;
 

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -203,6 +203,8 @@ pub enum Error {
     /// Cannot handle more queries at this point
     #[error("Cannot handle more queries at this point: {0:?}")]
     CannotHandleQuery(DataQuery),
+    #[error("BLS error: {0}")]
+    BlsError(#[from] bls::Error),
 }
 
 impl From<qp2p::ClientEndpointError> for Error {

--- a/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
@@ -50,7 +50,7 @@ pub(crate) fn get_genesis_dbc_spend_info(
     BTreeSet<SpentProof>,
     BTreeSet<RingCtTransaction>,
 )> {
-    let genesis_dbc = gen_genesis_dbc(sk_set)?;
+    let genesis_dbc = gen_genesis_dbc(sk_set, &sk_set.secret_key())?;
     let dbc_owner = genesis_dbc.owner_base().clone();
     let output_owner = OwnerOnce::from_owner_base(dbc_owner, &mut rand::thread_rng());
     let tx_builder = TransactionBuilder::default()

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -1417,7 +1417,7 @@ async fn spentbook_spend_spent_proofs_do_not_relate_to_input_dbcs_should_return_
             // from `new_dbc`, which was our input to `new_dbc2`.
             let sap = section.section_auth();
             let keys_provider = dispatcher.node().read().await.section_keys_provider.clone();
-            let genesis_dbc = gen_genesis_dbc(&sk_set)?;
+            let genesis_dbc = gen_genesis_dbc(&sk_set, &sk_set.secret_key())?;
             let new_dbc = reissue_dbc(
                 &genesis_dbc,
                 10,
@@ -1485,7 +1485,7 @@ async fn spentbook_spend_transaction_with_no_inputs_should_return_spentbook_erro
             // These conditions will produce a failure on `tx.verify` in the message handler.
             let sap = section.section_auth();
             let keys_provider = dispatcher.node().read().await.section_keys_provider.clone();
-            let genesis_dbc = gen_genesis_dbc(&sk_set)?;
+            let genesis_dbc = gen_genesis_dbc(&sk_set, &sk_set.secret_key())?;
             let new_dbc = reissue_dbc(
                 &genesis_dbc,
                 10,
@@ -1553,7 +1553,7 @@ async fn spentbook_spend_with_random_key_image_should_return_spentbook_error() -
 
             let sap = section.section_auth();
             let keys_provider = dispatcher.node().read().await.section_keys_provider.clone();
-            let genesis_dbc = gen_genesis_dbc(&sk_set)?;
+            let genesis_dbc = gen_genesis_dbc(&sk_set, &sk_set.secret_key())?;
             let new_dbc = reissue_dbc(
                 &genesis_dbc,
                 10,
@@ -1661,7 +1661,7 @@ async fn spentbook_spend_with_updated_network_knowledge_should_update_the_node()
             // The owners of the DBCs here don't really matter, so we just use random keys.
             let skp = SectionKeysProvider::new(Some(other_section_key_share.clone()));
             let sap = other_section.signed_sap();
-            let genesis_dbc = gen_genesis_dbc(&genesis_sk_set)?;
+            let genesis_dbc = gen_genesis_dbc(&genesis_sk_set, &genesis_sk_set.secret_key())?;
             let new_dbc = reissue_dbc(&genesis_dbc, 10, &bls::SecretKey::random(), &sap, &skp)?;
             let new_dbc2 = reissue_dbc(&new_dbc, 5, &bls::SecretKey::random(), &sap, &skp)?;
             let new_dbc2_spent_proof =

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -37,7 +37,7 @@ fn dkg_peers(our_index: usize, session_id: &DkgSessionId) -> BTreeSet<Peer> {
     session_id
         .elder_peers()
         .enumerate()
-        .filter_map(|(index, peer)| (index != our_index).then(|| peer))
+        .filter_map(|(index, peer)| (index != our_index).then_some(peer))
         .collect()
 }
 


### PR DESCRIPTION
For more information, see the comment on the diff.

The generation of the DBC was also updated to use non-zero values for the `alpha` and `r` fields of `MlsagMaterial`, because zeroes and ones are special values in elliptic curve cryptography.

Also fixed a Clippy warning.