### PR TITLE
Refactored Aggregator

### DIFF
--- a/sn_interface/src/messaging/signature_aggregator.rs
+++ b/sn_interface/src/messaging/signature_aggregator.rs
@@ -68,7 +68,7 @@ impl SignatureAggregator {
         hasher.finalize(&mut hash);
 
         // save the sig share
-        let current_shares = self.map.entry(hash).or_insert(BTreeSet::new());
+        let current_shares = self.map.entry(hash).or_default();
         let _ = current_shares.insert(sig_share.clone());
 
         // try aggregate

--- a/sn_interface/src/messaging/signature_aggregator.rs
+++ b/sn_interface/src/messaging/signature_aggregator.rs
@@ -7,17 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::messaging::system::{SectionSig, SectionSigShare};
-use std::{
-    collections::BTreeMap,
-    time::{Duration, Instant},
-};
+use crate::types::keys::ed25519::Digest256;
+use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
 use tiny_keccak::{Hasher, Sha3};
-
-/// Default duration since their last modification after which all unaggregated entries expire.
-const DEFAULT_EXPIRATION: Duration = Duration::from_secs(120);
-
-type Digest256 = [u8; 32];
 
 /// Aggregator for signature shares for arbitrary payloads.
 ///
@@ -30,35 +23,37 @@ type Digest256 = [u8; 32];
 /// corresponding to a different BLS public key. In that case, the payloads will be aggregated
 /// separately. This avoids mixing signature shares created from different curves which would
 /// otherwise lead to invalid signature to be produced even though all the shares are valid.
-///
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SignatureAggregator {
-    map: BTreeMap<Digest256, State>,
-    expiration: Duration,
+    /// a map of the hash(payload + bls pubkey) to the signature shares
+    map: BTreeMap<Digest256, BTreeSet<SectionSigShare>>,
+}
+
+/// AggregatorErrors returned from `SignatureAggregator::add`.
+#[derive(Debug, Error)]
+pub enum AggregatorError {
+    /// The signature share being added is invalid. Such share is rejected but the already collected
+    /// shares are kept intact. If enough new valid shares are collected afterwards, the
+    /// aggregation might still succeed.
+    #[error("signature share is invalid")]
+    InvalidSigShare,
+    /// The signature combination failed even though there are enough valid signature shares. This
+    /// should probably never happen.
+    #[error("failed to combine signature shares: {0}")]
+    FailedToCombineSigShares(#[from] bls::error::Error),
 }
 
 impl SignatureAggregator {
-    /// Create new aggregator with the given expiration.
-    pub fn with_expiration(expiration: Duration) -> Self {
-        Self {
-            map: Default::default(),
-            expiration,
-        }
-    }
-
     /// Add new share into the aggregator. If enough valid signature shares were collected, returns
-    /// its `SectionSig` (signature + public key). Otherwise returns error which details why the
-    /// aggregation did not succeed yet.
-    ///
-    /// Note: returned `Error::NotEnoughShares` does not indicate a failure. It simply means more
-    /// shares still need to be added for that particular payload. This error could be safely
-    /// ignored (it might still be useful perhaps for debugging). The other error variants, however,
-    /// indicate failures and should be treated a such. See [`enum@Error`] for more info.
-    pub fn add(&mut self, payload: &[u8], sig_share: SectionSigShare) -> Result<SectionSig, Error> {
-        self.remove_expired();
-
+    /// the aggregated signature: `Some(SectionSig)` else returns None.
+    /// Checks if the signature are valid
+    pub fn try_aggregate(
+        &mut self,
+        payload: &[u8],
+        sig_share: SectionSigShare,
+    ) -> Result<Option<SectionSig>, AggregatorError> {
         if !sig_share.verify(payload) {
-            return Err(Error::InvalidShare);
+            return Err(AggregatorError::InvalidSigShare);
         }
 
         // Use the hash of the payload + the public key as the key in the map to avoid mixing
@@ -71,90 +66,27 @@ impl SignatureAggregator {
         hasher.update(&public_key.to_bytes());
         hasher.finalize(&mut hash);
 
-        self.map
-            .entry(hash)
-            .or_insert_with(State::new)
-            .add(sig_share)
-            .map(|signature| SectionSig {
-                public_key,
-                signature,
-            })
-    }
+        // save the sig share
+        let current_shares = self.map.entry(hash).or_insert(BTreeSet::new());
+        let _ = current_shares.insert(sig_share.clone());
 
-    fn remove_expired(&mut self) {
-        let expiration = self.expiration;
-        let mut to_remove = vec![];
-
-        for (digest, state) in &self.map {
-            if state.modified.elapsed() >= expiration {
-                to_remove.push(*digest);
-            }
-        }
-
-        self.map.retain(|digest, _| !to_remove.contains(digest))
-    }
-}
-
-impl Default for SignatureAggregator {
-    fn default() -> Self {
-        Self::with_expiration(DEFAULT_EXPIRATION)
-    }
-}
-
-/// Error returned from `SignatureAggregator::add`.
-#[derive(Debug, Error)]
-pub enum Error {
-    /// There are not enough signature shares yet, more need to be added. This is not a failure.
-    #[error("not enough signature shares")]
-    NotEnoughShares,
-    /// The signature share being added is invalid. Such share is rejected but the already collected
-    /// shares are kept intact. If enough new valid shares are collected afterwards, the
-    /// aggregation might still succeed.
-    #[error("signature share is invalid")]
-    InvalidShare,
-    /// The signature combination failed even though there are enough valid signature shares. This
-    /// should probably never happen.
-    #[error("failed to combine signature shares: {0}")]
-    Combine(#[from] bls::error::Error),
-}
-
-#[derive(Debug)]
-struct State {
-    shares: BTreeMap<usize, bls::SignatureShare>,
-    modified: Instant,
-}
-
-impl State {
-    fn new() -> Self {
-        Self {
-            shares: Default::default(),
-            modified: Instant::now(),
-        }
-    }
-
-    fn add(&mut self, sig_share: SectionSigShare) -> Result<bls::Signature, Error> {
-        if self
-            .shares
-            .insert(sig_share.index, sig_share.signature_share)
-            .is_none()
-        {
-            self.modified = Instant::now();
-        } else {
-            // Duplicate share
-            return Err(Error::NotEnoughShares);
-        }
-
-        if self.shares.len() > sig_share.public_key_set.threshold() {
+        // try aggregate
+        if current_shares.len() > sig_share.public_key_set.threshold() {
             let signature = sig_share
                 .public_key_set
-                .combine_signatures(&self.shares)
-                .map_err(Error::Combine)?;
-
-            self.shares.clear();
-
-            Ok(signature)
+                .combine_signatures(
+                    current_shares
+                        .iter()
+                        .map(|s| (s.index, s.signature_share.clone())),
+                )
+                .map_err(AggregatorError::FailedToCombineSigShares)?;
+            let section_sig = SectionSig {
+                public_key,
+                signature,
+            };
+            Ok(Some(section_sig))
         } else {
-            Err(Error::NotEnoughShares)
+            Ok(None)
         }
     }
 }
@@ -163,10 +95,9 @@ impl State {
 mod tests {
     use super::*;
     use rand::thread_rng;
-    use std::thread::sleep;
 
     #[test]
-    fn smoke() -> Result<(), Error> {
+    fn smoke() -> Result<(), AggregatorError> {
         let mut rng = thread_rng();
         let threshold = 3;
         let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
@@ -177,32 +108,32 @@ mod tests {
         // Not enough shares yet
         for index in 0..threshold {
             let sig_share = create_sig_share(&sk_set, index, payload);
-            let result = aggregator.add(payload, sig_share);
+            let result = aggregator.try_aggregate(payload, sig_share);
 
             match result {
-                Err(Error::NotEnoughShares) => (),
+                Ok(None) => (),
                 _ => panic!("unexpected result: {:?}", result),
             }
         }
 
         // Enough shares now
         let sig_share = create_sig_share(&sk_set, threshold, payload);
-        let sig = aggregator.add(payload, sig_share)?;
+        let sig = aggregator.try_aggregate(payload, sig_share)?;
 
-        assert!(sig.verify(payload));
+        assert!(sig.expect("some key").verify(payload));
 
         // Extra shares start another round
         let sig_share = create_sig_share(&sk_set, threshold + 1, payload);
-        let result = aggregator.add(payload, sig_share);
+        let result = aggregator.try_aggregate(payload, sig_share);
 
         match result {
-            Err(Error::NotEnoughShares) => Ok(()),
+            Ok(None) => Ok(()),
             _ => panic!("unexpected result: {:?}", result),
         }
     }
 
     #[test]
-    fn invalid_share() -> Result<(), Error> {
+    fn invalid_share() -> Result<(), AggregatorError> {
         let mut rng = thread_rng();
         let threshold = 3;
         let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
@@ -213,51 +144,25 @@ mod tests {
         // First insert less than threshold + 1 valid shares.
         for index in 0..threshold {
             let sig_share = create_sig_share(&sk_set, index, payload);
-            let _keyed_sig = aggregator.add(payload, sig_share);
+            let _keyed_sig = aggregator.try_aggregate(payload, sig_share);
         }
 
         // Then try to insert invalid share.
         let invalid_sig_share = create_sig_share(&sk_set, threshold, b"bad");
-        let result = aggregator.add(payload, invalid_sig_share);
+        let result = aggregator.try_aggregate(payload, invalid_sig_share);
 
         match result {
-            Err(Error::InvalidShare) => (),
+            Err(AggregatorError::InvalidSigShare) => (),
             _ => panic!("unexpected result: {:?}", result),
         }
 
         // The invalid share doesn't spoil the aggregation - we can still aggregate once enough
         // valid shares are inserted.
         let sig_share = create_sig_share(&sk_set, threshold + 1, payload);
-        let sig = aggregator.add(payload, sig_share)?;
-        assert!(sig.verify(payload));
+        let sig = aggregator.try_aggregate(payload, sig_share)?;
+        assert!(sig.expect("some key").verify(payload));
 
         Ok(())
-    }
-
-    #[test]
-    fn expiration() {
-        let mut rng = thread_rng();
-        let threshold = 3;
-        let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
-
-        let mut aggregator = SignatureAggregator::with_expiration(Duration::from_millis(500));
-        let payload = b"hello";
-
-        for index in 0..threshold {
-            let sig_share = create_sig_share(&sk_set, index, payload);
-            let _keyed_sig = aggregator.add(payload, sig_share);
-        }
-
-        sleep(Duration::from_secs(1));
-
-        // Adding another share does nothing now, because the previous shares expired.
-        let sig_share = create_sig_share(&sk_set, threshold, payload);
-        let result = aggregator.add(payload, sig_share);
-
-        match result {
-            Err(Error::NotEnoughShares) => (),
-            _ => panic!("unexpected result: {:?}", result),
-        }
     }
 
     #[test]
@@ -274,11 +179,11 @@ mod tests {
 
         for index in 0..threshold {
             let sig_share = create_sig_share(&sk_set, index, payload);
-            assert!(aggregator.add(payload, sig_share).is_err());
+            assert!(aggregator.try_aggregate(payload, sig_share).is_err());
         }
 
         let sig_share = create_sig_share(&sk_set, threshold, payload);
-        assert!(aggregator.add(payload, sig_share).is_ok());
+        assert!(aggregator.try_aggregate(payload, sig_share).is_ok());
 
         // round 2
 
@@ -286,11 +191,11 @@ mod tests {
 
         for index in offset..(threshold + offset) {
             let sig_share = create_sig_share(&sk_set, index, payload);
-            assert!(aggregator.add(payload, sig_share).is_err());
+            assert!(aggregator.try_aggregate(payload, sig_share).is_err());
         }
 
         let sig_share = create_sig_share(&sk_set, threshold + offset + 1, payload);
-        assert!(aggregator.add(payload, sig_share).is_ok());
+        assert!(aggregator.try_aggregate(payload, sig_share).is_ok());
     }
 
     fn create_sig_share(

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -25,7 +25,6 @@ use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
         data::StorageLevel,
-        signature_aggregator::Error as AggregatorError,
         system::{JoinResponse, NodeCmd, NodeEvent, NodeMsg, NodeQuery, Proposal as ProposalMsg},
         MsgId, NodeMsgAuthority, SectionSig,
     },
@@ -581,11 +580,11 @@ impl MyNode {
             bls_share_auth.into_inner(),
             &payload,
         ) {
-            Ok(section_auth) => {
+            Ok(Some(section_auth)) => {
                 info!("Successfully aggregated message");
                 Ok(Some(NodeMsgAuthority::Section(section_auth)))
             }
-            Err(AggregatorError::NotEnoughShares) => {
+            Ok(None) => {
                 info!("Not enough shares to aggregate received message");
                 Ok(None)
             }

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -91,7 +91,7 @@ mod core {
             data::OperationId,
             signature_aggregator::SignatureAggregator,
             system::{DkgSessionId, NodeState, SectionSigned},
-            AuthorityProof, SectionAuthorityProvider, SectionSig, SectionSigShare,
+            AuthorityProof, SectionAuthorityProvider, SectionSig,
         },
         network_knowledge::{
             supermajority, MyNodeInfo, NetworkKnowledge,
@@ -169,7 +169,7 @@ mod core {
         pub(crate) message_aggregator: SignatureAggregator,
         pub(crate) proposal_aggregator: SignatureAggregator,
         // DKG/Split/Churn modules
-        pub(crate) dkg_start_aggregator: HashMap<Digest256, BTreeSet<SectionSigShare>>,
+        pub(crate) dkg_start_aggregator: SignatureAggregator,
         pub(crate) dkg_sessions_info: HashMap<Digest256, DkgSessionInfo>,
         pub(crate) dkg_voter: DkgVoter,
         pub(crate) pending_split_sections:
@@ -260,7 +260,7 @@ mod core {
                 proposal_aggregator: SignatureAggregator::default(),
                 pending_split_sections: Default::default(),
                 message_aggregator: SignatureAggregator::default(),
-                dkg_start_aggregator: HashMap::default(),
+                dkg_start_aggregator: SignatureAggregator::default(),
                 dkg_voter: DkgVoter::default(),
                 relocate_state: None,
                 event_sender,


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

- Simplifies `SignatureAggregator`'s innards
- Removes timers
- Distinguish the case when the aggregation is still waiting for more share from `Error`s by returning `None` instead of an `Error`
- Make DKG use this one now that timers are gone