### PR TITLE
refactor(client): verify each Chunk individually in the `upload_and_verify` API

### DIFF
--- a/sn_api/src/app/files/mod.rs
+++ b/sn_api/src/app/files/mod.rs
@@ -623,8 +623,7 @@ impl Safe {
         } else {
             debug!("Storing {} bytes of data", bytes.len());
             let client = self.get_safe_client()?;
-            let (address, _) = client.upload_and_verify(bytes).await?;
-            address
+            client.upload_and_verify(bytes).await?
         };
         let xorurl = SafeUrl::from_bytes(address, content_type)?.encode(self.xorurl_base);
 

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -12,120 +12,27 @@ use crate::Error;
 use sn_interface::{
     messaging::{
         data::{ClientMsg, DataCmd},
-        ClientAuth, MsgId, WireMsg,
+        ClientAuth, WireMsg,
     },
     types::{PublicKey, Signature},
 };
 
-use backoff::{backoff::Backoff, ExponentialBackoff};
 use bytes::Bytes;
 use xor_name::XorName;
 
 impl Client {
-    /// Send a Cmd to the network and await a response.
-    /// Cmds are not retried.
-    #[instrument(skip(self), level = "debug")]
-    pub async fn send_cmd_without_retry(&self, cmd: DataCmd) -> Result<(), Error> {
-        self.send_cmd_with_retry(cmd, false).await
-    }
-
     /// Sign data using the client keypair
     pub fn sign(&self, data: &[u8]) -> Signature {
         self.keypair.sign(data)
     }
 
-    // Send a Cmd to the network and await a response.
-    // Cmds are automatically retried if an error is returned
-    // This function is a private helper.
-    #[instrument(skip(self), level = "debug")]
-    async fn send_cmd_with_retry(&self, cmd: DataCmd, retry: bool) -> Result<(), Error> {
-        let client_pk = self.public_key();
-        let dst_name = cmd.dst_name();
-
-        let debug_cmd = format!("{:?}", cmd);
-
-        let serialised_cmd = {
-            let msg = ClientMsg::Cmd(cmd);
-            WireMsg::serialize_msg_payload(&msg)?
-        };
-        let signature = self.sign(&serialised_cmd);
-
-        let op_limit = self.cmd_timeout;
-        let max_interval = self.max_backoff_interval;
-
-        let mut backoff = ExponentialBackoff {
-            initial_interval: max_interval / 2,
-            max_interval,
-            max_elapsed_time: Some(op_limit),
-            randomization_factor: 0.5,
-            ..Default::default()
-        };
-
-        let msg_id = MsgId::new();
-
-        // this seems needed for custom settings to take effect
-        backoff.reset();
-
-        let span = info_span!("Attempting a cmd with total timeout of {op_limit:?}");
-        let _ = span.enter();
-
-        let mut attempt = 1;
-        let force_new_link = false;
-        loop {
-            debug!(
-                "Attempting {:?} (attempt #{}), forcing new: {force_new_link}",
-                debug_cmd, attempt
-            );
-
-            let res = self
-                .send_signed_cmd(
-                    dst_name,
-                    client_pk,
-                    msg_id,
-                    serialised_cmd.clone(),
-                    signature.clone(),
-                    force_new_link,
-                )
-                .await;
-
-            // force_new_link = true;
-
-            // no retries wanted, so we bail on first response
-            if !retry {
-                break res;
-            }
-
-            if let Ok(cmd_result) = res {
-                debug!("{debug_cmd} sent okay");
-                break Ok(cmd_result);
-            }
-
-            trace!(
-                "Failed response on {debug_cmd} cmd attempt #{attempt}: {:?}",
-                res
-            );
-
-            attempt += 1;
-
-            if let Some(delay) = backoff.next_backoff() {
-                debug!("Sleeping for {delay:?} before trying attempt {attempt} cmd {debug_cmd:?} again");
-                tokio::time::sleep(delay).await;
-            } else {
-                debug!("backoff done affter #{:?} attempts", attempt - 1);
-                // we're done trying
-                break res;
-            }
-        }
-    }
-
     /// Send a signed `DataCmd` to the network.
-    /// This is to be part of a public API, for the user to
+    /// This is part of the public API, for the user to
     /// provide the serialised and already signed cmd.
     pub async fn send_signed_cmd(
         &self,
         dst_address: XorName,
         client_pk: PublicKey,
-        msg_id: MsgId,
         serialised_cmd: Bytes,
         signature: Signature,
         force_new_link: bool,
@@ -135,24 +42,56 @@ impl Client {
             signature,
         };
 
-        self.session
-            .send_cmd(
-                dst_address,
-                auth,
-                serialised_cmd,
-                msg_id,
-                force_new_link,
-                #[cfg(feature = "traceroute")]
-                self.public_key(),
-            )
-            .await
+        tokio::time::timeout(self.cmd_timeout, async {
+            self.session
+                .send_cmd(
+                    dst_address,
+                    auth,
+                    serialised_cmd,
+                    force_new_link,
+                    #[cfg(feature = "traceroute")]
+                    self.public_key(),
+                )
+                .await
+        })
+        .await
+        .map_err(|_| Error::CmdAckValidationTimeout(dst_address))?
     }
 
-    /// Send a DataCmd to the network and await a response.
-    /// Cmds are automatically retried using exponential backoff if an error is returned.
-    /// This function is a helper private to this module.
+    /// Public API to send a `DataCmd` to the network.
+    /// The provided `DataCmd` is serialised and signed with the
+    /// keypair this Client instance has been setup with.
     #[instrument(skip_all, level = "debug", name = "client-api send cmd")]
-    pub(crate) async fn send_cmd(&self, cmd: DataCmd) -> Result<(), Error> {
-        self.send_cmd_with_retry(cmd, true).await
+    pub async fn send_cmd(&self, cmd: DataCmd) -> Result<(), Error> {
+        let client_pk = self.public_key();
+        let dst_name = cmd.dst_name();
+
+        let debug_cmd = format!("{:?}", cmd);
+        debug!("Attempting {:?}", debug_cmd);
+
+        let serialised_cmd = {
+            let msg = ClientMsg::Cmd(cmd);
+            WireMsg::serialize_msg_payload(&msg)?
+        };
+        let signature = self.sign(&serialised_cmd);
+        let force_new_link = false;
+
+        let res = self
+            .send_signed_cmd(
+                dst_name,
+                client_pk,
+                serialised_cmd,
+                signature,
+                force_new_link,
+            )
+            .await;
+
+        if res.is_ok() {
+            debug!("{debug_cmd} sent okay: {:?}", res);
+        } else {
+            trace!("Failed response on {debug_cmd} cmd: {:?}", res);
+        }
+
+        res
     }
 }

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -22,7 +22,7 @@ use bytes::Bytes;
 use futures::future::join_all;
 use itertools::Itertools;
 use self_encryption::{self, ChunkInfo, DataMap, EncryptedChunk};
-use tokio::task;
+use tokio::{task, time::sleep};
 use tracing::trace;
 use xor_name::XorName;
 
@@ -141,43 +141,16 @@ impl Client {
     /// form of immutable chunks, without any batching.
     #[instrument(skip(self, bytes), level = "debug")]
     pub async fn upload(&self, bytes: Bytes) -> Result<XorName> {
-        if let Ok(file) = LargeFile::new(bytes.clone()) {
-            self.upload_large(file).await
-        } else {
-            let file = SmallFile::new(bytes)?;
-            self.upload_small(file).await
-        }
+        self.upload_bytes(bytes, false).await
     }
 
     /// Directly writes [`Bytes`] to the network in the
     /// form of immutable chunks, without any batching.
     /// It also attempts to verify that all the data was uploaded to the network before returning.
-    /// It does this via repeatedly running `read_bytes` until we hit `query_timeout`.
+    /// It does this via running `read_bytes` with each chunk with `query_timeout` set.
     #[instrument(skip_all, level = "trace")]
-    pub async fn upload_and_verify(&self, bytes: Bytes) -> Result<(XorName, Bytes)> {
-        let address = self.upload(bytes).await?;
-
-        // each individual `read_bytes` could return earlier than
-        // query_timeout with `DataNotFound` eg,
-        // but this could just mean that the data has not yet
-        // reached adults...
-        //
-        // and so, we loop until the timeout _over_ our
-        let bytes = tokio::time::timeout(self.query_timeout, async {
-            let mut last_response = self.read_bytes(address).await;
-            while last_response.is_err() {
-                error!(
-                    "Error when attempting to verify bytes were uploaded: {:?}",
-                    last_response
-                );
-                last_response = self.read_bytes(address).await;
-            }
-            last_response
-        })
-        .await
-        .map_err(|_| Error::NoResponsesForUploadValidation)??;
-
-        Ok((address, bytes))
+    pub async fn upload_and_verify(&self, bytes: Bytes) -> Result<XorName> {
+        self.upload_bytes(bytes, true).await
     }
 
     /// Calculates a LargeFile's/SmallFile's address from self encrypted chunks,
@@ -194,15 +167,36 @@ impl Client {
         }
     }
 
+    // --------------------------------------------
+    // ---------- Private helpers -----------------
+    // --------------------------------------------
+
+    #[instrument(skip(self, bytes), level = "trace")]
+    async fn upload_bytes(&self, bytes: Bytes, verify: bool) -> Result<XorName> {
+        if let Ok(file) = LargeFile::new(bytes.clone()) {
+            self.upload_large(file, verify).await
+        } else {
+            let file = SmallFile::new(bytes)?;
+            self.upload_small(file, verify).await
+        }
+    }
+
     /// Directly writes a [`LargeFile`] to the network in the
     /// form of immutable self encrypted chunks, without any batching.
     #[instrument(skip_all, level = "trace")]
-    async fn upload_large(&self, large: LargeFile) -> Result<XorName> {
+    async fn upload_large(&self, large: LargeFile, verify: bool) -> Result<XorName> {
         let (head_address, all_chunks) = Self::encrypt_large(large)?;
 
         let tasks = all_chunks.into_iter().map(|chunk| {
-            let writer = self.clone();
-            task::spawn(async move { writer.send_cmd(DataCmd::StoreChunk(chunk)).await })
+            let client_clone = self.clone();
+            task::spawn(async move {
+                let chunk_addr = *chunk.address().name();
+                client_clone.send_cmd(DataCmd::StoreChunk(chunk)).await?;
+                if verify {
+                    client_clone.verify_chunk_is_stored(chunk_addr).await?;
+                }
+                Ok::<(), Error>(())
+            })
         });
 
         let respones = join_all(tasks)
@@ -222,16 +216,41 @@ impl Client {
     /// Directly writes a [`SmallFile`] to the network in the
     /// form of a single chunk, without any batching.
     #[instrument(skip_all, level = "trace")]
-    async fn upload_small(&self, small: SmallFile) -> Result<XorName> {
+    async fn upload_small(&self, small: SmallFile, verify: bool) -> Result<XorName> {
         let chunk = Self::package_small(small)?;
         let address = *chunk.name();
         self.send_cmd(DataCmd::StoreChunk(chunk)).await?;
+
+        if verify {
+            self.verify_chunk_is_stored(address).await?;
+        }
+
         Ok(address)
     }
 
-    // --------------------------------------------
-    // ---------- Private helpers -----------------
-    // --------------------------------------------
+    // Verify a chunk is stored at provided address
+    async fn verify_chunk_is_stored(&self, address: XorName) -> Result<()> {
+        // `read_bytes` could return earlier than query_timeout
+        // with `DataNotFound` eg, but this could just mean that the data has not yet
+        // reached adults...and so, we retry once but within the timeout limit set
+        let _bytes = tokio::time::timeout(self.query_timeout, async {
+            let mut response = self.read_bytes(address).await;
+            if response.is_err() {
+                error!(
+                    "Error when attempting to verify chunk was stored at {:?}: {:?}",
+                    address, response
+                );
+
+                sleep(self.max_backoff_interval).await;
+                response = self.read_bytes(address).await;
+            }
+            response
+        })
+        .await
+        .map_err(|_| Error::ChunkUploadValidationTimeout(address))??;
+
+        Ok(())
+    }
 
     // Gets and decrypts chunks from the network using nothing else but the data map,
     // then returns the raw data.
@@ -270,7 +289,6 @@ impl Client {
         chunks_info: Vec<ChunkInfo>,
     ) -> Result<Vec<EncryptedChunk>> {
         let expected_count = chunks_info.len();
-
         let tasks = chunks_info.into_iter().map(|chunk_info| {
             let client = client.clone();
             task::spawn(async move {
@@ -342,7 +360,6 @@ mod tests {
     use bytes::Bytes;
     use eyre::{eyre, Result};
     use futures::future::join_all;
-    use std::time::Duration;
     use tokio::time::Instant;
     use tracing::{instrument::Instrumented, Instrument};
     use xor_name::XorName;
@@ -377,14 +394,14 @@ mod tests {
         let file = LargeFile::new(random_bytes(MIN_ENCRYPTABLE_BYTES))?;
 
         // Store file (also verifies that the file is stored)
-        let (address, read_data) = client.upload_and_verify(file.bytes()).await?;
-
+        let address = client.upload_and_verify(file.bytes()).await?;
+        let read_data = client.read_bytes(address).await?;
         compare(file.bytes(), read_data)?;
 
         // Test storing file with the same value.
         // Should not conflict and should return same address
         let reupload_address = client
-            .upload_large(file.clone())
+            .upload_large(file.clone(), false)
             .instrument(tracing::info_span!(
                 "checking no conflict on same private upload"
             ))
@@ -404,7 +421,7 @@ mod tests {
         let size = 2 * MIN_ENCRYPTABLE_BYTES;
         let file = LargeFile::new(random_bytes(size))?;
 
-        let (address, _) = client.upload_and_verify(file.bytes()).await?;
+        let address = client.upload_and_verify(file.bytes()).await?;
 
         let pos = 512;
         let read_data = read_from_pos(&file, address, pos, usize::MAX, &client).await?;
@@ -429,7 +446,7 @@ mod tests {
                 let len = size / divisor;
                 let file = LargeFile::new(random_bytes(size))?;
 
-                let (address, _) = client.upload_and_verify(file.bytes()).await?;
+                let address = client.upload_and_verify(file.bytes()).await?;
 
                 // Read first part
                 let read_data_1 = {
@@ -467,17 +484,12 @@ mod tests {
         let bytes = random_bytes(5 * 1024 * 1024);
         let file = LargeFile::new(bytes)?;
 
-        // Store file (also verifies that the file is stored)
-        let (address, read_data) = uploader.upload_and_verify(file.bytes()).await?;
-
-        compare(file.bytes(), read_data)?;
+        // Store file (also verifies that the chunks are stored)
+        let address = uploader.upload_and_verify(file.bytes()).await?;
 
         debug!("======> Data uploaded");
 
         let concurrent_client_count = 25;
-        // clients already retry to send cmds/queries, so we should not need a
-        // massive retry count here.
-        let retry_count = 10;
         let clients = create_clients(concurrent_client_count).await?;
         assert_eq!(concurrent_client_count, clients.len());
 
@@ -486,29 +498,18 @@ mod tests {
         for client in clients {
             let handle: Instrumented<tokio::task::JoinHandle<Result<()>>> =
                 tokio::spawn(async move {
-                    let mut last_try = true;
-                    // get the data with many retries
-                    for i in 0..retry_count {
-                        match client.read_bytes(address).await {
-                            Ok(_data) => {
-                                last_try = false;
-                                break;
-                            }
-                            Err(_) => {
-                                debug!(
-                                    "client #{:?} failed the data, sleeping..",
-                                    client.public_key()
-                                );
-                                tokio::time::sleep(Duration::from_millis(i * 100)).await;
-                            }
-                        };
+                    match client.read_bytes(address).await {
+                        Ok(_data) => {
+                            debug!("client #{:?} got the data", client.public_key());
+                        }
+                        Err(err) => {
+                            debug!(
+                                "client #{:?} failed to get the data: {:?}",
+                                client.public_key(),
+                                err
+                            );
+                        }
                     }
-                    if last_try {
-                        let _ = client.read_bytes(address).await?;
-                    }
-
-                    debug!("client #{:?} got the data", client.public_key());
-
                     Ok(())
                 })
                 .in_current_span();
@@ -652,6 +653,7 @@ mod tests {
         let client = create_test_client().await?;
         store_and_read(&client, 40 * 1024 * 1024).await
     }
+
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "too heavy for CI"]
     async fn store_and_read_100mb() -> Result<()> {
@@ -675,7 +677,7 @@ mod tests {
             .map(|(i, client)| {
                 tokio::spawn(async move {
                     let file = LargeFile::new(random_bytes(MIN_ENCRYPTABLE_BYTES))?;
-                    let _ = client.upload_large(file).await?;
+                    let _ = client.upload_large(file, false).await?;
                     println!("Iter: {}", i);
                     let res: Result<()> = Ok(());
                     res
@@ -708,7 +710,7 @@ mod tests {
         for i in 0..1000_usize {
             let file = LargeFile::new(random_bytes(MIN_ENCRYPTABLE_BYTES))?;
             let now = Instant::now();
-            let _ = client.upload_large(file).await?;
+            let _ = client.upload_large(file, false).await?;
             let elapsed = now.elapsed();
             println!("Iter: {}, in {} millis", i, elapsed.as_millis());
         }
@@ -726,11 +728,12 @@ mod tests {
         // we'll also test we can calculate address offline using `calculate_address` API
         let expected_address = Client::calculate_address(bytes.clone())?;
 
-        // we use upload_and_verify since it uploads and also confirms it was uploaded
-        let (address, read_data) = client.upload_and_verify(bytes.clone()).await?;
+        // we use upload_and_verify since it uploads and also confirms chunks were uploaded
+        let address = client.upload_and_verify(bytes.clone()).await?;
         assert_eq!(address, expected_address);
 
         // then the content should be what we stored
+        let read_data = client.read_bytes(address).await?;
         compare(bytes, read_data)?;
 
         Ok(())

--- a/sn_client/src/bin/query-adult/main.rs
+++ b/sn_client/src/bin/query-adult/main.rs
@@ -8,7 +8,7 @@ use sn_interface::{
     data_copy_count,
     messaging::{
         data::{ClientMsg, DataQuery, DataQueryVariant, QueryResponse},
-        MsgId, WireMsg,
+        WireMsg,
     },
     types::{Chunk, ChunkAddress},
 };
@@ -131,13 +131,11 @@ async fn send_query(client: &Client, query: DataQuery) -> Result<QueryResponse> 
     let msg = ClientMsg::Query(query.clone());
     let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
     let signature = client.keypair().sign(&serialised_query);
-    let msg_id = MsgId::new();
     Ok(client
         .send_signed_query(
             query,
             client_pk,
             serialised_query.clone(),
-            msg_id,
             signature.clone(),
         )
         .await?

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -55,7 +55,6 @@ impl Session {
         dst_address: XorName,
         auth: ClientAuth,
         payload: Bytes,
-        msg_id: MsgId,
         force_new_link: bool,
         #[cfg(feature = "traceroute")] client_pk: PublicKey,
     ) -> Result<()> {
@@ -64,6 +63,7 @@ impl Session {
         let (section_pk, elders) = self.get_cmd_elders(dst_address).await?;
 
         let elders_len = elders.len();
+        let msg_id = MsgId::new();
 
         debug!(
             "Sending cmd w/id {msg_id:?}, from {}, to {elders_len} Elders w/ dst: {dst_address:?}",
@@ -195,7 +195,6 @@ impl Session {
         query: DataQuery,
         auth: ClientAuth,
         payload: Bytes,
-        msg_id: MsgId,
         dst_section_info: Option<(bls::PublicKey, Vec<Peer>)>,
         force_new_link: bool,
         #[cfg(feature = "traceroute")] client_pk: PublicKey,
@@ -217,6 +216,7 @@ impl Session {
         };
 
         let elders_len = elders.len();
+        let msg_id = MsgId::new();
 
         debug!(
             "Sending query message {:?}, from {}, {:?} to the {} Elders closest to data name: {:?}",

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -8,7 +8,7 @@
 
 use sn_interface::{
     messaging::{
-        data::{DataQuery, DataQueryVariant, Error as ErrorMsg, QueryResponse},
+        data::{DataQueryVariant, Error as ErrorMsg, QueryResponse},
         Error as MessagingError, MsgId,
     },
     types::{Error as DtError, Peer},
@@ -110,25 +110,15 @@ pub enum Error {
         /// Maximum number of bytes for a `SmallFile`
         maximum: usize,
     },
-    /// Failed to obtain any response
-    #[error("No responses were returned for file upload validation")]
-    NoResponsesForUploadValidation,
+    /// Timeout occurred when trying to verify chunk was uploaded
+    #[error("Timeout occurred when trying to verify chunk at xorname address {0} was uploaded")]
+    ChunkUploadValidationTimeout(XorName),
     /// Failed to obtain a response from Elders.
     #[error("Failed to obtain any response from: {0:?}")]
     NoResponse(Vec<Peer>),
-    /// Failed to obtain a response from Elders even after retrying.
-    #[error(
-        "Failed to obtain any response, even after {attempts} attempts, for query: {query:?}. \
-        Error in last attempt: {last_error}"
-    )]
-    NoResponseAfterRetrying {
-        /// Number of attempts made
-        attempts: usize,
-        /// Query sent to Elders
-        query: DataQuery,
-        /// Source of error in last attempt
-        last_error: Box<Self>,
-    },
+    /// Timeout when awaiting command ACK from Elders.
+    #[error("Timeout when awaiting command ACK from Elders for data address {0}")]
+    CmdAckValidationTimeout(XorName),
     /// No operation Id could be found
     #[error("Could not retrieve the operation id of a query or response")]
     UnknownOperationId,


### PR DESCRIPTION
- This shouldn't only reduce the amount of memory used when uploading large files, but it shall also be more precise as to when a Chunk is ready for verification after uploading it.
- Sending a DataCmd now is not retried but only make sure it returns within the configured cmd timeout window.
- Minor refactor to client Register tests to always await the same amount of time before querying Register ops were applied to the network.