### PR TITLE
refactor(messaging)!: removing op id from query response

### DIFF
--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -132,7 +132,7 @@ impl Client {
             .await
     }
 
-    /// Send a DataCmd to the network without awaiting for a response.
+    /// Send a DataCmd to the network and await a response.
     /// Cmds are automatically retried using exponential backoff if an error is returned.
     /// This function is a helper private to this module.
     #[instrument(skip_all, level = "debug", name = "client-api send cmd")]

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -96,10 +96,9 @@ impl Client {
         let query = DataQueryVariant::GetChunk(ChunkAddress(*name));
         let res = self.send_query(query.clone()).await?;
 
-        let op_id = res.operation_id;
         let chunk: Chunk = match res.response {
             QueryResponse::GetChunk(result) => {
-                result.map_err(|err| Error::ErrorMsg { source: err, op_id })
+                result.map_err(|err| Error::ErrorMsg { source: err })
             }
             response => return Err(Error::UnexpectedQueryResponse { query, response }),
         }?;

--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -135,9 +135,7 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::Get(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegister((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
-            }
+            QueryResponse::GetRegister(res) => res.map_err(|err| Error::ErrorMsg { source: err }),
             other => Err(Error::UnexpectedQueryResponse {
                 query,
                 response: other,
@@ -154,9 +152,7 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::Read(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::ReadRegister((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
-            }
+            QueryResponse::ReadRegister(res) => res.map_err(|err| Error::ErrorMsg { source: err }),
             other => Err(Error::UnexpectedQueryResponse {
                 query,
                 response: other,
@@ -174,8 +170,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetEntry { address, hash });
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterEntry((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterEntry(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -194,8 +190,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetOwner(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterOwner((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterOwner(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -218,8 +214,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetUserPermissions { address, user });
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterUserPermissions((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterUserPermissions(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -234,8 +230,8 @@ impl Client {
         let query = DataQueryVariant::Register(RegisterQuery::GetPolicy(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::GetRegisterPolicy((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::GetRegisterPolicy(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -473,7 +469,6 @@ mod tests {
             Ok(_) => bail!("Should not be able to retrieve an entry for a random user"),
             Err(Error::ErrorMsg {
                 source: ErrorMsg::NoSuchEntry,
-                ..
             }) => Ok(()),
             Err(err) => Err(eyre!(
                 "Unexpected error returned when retrieving non-existing Register user permission: {:?}", err,
@@ -610,7 +605,6 @@ mod tests {
         {
             Err(Error::ErrorMsg {
                 source: ErrorMsg::NoSuchEntry,
-                ..
             }) => Ok(()),
             Err(err) => Err(eyre!(
                 "Unexpected error returned when retrieving a non-existing Register entry: {:?}",

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -118,8 +118,8 @@ impl Client {
         let query = DataQueryVariant::Spentbook(SpentbookQuery::SpentProofShares(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
-            QueryResponse::SpentProofShares((res, op_id)) => {
-                res.map_err(|err| Error::ErrorMsg { source: err, op_id })
+            QueryResponse::SpentProofShares(res) => {
+                res.map_err(|err| Error::ErrorMsg { source: err })
             }
             other => Err(Error::UnexpectedQueryResponse {
                 query,

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -235,36 +235,32 @@ impl Session {
                     );
                     // Note that this doesn't remove the sender from here since multiple
                     // responses corresponding to the same msg ID might arrive.
-                    // Once we are satisfied with the response this is channel is discarded in
+                    // Once we are satisfied with the response this channel is discarded in
                     // ConnectionManager::send_query
 
-                    if let Ok(op_id) = response.operation_id() {
-                        if let Some(entry) = queries.get(&op_id) {
-                            let all_senders = entry.value();
-                            // Only valid response shall get broadcast to all
-                            for (ori_msg_id, sender) in all_senders {
-                                let res = if response.is_success() || ori_msg_id == &correlation_id
-                                {
-                                    sender.try_send(response.clone())
-                                } else {
-                                    continue;
-                                };
-                                if res.is_err() {
-                                    trace!("Error relaying query response internally on a channel for {:?} op_id {:?}: {:?}. (It has likely been removed)", msg_id, op_id, res)
-                                }
+                    if let Some(entry) = queries.get(&correlation_id) {
+                        let all_senders = entry.value();
+                        // Only valid response shall get broadcast to all
+                        for (addr, sender) in all_senders {
+                            let res = if response.is_success() || addr == &src_peer.addr() {
+                                sender.try_send(response.clone())
+                            } else {
+                                continue;
+                            };
+                            if res.is_err() {
+                                trace!("Error relaying query response ({:?}) internally on a channel for correlation_id {:?}: {:?}. (It has likely been removed)", msg_id, correlation_id, res)
                             }
-                        } else {
-                            // TODO: The trace is only needed when we have an identified case of not finding a channel, but expecting one.
-                            // When expecting one, we can log "No channel found for operation", (and then probably at warn or error level).
-                            // But when we have received enough responses, we aren't really expecting a channel there, so there is no reason to log anything.
-                            // Right now, if we have already received enough responses for a query,
-                            // we drop the channels and drop any further responses for that query.
-                            // but we should not drop it immediately, but clean it up after a while
-                            // and then not log that "no channel was found" when we already had enough responses.
-                            //trace!("No channel found for operation {}", op_id);
                         }
                     } else {
-                        warn!("Ignoring query response without operation id");
+                        // TODO: The trace is only needed when we have an identified case of not finding a channel, but expecting one.
+                        // When expecting one, we can log "No channel found for operation", (and then probably at warn or error level).
+                        // But when we have received enough responses, we aren't really expecting a channel there, so there is no reason to log anything.
+                        // Right now, if we have already received enough responses for a query,
+                        // we drop the channels and drop any further responses for that query.
+                        // but we should not drop it immediately, but clean it up after a while
+                        // and then not log that "no channel was found" when we already had enough responses.
+
+                        //trace!("No channel found for correlation id {:?}", correlation_id);
                     }
                 }
                 ClientMsg::CmdError {

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -12,7 +12,7 @@ mod messaging;
 use crate::Result;
 use sn_interface::{
     messaging::{
-        data::{Error as ErrorMsg, OperationId, QueryResponse},
+        data::{Error as ErrorMsg, QueryResponse},
         MsgId,
     },
     network_knowledge::SectionTree,
@@ -25,7 +25,7 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::sync::{mpsc::Sender, RwLock};
 
 // Here we dont track the msg_id across the network, but just use it as a local identifier to remove the correct listener
-type PendingQueryResponses = Arc<DashMap<OperationId, Vec<(MsgId, QueryResponseSender)>>>;
+type PendingQueryResponses = Arc<DashMap<MsgId, Vec<(SocketAddr, QueryResponseSender)>>>;
 type QueryResponseSender = Sender<QueryResponse>;
 
 type CmdResponse = (SocketAddr, Option<ErrorMsg>);
@@ -34,7 +34,6 @@ type PendingCmdAcks = Arc<DashMap<MsgId, Sender<CmdResponse>>>;
 #[derive(Debug)]
 pub struct QueryResult {
     pub response: QueryResponse,
-    pub operation_id: OperationId,
 }
 
 impl QueryResult {

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -8,7 +8,7 @@
 
 use sn_interface::{
     messaging::{
-        data::{DataQuery, DataQueryVariant, Error as ErrorMsg, OperationId, QueryResponse},
+        data::{DataQuery, DataQueryVariant, Error as ErrorMsg, QueryResponse},
         Error as MessagingError, MsgId,
     },
     types::{Error as DtError, Peer},
@@ -116,9 +116,6 @@ pub enum Error {
         /// Source of error in last attempt
         last_error: Box<Self>,
     },
-    /// No operation Id could be found
-    #[error("Could not retrieve the operation id of a query response: {0:?}")]
-    UnknownOperationId(QueryResponse),
     /// Unexpected query response received
     #[error("Unexpected response received for {query:?}. Received: {response:?}")]
     UnexpectedQueryResponse {
@@ -131,12 +128,10 @@ pub enum Error {
     #[error(transparent)]
     NetworkDataError(#[from] DtError),
     /// Errors received from the network via sn_messaging
-    #[error("Error received from the network: {source:?} Operationid: {op_id:?}")]
+    #[error("Error received from the network: {source:?}")]
     ErrorMsg {
         /// The source of an error msg
         source: ErrorMsg,
-        /// operation ID that was used to send the query
-        op_id: OperationId,
     },
     /// Error response received for a client cmd sent to the network
     #[error("Error received from the network: {source:?} for cmd: {msg_id:?}")]
@@ -205,4 +200,7 @@ pub enum Error {
     /// Occurs if a section key is not found when searching the sections DAG.
     #[error("Section key {0:?} was not found in the sections DAG")]
     SectionsDagKeyNotFound(PublicKey),
+    /// The random msg id generated for a query collides with a pending query already sent
+    #[error("The msg id generated ({0:?}) for a query collides with a pending query already sent")]
+    MsgIdCollision(MsgId),
 }

--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -91,7 +91,7 @@ impl DysfunctionDetection {
                 *node,
                 self.calculate_node_score_for_type(
                     node,
-                    &IssueType::PendingRequestOperation(rand_op_id()),
+                    &IssueType::PendingRequestOperation(OperationId::random()),
                 ),
             );
         }
@@ -281,18 +281,12 @@ impl DysfunctionDetection {
     }
 }
 
-fn rand_op_id() -> OperationId {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    OperationId(rng.gen())
-}
-
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;
 
     use crate::{detection::IssueType, tests::init_test_logger, DysfunctionDetection};
-    use sn_interface::messaging::data::OperationId;
+    use sn_interface::messaging::system::OperationId;
 
     use eyre::bail;
     use proptest::prelude::*;
@@ -898,7 +892,7 @@ mod ops_tests {
         let mut pending_operations = Vec::new();
         for node in &nodes {
             for _ in 0..NORMAL_OPERATIONS_ISSUES {
-                let op_id = rand_op_id();
+                let op_id = OperationId::random();
                 pending_operations.push((node, op_id));
                 dysfunctional_detection
                     .track_issue(*node, IssueType::PendingRequestOperation(op_id));
@@ -917,7 +911,7 @@ mod ops_tests {
 
         // adding more issues though, and we should see some dysfunction
         for _ in 0..300 {
-            let op_id = rand_op_id();
+            let op_id = OperationId::random();
             dysfunctional_detection
                 .track_issue(nodes[0], IssueType::PendingRequestOperation(op_id));
         }

--- a/sn_dysfunction/src/lib.rs
+++ b/sn_dysfunction/src/lib.rs
@@ -50,7 +50,7 @@ mod error;
 pub use detection::IssueType;
 
 pub use crate::error::Error;
-use sn_interface::messaging::data::OperationId;
+use sn_interface::messaging::system::OperationId;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     time::Instant,
@@ -279,7 +279,7 @@ fn std_deviation(data: &[f32]) -> Option<f32> {
 #[cfg(test)]
 mod tests {
     use super::{DysfunctionDetection, IssueType};
-    use sn_interface::messaging::data::OperationId;
+    use sn_interface::messaging::system::OperationId;
 
     use eyre::Error;
     use std::{collections::BTreeSet, sync::Once};

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -47,12 +47,6 @@ pub enum Error {
     /// Invalid Operation such as a POST on ImmutableData
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
-    /// There was an error forming the OperationId
-    #[error("Operation id could not be derived.")]
-    NoOperationId,
-    /// Error is not valid for operation id generation. This should not absolve a pending (and thus far unfulfilled) operation
-    #[error("Could not generate operation id for chunk retrieval. Error was not 'DataNotFound'.")]
-    InvalidQueryResponseErrorForOperationId,
     /// A DBC spend request could not be processed because the processing section was unaware of
     /// the section that signed one of the input spent proofs.
     #[error("Spent proof is signed by section key {0:?} that is unknown to the current section")]

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -28,10 +28,10 @@ pub use self::{
     spentbook::{SpentbookCmd, SpentbookQuery},
 };
 
-use crate::messaging::{data::Error as ErrorMsg, MsgId};
+use crate::messaging::MsgId;
 use crate::types::{
     register::{Entry, EntryHash, Permissions, Policy, Register, User},
-    utils, Chunk, ChunkAddress, DataAddress,
+    Chunk,
 };
 
 use serde::{Deserialize, Serialize};
@@ -41,41 +41,8 @@ use std::{
     convert::TryFrom,
     fmt::{self, Debug, Display, Formatter},
 };
-use tiny_keccak::{Hasher, Sha3};
 
-/// Derivable Id of an operation. Query/Response should return the same id for simple tracking purposes.
-/// TODO: make uniquer per requester for some operations
-#[derive(Deserialize, Serialize, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct OperationId(pub [u8; 32]);
-
-impl Display for OperationId {
-    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        write!(
-            fmt,
-            "OpId-{:02x}{:02x}{:02x}..",
-            self.0[0], self.0[1], self.0[2]
-        )
-    }
-}
-
-impl Debug for OperationId {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "{}", self)
-    }
-}
-
-/// Return operation Id of a chunk
-pub fn chunk_operation_id(address: &ChunkAddress) -> Result<OperationId> {
-    let bytes = utils::serialise(address).map_err(|_| Error::NoOperationId)?;
-    let mut hasher = Sha3::v256();
-    let mut output = [0; 32];
-    hasher.update(&bytes);
-    hasher.finalize(&mut output);
-
-    Ok(OperationId(output))
-}
-
-/// Network messages exchanged between clients
+/// Network service messages exchanged between clients
 /// and nodes in order for the clients to use the network services.
 /// NB: These are not used for node-to-node comms (see [`NodeMsg`] for those).
 ///
@@ -169,27 +136,22 @@ pub enum QueryResponse {
     // ===== Register Data =====
     //
     /// Response to [`RegisterQuery::Get`].
-    GetRegister((Result<Register>, OperationId)),
+    GetRegister(Result<Register>),
     /// Response to [`RegisterQuery::GetEntry`].
-    GetRegisterEntry((Result<Entry>, OperationId)),
+    GetRegisterEntry(Result<Entry>),
     /// Response to [`RegisterQuery::GetOwner`].
-    GetRegisterOwner((Result<User>, OperationId)),
+    GetRegisterOwner(Result<User>),
     /// Response to [`RegisterQuery::Read`].
-    ReadRegister((Result<BTreeSet<(EntryHash, Entry)>>, OperationId)),
+    ReadRegister(Result<BTreeSet<(EntryHash, Entry)>>),
     /// Response to [`RegisterQuery::GetPolicy`].
-    GetRegisterPolicy((Result<Policy>, OperationId)),
+    GetRegisterPolicy(Result<Policy>),
     /// Response to [`RegisterQuery::GetUserPermissions`].
-    GetRegisterUserPermissions((Result<Permissions>, OperationId)),
+    GetRegisterUserPermissions(Result<Permissions>),
     //
     // ===== Spentbook Data =====
     //
     /// Response to [`SpentbookQuery::SpentProofShares`].
-    SpentProofShares((Result<Vec<SpentProofShare>>, OperationId)),
-    //
-    // ===== Other =====
-    //
-    /// Failed to create id generation
-    FailedToCreateOperationId,
+    SpentProofShares(Result<Vec<SpentProofShare>>),
 }
 
 impl QueryResponse {
@@ -199,13 +161,13 @@ impl QueryResponse {
         matches!(
             self,
             GetChunk(Ok(_))
-                | GetRegister((Ok(_), _))
-                | GetRegisterEntry((Ok(_), _))
-                | GetRegisterOwner((Ok(_), _))
-                | ReadRegister((Ok(_), _))
-                | GetRegisterPolicy((Ok(_), _))
-                | GetRegisterUserPermissions((Ok(_), _))
-                | SpentProofShares((Ok(_), _))
+                | GetRegister(Ok(_))
+                | GetRegisterEntry(Ok(_))
+                | GetRegisterOwner(Ok(_))
+                | ReadRegister(Ok(_))
+                | GetRegisterPolicy(Ok(_))
+                | GetRegisterUserPermissions(Ok(_))
+                | SpentProofShares(Ok(_))
         )
     }
 
@@ -215,52 +177,19 @@ impl QueryResponse {
         matches!(
             self,
             GetChunk(Err(Error::DataNotFound(_)))
-                | GetRegister((Err(Error::DataNotFound(_)), _))
-                | GetRegisterEntry((Err(Error::DataNotFound(_)), _))
-                | GetRegisterOwner((Err(Error::DataNotFound(_)), _))
-                | ReadRegister((Err(Error::DataNotFound(_)), _))
-                | GetRegisterPolicy((Err(Error::DataNotFound(_)), _))
-                | GetRegisterUserPermissions((Err(Error::DataNotFound(_)), _))
-                | SpentProofShares((Err(Error::DataNotFound(_)), _))
+                | GetRegister(Err(Error::DataNotFound(_)))
+                | GetRegisterEntry(Err(Error::DataNotFound(_)))
+                | GetRegisterOwner(Err(Error::DataNotFound(_)))
+                | ReadRegister(Err(Error::DataNotFound(_)))
+                | GetRegisterPolicy(Err(Error::DataNotFound(_)))
+                | GetRegisterUserPermissions(Err(Error::DataNotFound(_)))
+                | SpentProofShares(Err(Error::DataNotFound(_)))
         )
-    }
-
-    /// Retrieves the operation identifier for this response, use in tracking node liveness
-    /// and responses at clients.
-    pub fn operation_id(&self) -> Result<OperationId> {
-        use QueryResponse::*;
-
-        // TODO: Operation Id should eventually encompass _who_ the op is for.
-        match self {
-            GetChunk(result) => match result {
-                Ok(chunk) => chunk_operation_id(chunk.address()),
-                Err(ErrorMsg::DataNotFound(DataAddress::Bytes(name))) => chunk_operation_id(name),
-                Err(ErrorMsg::DataNotFound(another_address)) => {
-                    error!(
-                        "{:?} address returned when we were expecting a ChunkAddress",
-                        another_address
-                    );
-                    Err(Error::NoOperationId)
-                }
-                Err(another_error) => {
-                    error!("Could not form operation id: {:?}", another_error);
-                    Err(Error::InvalidQueryResponseErrorForOperationId)
-                }
-            },
-            GetRegister((_, operation_id))
-            | GetRegisterEntry((_, operation_id))
-            | GetRegisterOwner((_, operation_id))
-            | ReadRegister((_, operation_id))
-            | GetRegisterPolicy((_, operation_id))
-            | GetRegisterUserPermissions((_, operation_id))
-            | SpentProofShares((_, operation_id)) => Ok(*operation_id),
-            FailedToCreateOperationId => Err(Error::NoOperationId),
-        }
     }
 }
 
-/// Error type for an attempted conversion from a [`QueryResponse`] variant to an expected wrapped
-/// value.
+/// Error type for an attempted conversion from a [`QueryResponse`] variant
+/// to an expected wrapped value.
 #[derive(Debug, Eq, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum TryFromError {
@@ -277,8 +206,8 @@ macro_rules! try_from {
             fn try_from(response: QueryResponse) -> std::result::Result<Self, Self::Error> {
                 match response {
                     $(
-                        QueryResponse::$variant((Ok(data), _op_id)) => Ok(data),
-                        QueryResponse::$variant((Err(error), _op_id)) => Err(TryFromError::Response(error)),
+                        QueryResponse::$variant(Ok(data)) => Ok(data),
+                        QueryResponse::$variant(Err(error)) => Err(TryFromError::Response(error)),
                     )*
                     _ => Err(TryFromError::WrongType),
                 }
@@ -334,14 +263,9 @@ mod tests {
     #[test]
     fn debug_format_functional() -> Result<()> {
         if let Some(key) = gen_keys().first() {
-            let errored_response = QueryResponse::GetRegister((
-                Err(Error::AccessDenied(User::Key(*key))),
-                OperationId([
-                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5,
-                    6, 7, 8, 9, 1, 2,
-                ]), // some op id
-            ));
-            assert!(format!("{:?}", errored_response).contains("GetRegister((Err(AccessDenied("));
+            let errored_response =
+                QueryResponse::GetRegister(Err(Error::AccessDenied(User::Key(*key))));
+            assert!(format!("{:?}", errored_response).contains("GetRegister(Err(AccessDenied("));
             Ok(())
         } else {
             Err(eyre!("Could not generate public key"))

--- a/sn_interface/src/messaging/data/query.rs
+++ b/sn_interface/src/messaging/data/query.rs
@@ -6,10 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{
-    chunk_operation_id, register::RegisterQuery, spentbook::SpentbookQuery, Error, OperationId,
-    QueryResponse, Result,
-};
+use super::{register::RegisterQuery, spentbook::SpentbookQuery, Error, QueryResponse};
 use crate::types::{ChunkAddress, DataAddress, SpentbookAddress};
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
@@ -53,11 +50,11 @@ pub enum DataQueryVariant {
 impl DataQueryVariant {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error) -> Result<QueryResponse> {
+    pub fn error(&self, error: Error) -> QueryResponse {
         use DataQueryVariant::*;
         match self {
             #[cfg(feature = "chunks")]
-            GetChunk(_) => Ok(QueryResponse::GetChunk(Err(error))),
+            GetChunk(_) => QueryResponse::GetChunk(Err(error)),
             #[cfg(feature = "registers")]
             Register(q) => q.error(error),
             #[cfg(feature = "spentbook")]
@@ -89,21 +86,6 @@ impl DataQueryVariant {
             Self::Spentbook(read) => {
                 DataAddress::Spentbook(SpentbookAddress::new(*read.dst_address().name()))
             }
-        }
-    }
-
-    /// Retrieves the operation identifier for this response, use in tracking node liveness
-    /// and responses at clients.
-    /// Must be the same as the query response
-    /// Right now returning result to fail for anything non-chunk, as that's all we're tracking from other nodes here just now.
-    pub fn operation_id(&self) -> Result<OperationId> {
-        match self {
-            #[cfg(feature = "chunks")]
-            Self::GetChunk(address) => chunk_operation_id(address),
-            #[cfg(feature = "registers")]
-            Self::Register(read) => read.operation_id(),
-            #[cfg(feature = "spentbook")]
-            Self::Spentbook(read) => read.operation_id(),
         }
     }
 }

--- a/sn_interface/src/messaging/data/register.rs
+++ b/sn_interface/src/messaging/data/register.rs
@@ -6,16 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{Error, QueryResponse, Result};
+use super::{Error, QueryResponse};
 
-use crate::messaging::{data::OperationId, ClientAuth, SectionSig};
+use crate::messaging::{ClientAuth, SectionSig};
 #[allow(unused_imports)] // needed by rustdocs links
 use crate::types::register::Register;
 use crate::types::{
     register::{Entry, EntryHash, Policy, RegisterOp, User},
-    utils, RegisterAddress,
+    RegisterAddress,
 };
-use tiny_keccak::{Hasher, Sha3};
 
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
@@ -164,18 +163,16 @@ impl SignedRegisterEdit {
 impl RegisterQuery {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error) -> Result<QueryResponse> {
-        let op_id = self.operation_id()?;
-        match *self {
-            Self::Get(_) => Ok(QueryResponse::GetRegister((Err(error), op_id))),
-            Self::Read(_) => Ok(QueryResponse::ReadRegister((Err(error), op_id))),
-            Self::GetPolicy(_) => Ok(QueryResponse::GetRegisterPolicy((Err(error), op_id))),
-            Self::GetUserPermissions { .. } => Ok(QueryResponse::GetRegisterUserPermissions((
-                Err(error),
-                op_id,
-            ))),
-            Self::GetEntry { .. } => Ok(QueryResponse::GetRegisterEntry((Err(error), op_id))),
-            Self::GetOwner(_) => Ok(QueryResponse::GetRegisterOwner((Err(error), op_id))),
+    pub fn error(&self, error: Error) -> QueryResponse {
+        match self {
+            Self::Get(_) => QueryResponse::GetRegister(Err(error)),
+            Self::Read(_) => QueryResponse::ReadRegister(Err(error)),
+            Self::GetPolicy(_) => QueryResponse::GetRegisterPolicy(Err(error)),
+            Self::GetUserPermissions { .. } => {
+                QueryResponse::GetRegisterUserPermissions(Err(error))
+            }
+            Self::GetEntry { .. } => QueryResponse::GetRegisterEntry(Err(error)),
+            Self::GetOwner(_) => QueryResponse::GetRegisterOwner(Err(error)),
         }
     }
 
@@ -201,18 +198,6 @@ impl RegisterQuery {
             | Self::GetEntry { ref address, .. }
             | Self::GetOwner(ref address) => *address.name(),
         }
-    }
-
-    /// Retrieves the operation identifier for this response, use in tracking node liveness
-    /// and responses at clients.
-    /// Must be the same as the query response
-    pub fn operation_id(&self) -> Result<OperationId> {
-        let bytes = utils::serialise(&self).map_err(|_| Error::NoOperationId)?;
-        let mut hasher = Sha3::v256();
-        let mut output = [0; 32];
-        hasher.update(&bytes);
-        hasher.finalize(&mut output);
-        Ok(OperationId(output))
     }
 }
 

--- a/sn_interface/src/messaging/data/spentbook.rs
+++ b/sn_interface/src/messaging/data/spentbook.rs
@@ -6,13 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{Error, QueryResponse, Result};
+use super::{Error, QueryResponse};
 
-use crate::messaging::data::OperationId;
 use crate::messaging::system::SectionSigned;
 use crate::network_knowledge::{SectionAuthorityProvider, SectionsDAG};
-use crate::types::{utils, SpentbookAddress};
-use tiny_keccak::{Hasher, Sha3};
+use crate::types::SpentbookAddress;
 
 use serde::{Deserialize, Serialize};
 use sn_dbc::{KeyImage, RingCtTransaction, SpentProof};
@@ -50,12 +48,9 @@ pub enum SpentbookCmd {
 impl SpentbookQuery {
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
-    pub fn error(&self, error: Error) -> Result<QueryResponse> {
-        match *self {
-            Self::SpentProofShares(_) => Ok(QueryResponse::SpentProofShares((
-                Err(error),
-                self.operation_id()?,
-            ))),
+    pub fn error(&self, error: Error) -> QueryResponse {
+        match self {
+            Self::SpentProofShares(_) => QueryResponse::SpentProofShares(Err(error)),
         }
     }
 
@@ -69,18 +64,6 @@ impl SpentbookQuery {
     /// Returns the xorname of the data for request.
     pub fn dst_name(&self) -> XorName {
         *self.dst_address().name()
-    }
-
-    /// Retrieves the operation identifier for this request, use in tracking node liveness
-    /// and responses at clients.
-    /// Must be the same as the query response
-    pub fn operation_id(&self) -> Result<OperationId> {
-        let bytes = utils::serialise(&self).map_err(|_| Error::NoOperationId)?;
-        let mut hasher = Sha3::v256();
-        let mut output = [0; 32];
-        hasher.update(&bytes);
-        hasher.finalize(&mut output);
-        Ok(OperationId(output))
     }
 }
 

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -11,18 +11,18 @@ use crate::messaging::{
     data::ClientMsg, system::NodeMsg, AuthKind, AuthorityProof, ClientAuth, Dst, Error, MsgId,
     MsgType, NodeMsgAuthority, Result,
 };
+
 use bytes::Bytes;
 use custom_debug::Debug;
+use qp2p::UsrMsgBytes;
 use serde::Serialize;
 
 #[cfg(feature = "traceroute")]
 use crate::types::PublicKey;
 #[cfg(feature = "traceroute")]
-use serde::Deserialize;
-
-#[cfg(feature = "traceroute")]
 use itertools::Itertools;
-use qp2p::UsrMsgBytes;
+#[cfg(feature = "traceroute")]
+use serde::Deserialize;
 #[cfg(feature = "traceroute")]
 use std::fmt::{Debug as StdDebug, Display, Formatter};
 

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -11,15 +11,17 @@ mod join;
 mod join_as_relocated;
 mod node_msgs;
 mod node_state;
+mod op_id;
 mod section_sig;
 
-use crate::messaging::{AuthorityProof, EndUser, MsgId, SectionTreeUpdate};
+use crate::messaging::{AuthorityProof, SectionTreeUpdate};
 use crate::network_knowledge::SapCandidate;
 pub use agreement::{DkgSessionId, Proposal, SectionSigned};
 pub use join::{JoinRejectionReason, JoinRequest, JoinResponse, ResourceProof};
 pub use join_as_relocated::{JoinAsRelocatedRequest, JoinAsRelocatedResponse};
 pub use node_msgs::{NodeCmd, NodeEvent, NodeQuery, NodeQueryResponse};
 pub use node_state::{MembershipState, NodeState, RelocateDetails};
+pub use op_id::OperationId;
 pub use section_sig::{SectionSig, SectionSigShare};
 
 use bls::PublicKey as BlsPublicKey;
@@ -127,10 +129,8 @@ pub enum NodeMsg {
     NodeQueryResponse {
         /// QueryResponse.
         response: NodeQueryResponse,
-        /// ID of causing query.
-        correlation_id: MsgId,
-        /// TEMP: Add user here as part of return flow. Remove this as we have chunk routing etc
-        user: EndUser,
+        /// ID of the requested operation.
+        operation_id: OperationId,
     },
 }
 

--- a/sn_interface/src/messaging/system/node_msgs.rs
+++ b/sn_interface/src/messaging/system/node_msgs.rs
@@ -6,18 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::OperationId;
 use crate::messaging::{
-    data::{DataQueryVariant, MetadataExchange, OperationId, QueryResponse, Result, StorageLevel},
-    ClientAuth, EndUser, MsgId,
+    data::{DataQueryVariant, MetadataExchange, QueryResponse, StorageLevel},
+    ClientAuth,
 };
-use crate::types::{
-    register::{Entry, EntryHash, Permissions, Policy, Register, User},
-    Chunk, DataAddress, PublicKey, ReplicatedData,
-};
+use crate::types::{DataAddress, PublicKey, ReplicatedData};
 
 use serde::{Deserialize, Serialize};
-use sn_dbc::SpentProofShare;
-use std::collections::BTreeSet;
 use xor_name::XorName;
 
 /// cmd message sent among nodes
@@ -71,84 +67,12 @@ pub enum NodeQuery {
         query: DataQueryVariant,
         /// Client signature
         auth: ClientAuth,
-        /// The user that has initiated this query
-        origin: EndUser,
-        /// The correlation id that recorded in Elders for this query
-        correlation_id: MsgId,
+        /// The operation id that recorded in Elders for this query
+        operation_id: OperationId,
     },
 }
 
-/// Responses to queries from Elders to Adults.
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub enum NodeQueryResponse {
-    //
-    // ===== Chunk =====
-    //
-    #[cfg(feature = "chunks")]
-    /// Response to [`GetChunk`]
-    ///
-    /// [`GetChunk`]: crate::messaging::data::DataQueryVariant::GetChunk
-    GetChunk(Result<Chunk>),
-    //
-    // ===== Register Data =====
-    //
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::Get`].
-    GetRegister((Result<Register>, OperationId)),
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::GetOwner`].
-    GetRegisterOwner((Result<User>, OperationId)),
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::GetEntry`].
-    GetRegisterEntry((Result<Entry>, OperationId)),
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::GetPolicy`].
-    GetRegisterPolicy((Result<Policy>, OperationId)),
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::Read`].
-    ReadRegister((Result<BTreeSet<(EntryHash, Entry)>>, OperationId)),
-    #[cfg(feature = "registers")]
-    /// Response to [`crate::messaging::data::RegisterQuery::GetUserPermissions`].
-    GetRegisterUserPermissions((Result<Permissions>, OperationId)),
-    //
-    // ===== Spentbook Data =====
-    //
-    #[cfg(feature = "spentbook")]
-    /// Response to [`crate::messaging::data::SpentbookQuery::SpentProofShares`].
-    SpentProofShares((Result<Vec<SpentProofShare>>, OperationId)),
-    //
-    // ===== Other =====
-    //
-    /// Failed to create id generation
-    FailedToCreateOperationId,
-}
-
-impl NodeQueryResponse {
-    pub fn convert(self) -> QueryResponse {
-        use NodeQueryResponse::*;
-        match self {
-            #[cfg(feature = "chunks")]
-            GetChunk(res) => QueryResponse::GetChunk(res),
-            #[cfg(feature = "registers")]
-            GetRegister(res) => QueryResponse::GetRegister(res),
-            #[cfg(feature = "registers")]
-            GetRegisterEntry(res) => QueryResponse::GetRegisterEntry(res),
-            #[cfg(feature = "registers")]
-            GetRegisterOwner(res) => QueryResponse::GetRegisterOwner(res),
-            #[cfg(feature = "registers")]
-            ReadRegister(res) => QueryResponse::ReadRegister(res),
-            #[cfg(feature = "registers")]
-            GetRegisterPolicy(res) => QueryResponse::GetRegisterPolicy(res),
-            #[cfg(feature = "registers")]
-            GetRegisterUserPermissions(res) => QueryResponse::GetRegisterUserPermissions(res),
-            #[cfg(feature = "spentbook")]
-            SpentProofShares(res) => QueryResponse::SpentProofShares(res),
-            FailedToCreateOperationId => QueryResponse::FailedToCreateOperationId,
-        }
-    }
-
-    pub fn operation_id(&self) -> Result<OperationId> {
-        self.clone().convert().operation_id()
-    }
-}
+/// Responses to queries sent from Elders to Adults.
+/// We define it as an alias to `QueryResponse` type, but we keep it as
+/// a separate system message type for more clarity in logs and messaging tracking/debugging.
+pub type NodeQueryResponse = QueryResponse;

--- a/sn_interface/src/messaging/system/op_id.rs
+++ b/sn_interface/src/messaging/system/op_id.rs
@@ -1,0 +1,50 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Debug, Display, Formatter};
+use tiny_keccak::{Hasher, Sha3};
+
+/// Id of an operation. Node to node query/response should return the same id for simple
+/// nodes tracking purposes.
+#[derive(Deserialize, Serialize, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct OperationId(pub [u8; 32]);
+
+impl Display for OperationId {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "OpId-{:02x}{:02x}{:02x}..",
+            self.0[0], self.0[1], self.0[2]
+        )
+    }
+}
+
+impl Debug for OperationId {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{}", self)
+    }
+}
+
+impl OperationId {
+    /// Creates an operation id by hashing the provided bytes
+    pub fn from(bytes: &Bytes) -> Self {
+        let mut hasher = Sha3::v256();
+        let mut output = [0; 32];
+        hasher.update(bytes);
+        hasher.finalize(&mut output);
+
+        Self(output)
+    }
+
+    /// Creates a random operation id
+    pub fn random() -> Self {
+        Self(rand::random())
+    }
+}

--- a/sn_interface/src/types/cache/mod.rs
+++ b/sn_interface/src/types/cache/mod.rs
@@ -10,9 +10,7 @@ mod item;
 
 use self::item::Item;
 use itertools::Itertools;
-use std::collections::BTreeMap;
-use std::hash::Hash;
-use std::time::Duration;
+use std::{collections::BTreeMap, hash::Hash, time::Duration};
 
 /// A [`BTreeMap`]-backed cache supporting capacity- and duration-based expiry.
 #[derive(Debug)]

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -200,8 +200,8 @@ pub enum Error {
     /// Error thrown by DBC public API
     #[error("DbcError: {0}")]
     DbcError(#[from] DbcError),
-    /// Cannot handle more queries at this point
-    #[error("Cannot handle more queries at this point: {0:?}")]
+    /// Cannot handle the same query at this point
+    #[error("Cannot handle the same query at this point: {0:?}")]
     CannotHandleQuery(DataQuery),
     #[error("BLS error: {0}")]
     BlsError(#[from] bls::Error),

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -17,8 +17,8 @@ use sn_dysfunction::IssueType;
 use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
-        data::{ClientMsg, OperationId},
-        system::{NodeMsg, NodeState, SectionSig, SectionSigned},
+        data::ClientMsg,
+        system::{NodeMsg, NodeState, OperationId, SectionSig, SectionSigned},
         AuthorityProof, ClientAuth, MsgId, NodeMsgAuthority, WireMsg,
     },
     network_knowledge::{SectionAuthorityProvider, SectionKeyShare, SectionsDAG},
@@ -117,6 +117,7 @@ pub(crate) enum Cmd {
     /// Adds peer to set of recipients of an already pending query,
     /// or adds a pending query if it didn't already exist.
     AddToPendingQueries {
+        msg_id: MsgId,
         operation_id: OperationId,
         origin: Peer,
         target_adult: XorName,

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -101,6 +101,7 @@ impl Dispatcher {
                 Ok(vec![])
             }
             Cmd::AddToPendingQueries {
+                msg_id,
                 operation_id,
                 origin,
                 target_adult,
@@ -109,22 +110,11 @@ impl Dispatcher {
                 // cleanup
                 node.pending_data_queries.remove_expired();
 
-                if let Some(peers) = node
-                    .pending_data_queries
-                    .get_mut(&(operation_id, origin.name()))
-                {
-                    trace!(
-                        "Adding to pending data queries for op id: {:?}",
-                        operation_id
-                    );
-                    let _ = peers.insert(origin);
-                } else {
-                    let _prior_value = node.pending_data_queries.set(
-                        (operation_id, target_adult),
-                        BTreeSet::from([origin]),
-                        None,
-                    );
-                };
+                let _prior_value = node.pending_data_queries.set(
+                    (operation_id, target_adult),
+                    (msg_id, origin),
+                    None,
+                );
 
                 Ok(vec![])
             }

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -98,7 +98,6 @@ impl Node {
 
     // Handler for data messages which have successfully
     // passed all signature checks and msg verifications
-    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn handle_valid_system_msg(
         &mut self,
         msg_id: MsgId,
@@ -471,22 +470,20 @@ impl Node {
             NodeMsg::NodeQuery(NodeQuery::Data {
                 query,
                 auth,
-                origin,
-                correlation_id,
+                operation_id,
             }) => {
                 // A request from EndUser - via elders - for locally stored data
                 debug!(
-                    "Handle NodeQuery with msg_id {:?} and correlation_id {:?}",
-                    msg_id, correlation_id,
+                    "Handle NodeQuery with msg_id {:?}, operation_id {}",
+                    msg_id, operation_id
                 );
                 // There is no point in verifying a sig from a sender A or B here.
                 // Send back response to the sending elder
                 Ok(vec![
                     self.handle_data_query_at_adult(
-                        correlation_id,
+                        operation_id,
                         &query,
                         auth,
-                        origin,
                         sender,
                         #[cfg(feature = "traceroute")]
                         traceroute,
@@ -496,26 +493,12 @@ impl Node {
             }
             NodeMsg::NodeQueryResponse {
                 response,
-                correlation_id,
-                user,
+                operation_id,
             } => {
-                let op_id = if let Ok(op_id) = response.operation_id() {
-                    op_id
-                } else {
-                    debug!(
-                        "{:?}: op_id None, correlation_id: {correlation_id:?}, sender: {sender} origin msg_id: {msg_id:?}",
-                        LogMarker::ChunkQueryResponseReceviedFromAdult,
-                    );
-                    warn!(
-                        "There is no operation id. Dropping chunk query response from Adult {sender}, for user: {}.",
-                        user.0
-                    );
-                    return Ok(vec![]);
-                };
-
                 debug!(
-                    "{:?}: op_id {op_id:?}, correlation_id: {correlation_id:?}, sender: {sender} origin msg_id: {msg_id:?}",
+                    "{:?}: op_id {}, sender: {sender} origin msg_id: {msg_id:?}",
                     LogMarker::ChunkQueryResponseReceviedFromAdult,
+                    operation_id
                 );
 
                 match msg_authority {
@@ -523,11 +506,9 @@ impl Node {
                         let sending_nodes_pk = PublicKey::from(auth.into_inner().node_ed_pk);
                         Ok(self
                             .handle_data_query_response_at_elder(
-                                correlation_id,
+                                operation_id,
                                 response,
-                                user,
                                 sending_nodes_pk,
-                                op_id,
                                 #[cfg(feature = "traceroute")]
                                 traceroute,
                             )

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -32,8 +32,8 @@ mod statemap;
 use self::{
     bootstrap::join_network,
     core::{
-        Node, StateSnapshot, DATA_QUERY_LIMIT, GENESIS_DBC_AMOUNT, MAX_WAITING_PEERS_PER_QUERY,
-        RESOURCE_PROOF_DATA_SIZE, RESOURCE_PROOF_DIFFICULTY,
+        Node, StateSnapshot, DATA_QUERY_LIMIT, GENESIS_DBC_AMOUNT, RESOURCE_PROOF_DATA_SIZE,
+        RESOURCE_PROOF_DIFFICULTY,
     },
     data::MIN_LEVEL_WHEN_FULL,
     flow_ctrl::{
@@ -89,10 +89,9 @@ mod core {
 
     use sn_interface::{
         messaging::{
-            data::OperationId,
             signature_aggregator::SignatureAggregator,
-            system::{DkgSessionId, NodeState, SectionSigned},
-            AuthorityProof, SectionAuthorityProvider, SectionSig,
+            system::{DkgSessionId, NodeState, OperationId, SectionSigned},
+            AuthorityProof, MsgId, SectionAuthorityProvider, SectionSig,
         },
         network_knowledge::{
             supermajority, NetworkKnowledge, NodeInfo,
@@ -127,10 +126,6 @@ mod core {
     // This prevents pending query limit unbound growth
     // One insert per OpId/Adult.
     pub(crate) const DATA_QUERY_LIMIT: usize = 10_000;
-    // per query we can have this many peers, so the total peers waiting can be QUERY_LIMIT * MAX_WAITING_PEERS_PER_QUERY
-    // It's worth noting that nodes clean up all connections every two mins, so this max can only last that long.
-    // (and yes, some clients may unfortunately be disconnected quickly)
-    pub(crate) const MAX_WAITING_PEERS_PER_QUERY: usize = 100;
 
     const BACKOFF_CACHE_LIMIT: usize = 100;
 
@@ -188,7 +183,7 @@ mod core {
         pub(crate) capacity: Capacity,
         pub(crate) dysfunction_tracking: DysfunctionDetection,
         /// Cache the request combo,  (OperationId -> An adult xorname), to waiting Clients peers for that combo
-        pub(crate) pending_data_queries: Cache<(OperationId, XorName), BTreeSet<Peer>>,
+        pub(crate) pending_data_queries: Cache<(OperationId, XorName), (MsgId, Peer)>,
         // Caches
         pub(crate) ae_backoff_cache: AeBackoffCache,
     }

--- a/sn_node/src/storage/registers.rs
+++ b/sn_node/src/storage/registers.rs
@@ -14,8 +14,8 @@ use super::{
 use sn_interface::{
     messaging::{
         data::{
-            CreateRegister, EditRegister, OperationId, RegisterCmd, RegisterQuery,
-            SignedRegisterCreate, SignedRegisterEdit,
+            CreateRegister, EditRegister, RegisterCmd, RegisterQuery, SignedRegisterCreate,
+            SignedRegisterEdit,
         },
         system::NodeQueryResponse,
         ClientAuth, SectionSig, VerifyAuthority,
@@ -122,27 +122,16 @@ impl RegisterStorage {
     /// --- Reading ---
 
     pub(super) async fn read(&self, read: &RegisterQuery, requester: User) -> NodeQueryResponse {
-        trace!("Reading register {:?}", read.dst_address());
-        let operation_id = match read.operation_id() {
-            Ok(id) => id,
-            Err(_e) => {
-                return NodeQueryResponse::FailedToCreateOperationId;
-            }
-        };
-        trace!("Operation of register read: {:?}", operation_id);
+        trace!("Reading register: {:?}", read.dst_address());
         use RegisterQuery::*;
         match read {
-            Get(address) => self.get(*address, requester, operation_id).await,
-            Read(address) => self.read_register(*address, requester, operation_id).await,
-            GetOwner(address) => self.get_owner(*address, requester, operation_id).await,
-            GetEntry { address, hash } => {
-                self.get_entry(*address, *hash, requester, operation_id)
-                    .await
-            }
-            GetPolicy(address) => self.get_policy(*address, requester, operation_id).await,
+            Get(address) => self.get(*address, requester).await,
+            Read(address) => self.read_register(*address, requester).await,
+            GetOwner(address) => self.get_owner(*address, requester).await,
+            GetEntry { address, hash } => self.get_entry(*address, *hash, requester).await,
+            GetPolicy(address) => self.get_policy(*address, requester).await,
             GetUserPermissions { address, user } => {
-                self.get_user_permissions(*address, *user, requester, operation_id)
-                    .await
+                self.get_user_permissions(*address, *user, requester).await
             }
         }
     }
@@ -167,12 +156,7 @@ impl RegisterStorage {
     }
 
     /// Get entire Register.
-    async fn get(
-        &self,
-        address: RegisterAddress,
-        requester: User,
-        operation_id: OperationId,
-    ) -> NodeQueryResponse {
+    async fn get(&self, address: RegisterAddress, requester: User) -> NodeQueryResponse {
         let result = match self.get_register(&address, Action::Read, requester).await {
             Ok(register) => Ok(register),
             Err(error) => {
@@ -181,35 +165,25 @@ impl RegisterStorage {
             }
         };
 
-        NodeQueryResponse::GetRegister((result, operation_id))
+        NodeQueryResponse::GetRegister(result)
     }
 
-    async fn read_register(
-        &self,
-        address: RegisterAddress,
-        requester: User,
-        operation_id: OperationId,
-    ) -> NodeQueryResponse {
+    async fn read_register(&self, address: RegisterAddress, requester: User) -> NodeQueryResponse {
         let result = match self.get_register(&address, Action::Read, requester).await {
             Ok(register) => Ok(register.read()),
             Err(error) => Err(error),
         };
 
-        NodeQueryResponse::ReadRegister((result.map_err(|error| error.into()), operation_id))
+        NodeQueryResponse::ReadRegister(result.map_err(|error| error.into()))
     }
 
-    async fn get_owner(
-        &self,
-        address: RegisterAddress,
-        requester: User,
-        operation_id: OperationId,
-    ) -> NodeQueryResponse {
+    async fn get_owner(&self, address: RegisterAddress, requester: User) -> NodeQueryResponse {
         let result = match self.get_register(&address, Action::Read, requester).await {
             Ok(res) => Ok(res.owner()),
             Err(error) => Err(error.into()),
         };
 
-        NodeQueryResponse::GetRegisterOwner((result, operation_id))
+        NodeQueryResponse::GetRegisterOwner(result)
     }
 
     async fn get_entry(
@@ -217,7 +191,6 @@ impl RegisterStorage {
         address: RegisterAddress,
         hash: EntryHash,
         requester: User,
-        operation_id: OperationId,
     ) -> NodeQueryResponse {
         let result = match self
             .get_register(&address, Action::Read, requester)
@@ -228,7 +201,7 @@ impl RegisterStorage {
             Err(error) => Err(error.into()),
         };
 
-        NodeQueryResponse::GetRegisterEntry((result, operation_id))
+        NodeQueryResponse::GetRegisterEntry(result)
     }
 
     async fn get_user_permissions(
@@ -236,7 +209,6 @@ impl RegisterStorage {
         address: RegisterAddress,
         user: User,
         requester: User,
-        operation_id: OperationId,
     ) -> NodeQueryResponse {
         let result = match self
             .get_register(&address, Action::Read, requester)
@@ -247,15 +219,10 @@ impl RegisterStorage {
             Err(error) => Err(error.into()),
         };
 
-        NodeQueryResponse::GetRegisterUserPermissions((result, operation_id))
+        NodeQueryResponse::GetRegisterUserPermissions(result)
     }
 
-    async fn get_policy(
-        &self,
-        address: RegisterAddress,
-        requester_pk: User,
-        operation_id: OperationId,
-    ) -> NodeQueryResponse {
+    async fn get_policy(&self, address: RegisterAddress, requester_pk: User) -> NodeQueryResponse {
         let result = match self
             .get_register(&address, Action::Read, requester_pk)
             .await
@@ -265,7 +232,7 @@ impl RegisterStorage {
             Err(error) => Err(error.into()),
         };
 
-        NodeQueryResponse::GetRegisterPolicy((result, operation_id))
+        NodeQueryResponse::GetRegisterPolicy(result)
     }
 
     // ========================================================================
@@ -694,7 +661,7 @@ mod test {
         // get register
         let address = cmd.dst_address();
         match store.read(&RegisterQuery::Get(address), authority).await {
-            NodeQueryResponse::GetRegister((Ok(reg), _)) => {
+            NodeQueryResponse::GetRegister(Ok(reg)) => {
                 assert_eq!(reg.address(), &address, "Should have same address!");
                 assert_eq!(reg.owner(), authority, "Should have same owner!");
             }
@@ -774,7 +741,7 @@ mod test {
         let res = new_store.read(&RegisterQuery::Get(addr), authority).await;
 
         match res {
-            NodeQueryResponse::GetRegister((Ok(reg), _)) => {
+            NodeQueryResponse::GetRegister(Ok(reg)) => {
                 assert_eq!(reg.address(), &addr, "Should have same address!");
                 assert_eq!(reg.owner(), authority, "Should have same owner!");
             }
@@ -801,10 +768,10 @@ mod test {
             .read(&RegisterQuery::GetEntry { address, hash }, authority)
             .await;
         match res {
-            NodeQueryResponse::GetRegisterEntry((Err(e), _)) => {
+            NodeQueryResponse::GetRegisterEntry(Err(e)) => {
                 assert_eq!(e, sn_interface::messaging::data::Error::NoSuchEntry)
             }
-            NodeQueryResponse::GetRegisterEntry((Ok(entry), _)) => {
+            NodeQueryResponse::GetRegisterEntry(Ok(entry)) => {
                 panic!("Should not exist any entry for random hash! {:?}", entry)
             }
             e => panic!("Could not read! {:?}", e),
@@ -833,10 +800,10 @@ mod test {
             )
             .await;
         match res {
-            NodeQueryResponse::GetRegisterUserPermissions((Err(e), _)) => {
+            NodeQueryResponse::GetRegisterUserPermissions(Err(e)) => {
                 assert_eq!(e, sn_interface::messaging::data::Error::NoSuchEntry)
             }
-            NodeQueryResponse::GetRegisterUserPermissions((Ok(perms), _)) => panic!(
+            NodeQueryResponse::GetRegisterUserPermissions(Ok(perms)) => panic!(
                 "Should not exist any permissions for random user! {:?}",
                 perms
             ),


### PR DESCRIPTION
- Generate query/cmd `OperationId` from the query msg id when received at Elders to
  track the response from Adults.
- Removing correlation id from `SystemMsg` node query/response
- Redefine system::`NodeQueryResponse` type just as an alias to data::QueryResponse
- Removing `OperationId` from `ClientMsg` msgs
- Removing `OperationId` from sn_client queries/responses tracker
- Removing `correlation_id` from `SystemMsg` node query/response msgs
- Returning error to client when an Elder is already handling a query with the same msg id and target Adult.