### PR TITLE
fix(node): call to File::sync_data right after writing a Chunk or Register op to disk

### DIFF
--- a/sn_node/src/storage/register_store.rs
+++ b/sn_node/src/storage/register_store.rs
@@ -203,6 +203,9 @@ impl RegisterStore {
 
         let serialized_data = serialise(cmd)?;
         file.write_all(&serialized_data).await?;
+        // Let's sync up OS data to disk to reduce the chances of
+        // concurrent reading failing by reading an empty/incomplete file
+        file.sync_data().await?;
 
         self.used_space.increase(required_space);
 


### PR DESCRIPTION
- Syncing data to disk right after writing reduces the changes of another task/thread reading the file obtains an empty content.
- Also this change checks the address of recreated Chunk after read from disk to make sure the content read is complete and matching the expected address.
