### PR TITLE
refactor: NodeAuth -> NodeEvidence

### DIFF
--- a/sn_interface/src/messaging/auth_kind.rs
+++ b/sn_interface/src/messaging/auth_kind.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{ClientAuth, NodeAuth, SectionAuthShare};
+use super::{ClientAuth, NodeEvidence, SectionAuthShare};
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
@@ -29,7 +29,7 @@ pub enum AuthKind {
     ///
     /// Node authority is needed when nodes send messages directly to other nodes.
     // FIXME: is the above true? What does is the recieving node validating against?
-    Node(NodeAuth),
+    Node(NodeEvidence),
 
     /// A message from an Elder node with its share of the section authority.
     ///

--- a/sn_interface/src/messaging/auth_kind.rs
+++ b/sn_interface/src/messaging/auth_kind.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{ClientAuth, NodeEvidence, SectionAuthShare};
+use super::{ClientAuth, NodeSig, SectionAuthShare};
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
@@ -29,7 +29,7 @@ pub enum AuthKind {
     ///
     /// Node authority is needed when nodes send messages directly to other nodes.
     // FIXME: is the above true? What does is the recieving node validating against?
-    Node(NodeEvidence),
+    Node(NodeSig),
 
     /// A message from an Elder node with its share of the section authority.
     ///

--- a/sn_interface/src/messaging/authority.rs
+++ b/sn_interface/src/messaging/authority.rs
@@ -33,7 +33,7 @@ pub struct ClientAuth {
 
 /// Authority of a single peer.
 #[derive(Clone, Eq, PartialEq, custom_debug::Debug, serde::Deserialize, serde::Serialize)]
-pub struct NodeEvidence {
+pub struct NodeSig {
     /// Section key of the source.
     pub section_pk: BlsPublicKey,
     /// Public key of the source peer.
@@ -45,7 +45,7 @@ pub struct NodeEvidence {
     pub signature: EdSignature,
 }
 
-impl NodeEvidence {
+impl NodeSig {
     /// Construct verified node authority by signing a payload.
     pub fn authorize(
         section_pk: BlsPublicKey,
@@ -158,7 +158,7 @@ impl VerifyAuthority for ClientAuth {
 }
 impl sealed::Sealed for ClientAuth {}
 
-impl VerifyAuthority for NodeEvidence {
+impl VerifyAuthority for NodeSig {
     fn verify_authority(self, payload: impl AsRef<[u8]>) -> Result<Self> {
         self.node_ed_pk
             .verify(payload.as_ref(), &self.signature)
@@ -166,7 +166,7 @@ impl VerifyAuthority for NodeEvidence {
         Ok(self)
     }
 }
-impl sealed::Sealed for NodeEvidence {}
+impl sealed::Sealed for NodeSig {}
 
 impl VerifyAuthority for SectionAuthShare {
     fn verify_authority(self, payload: impl AsRef<[u8]>) -> Result<Self> {

--- a/sn_interface/src/messaging/authority.rs
+++ b/sn_interface/src/messaging/authority.rs
@@ -33,7 +33,7 @@ pub struct ClientAuth {
 
 /// Authority of a single peer.
 #[derive(Clone, Eq, PartialEq, custom_debug::Debug, serde::Deserialize, serde::Serialize)]
-pub struct NodeAuth {
+pub struct NodeEvidence {
     /// Section key of the source.
     pub section_pk: BlsPublicKey,
     /// Public key of the source peer.
@@ -45,7 +45,7 @@ pub struct NodeAuth {
     pub signature: EdSignature,
 }
 
-impl NodeAuth {
+impl NodeEvidence {
     /// Construct verified node authority by signing a payload.
     pub fn authorize(
         section_pk: BlsPublicKey,
@@ -158,7 +158,7 @@ impl VerifyAuthority for ClientAuth {
 }
 impl sealed::Sealed for ClientAuth {}
 
-impl VerifyAuthority for NodeAuth {
+impl VerifyAuthority for NodeEvidence {
     fn verify_authority(self, payload: impl AsRef<[u8]>) -> Result<Self> {
         self.node_ed_pk
             .verify(payload.as_ref(), &self.signature)
@@ -166,7 +166,7 @@ impl VerifyAuthority for NodeAuth {
         Ok(self)
     }
 }
-impl sealed::Sealed for NodeAuth {}
+impl sealed::Sealed for NodeEvidence {}
 
 impl VerifyAuthority for SectionAuthShare {
     fn verify_authority(self, payload: impl AsRef<[u8]>) -> Result<Self> {

--- a/sn_interface/src/messaging/mod.rs
+++ b/sn_interface/src/messaging/mod.rs
@@ -46,7 +46,7 @@ pub use self::serialisation::{Entity, Traceroute};
 pub use self::{
     auth_kind::AuthKind,
     authority::{
-        AuthorityProof, ClientAuth, NodeAuth, SectionAuth, SectionAuthShare, VerifyAuthority,
+        AuthorityProof, ClientAuth, NodeEvidence, SectionAuth, SectionAuthShare, VerifyAuthority,
     },
     dst::Dst,
     errors::{Error, Result},

--- a/sn_interface/src/messaging/mod.rs
+++ b/sn_interface/src/messaging/mod.rs
@@ -46,7 +46,7 @@ pub use self::serialisation::{Entity, Traceroute};
 pub use self::{
     auth_kind::AuthKind,
     authority::{
-        AuthorityProof, ClientAuth, NodeEvidence, SectionAuth, SectionAuthShare, VerifyAuthority,
+        AuthorityProof, ClientAuth, NodeSig, SectionAuth, SectionAuthShare, VerifyAuthority,
     },
     dst::Dst,
     errors::{Error, Result},

--- a/sn_interface/src/messaging/serialisation/mod.rs
+++ b/sn_interface/src/messaging/serialisation/mod.rs
@@ -12,7 +12,7 @@ mod wire_msg_header;
 pub use self::wire_msg::WireMsg;
 #[cfg(feature = "traceroute")]
 pub use self::wire_msg::{Entity, Traceroute};
-use super::{AuthorityProof, NodeAuth, SectionAuth, SectionAuthShare};
+use super::{AuthorityProof, NodeEvidence, SectionAuth, SectionAuthShare};
 
 use crate::types::PublicKey;
 
@@ -23,7 +23,7 @@ use xor_name::XorName;
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum NodeMsgAuthority {
     /// Authority of a single peer.
-    Node(AuthorityProof<NodeAuth>),
+    Node(AuthorityProof<NodeEvidence>),
     /// Authority of a single peer that uses it's BLS Keyshare to sign the message.
     BlsShare(AuthorityProof<SectionAuthShare>),
     /// Authority of a whole section.

--- a/sn_interface/src/messaging/serialisation/mod.rs
+++ b/sn_interface/src/messaging/serialisation/mod.rs
@@ -12,7 +12,7 @@ mod wire_msg_header;
 pub use self::wire_msg::WireMsg;
 #[cfg(feature = "traceroute")]
 pub use self::wire_msg::{Entity, Traceroute};
-use super::{AuthorityProof, NodeEvidence, SectionAuth, SectionAuthShare};
+use super::{AuthorityProof, NodeSig, SectionAuth, SectionAuthShare};
 
 use crate::types::PublicKey;
 
@@ -23,7 +23,7 @@ use xor_name::XorName;
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum NodeMsgAuthority {
     /// Authority of a single peer.
-    Node(AuthorityProof<NodeEvidence>),
+    Node(AuthorityProof<NodeSig>),
     /// Authority of a single peer that uses it's BLS Keyshare to sign the message.
     BlsShare(AuthorityProof<SectionAuthShare>),
     /// Authority of a whole section.

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -369,7 +369,7 @@ mod tests {
         messaging::{
             data::{ClientMsg, DataQuery, DataQueryVariant, StorageLevel},
             system::{NodeCmd, NodeMsg},
-            AuthorityProof, ClientAuth, MsgId, NodeAuth,
+            AuthorityProof, ClientAuth, MsgId, NodeEvidence,
         },
         types::{ChunkAddress, Keypair},
     };
@@ -398,7 +398,7 @@ mod tests {
         });
 
         let payload = WireMsg::serialize_msg_payload(&msg)?;
-        let node_auth = NodeAuth::authorize(src_section_pk, &src_node_keypair, &payload);
+        let node_auth = NodeEvidence::authorize(src_section_pk, &src_node_keypair, &payload);
 
         let auth = AuthKind::Node(node_auth.clone().into_inner());
 

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -369,7 +369,7 @@ mod tests {
         messaging::{
             data::{ClientMsg, DataQuery, DataQueryVariant, StorageLevel},
             system::{NodeCmd, NodeMsg},
-            AuthorityProof, ClientAuth, MsgId, NodeEvidence,
+            AuthorityProof, ClientAuth, MsgId, NodeSig,
         },
         types::{ChunkAddress, Keypair},
     };
@@ -398,7 +398,7 @@ mod tests {
         });
 
         let payload = WireMsg::serialize_msg_payload(&msg)?;
-        let node_auth = NodeEvidence::authorize(src_section_pk, &src_node_keypair, &payload);
+        let node_auth = NodeSig::authorize(src_section_pk, &src_node_keypair, &payload);
 
         let auth = AuthKind::Node(node_auth.clone().into_inner());
 

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -17,7 +17,7 @@ use sn_interface::{
         system::{
             JoinRejectionReason, JoinRequest, JoinResponse, MembershipState, NodeMsg, ResourceProof,
         },
-        AuthKind, Dst, MsgType, NodeEvidence, WireMsg,
+        AuthKind, Dst, MsgType, NodeSig, WireMsg,
     },
     network_knowledge::{NetworkKnowledge, NodeInfo, SectionTree},
     types::{keys::ed25519, log_markers::LogMarker, Peer},
@@ -456,7 +456,7 @@ impl<'a> Joiner<'a> {
                         trace!("Bootstrap message discarded: sender: {sender:?} wire_msg: {wire_msg:?}");
                         continue;
                     }
-                    AuthKind::Node(NodeEvidence { .. }) => match wire_msg.into_msg() {
+                    AuthKind::Node(NodeSig { .. }) => match wire_msg.into_msg() {
                         Ok(MsgType::Node {
                             msg: NodeMsg::JoinResponse(resp),
                             ..

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -17,7 +17,7 @@ use sn_interface::{
         system::{
             JoinRejectionReason, JoinRequest, JoinResponse, MembershipState, NodeMsg, ResourceProof,
         },
-        AuthKind, Dst, MsgType, NodeAuth, WireMsg,
+        AuthKind, Dst, MsgType, NodeEvidence, WireMsg,
     },
     network_knowledge::{NetworkKnowledge, NodeInfo, SectionTree},
     types::{keys::ed25519, log_markers::LogMarker, Peer},
@@ -456,7 +456,7 @@ impl<'a> Joiner<'a> {
                         trace!("Bootstrap message discarded: sender: {sender:?} wire_msg: {wire_msg:?}");
                         continue;
                     }
-                    AuthKind::Node(NodeAuth { .. }) => match wire_msg.into_msg() {
+                    AuthKind::Node(NodeEvidence { .. }) => match wire_msg.into_msg() {
                         Ok(MsgType::Node {
                             msg: NodeMsg::JoinResponse(resp),
                             ..

--- a/sn_node/src/node/flow_ctrl/event.rs
+++ b/sn_node/src/node/flow_ctrl/event.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use sn_interface::messaging::{
-    data::ClientMsg, system::NodeMsg, AuthorityProof, ClientAuth, Dst, EndUser, MsgId, NodeAuth,
+    data::ClientMsg, system::NodeMsg, AuthorityProof, ClientAuth, Dst, EndUser, MsgId, NodeEvidence,
 };
 
 use bls::PublicKey as BlsPublicKey;
@@ -55,7 +55,7 @@ pub enum MessagingEvent {
         /// The msg ID
         msg_id: MsgId,
         /// Msg authority
-        auth: AuthorityProof<NodeAuth>,
+        auth: AuthorityProof<NodeEvidence>,
         /// Dst of the msg
         dst: Dst,
         /// The msg.

--- a/sn_node/src/node/flow_ctrl/event.rs
+++ b/sn_node/src/node/flow_ctrl/event.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use sn_interface::messaging::{
-    data::ClientMsg, system::NodeMsg, AuthorityProof, ClientAuth, Dst, EndUser, MsgId, NodeEvidence,
+    data::ClientMsg, system::NodeMsg, AuthorityProof, ClientAuth, Dst, EndUser, MsgId, NodeSig,
 };
 
 use bls::PublicKey as BlsPublicKey;
@@ -55,7 +55,7 @@ pub enum MessagingEvent {
         /// The msg ID
         msg_id: MsgId,
         /// Msg authority
-        auth: AuthorityProof<NodeEvidence>,
+        auth: AuthorityProof<NodeSig>,
         /// Dst of the msg
         dst: Dst,
         /// The msg.

--- a/sn_node/src/node/messages.rs
+++ b/sn_node/src/node/messages.rs
@@ -11,7 +11,7 @@ use crate::node::{Error, Result};
 use sn_interface::{
     messaging::{
         system::{NodeMsg, SigShare},
-        AuthKind, AuthorityProof, Dst, MsgId, NodeAuth, SectionAuthShare, WireMsg,
+        AuthKind, AuthorityProof, Dst, MsgId, NodeEvidence, SectionAuthShare, WireMsg,
     },
     network_knowledge::{NodeInfo, SectionKeyShare},
 };
@@ -74,7 +74,7 @@ impl WireMsgUtils for WireMsg {
             WireMsg::serialize_msg_payload(&msg).map_err(|_| Error::InvalidMessage)?;
 
         let auth = AuthKind::Node(
-            NodeAuth::authorize(src_section_pk, &node.keypair, &msg_payload).into_inner(),
+            NodeEvidence::authorize(src_section_pk, &node.keypair, &msg_payload).into_inner(),
         );
 
         let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth, dst);

--- a/sn_node/src/node/messages.rs
+++ b/sn_node/src/node/messages.rs
@@ -11,7 +11,7 @@ use crate::node::{Error, Result};
 use sn_interface::{
     messaging::{
         system::{NodeMsg, SigShare},
-        AuthKind, AuthorityProof, Dst, MsgId, NodeEvidence, SectionAuthShare, WireMsg,
+        AuthKind, AuthorityProof, Dst, MsgId, NodeSig, SectionAuthShare, WireMsg,
     },
     network_knowledge::{NodeInfo, SectionKeyShare},
 };
@@ -74,7 +74,7 @@ impl WireMsgUtils for WireMsg {
             WireMsg::serialize_msg_payload(&msg).map_err(|_| Error::InvalidMessage)?;
 
         let auth = AuthKind::Node(
-            NodeEvidence::authorize(src_section_pk, &node.keypair, &msg_payload).into_inner(),
+            NodeSig::authorize(src_section_pk, &node.keypair, &msg_payload).into_inner(),
         );
 
         let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth, dst);

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -448,7 +448,7 @@ mod tests {
     use sn_interface::{
         elder_count,
         messaging::{
-            AuthKind, AuthorityProof, Dst, MsgId, NodeEvidence, NodeMsgAuthority,
+            AuthKind, AuthorityProof, Dst, MsgId, NodeMsgAuthority, NodeSig,
             SectionAuth as SectionAuthMsg,
         },
         network_knowledge::{
@@ -770,7 +770,7 @@ mod tests {
             };
 
             let msg_id = MsgId::new();
-            let node_auth = NodeEvidence::authorize(src_section_pk, &sender.keypair, &payload);
+            let node_auth = NodeSig::authorize(src_section_pk, &sender.keypair, &payload);
             let auth = AuthKind::Node(node_auth.into_inner());
 
             Ok(WireMsg::new_msg(msg_id, payload, auth, dst))

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -448,7 +448,7 @@ mod tests {
     use sn_interface::{
         elder_count,
         messaging::{
-            AuthKind, AuthorityProof, Dst, MsgId, NodeAuth, NodeMsgAuthority,
+            AuthKind, AuthorityProof, Dst, MsgId, NodeEvidence, NodeMsgAuthority,
             SectionAuth as SectionAuthMsg,
         },
         network_knowledge::{
@@ -770,7 +770,7 @@ mod tests {
             };
 
             let msg_id = MsgId::new();
-            let node_auth = NodeAuth::authorize(src_section_pk, &sender.keypair, &payload);
+            let node_auth = NodeEvidence::authorize(src_section_pk, &sender.keypair, &payload);
             let auth = AuthKind::Node(node_auth.into_inner());
 
             Ok(WireMsg::new_msg(msg_id, payload, auth, dst))

--- a/sn_node/src/node/messaging/signing.rs
+++ b/sn_node/src/node/messaging/signing.rs
@@ -11,7 +11,7 @@ use super::OutgoingMsg;
 use crate::node::{Node, Result};
 
 use sn_interface::{
-    messaging::{data::ClientMsg, system::NodeMsg, AuthKind, ClientAuth, NodeEvidence, WireMsg},
+    messaging::{data::ClientMsg, system::NodeMsg, AuthKind, ClientAuth, NodeSig, WireMsg},
     types::{PublicKey, Signature},
 };
 
@@ -53,7 +53,7 @@ impl Node {
         let payload = WireMsg::serialize_msg_payload(&msg)?;
         let src_section_pk = self.network_knowledge.section_key();
         let auth = AuthKind::Node(
-            NodeEvidence::authorize(src_section_pk, &self.keypair, &payload).into_inner(),
+            NodeSig::authorize(src_section_pk, &self.keypair, &payload).into_inner(),
         );
 
         Ok((auth, payload))

--- a/sn_node/src/node/messaging/signing.rs
+++ b/sn_node/src/node/messaging/signing.rs
@@ -11,7 +11,7 @@ use super::OutgoingMsg;
 use crate::node::{Node, Result};
 
 use sn_interface::{
-    messaging::{data::ClientMsg, system::NodeMsg, AuthKind, ClientAuth, NodeAuth, WireMsg},
+    messaging::{data::ClientMsg, system::NodeMsg, AuthKind, ClientAuth, NodeEvidence, WireMsg},
     types::{PublicKey, Signature},
 };
 
@@ -53,7 +53,7 @@ impl Node {
         let payload = WireMsg::serialize_msg_payload(&msg)?;
         let src_section_pk = self.network_knowledge.section_key();
         let auth = AuthKind::Node(
-            NodeAuth::authorize(src_section_pk, &self.keypair, &payload).into_inner(),
+            NodeEvidence::authorize(src_section_pk, &self.keypair, &payload).into_inner(),
         );
 
         Ok((auth, payload))


### PR DESCRIPTION
Nodes signs messages they send.

This signature is irrefutable proof of the nodes actions & is used to penalise bad behaviour.

BREAKING CHANGE:
