### PR TITLE
refactor: adapt confusing auth related code

### DIFF
--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -154,8 +154,8 @@ impl Session {
             .cloned()
             .collect();
 
-        if !NetworkKnowledge::verify_node_msg_can_be_trusted(&msg_authority, &msg, &known_keys) {
-            warn!("Untrusted message has been dropped, from {sender:?}: {msg:?} ");
+        if !NetworkKnowledge::verify_msg_section_key(&msg_authority, &msg, &known_keys) {
+            warn!("Message with unknown section key has been dropped, from {sender:?}: {msg:?} ");
             let pk = msg_authority.src_public_key();
             return Err(Error::UntrustedMessage(pk));
         }

--- a/sn_interface/src/messaging/serialisation/mod.rs
+++ b/sn_interface/src/messaging/serialisation/mod.rs
@@ -13,7 +13,6 @@ pub use self::wire_msg::WireMsg;
 #[cfg(feature = "traceroute")]
 pub use self::wire_msg::{Entity, Traceroute};
 use super::{AuthorityProof, NodeSig, SectionSig, SectionSigShare};
-use std::collections::BTreeSet;
 
 /// Authority of a `NodeMsg`.
 /// Src of message and authority to send it. Authority is validated by the signature.
@@ -28,17 +27,6 @@ pub enum NodeMsgAuthority {
 }
 
 impl NodeMsgAuthority {
-    pub fn verify_src_section_key_is_known(&self, known_keys: &BTreeSet<bls::PublicKey>) -> bool {
-        let section_pk = match &self {
-            // NB TODO this shouldnt be true! Remove all this
-            Self::Node(_) => return true,
-            Self::BlsShare(bls_share_auth) => bls_share_auth.public_key_set.public_key(),
-            Self::Section(section_auth) => section_auth.public_key,
-        };
-
-        known_keys.contains(&section_pk)
-    }
-
     pub fn src_public_key(&self) -> bls::PublicKey {
         match self {
             Self::Node(node_auth) => node_auth.section_pk,

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -383,7 +383,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
                 let (payload, recipients) = match cmd {
                     Cmd::SendMsg {
                         recipients,
-                        msg: OutgoingMsg::SectionAuth((_, payload)),
+                        msg: OutgoingMsg::Elder((_, payload)),
                         ..
                     } => (payload, recipients),
                     _ => continue,

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -504,7 +504,7 @@ mod tests {
                 let (msg, msg_authority) = env.create_update_msg(proof_chain)?;
 
                 // AeUpdate message shall get pass through.
-                assert!(NetworkKnowledge::verify_node_msg_can_be_trusted(
+                assert!(NetworkKnowledge::verify_msg_section_key(
                     &msg_authority,
                     &msg,
                     &known_keys
@@ -514,7 +514,7 @@ mod tests {
                 let other_env = Env::new().await?;
                 let (corrupted_msg, _msg_authority) =
                     env.create_update_msg(other_env.proof_chain)?;
-                assert!(!NetworkKnowledge::verify_node_msg_can_be_trusted(
+                assert!(!NetworkKnowledge::verify_msg_section_key(
                     &msg_authority,
                     &corrupted_msg,
                     &known_keys
@@ -522,7 +522,7 @@ mod tests {
 
                 // Other messages shall get rejected.
                 let other_msg = NodeMsg::AntiEntropyProbe(known_key);
-                assert!(!NetworkKnowledge::verify_node_msg_can_be_trusted(
+                assert!(!NetworkKnowledge::verify_msg_section_key(
                     &msg_authority,
                     &other_msg,
                     &known_keys

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -104,7 +104,7 @@ impl Node {
 
         if !others.is_empty() {
             cmds.push(Cmd::send_msg(
-                OutgoingMsg::SectionAuth((auth.clone(), payload.clone())),
+                OutgoingMsg::Elder((auth.clone(), payload.clone())),
                 Peers::Multiple(others),
             ));
         }

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -38,7 +38,7 @@ use std::collections::BTreeSet;
 pub(crate) enum OutgoingMsg {
     Node(NodeMsg),
     Client(ClientMsg),
-    SectionAuth((SectionSigShare, Bytes)),
+    Elder((SectionSigShare, Bytes)),
 }
 
 #[derive(Debug, Clone)]
@@ -185,7 +185,7 @@ impl Node {
     #[instrument(skip_all)]
     async fn verify_section_key(&self, msg_authority: &NodeMsgAuthority, msg: &NodeMsg) -> bool {
         let known_keys = self.network_knowledge.known_keys();
-        NetworkKnowledge::verify_node_msg_can_be_trusted(msg_authority, msg, &known_keys)
+        NetworkKnowledge::verify_msg_section_key(msg_authority, msg, &known_keys)
     }
 
     /// Check if the origin needs to be updated on network structure/members.

--- a/sn_node/src/node/messaging/signing.rs
+++ b/sn_node/src/node/messaging/signing.rs
@@ -29,9 +29,7 @@ impl Node {
         match msg {
             OutgoingMsg::Node(msg) => self.sign_system_msg(msg),
             OutgoingMsg::Client(msg) => self.sign_client_msg(msg),
-            OutgoingMsg::SectionAuth((auth, payload)) => {
-                Ok((AuthKind::SectionShare(auth), payload))
-            }
+            OutgoingMsg::Elder((auth, payload)) => Ok((AuthKind::SectionShare(auth), payload)),
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

Removes the confusion @dirvine pointed out around:

```rust
pub fn verify_src_section_key_is_known(&self, known_keys: &BTreeSet<bls::PublicKey>) -> bool {
         let section_pk = match &self {
             // NB TODO this shouldnt be true! Remove all this
             Self::Node(_) => return true,
```