### PR TITLE
Sign Registers and Chunks with Section Key

### DIFF
--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -27,7 +27,7 @@ use sn_interface::{
         ClientAuth, WireMsg,
     },
     network_knowledge::SectionTree,
-    types::{Chunk, Keypair, PublicKey, RegisterAddress},
+    types::{Keypair, PublicKey, RegisterAddress, SignedChunk},
 };
 
 use bytes::Bytes;
@@ -50,7 +50,7 @@ const CHUNK_CACHE_SIZE: usize = 50;
 const NETWORK_PROBE_RETRY_COUNT: usize = 5; // 5 x 5 second wait in between = ~25 seconds (plus ~ 3 seconds in between attempts internal to `make_contact`)
 
 // LRU cache to keep the Chunks we retrieve.
-type ChunksCache = LRUCache<Chunk, CHUNK_CACHE_SIZE>;
+type ChunksCache = LRUCache<SignedChunk, CHUNK_CACHE_SIZE>;
 
 /// Client object
 #[derive(Clone, Debug)]

--- a/sn_client/src/bin/query-adult/main.rs
+++ b/sn_client/src/bin/query-adult/main.rs
@@ -10,7 +10,7 @@ use sn_interface::{
         data::{ClientMsg, DataQuery, DataQueryVariant, QueryResponse},
         WireMsg,
     },
-    types::{Chunk, ChunkAddress},
+    types::{ChunkAddress, SignedChunk},
 };
 use std::{
     fs::File,
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn query_chunk(client: &Client, adult_index: usize, address: XorName) -> Result<Chunk> {
+async fn query_chunk(client: &Client, adult_index: usize, address: XorName) -> Result<SignedChunk> {
     let variant = DataQueryVariant::GetChunk(ChunkAddress(address));
     let query = DataQuery {
         adult_index,

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -243,14 +243,15 @@ impl Session {
         let response = loop {
             let mut error_response = None;
             match (receiver.recv().await, chunk_addr) {
-                (Some(QueryResponse::GetChunk(Ok(chunk))), Some(chunk_addr)) => {
+                (Some(QueryResponse::GetChunk(Ok(signed_chunk))), Some(chunk_addr)) => {
                     // We are dealing with Chunk query responses, thus we validate its hash
                     // matches its xorname, if so, we don't need to await for more responses
+                    let chunk = &signed_chunk.chunk;
                     debug!("Chunk QueryResponse received is: {:#?}", chunk);
 
                     if chunk_addr.name() == chunk.name() {
                         trace!("Valid Chunk received for {:?}", msg_id);
-                        break Some(QueryResponse::GetChunk(Ok(chunk)));
+                        break Some(QueryResponse::GetChunk(Ok(signed_chunk)));
                     } else {
                         // the Chunk content doesn't match its XorName,
                         // this is suspicious and it could be a byzantine node

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
 
 use crate::messaging::{data::Error as ErrorMsg, MsgId};
 use crate::types::{
-    register::{Entry, EntryHash, Permissions, Policy, Register, User},
+    register::{Entry, EntryHash, Permissions, Policy, SignedRegister, User},
     utils, ChunkAddress, DataAddress, SignedChunk,
 };
 
@@ -169,7 +169,7 @@ pub enum QueryResponse {
     // ===== Register Data =====
     //
     /// Response to [`RegisterQuery::Get`].
-    GetRegister((Result<Register>, OperationId)),
+    GetRegister((Result<SignedRegister>, OperationId)),
     /// Response to [`RegisterQuery::GetEntry`].
     GetRegisterEntry((Result<Entry>, OperationId)),
     /// Response to [`RegisterQuery::GetOwner`].
@@ -300,7 +300,7 @@ impl TryFrom<QueryResponse> for SignedChunk {
     }
 }
 
-try_from!(Register, GetRegister);
+try_from!(SignedRegister, GetRegister);
 try_from!(User, GetRegisterOwner);
 try_from!(BTreeSet<(EntryHash, Entry)>, ReadRegister);
 try_from!(Policy, GetRegisterPolicy);

--- a/sn_interface/src/messaging/data/register.rs
+++ b/sn_interface/src/messaging/data/register.rs
@@ -83,7 +83,7 @@ pub enum RegisterCmd {
         cmd: SignedRegisterCreate,
         /// Section signature over the operation,
         /// verifying that it was paid for.
-        section_sig: SectionSig,
+        section_sig: Option<SectionSig>,
     },
     /// Edit the [`Register`].
     Edit(SignedRegisterEdit),
@@ -238,6 +238,13 @@ impl RegisterCmd {
                 cmd: SignedRegisterCreate { op, .. },
                 ..
             } => Some(op.owner()),
+            _ => None,
+        }
+    }
+
+    pub fn section_sig(&self) -> Option<SectionSig> {
+        match self {
+            Self::Create { section_sig, .. } => section_sig.clone(),
             _ => None,
         }
     }

--- a/sn_interface/src/messaging/system/node_msgs.rs
+++ b/sn_interface/src/messaging/system/node_msgs.rs
@@ -11,7 +11,7 @@ use crate::messaging::{
     ClientAuth, EndUser, MsgId,
 };
 use crate::types::{
-    register::{Entry, EntryHash, Permissions, Policy, Register, User},
+    register::{Entry, EntryHash, Permissions, Policy, SignedRegister, User},
     DataAddress, PublicKey, ReplicatedData, SignedChunk,
 };
 
@@ -95,7 +95,7 @@ pub enum NodeQueryResponse {
     //
     #[cfg(feature = "registers")]
     /// Response to [`crate::messaging::data::RegisterQuery::Get`].
-    GetRegister((Result<Register>, OperationId)),
+    GetRegister((Result<SignedRegister>, OperationId)),
     #[cfg(feature = "registers")]
     /// Response to [`crate::messaging::data::RegisterQuery::GetOwner`].
     GetRegisterOwner((Result<User>, OperationId)),

--- a/sn_interface/src/messaging/system/node_msgs.rs
+++ b/sn_interface/src/messaging/system/node_msgs.rs
@@ -12,7 +12,7 @@ use crate::messaging::{
 };
 use crate::types::{
     register::{Entry, EntryHash, Permissions, Policy, Register, User},
-    Chunk, DataAddress, PublicKey, ReplicatedData,
+    DataAddress, PublicKey, ReplicatedData, SignedChunk,
 };
 
 use serde::{Deserialize, Serialize};
@@ -89,7 +89,7 @@ pub enum NodeQueryResponse {
     /// Response to [`GetChunk`]
     ///
     /// [`GetChunk`]: crate::messaging::data::DataQueryVariant::GetChunk
-    GetChunk(Result<Chunk>),
+    GetChunk(Result<SignedChunk>),
     //
     // ===== Register Data =====
     //

--- a/sn_interface/src/types/chunk.rs
+++ b/sn_interface/src/types/chunk.rs
@@ -6,22 +6,31 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{ChunkAddress, XorName};
+use super::{ChunkAddress, SectionSig, XorName};
 use bytes::Bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Maximum allowed size for a serialised Chunk to grow to.
 pub const MAX_CHUNK_SIZE_IN_BYTES: usize = 1024 * 1024 + 10 * 1024;
 
-/// Chunk, an immutable chunk of data
+/// Represents an immutable chunk of data.
+///
+/// This is one of the primitive data types for the network.
 #[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, custom_debug::Debug)]
 pub struct Chunk {
-    /// Network address. Omitted when serialising and
-    /// calculated from the `value` when deserialising.
+    /// Network address.
+    ///
+    /// Omitted when serialising and calculated from `value` when deserialising.
     address: ChunkAddress,
-    /// Contained data.
+    /// The data for the chunk.
     #[debug(skip)]
     value: Bytes,
+}
+
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
+pub struct SignedChunk {
+    pub chunk: Chunk,
+    pub authority: SectionSig,
 }
 
 impl Chunk {

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -29,7 +29,7 @@ pub use crate::messaging::{data::RegisterCmd, SectionSig};
 
 pub use address::{ChunkAddress, DataAddress, RegisterAddress, SpentbookAddress};
 pub use cache::Cache;
-pub use chunk::{Chunk, MAX_CHUNK_SIZE_IN_BYTES};
+pub use chunk::{Chunk, SignedChunk, MAX_CHUNK_SIZE_IN_BYTES};
 pub use connections::{PeerLinks, SendToOneError};
 pub use errors::{convert_dt_error_to_error_msg, Error, Result};
 pub use keys::{
@@ -65,7 +65,7 @@ pub struct ReplicatedRegisterLog {
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum ReplicatedData {
     /// A chunk of data.
-    Chunk(Chunk),
+    Chunk(SignedChunk),
     /// A single cmd for a register.
     RegisterWrite(RegisterCmd),
     /// An entire op log of a register.
@@ -79,7 +79,7 @@ pub enum ReplicatedData {
 impl ReplicatedData {
     pub fn name(&self) -> XorName {
         match self {
-            Self::Chunk(chunk) => *chunk.name(),
+            Self::Chunk(signed_chunk) => *signed_chunk.chunk.name(),
             Self::RegisterLog(log) => *log.address.name(),
             Self::RegisterWrite(cmd) => *cmd.dst_address().name(),
             Self::SpentbookLog(log) => *log.address.name(),
@@ -89,7 +89,7 @@ impl ReplicatedData {
 
     pub fn address(&self) -> DataAddress {
         match self {
-            Self::Chunk(chunk) => DataAddress::Bytes(*chunk.address()),
+            Self::Chunk(signed_chunk) => DataAddress::Bytes(*signed_chunk.chunk.address()),
             Self::RegisterLog(log) => DataAddress::Register(log.address),
             Self::RegisterWrite(cmd) => DataAddress::Register(cmd.dst_address()),
             Self::SpentbookLog(log) => {

--- a/sn_interface/src/types/register/mod.rs
+++ b/sn_interface/src/types/register/mod.rs
@@ -17,7 +17,7 @@ pub use reg_crdt::EntryHash;
 pub(crate) use reg_crdt::{CrdtOperation, RegisterCrdt};
 
 use super::{Error, Result};
-use crate::types::RegisterAddress;
+use crate::types::{RegisterAddress, SectionSig};
 use self_encryption::MIN_ENCRYPTABLE_BYTES;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -41,6 +41,12 @@ pub struct Register {
     owner: User,
     pub(super) crdt: RegisterCrdt, // Temporarily exposed to 'super' till spentbook fully implemented.
     policy: Policy,
+}
+
+#[derive(Clone, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub struct SignedRegister {
+    pub register: Register,
+    pub authority: SectionSig,
 }
 
 impl Register {

--- a/sn_node/benches/data_storage.rs
+++ b/sn_node/benches/data_storage.rs
@@ -261,7 +261,7 @@ pub fn create_random_register_replicated_data() -> ReplicatedData {
                 signature,
             },
         },
-        section_sig: section_sig(), // obtained after presenting a valid payment to the network
+        section_sig: Some(section_sig()), // obtained after presenting a valid payment to the network
     };
 
     ReplicatedData::RegisterWrite(reg_cmd)

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -208,6 +208,9 @@ pub enum Error {
     CannotHandleQuery(DataQuery),
     #[error("BLS error: {0}")]
     BlsError(#[from] bls::Error),
+    /// RMP Serde encode error.
+    #[error("Serialisation error: {0}")]
+    SerialisationError(#[from] rmp_serde::encode::Error),
 }
 
 impl From<qp2p::ClientEndpointError> for Error {

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -17,7 +17,7 @@ use sn_interface::{
         AuthorityProof, ClientAuth, MsgId, MsgType,
     },
     network_knowledge::{test_utils::*, NodeState, SectionAuthorityProvider},
-    types::{Keypair, Peer, ReplicatedData, SecretKeySet},
+    types::{Chunk, Keypair, Peer, ReplicatedData, SecretKeySet, SignedChunk},
 };
 use std::collections::BTreeSet;
 
@@ -129,6 +129,13 @@ pub(crate) fn wrap_client_msg_for_handling(msg: ClientMsg, peer: Peer) -> Result
         #[cfg(feature = "traceroute")]
         traceroute: Traceroute(Vec::new()),
     })
+}
+
+pub(crate) fn get_signed_chunk(replicated_data: ReplicatedData) -> Result<SignedChunk> {
+    match replicated_data {
+        ReplicatedData::Chunk(chunk) => Ok(chunk),
+        _ => Err(eyre!("A ReplicatedData::Chunk variant was expected")),
+    }
 }
 
 /// Extend the `Cmd` enum with some utilities for testing.

--- a/sn_node/src/storage/errors.rs
+++ b/sn_node/src/storage/errors.rs
@@ -29,6 +29,9 @@ pub enum Error {
     /// Register not found in local storage.
     #[error("Register data not found in local storage: {0:?}")]
     RegisterNotFound(RegisterAddress),
+    /// The register create command was not signed with a section signature.
+    #[error("The register creation command was not signed with a section signature")]
+    RegisterCreateCmdNotSigned,
     /// Chunk not found.
     #[error("Chunk not found: {0:?}")]
     ChunkNotFound(XorName),
@@ -76,6 +79,8 @@ pub enum Error {
     /// RMP Serde decode error.
     #[error("Deserialisation error: {0}")]
     DeserialisationError(#[from] rmp_serde::decode::Error),
+    #[error("BLS error: {0}")]
+    BlsError(#[from] bls::Error),
 }
 
 // Convert storage error to messaging error message for sending over the network.

--- a/sn_node/src/storage/errors.rs
+++ b/sn_node/src/storage/errors.rs
@@ -70,6 +70,12 @@ pub enum Error {
         cmd_dst_addr: RegisterAddress,
         reg_addr: RegisterAddress,
     },
+    /// RMP Serde encode error.
+    #[error("Serialisation error: {0}")]
+    SerialisationError(#[from] rmp_serde::encode::Error),
+    /// RMP Serde decode error.
+    #[error("Deserialisation error: {0}")]
+    DeserialisationError(#[from] rmp_serde::decode::Error),
 }
 
 // Convert storage error to messaging error message for sending over the network.


### PR DESCRIPTION
- fa8c617e9 **feat: sign replicated chunks with section key**

  BREAKING CHANGE: the `ReplicatedData::Chunk` enum variant now uses a new `SignedChunk` type and
  several APIs were updated to use this type rather than `Chunk`.

  A new `SignedChunk` type is introduced. It wraps a `Chunk` and provides an `authority` field, which
  is a `SectionSig`. When a chunk is replicated, it is signed using the current section key and the
  signed chunk is then stored. The local node storage was updated to store this new type. Previously,
  only the bytes of the chunk were being stored and not a serialised representation of the type, but
  now the serialised representation is being stored so that the signature is also persisted.

- 36feda252 **refactor: rename authority field to owner**

  This was something we discussed in a team meeting.

  Since a new `SignedRegister` type will be introduced which will have an `authority` field with a
  section signature, it was more appropriate for the current `authority` field to be renamed to `owner`.

  The `SignedChunk` type also uses `authority`, so that keeps it consistent with that.

- e7590ab43 **feat: sign registers with section key**

  The register creation command already had a `section_sig` field on it, but this was being populated
  with a dummy value. It has now been changed to an `Option` field. It is assigned `None` when the
  register creation command is created on the client, then when it's received by the node, the field
  is populated with the section key.

  BREAKING CHANGE: in similar fashion to the `SignedChunk` type, a new `SignedRegister` type is
  introduced. Register storage now uses this new type and queries also return it.