### PR TITLE
(tests): assert_lists actually asserts; switch SectionPeers to using BTreeMap's instead of DashMaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4148,7 +4148,6 @@ dependencies = [
 name = "sn_dysfunction"
 version = "0.14.0"
 dependencies = [
- "dashmap",
  "eyre",
  "itertools",
  "proptest",
@@ -4172,7 +4171,6 @@ dependencies = [
  "cargo-husky",
  "crdts",
  "custom_debug",
- "dashmap",
  "ed25519",
  "ed25519-dalek",
  "eyre",

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -151,7 +151,6 @@ impl Session {
             .await
             .get_sections_dag()
             .keys()
-            .cloned()
             .collect();
 
         if !NetworkKnowledge::verify_msg_section_key(&msg_authority, &msg, &known_keys) {

--- a/sn_dysfunction/Cargo.toml
+++ b/sn_dysfunction/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.14.0"
 default = []
 
 [dependencies]
-dashmap = { version = "5.1.0", features = [ "serde" ] }
 eyre = "~0.6.5"
 rand = "~0.8"
 thiserror = "1.0.23"

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -25,7 +25,6 @@ bls = { package = "blsttc", version = "7.0.0" }
 bytes = { version = "1.0.1", features = ["serde"] }
 crdts = { version = "7.2", default-features=false, features = ["merkle"] }
 custom_debug = "~0.5.0"
-dashmap = {version = "5.1.0", features = ["serde"]}
 ed25519 = { version = "1.2.0", features = ["serde_bytes"] }
 ed25519-dalek = { version = "1.0.0", features = ["serde"] }
 eyre = "~0.6.5"

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -433,11 +433,7 @@ impl NetworkKnowledge {
 
     /// Return the set of known keys
     pub fn known_keys(&self) -> BTreeSet<bls::PublicKey> {
-        self.section_tree
-            .get_sections_dag()
-            .keys()
-            .cloned()
-            .collect()
+        self.section_tree.get_sections_dag().keys().collect()
     }
 
     /// Try to merge this `NetworkKnowledge` members with `peers`.

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -194,7 +194,7 @@ impl NetworkKnowledge {
                 create_first_section_authority_provider(&public_key_set, &secret_key_share, peer)?;
             SectionTreeUpdate::new(section_auth, SectionsDAG::new(genesis_key))
         };
-        let network_knowledge = Self::new(SectionTree::new(genesis_key), section_tree_update)?;
+        let mut network_knowledge = Self::new(SectionTree::new(genesis_key), section_tree_update)?;
 
         for peer in network_knowledge.signed_sap.elders() {
             let node_state = NodeState::joined(*peer, None);
@@ -438,7 +438,7 @@ impl NetworkKnowledge {
 
     /// Try to merge this `NetworkKnowledge` members with `peers`.
     /// Checks if we're already up to date before attempting to verify and merge members
-    pub fn merge_members(&self, peers: BTreeSet<SectionSigned<NodeState>>) -> Result<bool> {
+    pub fn merge_members(&mut self, peers: BTreeSet<SectionSigned<NodeState>>) -> Result<bool> {
         let mut there_was_an_update = false;
         let our_current_members = self.section_peers.members();
 
@@ -469,7 +469,7 @@ impl NetworkKnowledge {
     }
 
     /// Update the member. Returns whether it actually updated it.
-    pub fn update_member(&self, node_state: SectionSigned<NodeState>) -> bool {
+    pub fn update_member(&mut self, node_state: SectionSigned<NodeState>) -> bool {
         let node_name = node_state.name();
         trace!(
             "Updating section member state, name: {node_name:?}, new state: {:?}",

--- a/sn_interface/src/network_knowledge/section_peers.rs
+++ b/sn_interface/src/network_knowledge/section_peers.rs
@@ -170,7 +170,7 @@ mod tests {
                 .iter()
                 .map(|item| item.value().clone()),
             nodes_1.clone(),
-        )?;
+        );
 
         // adding node set 2 as MembershipState::Relocated
         let sk_2 = SecretKeySet::random(None).secret_key().clone();
@@ -197,8 +197,8 @@ mod tests {
                 .archive
                 .iter()
                 .map(|item| item.value().clone()),
-            nodes_1.iter().cloned().chain(nodes_2.clone()),
-        )?;
+            nodes_1.iter().chain(&nodes_2).cloned(),
+        );
 
         // adding node set 3
         let sk_3 = SecretKeySet::random(None).secret_key().clone();
@@ -215,12 +215,8 @@ mod tests {
                 .archive
                 .iter()
                 .map(|item| item.value().clone()),
-            nodes_1
-                .iter()
-                .cloned()
-                .chain(nodes_2.clone())
-                .chain(nodes_3.clone()),
-        )?;
+            nodes_1.iter().chain(&nodes_2).chain(&nodes_3).cloned(),
+        );
 
         // adding node set 4
         let sk_4 = SecretKeySet::random(None).secret_key().clone();
@@ -237,12 +233,8 @@ mod tests {
                 .archive
                 .iter()
                 .map(|item| item.value().clone()),
-            nodes_2
-                .iter()
-                .cloned()
-                .chain(nodes_3.clone())
-                .chain(nodes_4),
-        )?;
+            nodes_2.iter().chain(&nodes_3).chain(&nodes_4).cloned(),
+        );
 
         // adding node set 5 as a branch to 3
         // 1 -> 2 -> 3 -> 4
@@ -262,8 +254,8 @@ mod tests {
                 .archive
                 .iter()
                 .map(|item| item.value().clone()),
-            nodes_2.iter().cloned().chain(nodes_3).chain(nodes_5),
-        )?;
+            nodes_2.iter().chain(&nodes_3).chain(&nodes_5).cloned(),
+        );
 
         Ok(())
     }
@@ -300,7 +292,7 @@ mod tests {
                 .iter()
                 .map(|item| item.value().clone()),
             [node_left, node_relocated],
-        )?;
+        );
         assert!(section_peers.members().is_empty());
         Ok(())
     }
@@ -339,7 +331,7 @@ mod tests {
                 .iter()
                 .map(|item| item.value().clone()),
             [node_1, node_2],
-        )?;
+        );
         Ok(())
     }
 

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -803,16 +803,22 @@ pub(crate) mod tests {
         #[test]
         #[allow(clippy::unwrap_used)]
         fn proptest_section_tree_fields_should_stay_in_sync((main_dag, list_of_proof_chains) in arb_sections_dag_and_proof_chains(100, true)) {
-                let mut section_tree = SectionTree::new(*main_dag.genesis_key());
-                for (proof_chain, sap) in &list_of_proof_chains {
-                    let tree_update = SectionTreeUpdate::new(sap.clone(), proof_chain.clone());
-                    assert!(section_tree.update(tree_update)?);
-                    // The `sections` are supposed to hold the SAP of the `sections_dag`'s leaves. Verify it
-                    assert_lists(section_tree.sections.values().map(|sap|sap.section_key()), section_tree.sections_dag.leaf_keys()).unwrap();
-                }
-                assert_lists(section_tree.sections.values().map(|sap|sap.section_key()), section_tree.sections_dag.leaf_keys()).unwrap();
-                // Finally, verify that we got the main_dag back
-                prop_assert_eq!(main_dag, section_tree.sections_dag);
+            let mut section_tree = SectionTree::new(*main_dag.genesis_key());
+            for (proof_chain, sap) in &list_of_proof_chains {
+                let tree_update = SectionTreeUpdate::new(sap.clone(), proof_chain.clone());
+                assert!(section_tree.update(tree_update)?);
+                // The `sections` are supposed to hold the SAP of the `sections_dag`'s leaves. Verify it
+                assert_lists(
+                    section_tree.sections.values().map(|sap| sap.section_key()),
+                    section_tree.sections_dag.leaf_keys()
+                );
+            }
+            assert_lists(
+                section_tree.sections.values().map(|sap| sap.section_key()),
+                section_tree.sections_dag.leaf_keys()
+            );
+            // Finally, verify that we got the main_dag back
+            prop_assert_eq!(main_dag, section_tree.sections_dag);
         }
     }
 

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -53,7 +53,7 @@ impl<'de> Deserialize<'de> for SectionsDAG {
 
 impl Debug for SectionsDAG {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        let keys: Vec<_> = self.keys().cloned().collect();
+        let keys: Vec<_> = self.keys().collect();
         let key_positions: BTreeMap<&bls::PublicKey, usize> = keys
             .iter()
             .enumerate()
@@ -304,8 +304,8 @@ impl SectionsDAG {
     }
 
     /// Iterator over all the keys in the `SectionsDAG`
-    pub fn keys(&self) -> impl Iterator<Item = &bls::PublicKey> {
-        iter::once(&self.genesis_key).chain(self.dag.all_nodes().map(|node| &node.value.key))
+    pub fn keys(&self) -> impl Iterator<Item = bls::PublicKey> + '_ {
+        iter::once(self.genesis_key).chain(self.dag.all_nodes().map(|node| node.value.key))
     }
 
     /// Returns whether `key` is present in this `SectionsDAG`.
@@ -353,12 +353,11 @@ impl SectionsDAG {
     }
 
     /// Returns `true` if the `genesis_key` is present in the list of `trusted_keys`
-    pub fn check_trust<'a, I>(&self, trusted_keys: I) -> bool
+    pub fn check_trust<I>(&self, trusted_keys: I) -> bool
     where
-        I: IntoIterator<Item = &'a bls::PublicKey>,
+        I: IntoIterator<Item = bls::PublicKey>,
     {
-        let trusted_keys: BTreeSet<_> = trusted_keys.into_iter().collect();
-        trusted_keys.contains(&self.genesis_key)
+        trusted_keys.into_iter().any(|k| k == self.genesis_key)
     }
 
     /// Returns the parent of the provided key. None is returned if we're provided the `genesis_key`
@@ -501,7 +500,7 @@ pub(super) mod tests {
             expected_keys.push(info.key);
             last_sk = sk;
         }
-        assert_lists(dag.keys(), &expected_keys)?;
+        assert_lists(dag.keys(), expected_keys);
         Ok(())
     }
 
@@ -522,21 +521,18 @@ pub(super) mod tests {
         dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
         dag.insert(&pk_gen, info_b.key, info_b.sig)?;
 
-        assert_lists(
-            dag.keys(),
-            &vec![pk_gen, info_a1.key, info_a2.key, info_b.key],
-        )?;
+        assert_lists(dag.keys(), [pk_gen, info_a1.key, info_a2.key, info_b.key]);
 
         // cannot get partial dag till genesis
         assert!(dag.partial_dag(&pk_gen, &pk_gen).is_err());
         assert_lists(
             dag.partial_dag(&pk_gen, &info_a2.key)?.keys(),
-            &vec![pk_gen, info_a1.key, info_a2.key],
-        )?;
+            [pk_gen, info_a1.key, info_a2.key],
+        );
         assert_lists(
             dag.partial_dag(&pk_gen, &info_b.key)?.keys(),
-            &vec![pk_gen, info_b.key],
-        )?;
+            [pk_gen, info_b.key],
+        );
 
         assert!(dag.partial_dag(&info_a2.key, &pk_gen).is_err());
         assert!(dag.partial_dag(&info_a1.key, &info_b.key).is_err());
@@ -568,7 +564,7 @@ pub(super) mod tests {
         let (partial_gen, last_key_gen) = dag.single_branch_dag_for_key(&pk_gen)?;
         assert!(partial_gen.self_verify());
         assert_eq!(last_key_gen, pk_gen);
-        assert_lists(partial_gen.keys(), &vec![pk_gen])?;
+        assert_lists(partial_gen.keys(), [pk_gen]);
 
         // let's insert only a1 into the DAG for now
         dag.insert(&pk_gen, info_a1.key, info_a1.sig)?;
@@ -580,8 +576,8 @@ pub(super) mod tests {
         assert!(partial_a1.self_verify());
         assert_eq!(last_key_gen, info_a1.key);
         assert_eq!(last_key_a1, info_a1.key);
-        assert_lists(partial_gen.keys(), &vec![pk_gen, info_a1.key])?;
-        assert_lists(partial_a1.keys(), partial_gen.keys())?;
+        assert_lists(partial_gen.keys(), [pk_gen, info_a1.key]);
+        assert_lists(partial_a1.keys(), partial_gen.keys());
 
         // let's now insert a2 into the DAG
         dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
@@ -596,9 +592,9 @@ pub(super) mod tests {
         assert_eq!(last_key_gen, info_a2.key);
         assert_eq!(last_key_a1, info_a2.key);
         assert_eq!(last_key_a2, info_a2.key);
-        assert_lists(partial_gen.keys(), &vec![pk_gen, info_a1.key, info_a2.key])?;
-        assert_lists(partial_a1.keys(), partial_gen.keys())?;
-        assert_lists(partial_a2.keys(), partial_gen.keys())?;
+        assert_lists(partial_gen.keys(), [pk_gen, info_a1.key, info_a2.key]);
+        assert_lists(partial_a1.keys(), partial_gen.keys());
+        assert_lists(partial_a2.keys(), partial_gen.keys());
 
         // let's now insert the other two branches (b and c) into the DAG
         dag.insert(&pk_gen, info_b1.key, info_b1.sig)?;
@@ -608,7 +604,7 @@ pub(super) mod tests {
         assert!(dag.self_verify());
         assert_lists(
             dag.keys(),
-            &vec![
+            [
                 pk_gen,
                 info_a1.key,
                 info_a2.key,
@@ -617,7 +613,7 @@ pub(super) mod tests {
                 info_b3.key,
                 info_c.key,
             ],
-        )?;
+        );
 
         let (partial_gen, last_key_gen) = dag.single_branch_dag_for_key(&pk_gen)?;
         let (partial_a1, last_key_a1) = dag.single_branch_dag_for_key(&info_a1.key)?;
@@ -656,45 +652,53 @@ pub(super) mod tests {
         );
 
         // branch from a1 or a2 is a partial DAG with [genesis key, a1, a2]
-        assert_lists(partial_a1.keys(), &vec![pk_gen, info_a1.key, info_a2.key])?;
-        assert_lists(partial_a1.keys(), partial_a2.keys())?;
+        assert_lists(partial_a1.keys(), [pk_gen, info_a1.key, info_a2.key]);
+        assert_lists(partial_a1.keys(), partial_a2.keys());
 
         // branch from b3 is a partial DAG with [genesis key, b1, b2, b3]
         assert_lists(
             partial_b3.keys(),
-            &vec![pk_gen, info_b1.key, info_b2.key, info_b3.key],
-        )?;
+            [pk_gen, info_b1.key, info_b2.key, info_b3.key],
+        );
 
         // branch from c is a partial DAG with [genesis key, b1, b2, c]
         assert_lists(
             partial_c.keys(),
-            &vec![pk_gen, info_b1.key, info_b2.key, info_c.key],
-        )?;
+            [pk_gen, info_b1.key, info_b2.key, info_c.key],
+        );
 
         // branch from b1 is a partial DAG with either:
         // - [genesis key, b1, b2, b3]
         // - or [genesis key, b1, b2, c]
-        assert!(
-            assert_lists(partial_b1.keys(), partial_b3.keys()).is_ok()
-                ^ assert_lists(partial_b1.keys(), partial_c.keys()).is_ok()
+        assert_eq!(
+            [&partial_b3, &partial_c]
+                .into_iter()
+                .filter(|b| b == &&partial_b1)
+                .count(),
+            1
         );
 
         // branch from b2 is a partial DAG with either:
         // - [genesis key, b1, b2, b3]
         // - or [genesis key, b1, b2, c]
-        assert!(
-            assert_lists(partial_b2.keys(), partial_b3.keys()).is_ok()
-                ^ assert_lists(partial_b2.keys(), partial_c.keys()).is_ok()
+        assert_eq!(
+            [&partial_b3, &partial_c]
+                .into_iter()
+                .filter(|b| b == &&partial_b2)
+                .count(),
+            1
         );
 
         // branch from genesis key is a partial DAG with either:
         // - [genesis key, a1, a2]
         // - or [genesis key, b1, b2, b3]
         // - or [genesis key, b1, b2, c]
-        assert!(
-            assert_lists(partial_gen.keys(), partial_a2.keys()).is_ok()
-                ^ assert_lists(partial_gen.keys(), partial_b3.keys()).is_ok()
-                ^ assert_lists(partial_gen.keys(), partial_c.keys()).is_ok()
+        assert_eq!(
+            [partial_a2, partial_b3, partial_c]
+                .into_iter()
+                .filter(|b| b == &partial_gen)
+                .count(),
+            1
         );
 
         // trying to get branch from a random/non-existing key returns `KeyNotFound` error
@@ -715,7 +719,7 @@ pub(super) mod tests {
         let mut dag = SectionsDAG::new(pk_gen);
         assert!(dag.insert(&pk_gen, info_a.key, info_a.sig.clone()).is_ok());
         assert!(dag.insert(&pk_gen, info_a.key, info_a.sig).is_ok());
-        assert_lists(dag.keys(), &vec![info_a.key, pk_gen])?;
+        assert_lists(dag.keys(), [info_a.key, pk_gen]);
 
         Ok(())
     }
@@ -741,11 +745,11 @@ pub(super) mod tests {
         assert!(dag
             .insert(&info_a1.key, info_a2.key, info_a2.sig.clone())
             .is_err());
-        assert_lists(dag.keys(), &vec![pk_gen])?;
+        assert_lists(dag.keys(), [pk_gen]);
 
         dag.insert(&pk_gen, info_a1.key, info_a1.sig)?;
         dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
-        assert_lists(dag.keys(), &vec![pk_gen, info_a1.key, info_a2.key])?;
+        assert_lists(dag.keys(), [pk_gen, info_a1.key, info_a2.key]);
 
         Ok(())
     }
@@ -804,7 +808,7 @@ pub(super) mod tests {
         // out: Error
         let partial_dag = main_dag.partial_dag(&info_a2.key, &info_a3.key)?;
         assert!(dag_01_err.merge(partial_dag).is_err());
-        assert_lists(dag_01_err.keys(), &vec![pk_gen, info_a1.key])?;
+        assert_lists(dag_01_err.keys(), [pk_gen, info_a1.key]);
 
         Ok(())
     }
@@ -956,8 +960,8 @@ pub(super) mod tests {
         dag.insert(&pk_gen, info_b1.key, info_b1.sig)?;
         dag.insert(&info_b1.key, info_b2.key, info_b2.sig)?;
 
-        assert_lists(dag.get_child_keys(&pk_gen)?, vec![info_a.key, info_b1.key])?;
-        assert_lists(dag.get_child_keys(&info_b1.key)?, vec![info_b2.key])?;
+        assert_lists(dag.get_child_keys(&pk_gen)?, [info_a.key, info_b1.key]);
+        assert_lists(dag.get_child_keys(&info_b1.key)?, [info_b2.key]);
         assert!(dag.get_child_keys(&info_a.key)?.is_empty());
         Ok(())
     }
@@ -974,7 +978,7 @@ pub(super) mod tests {
         sections_dag.insert(&pk_gen, info_b1.key, info_b1.sig)?;
         sections_dag.insert(&info_b1.key, info_b2.key, info_b2.sig)?;
 
-        assert_lists(sections_dag.leaf_keys(), vec![info_a.key, info_b2.key])?;
+        assert_lists(sections_dag.leaf_keys(), [info_a.key, info_b2.key]);
         Ok(())
     }
 
@@ -993,12 +997,11 @@ pub(super) mod tests {
 
         assert_lists(
             dag.get_ancestors(&info_a3.key)?,
-            vec![pk_gen, info_a1.key, info_a2.key],
-        )?;
-        assert_lists(dag.get_ancestors(&info_a2.key)?, vec![pk_gen, info_a1.key])?;
-        assert_lists(dag.get_ancestors(&info_a1.key)?, vec![pk_gen])?;
-        let empty: Vec<bls::PublicKey> = Vec::new();
-        assert_lists(dag.get_ancestors(&pk_gen)?, empty)?;
+            [pk_gen, info_a1.key, info_a2.key],
+        );
+        assert_lists(dag.get_ancestors(&info_a2.key)?, [pk_gen, info_a1.key]);
+        assert_lists(dag.get_ancestors(&info_a1.key)?, [pk_gen]);
+        assert_lists(dag.get_ancestors(&pk_gen)?, []);
 
         Ok(())
     }
@@ -1138,9 +1141,7 @@ pub(super) mod tests {
                     leaves.swap_remove(index);
                 }
                 // update the inserted list
-                partial_dag.keys().for_each(|key| {
-                    inserted_keys.insert(*key);
-                });
+                inserted_keys.extend(partial_dag.keys());
 
                 let last_key_sap = map.get(&rand_to).unwrap();
                 list_of_part_dags.push((partial_dag, last_key_sap.clone()));

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -1589,13 +1589,13 @@ async fn spentbook_spend_with_updated_network_knowledge_should_update_the_node()
             let genesis_key = genesis_sk_set.public_keys().public_key();
             assert_eq!(
                 genesis_key,
-                *proof_chain_iter
+                proof_chain_iter
                     .next()
                     .ok_or_else(|| eyre!("The proof chain should include the genesis key"))?
             );
             assert_eq!(
                 other_section_key.public_key(),
-                *proof_chain_iter
+                proof_chain_iter
                     .next()
                     .ok_or_else(|| eyre!("The proof chain should include the other section key"))?
             );

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -205,7 +205,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
                 SectionTreeUpdate::new(signed_sap, section_chain)
             };
 
-            let section = NetworkKnowledge::new(SectionTree::new(pk), section_tree_update)?;
+            let mut section = NetworkKnowledge::new(SectionTree::new(pk), section_tree_update)?;
             let mut expected_new_elders = BTreeSet::new();
 
             for peer in section_auth.elders() {
@@ -381,7 +381,8 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
         .run_until(async move {
             let (section_auth, mut nodes, sk_set) = network_utils::create_section_auth();
 
-            let (section, _) = network_utils::create_section(&sk_set, &section_auth, None, None)?;
+            let (mut section, _) =
+                network_utils::create_section(&sk_set, &section_auth, None, None)?;
 
             let existing_peer = network_utils::create_peer(MIN_ADULT_AGE);
             let node_state = NodeState::joined(existing_peer, None);
@@ -655,7 +656,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
                 RelocatedPeerRole::NonElder => recommended_section_size(),
             };
             let (section_auth, mut nodes, sk_set) = random_sap(prefix, elder_count(), 0, None);
-            let (section, section_key_share) =
+            let (mut section, section_key_share) =
                 network_utils::create_section(&sk_set, &section_auth, None, None)?;
 
             let mut adults = section_size - elder_count();
@@ -816,7 +817,7 @@ async fn handle_elders_update() -> Result<()> {
             0,
         );
 
-        let (section0, section_key_share) = network_utils::create_section_with_elders(&sk_set0, &sap0)?;
+        let (mut section0, section_key_share) = network_utils::create_section_with_elders(&sk_set0, &sap0)?;
 
         for peer in [&adult_peer, &promoted_peer] {
             let node_state = NodeState::joined(*peer, None);
@@ -969,7 +970,7 @@ async fn handle_demote_during_split() -> Result<()> {
                 sk_set_v0.public_keys(),
                 0,
             );
-            let (section, section_key_share) =
+            let (mut section, section_key_share) =
                 network_utils::create_section_with_elders(&sk_set_v0, &section_auth_v0)?;
 
             // all peers b are added

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -230,7 +230,7 @@ impl TestNodeBuilder {
         self,
     ) -> Result<(Dispatcher, NetworkKnowledge, Peer, bls::SecretKeySet)> {
         std::env::set_var("SN_DATA_COPY_COUNT", self.data_copy_count.to_string());
-        let (section, section_key_share, keypair, peer, sk_set) = if let Some(custom_section) =
+        let (mut section, section_key_share, keypair, peer, sk_set) = if let Some(custom_section) =
             self.section
         {
             let first_node = self.first_node.ok_or_else(|| {
@@ -314,7 +314,7 @@ pub(crate) fn create_section(
     other_keys: Option<Vec<bls::SecretKey>>,
     parent_section_tree: Option<SectionTree>,
 ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
-    let (section, section_key_share) =
+    let (mut section, section_key_share) =
         do_create_section(sap, genesis_sk_set, other_keys, parent_section_tree)?;
     for ns in sap.members() {
         let auth_ns = section_signed(&genesis_sk_set.secret_key(), ns.clone())?;
@@ -330,7 +330,7 @@ pub(crate) fn create_section_with_elders(
     sk_set: &SecretKeySet,
     sap: &SectionAuthorityProvider,
 ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
-    let (section, section_key_share) = do_create_section(sap, sk_set, None, None)?;
+    let (mut section, section_key_share) = do_create_section(sap, sk_set, None, None)?;
     for peer in sap.elders() {
         let node_state = NodeState::joined(*peer, None);
         let node_state = section_signed(sk_set.secret_key(), node_state)?;

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -188,7 +188,7 @@ mod tests {
             SectionTreeUpdate::new(signed_sap, SectionsDAG::new(genesis_pk))
         };
 
-        let network_knowledge =
+        let mut network_knowledge =
             NetworkKnowledge::new(SectionTree::new(genesis_pk), section_tree_update)?;
 
         for peer in &peers {


### PR DESCRIPTION
- `assert_lists` checks if two lists have the same elements independent of order. It was returning Result's but it should really be asserting.

- SectionPeer reads and writes are single threaded so no need to use dashmap