### PR TITLE
refactor(messaging)!: breaking up client msg type separating requests from responses

### DIFF
--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -60,7 +60,7 @@ impl Client {
         let dst_name = cmd.dst_name();
 
         let debug_cmd = format!("{:?}", cmd);
-        debug!("Attempting {:?}", debug_cmd);
+        debug!("Attempting {debug_cmd}");
 
         let serialised_cmd = {
             let msg = ClientMsg::Cmd(cmd);
@@ -80,9 +80,9 @@ impl Client {
             .await;
 
         if res.is_ok() {
-            debug!("{debug_cmd} sent okay: {:?}", res);
+            debug!("{debug_cmd} sent okay: {res:?}");
         } else {
-            trace!("Failed response on {debug_cmd} cmd: {:?}", res);
+            trace!("Failed response on {debug_cmd} cmd: {res:?}");
         }
 
         res

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -8,9 +8,9 @@
 
 use sn_interface::{
     messaging::{
-        data::{ClientMsg, DataQueryVariant, Error as ErrorMsg, QueryResponse},
+        data::{DataQueryVariant, Error as ErrorMsg, QueryResponse},
         system::NodeMsg,
-        Error as MessagingError, MsgId,
+        Error as MessagingError, MsgId, MsgType,
     },
     types::{Error as DtError, Peer},
 };
@@ -146,24 +146,24 @@ pub enum Error {
         response: QueryResponse,
     },
     /// Unexpected NodeMsg received
-    #[error("Unexpected type of NodeMsg received from {peer} in response to {msg_id:?}. Received: {msg:?}")]
+    #[error("Unexpected type of NodeMsg received from {peer} in response to {correlation_id:?}. Received: {msg:?}")]
     UnexpectedNodeMsg {
         /// MsgId of the msg sent
-        msg_id: MsgId,
+        correlation_id: MsgId,
         /// Peer the unexpected msg was received from
         peer: Peer,
         /// Unexpected msg received
         msg: NodeMsg,
     },
-    /// Unexpected ClientMsg received
-    #[error("Unexpected type of ClientMsg received from {peer} in response to {msg_id:?}. Received: {msg:?}")]
-    UnexpectedClientMsg {
+    /// Unexpected msg type received
+    #[error("Unexpected type of message received from {peer} in response to {correlation_id:?}. Received: {msg:?}")]
+    UnexpectedMsgType {
         /// MsgId of the msg sent
-        msg_id: MsgId,
+        correlation_id: MsgId,
         /// Peer the unexpected msg was received from
         peer: Peer,
         /// Unexpected msg received
-        msg: ClientMsg,
+        msg: MsgType,
     },
     /// Other types errors
     #[error(transparent)]

--- a/sn_interface/src/messaging/msg_kind.rs
+++ b/sn_interface/src/messaging/msg_kind.rs
@@ -12,8 +12,8 @@ use xor_name::XorName;
 
 /// Message Kind
 ///
-/// There are two kinds of messages, messages from clients (apps, browser, cli clients, ...)
-/// and messages from Network Nodes
+/// There are three kinds of messages, messages from clients (apps, browser, cli clients, ...),
+/// response to clients from Network Nodes, and messages among Network Nodes
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum MsgKind {
@@ -21,6 +21,8 @@ pub enum MsgKind {
     /// A data message, with the requesting peer's authority.
     /// Authority is needed to access private data, such as reading or writing a private file.
     Client(ClientAuth),
+    /// A data response sent from a Node (along with its name) to the client
+    ClientMsgResponse(XorName),
     /// A message from a Node along with its name
     Node(XorName),
 }

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -8,8 +8,9 @@
 
 use super::wire_msg_header::WireMsgHeader;
 use crate::messaging::{
-    data::ClientMsg, system::NodeMsg, AuthorityProof, ClientAuth, Dst, Error, MsgId, MsgKind,
-    MsgType, Result,
+    data::{ClientMsg, ClientMsgResponse},
+    system::NodeMsg,
+    AuthorityProof, ClientAuth, Dst, Error, MsgId, MsgKind, MsgType, Result,
 };
 
 use bytes::Bytes;
@@ -192,6 +193,18 @@ impl WireMsg {
                     msg_id: self.header.msg_envelope.msg_id,
                     auth,
                     dst: self.dst,
+                    msg,
+                })
+            }
+            #[cfg(any(feature = "chunks", feature = "registers"))]
+            MsgKind::ClientMsgResponse(_) => {
+                let msg: ClientMsgResponse =
+                    rmp_serde::from_slice(&self.payload).map_err(|err| {
+                        Error::FailedToParse(format!("Data message payload as Msgpack: {}", err))
+                    })?;
+
+                Ok(MsgType::ClientMsgResponse {
+                    msg_id: self.header.msg_envelope.msg_id,
                     msg,
                 })
             }

--- a/sn_node/src/comm/listener.rs
+++ b/sn_node/src/comm/listener.rs
@@ -76,7 +76,7 @@ impl MsgListener {
 
                     let src_name = match wire_msg.kind() {
                         MsgKind::Client(auth) => auth.public_key.into(),
-                        MsgKind::Node(name) => *name,
+                        MsgKind::Node(name) | MsgKind::ClientMsgResponse(name) => *name,
                     };
 
                     if first {

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -389,7 +389,11 @@ impl<'a> Joiner<'a> {
                     msg: NodeMsg::JoinResponse(resp),
                     ..
                 }) => return Ok((*resp, sender)),
-                Ok(MsgType::Client { msg_id, .. } | MsgType::Node { msg_id, .. }) => {
+                Ok(
+                    MsgType::Client { msg_id, .. }
+                    | MsgType::ClientMsgResponse { msg_id, .. }
+                    | MsgType::Node { msg_id, .. },
+                ) => {
                     trace!("Bootstrap message discarded: sender: {sender:?} msg_id: {msg_id:?}");
                 }
                 Err(err) => {

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -17,7 +17,9 @@ use sn_interface::messaging::{MsgType, WireMsg};
 use sn_interface::{
     data_copy_count,
     messaging::{
-        data::{ClientMsg, CmdResponse, DataCmd, DataQuery, MetadataExchange, StorageLevel},
+        data::{
+            ClientMsgResponse, CmdResponse, DataCmd, DataQuery, MetadataExchange, StorageLevel,
+        },
         system::{NodeCmd, NodeEvent, NodeMsg, NodeQuery, OperationId},
         AuthorityProof, ClientAuth, Dst, MsgId, MsgKind,
     },
@@ -156,12 +158,12 @@ impl MyNode {
             ..
         } = response.into_msg()?
         {
-            let client_msg = ClientMsg::CmdResponse {
+            let client_msg = ClientMsgResponse::CmdResponse {
                 response: CmdResponse::StoreChunk(Ok(())),
                 correlation_id: msg_id,
             };
 
-            let (kind, payload) = self.serialize_sign_client_msg(client_msg)?;
+            let (kind, payload) = self.serialize_client_msg_response(client_msg)?;
 
             debug!("{msg_id:?} sending cmd response ack back to client");
             self.send_msg_on_stream(
@@ -266,12 +268,12 @@ impl MyNode {
             ..
         } = response.into_msg()?
         {
-            let client_msg = ClientMsg::QueryResponse {
+            let client_msg = ClientMsgResponse::QueryResponse {
                 response,
                 correlation_id: msg_id,
             };
 
-            let (kind, payload) = self.serialize_sign_client_msg(client_msg)?;
+            let (kind, payload) = self.serialize_client_msg_response(client_msg)?;
 
             self.send_msg_on_stream(payload, kind, client_response_stream, Some(target), msg_id)
                 .await?;

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -207,8 +207,8 @@ impl Cmd {
         }
     }
 
-    // /// Get a `ClientMsg` from a `Cmd::SendMsg` enum variant.
-    // pub(crate) fn get_client_msg(&self) -> Result<ClientMsg> {
+    // /// Get a `ClientMsgResponse` from a `Cmd::SendMsg` enum variant.
+    // pub(crate) fn get_client_msg_resp(&self) -> Result<ClientMsgResponse> {
     //     match self {
     //         Cmd::SendMsg { msg, .. } => match msg {
     //             OutgoingMsg::Client(client_msg) => Ok(client_msg.clone()),
@@ -223,11 +223,11 @@ impl Cmd {
     //     match self {
     //         Cmd::SendMsg { msg, .. } => match msg {
     //             OutgoingMsg::Client(client_msg) => match client_msg {
-    //                 ClientMsg::CmdResponse { response, .. } => match response.result() {
+    //                 ClientMsgResponse::CmdResponse { response, .. } => match response.result() {
     //                     Ok(_) => Err(eyre!("A CmdResponse error was expected")),
     //                     Err(error) => Ok(error.clone()),
     //                 },
-    //                 _ => Err(eyre!("A ClientMsg::CmdResponse variant was expected")),
+    //                 _ => Err(eyre!("A ClientMsgResponse::CmdResponse variant was expected")),
     //             },
     //             _ => Err(eyre!("A OutgoingMsg::Client variant was expected")),
     //         },

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -1118,8 +1118,8 @@ async fn spentbook_spend_client_message_should_replicate_to_adults_and_send_ack(
                 spent_proof_share.spentbook_pks().public_key().to_hex()
             );
 
-            // let client_msg = cmds[1].clone().get_client_msg()?;
-            // assert_matches!(client_msg, ClientMsg::CmdResponse { response, .. } => response.is_success());
+            // let client_msg_resp = cmds[1].clone().get_client_msg_resp()?;
+            // assert_matches!(client_msg_resp, ClientMsgResponse::CmdResponse { .. });
 
             Result::<()>::Ok(())
         })

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -18,7 +18,8 @@ use sn_interface::{
     data_copy_count,
     messaging::{
         data::{
-            ClientMsg, DataCmd, DataQueryVariant, EditRegister, SignedRegisterEdit, SpentbookCmd,
+            ClientMsg, ClientMsgResponse, DataCmd, DataQueryVariant, EditRegister,
+            SignedRegisterEdit, SpentbookCmd,
         },
         system::{NodeMsg, OperationId},
         AuthorityProof, ClientAuth, MsgId,
@@ -46,12 +47,12 @@ impl MyNode {
         correlation_id: MsgId,
         send_stream: Arc<Mutex<SendStream>>,
     ) -> Result<()> {
-        let the_error_msg = ClientMsg::QueryResponse {
+        let the_error_msg = ClientMsgResponse::QueryResponse {
             response: query.to_error_response(error.into()),
             correlation_id,
         };
 
-        let (kind, payload) = self.serialize_sign_client_msg(the_error_msg)?;
+        let (kind, payload) = self.serialize_client_msg_response(the_error_msg)?;
 
         self.send_msg_on_stream(
             payload,
@@ -71,12 +72,12 @@ impl MyNode {
         correlation_id: MsgId,
         send_stream: Arc<Mutex<SendStream>>,
     ) -> Result<()> {
-        let client_msg = ClientMsg::CmdResponse {
+        let client_msg = ClientMsgResponse::CmdResponse {
             response: cmd.to_error_response(error.into()),
             correlation_id,
         };
 
-        let (kind, payload) = self.serialize_sign_client_msg(client_msg)?;
+        let (kind, payload) = self.serialize_client_msg_response(client_msg)?;
 
         debug!("{correlation_id:?} sending cmd response error back to client");
         self.send_msg_on_stream(
@@ -168,13 +169,6 @@ impl MyNode {
                         send_stream,
                     )
                     .await
-            }
-            _ => {
-                warn!(
-                    "!!!! Unexpected ClientMsg received, and it was not handled: {:?}",
-                    msg
-                );
-                return Ok(vec![]);
             }
         };
 

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -125,18 +125,7 @@ impl MyNode {
                 // if it's otherwise a response for a client we shall skip drop it.
                 let dst_name = match &msg {
                     ClientMsg::Cmd(cmd) => cmd.dst_name(),
-
                     ClientMsg::Query(query) => query.variant.dst_name(),
-                    other => {
-                        error!(
-                            "Client msg {:?}, from {}, has been dropped since it's not meant \
-                            to be handled by a node: {:?}",
-                            msg_id,
-                            origin.addr(),
-                            other
-                        );
-                        return Ok(vec![]);
-                    }
                 };
 
                 // Then we perform AE checks
@@ -155,6 +144,14 @@ impl MyNode {
                 debug!("no aeeee");
                 self.handle_valid_client_msg(msg_id, msg, auth, origin, send_stream.clone())
                     .await
+            }
+            other @ MsgType::ClientMsgResponse { .. } => {
+                error!(
+                    "Client msg response {msg_id:?}, from {}, has been dropped since it's not \
+                    meant to be handled by a node: {other:?}",
+                    origin.addr()
+                );
+                Ok(vec![])
             }
         }
     }

--- a/sn_node/src/node/messaging/serialize.rs
+++ b/sn_node/src/node/messaging/serialize.rs
@@ -8,29 +8,23 @@
 
 use crate::node::{MyNode, Result};
 
-use sn_interface::{
-    messaging::{data::ClientMsg, system::NodeMsg, ClientAuth, MsgKind, WireMsg},
-    types::{PublicKey, Signature},
-};
+use sn_interface::messaging::{data::ClientMsgResponse, system::NodeMsg, MsgKind, WireMsg};
 
 use bytes::Bytes;
-use signature::Signer;
 
 impl MyNode {
-    /// Serialize and sign a message for a Client with our ed key
-    pub(crate) fn serialize_sign_client_msg(&self, msg: ClientMsg) -> Result<(MsgKind, Bytes)> {
+    /// Serialize a message for a Client
+    pub(crate) fn serialize_client_msg_response(
+        &self,
+        msg: ClientMsgResponse,
+    ) -> Result<(MsgKind, Bytes)> {
         let payload = WireMsg::serialize_msg_payload(&msg)?;
-        let signature = self.keypair.sign(&payload);
-
-        let kind = MsgKind::Client(ClientAuth {
-            public_key: PublicKey::Ed25519(self.keypair.public),
-            signature: Signature::Ed25519(signature),
-        });
+        let kind = MsgKind::ClientMsgResponse(self.name());
 
         Ok((kind, payload))
     }
 
-    /// Serialize a message for a Node with our ed key
+    /// Serialize a message for a Node
     pub(crate) fn serialize_node_msg(&self, msg: NodeMsg) -> Result<(MsgKind, Bytes)> {
         let payload = WireMsg::serialize_msg_payload(&msg)?;
         let kind = MsgKind::Node(self.name());


### PR DESCRIPTION
- A new messaging type `ClientMsgResponse` is introduced explicitly for client msg responses.
- With new msg type, a new msg kind `MsgKind::ClientMsgResponse` is introduced which removes the need of providing a fake client authority in each of the responses sent by nodes to clients.

Nest step would be to have all types of Anti Entropy responses for clients to be part of `ClientMsgResponse` instead of having clients to accept `NodeMsg::AntiEntropy` messages.