### PR TITLE
ci: cause clippy step to fail on warnings

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -114,7 +114,7 @@ jobs:
 
       - shell: bash
         if: steps.sn_changes.outputs.src == 'true'
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features -- -Dwarnings
 
       - name: Check documentation
         if: steps.sn_changes.outputs.src == 'true'


### PR DESCRIPTION
You need to explicitly add `-- -Dwarnings` to get Clippy to exit with a non-zero code. Not sure if this is behaviour that just changed recently or we've always just missed it.

Also fixed a warning here.