### PR TITLE
refactor(client): verify each Chunk individually in the `upload_and_verify` API

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -204,7 +204,7 @@ jobs:
       #   timeout-minutes: 60
 
       - name: Start the network
-        run: ./target/release/testnet
+        run: ./target/release/testnet --interval 30000
         id: section-startup
         env:
           RUST_LOG: "sn_node,sn_api,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
@@ -221,8 +221,8 @@ jobs:
       - name: Run client tests
         env:
           RUST_LOG: "sn_client=trace,qp2p=debug"
-        run: cargo test --release -p sn_client
-        timeout-minutes: 25
+        run: cargo test --release -p sn_client -- --test-threads=1
+        timeout-minutes: 50
 
       - name: Run example app for file API against local network
         timeout-minutes: 10
@@ -275,7 +275,9 @@ jobs:
         continue-on-error: true
 
   e2e-split:
-    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
+    #if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
+    # disabled temporarily since `self-hosted-ubuntu` runner not available for NodeRefactorBranch branch
+    if: false
     name: E2E tests w/ full network
     runs-on: self-hosted-ubuntu
     env:
@@ -367,13 +369,13 @@ jobs:
       - name: Run client tests
         env:
           RUST_LOG: "sn_client=trace,qp2p=debug"
-        run: cargo test --release -p sn_client
+        run: cargo test --release -p sn_client -- --test-threads=1
         timeout-minutes: 25
 
       - name: Run example app for file API against local network
         timeout-minutes: 10
         shell: bash
-        run: cargo run  --release --example client_files
+        run: cargo run --release --example client_files
 
       - name: Ensure no nodes have left during test runs
         timeout-minutes: 1
@@ -463,7 +465,7 @@ jobs:
   #       timeout-minutes: 60
 
   #     - name: Build testnet
-  #       run: cargo build  --release --bin testnet
+  #       run: cargo build  --release --bin testnet --interval 30000
   #       timeout-minutes: 60
 
   #     - name: Build log_cmds_inspector
@@ -597,7 +599,7 @@ jobs:
   #       timeout-minutes: 60
 
   #     - name: Start the network
-  #       run: ./target/release/testnet
+  #       run: ./target/release/testnet --interval 30000
   #       id: section-startup
   #       env:
   #         RUST_LOG: "sn_node,sn_api,sn_consensus,sn_dysfunction=trace,sn_interface=trace"

--- a/sn_api/src/app/files/mod.rs
+++ b/sn_api/src/app/files/mod.rs
@@ -623,8 +623,7 @@ impl Safe {
         } else {
             debug!("Storing {} bytes of data", bytes.len());
             let client = self.get_safe_client()?;
-            let (address, _) = client.upload_and_verify(bytes).await?;
-            address
+            client.upload_and_verify(bytes).await?
         };
         let xorurl = SafeUrl::from_bytes(address, content_type)?.encode(self.xorurl_base);
 

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -12,120 +12,27 @@ use crate::Error;
 use sn_interface::{
     messaging::{
         data::{ClientMsg, DataCmd},
-        ClientAuth, MsgId, WireMsg,
+        ClientAuth, WireMsg,
     },
     types::{PublicKey, Signature},
 };
 
-use backoff::{backoff::Backoff, ExponentialBackoff};
 use bytes::Bytes;
 use xor_name::XorName;
 
 impl Client {
-    /// Send a Cmd to the network and await a response.
-    /// Cmds are not retried.
-    #[instrument(skip(self), level = "debug")]
-    pub async fn send_cmd_without_retry(&self, cmd: DataCmd) -> Result<(), Error> {
-        self.send_cmd_with_retry(cmd, false).await
-    }
-
     /// Sign data using the client keypair
     pub fn sign(&self, data: &[u8]) -> Signature {
         self.keypair.sign(data)
     }
 
-    // Send a Cmd to the network and await a response.
-    // Cmds are automatically retried if an error is returned
-    // This function is a private helper.
-    #[instrument(skip(self), level = "debug")]
-    async fn send_cmd_with_retry(&self, cmd: DataCmd, retry: bool) -> Result<(), Error> {
-        let client_pk = self.public_key();
-        let dst_name = cmd.dst_name();
-
-        let debug_cmd = format!("{:?}", cmd);
-
-        let serialised_cmd = {
-            let msg = ClientMsg::Cmd(cmd);
-            WireMsg::serialize_msg_payload(&msg)?
-        };
-        let signature = self.sign(&serialised_cmd);
-
-        let op_limit = self.cmd_timeout;
-        let max_interval = self.max_backoff_interval;
-
-        let mut backoff = ExponentialBackoff {
-            initial_interval: max_interval / 2,
-            max_interval,
-            max_elapsed_time: Some(op_limit),
-            randomization_factor: 0.5,
-            ..Default::default()
-        };
-
-        let msg_id = MsgId::new();
-
-        // this seems needed for custom settings to take effect
-        backoff.reset();
-
-        let span = info_span!("Attempting a cmd with total timeout of {op_limit:?}");
-        let _ = span.enter();
-
-        let mut attempt = 1;
-        let force_new_link = false;
-        loop {
-            debug!(
-                "Attempting {:?} (attempt #{}), forcing new: {force_new_link}",
-                debug_cmd, attempt
-            );
-
-            let res = self
-                .send_signed_cmd(
-                    dst_name,
-                    client_pk,
-                    msg_id,
-                    serialised_cmd.clone(),
-                    signature.clone(),
-                    force_new_link,
-                )
-                .await;
-
-            // force_new_link = true;
-
-            // no retries wanted, so we bail on first response
-            if !retry {
-                break res;
-            }
-
-            if let Ok(cmd_result) = res {
-                debug!("{debug_cmd} sent okay");
-                break Ok(cmd_result);
-            }
-
-            trace!(
-                "Failed response on {debug_cmd} cmd attempt #{attempt}: {:?}",
-                res
-            );
-
-            attempt += 1;
-
-            if let Some(delay) = backoff.next_backoff() {
-                debug!("Sleeping for {delay:?} before trying attempt {attempt} cmd {debug_cmd:?} again");
-                tokio::time::sleep(delay).await;
-            } else {
-                debug!("backoff done affter #{:?} attempts", attempt - 1);
-                // we're done trying
-                break res;
-            }
-        }
-    }
-
     /// Send a signed `DataCmd` to the network.
-    /// This is to be part of a public API, for the user to
+    /// This is part of the public API, for the user to
     /// provide the serialised and already signed cmd.
     pub async fn send_signed_cmd(
         &self,
         dst_address: XorName,
         client_pk: PublicKey,
-        msg_id: MsgId,
         serialised_cmd: Bytes,
         signature: Signature,
         force_new_link: bool,
@@ -135,24 +42,56 @@ impl Client {
             signature,
         };
 
-        self.session
-            .send_cmd(
-                dst_address,
-                auth,
-                serialised_cmd,
-                msg_id,
-                force_new_link,
-                #[cfg(feature = "traceroute")]
-                self.public_key(),
-            )
-            .await
+        tokio::time::timeout(self.cmd_timeout, async {
+            self.session
+                .send_cmd(
+                    dst_address,
+                    auth,
+                    serialised_cmd,
+                    force_new_link,
+                    #[cfg(feature = "traceroute")]
+                    self.public_key(),
+                )
+                .await
+        })
+        .await
+        .map_err(|_| Error::CmdAckValidationTimeout(dst_address))?
     }
 
-    /// Send a DataCmd to the network and await a response.
-    /// Cmds are automatically retried using exponential backoff if an error is returned.
-    /// This function is a helper private to this module.
+    /// Public API to send a `DataCmd` to the network.
+    /// The provided `DataCmd` is serialised and signed with the
+    /// keypair this Client instance has been setup with.
     #[instrument(skip_all, level = "debug", name = "client-api send cmd")]
-    pub(crate) async fn send_cmd(&self, cmd: DataCmd) -> Result<(), Error> {
-        self.send_cmd_with_retry(cmd, true).await
+    pub async fn send_cmd(&self, cmd: DataCmd) -> Result<(), Error> {
+        let client_pk = self.public_key();
+        let dst_name = cmd.dst_name();
+
+        let debug_cmd = format!("{:?}", cmd);
+        debug!("Attempting {:?}", debug_cmd);
+
+        let serialised_cmd = {
+            let msg = ClientMsg::Cmd(cmd);
+            WireMsg::serialize_msg_payload(&msg)?
+        };
+        let signature = self.sign(&serialised_cmd);
+        let force_new_link = false;
+
+        let res = self
+            .send_signed_cmd(
+                dst_name,
+                client_pk,
+                serialised_cmd,
+                signature,
+                force_new_link,
+            )
+            .await;
+
+        if res.is_ok() {
+            debug!("{debug_cmd} sent okay: {:?}", res);
+        } else {
+            trace!("Failed response on {debug_cmd} cmd: {:?}", res);
+        }
+
+        res
     }
 }

--- a/sn_client/src/bin/query-adult/main.rs
+++ b/sn_client/src/bin/query-adult/main.rs
@@ -8,7 +8,7 @@ use sn_interface::{
     data_copy_count,
     messaging::{
         data::{ClientMsg, DataQuery, DataQueryVariant, QueryResponse},
-        MsgId, WireMsg,
+        WireMsg,
     },
     types::{Chunk, ChunkAddress},
 };
@@ -131,13 +131,11 @@ async fn send_query(client: &Client, query: DataQuery) -> Result<QueryResponse> 
     let msg = ClientMsg::Query(query.clone());
     let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
     let signature = client.keypair().sign(&serialised_query);
-    let msg_id = MsgId::new();
     Ok(client
         .send_signed_query(
             query,
             client_pk,
             serialised_query.clone(),
-            msg_id,
             signature.clone(),
         )
         .await?

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -55,7 +55,6 @@ impl Session {
         dst_address: XorName,
         auth: ClientAuth,
         payload: Bytes,
-        msg_id: MsgId,
         force_new_link: bool,
         #[cfg(feature = "traceroute")] client_pk: PublicKey,
     ) -> Result<()> {
@@ -64,6 +63,7 @@ impl Session {
         let (section_pk, elders) = self.get_cmd_elders(dst_address).await?;
 
         let elders_len = elders.len();
+        let msg_id = MsgId::new();
 
         debug!(
             "Sending cmd w/id {msg_id:?}, from {}, to {elders_len} Elders w/ dst: {dst_address:?}",
@@ -195,7 +195,6 @@ impl Session {
         query: DataQuery,
         auth: ClientAuth,
         payload: Bytes,
-        msg_id: MsgId,
         dst_section_info: Option<(bls::PublicKey, Vec<Peer>)>,
         force_new_link: bool,
         #[cfg(feature = "traceroute")] client_pk: PublicKey,
@@ -217,6 +216,7 @@ impl Session {
         };
 
         let elders_len = elders.len();
+        let msg_id = MsgId::new();
 
         debug!(
             "Sending query message {:?}, from {}, {:?} to the {} Elders closest to data name: {:?}",

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -8,7 +8,7 @@
 
 use sn_interface::{
     messaging::{
-        data::{DataQuery, DataQueryVariant, Error as ErrorMsg, QueryResponse},
+        data::{DataQueryVariant, Error as ErrorMsg, QueryResponse},
         Error as MessagingError, MsgId,
     },
     types::{Error as DtError, Peer},
@@ -110,25 +110,15 @@ pub enum Error {
         /// Maximum number of bytes for a `SmallFile`
         maximum: usize,
     },
-    /// Failed to obtain any response
-    #[error("No responses were returned for file upload validation")]
-    NoResponsesForUploadValidation,
+    /// Timeout occurred when trying to verify chunk was uploaded
+    #[error("Timeout occurred when trying to verify chunk at xorname address {0} was uploaded")]
+    ChunkUploadValidationTimeout(XorName),
     /// Failed to obtain a response from Elders.
     #[error("Failed to obtain any response from: {0:?}")]
     NoResponse(Vec<Peer>),
-    /// Failed to obtain a response from Elders even after retrying.
-    #[error(
-        "Failed to obtain any response, even after {attempts} attempts, for query: {query:?}. \
-        Error in last attempt: {last_error}"
-    )]
-    NoResponseAfterRetrying {
-        /// Number of attempts made
-        attempts: usize,
-        /// Query sent to Elders
-        query: DataQuery,
-        /// Source of error in last attempt
-        last_error: Box<Self>,
-    },
+    /// Timeout when awaiting command ACK from Elders.
+    #[error("Timeout when awaiting command ACK from Elders for data address {0}")]
+    CmdAckValidationTimeout(XorName),
     /// No operation Id could be found
     #[error("Could not retrieve the operation id of a query or response")]
     UnknownOperationId,

--- a/sn_client/src/utils/test_utils/mod.rs
+++ b/sn_client/src/utils/test_utils/mod.rs
@@ -13,6 +13,7 @@ pub mod test_client;
 #[cfg(test)]
 pub use test_client::{
     create_test_client, create_test_client_with, get_dbc_owner_from_secret_key_hex,
+    try_create_test_client,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/sn_client/src/utils/test_utils/test_client.rs
+++ b/sn_client/src/utils/test_utils/test_client.rs
@@ -17,10 +17,18 @@ const TEST_ENV_GENESIS_DBC_PATH: &str = "TEST_ENV_GENESIS_DBC_PATH";
 const DEFAULT_TEST_GENESIS_DBC_PATH: &str =
     ".safe/node/local-test-network/sn-node-genesis/genesis_dbc";
 
-/// Create a test client without providing any specific keypair, DBC owner, `bootstrap_config`, or
-/// timeout.
+/// Create a test client without providing any specific keypair,
+/// DBC owner, `bootstrap_config`, or timeout.
 pub async fn create_test_client() -> Result<Client> {
     create_test_client_with(None, None, None).await
+}
+
+/// Try to create a test client without providing any specific keypair,
+/// DBC owner, `bootstrap_config`, or timeout, and panicking if an error occured.
+pub async fn try_create_test_client() -> Client {
+    create_test_client_with(None, None, None)
+        .await
+        .expect("Couldn't create the test Client instance")
 }
 
 /// Create a test client optionally providing keypair and/or `bootstrap_config`

--- a/sn_node/src/bin/sn_node/main.rs
+++ b/sn_node/src/bin/sn_node/main.rs
@@ -40,7 +40,7 @@ use tokio::time::{sleep, Duration};
 use tracing::{self, error, info, trace, warn};
 
 const JOIN_TIMEOUT_SEC: u64 = 100;
-const BOOTSTRAP_RETRY_TIME_SEC: u64 = 5;
+const BOOTSTRAP_RETRY_TIME_SEC: u64 = 30;
 
 mod log;
 


### PR DESCRIPTION
- This shouldn't only reduce the amount of memory used when uploading large files, but it shall also be more precise as to when a Chunk is ready for verification after uploading it, and which chunk specifically failed the verification.
- Sending a DataCmd now is not retried but only make sure it returns within the configured cmd timeout window.
- Using `expect()` in some client file tests to make sure Rust return useful info when errors occur, there is an issue with Rust test when Err is returned not showing enough failure info.

Also some changes are included to improve CI stability until some performance/design issues are solved:
- Run sn_client tests in single-threaded mode.
- Nodes to wait 30secs before retrying to joining the network when rejected.
- Testnet to launch nodes with an interval of 30secs.