### PR TITLE
Remove section share auth

### DIFF
--- a/sn_interface/src/messaging/auth_kind.rs
+++ b/sn_interface/src/messaging/auth_kind.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::system::SectionSigShare;
 use super::{ClientAuth, NodeSig};
 use serde::{Deserialize, Serialize};
 
@@ -30,10 +29,4 @@ pub enum AuthKind {
     /// Node authority is needed when nodes send messages directly to other nodes.
     // FIXME: is the above true? What does is the recieving node validating against?
     Node(NodeSig),
-
-    /// A message from an Elder node with its share of the section authority.
-    ///
-    /// Section share authority is needed for messages related to section administration, such as
-    /// DKG and relocation.
-    SectionShare(SectionSigShare),
 }

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -266,24 +266,6 @@ impl WireMsg {
                     msg,
                 })
             }
-            AuthKind::SectionShare(bls_share_signed) => {
-                let msg: NodeMsg = rmp_serde::from_slice(&self.payload).map_err(|err| {
-                    Error::FailedToParse(format!(
-                        "Node message payload (BLS share signed) as Msgpack: {}",
-                        err
-                    ))
-                })?;
-
-                Ok(MsgType::Node {
-                    msg_id: self.header.msg_envelope.msg_id,
-                    msg_authority: NodeMsgAuthority::BlsShare(AuthorityProof::verify(
-                        bls_share_signed,
-                        &self.payload,
-                    )?),
-                    dst: self.dst,
-                    msg,
-                })
-            }
         }
     }
 
@@ -307,9 +289,6 @@ impl WireMsg {
     pub fn src_section_pk(&self) -> Option<bls::PublicKey> {
         match &self.header.msg_envelope.auth {
             AuthKind::Node(node_signed) => Some(node_signed.section_pk),
-            AuthKind::SectionShare(bls_share_signed) => {
-                Some(bls_share_signed.public_key_set.public_key())
-            }
             _ => None,
         }
     }

--- a/sn_node/src/comm/listener.rs
+++ b/sn_node/src/comm/listener.rs
@@ -67,8 +67,6 @@ impl MsgListener {
                     };
 
                     let src_name = match wire_msg.auth() {
-                        // NB TODO is default acceptable??
-                        AuthKind::SectionShare(_) => Default::default(),
                         AuthKind::Client(auth) => auth.public_key.into(),
                         AuthKind::Node(auth) => {
                             sn_interface::types::PublicKey::Ed25519(auth.node_ed_pk).into()

--- a/sn_node/src/node/messages.rs
+++ b/sn_node/src/node/messages.rs
@@ -9,21 +9,14 @@
 use crate::node::{Error, Result};
 
 use sn_interface::{
-    messaging::{system::NodeMsg, AuthKind, Dst, MsgId, NodeSig, SectionSigShare, WireMsg},
-    network_knowledge::{MyNodeInfo, SectionKeyShare},
+    messaging::{system::NodeMsg, AuthKind, Dst, MsgId, NodeSig, WireMsg},
+    network_knowledge::MyNodeInfo,
 };
 
 use bls::PublicKey as BlsPublicKey;
 
 // Utilities for WireMsg.
 pub(crate) trait WireMsgUtils {
-    /// Creates a message signed using a BLS `KeyShare` for destination accumulation
-    fn for_dst_accumulation(
-        key_share: &SectionKeyShare,
-        dst: Dst,
-        node_msg: NodeMsg,
-    ) -> Result<WireMsg, Error>;
-
     /// Creates a signed message from single node.
     fn single_src(
         node: &MyNodeInfo,
@@ -34,29 +27,6 @@ pub(crate) trait WireMsgUtils {
 }
 
 impl WireMsgUtils for WireMsg {
-    /// Creates a message signed using a BLS `KeyShare` for destination accumulation
-    fn for_dst_accumulation(
-        key_share: &SectionKeyShare,
-        dst: Dst,
-        msg: NodeMsg,
-    ) -> Result<WireMsg, Error> {
-        let msg_payload =
-            WireMsg::serialize_msg_payload(&msg).map_err(|_| Error::InvalidMessage)?;
-
-        let auth = AuthKind::SectionShare(SectionSigShare {
-            public_key_set: key_share.public_key_set.clone(),
-            index: key_share.index,
-            signature_share: key_share.secret_key_share.sign(&msg_payload),
-        });
-
-        let wire_msg = WireMsg::new_msg(MsgId::new(), msg_payload, auth, dst);
-
-        #[cfg(feature = "test-utils")]
-        let wire_msg = wire_msg.set_payload_debug(msg);
-
-        Ok(wire_msg)
-    }
-
     /// Creates a signed message from single node.
     fn single_src(
         node: &MyNodeInfo,


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

Removes `AuthKind::SectionShare` and all the awkwardness that came with it. 