### PR TITLE
 Add port 16685 to docker run command for OTLP

### DIFF
--- a/sn_node/README.md
+++ b/sn_node/README.md
@@ -21,6 +21,7 @@ Before running the node, an OTLP endpoint should be available. An example of an 
 ```
 docker run --name jaeger \
   -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16685:16685 \
   -p 16686:16686 \
   -p 4317:4317 \
   -p 4318:4318 \


### PR DESCRIPTION
fixes    [GRPC server 16685 connection refused ](https://github.com/jaegertracing/jaeger/issues/3852) issues with the  jaeger all-in-one image preventing sn_node traces being visible on the Jaeger UI

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
