### PR TITLE
Remove node auth

### DIFF
--- a/sn_interface/src/messaging/mod.rs
+++ b/sn_interface/src/messaging/mod.rs
@@ -50,7 +50,7 @@ pub use self::{
     errors::{Error, Result},
     msg_id::{MsgId, MESSAGE_ID_LEN},
     msg_type::MsgType,
-    serialisation::{NodeMsgAuthority, WireMsg},
+    serialisation::WireMsg,
 };
 
 use serde::{Deserialize, Serialize};

--- a/sn_interface/src/messaging/msg_type.rs
+++ b/sn_interface/src/messaging/msg_type.rs
@@ -8,9 +8,7 @@
 
 use crate::messaging::Dst;
 
-use super::{
-    data::ClientMsg, system::NodeMsg, AuthorityProof, ClientAuth, MsgId, NodeMsgAuthority,
-};
+use super::{data::ClientMsg, system::NodeMsg, AuthorityProof, ClientAuth, MsgId};
 use std::fmt::{Display, Formatter};
 
 // highest priority, since we must sort out membership first of all
@@ -54,8 +52,6 @@ pub enum MsgType {
     Node {
         /// Message ID
         msg_id: MsgId,
-        /// Node authority over this message
-        msg_authority: NodeMsgAuthority,
         /// Message dst
         dst: Dst,
         /// the message

--- a/sn_interface/src/messaging/serialisation/mod.rs
+++ b/sn_interface/src/messaging/serialisation/mod.rs
@@ -12,26 +12,3 @@ mod wire_msg_header;
 pub use self::wire_msg::WireMsg;
 #[cfg(feature = "traceroute")]
 pub use self::wire_msg::{Entity, Traceroute};
-use super::{AuthorityProof, NodeSig, SectionSig, SectionSigShare};
-
-/// Authority of a `NodeMsg`.
-/// Src of message and authority to send it. Authority is validated by the signature.
-#[derive(Eq, PartialEq, Debug, Clone)]
-pub enum NodeMsgAuthority {
-    /// Authority of a single peer.
-    Node(AuthorityProof<NodeSig>),
-    /// Authority of a single peer that uses it's BLS Keyshare to sign the message.
-    BlsShare(AuthorityProof<SectionSigShare>),
-    /// Authority of a whole section.
-    Section(AuthorityProof<SectionSig>),
-}
-
-impl NodeMsgAuthority {
-    pub fn src_public_key(&self) -> bls::PublicKey {
-        match self {
-            Self::Node(node_auth) => node_auth.section_pk,
-            Self::BlsShare(bls_share_auth) => bls_share_auth.public_key_set.public_key(),
-            Self::Section(section_auth) => section_auth.public_key,
-        }
-    }
-}

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -19,7 +19,7 @@ use sn_interface::{
     messaging::{
         data::{ClientMsg, OperationId},
         system::{NodeMsg, SectionSig, SectionSigned},
-        AuthorityProof, ClientAuth, MsgId, NodeMsgAuthority, WireMsg,
+        AuthorityProof, ClientAuth, MsgId, WireMsg,
     },
     network_knowledge::{NodeState, SectionAuthorityProvider, SectionKeyShare, SectionsDAG},
     types::{DataAddress, Peer},
@@ -124,7 +124,6 @@ pub(crate) enum Cmd {
         msg_id: MsgId,
         msg: NodeMsg,
         origin: Peer,
-        msg_authority: NodeMsgAuthority,
         #[cfg(feature = "traceroute")]
         traceroute: Traceroute,
     },

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -206,7 +206,6 @@ impl Dispatcher {
                 origin,
                 msg_id,
                 msg,
-                msg_authority,
                 #[cfg(feature = "traceroute")]
                 traceroute,
             } => {
@@ -214,7 +213,6 @@ impl Dispatcher {
                 MyNode::handle_valid_system_msg(
                     self.node.clone(),
                     msg_id,
-                    msg_authority,
                     msg,
                     origin,
                     &self.comm,

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -71,21 +71,7 @@ impl MyNode {
         };
 
         match msg_type {
-            MsgType::Node {
-                msg_id,
-                msg_authority,
-                dst,
-                msg,
-            } => {
-                // Verify that the section key in the msg authority is trusted
-                if !self.verify_section_key(&msg_authority, &msg).await {
-                    warn!(
-                        "Untrusted message ({:?}) dropped from {:?}: {:?} ",
-                        msg_id, origin, msg
-                    );
-                    return Ok(vec![]);
-                };
-
+            MsgType::Node { msg_id, dst, msg } => {
                 // Check for entropy before we proceed further
                 // Anythign returned here means there's an issue and we should
                 // short-circuit below
@@ -103,7 +89,6 @@ impl MyNode {
                     origin,
                     msg_id,
                     msg,
-                    msg_authority,
                     #[cfg(feature = "traceroute")]
                     traceroute,
                 }])

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -22,8 +22,7 @@ mod update_section;
 use crate::node::{flow_ctrl::cmds::Cmd, Error, MyNode, Result, DATA_QUERY_LIMIT};
 
 use sn_interface::{
-    messaging::{data::ClientMsg, system::NodeMsg, Dst, MsgType, NodeMsgAuthority, WireMsg},
-    network_knowledge::NetworkKnowledge,
+    messaging::{data::ClientMsg, system::NodeMsg, Dst, MsgType, WireMsg},
     types::Peer,
 };
 
@@ -155,14 +154,6 @@ impl MyNode {
                 }])
             }
         }
-    }
-
-    /// Verifies that the section key in the msg authority is trusted
-    /// based on our current knowledge of the network and sections chains.
-    #[instrument(skip_all)]
-    async fn verify_section_key(&self, msg_authority: &NodeMsgAuthority, msg: &NodeMsg) -> bool {
-        let known_keys = self.network_knowledge.known_keys();
-        NetworkKnowledge::verify_msg_section_key(msg_authority, msg, &known_keys)
     }
 
     /// Check if the origin needs to be updated on network structure/members.

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -11,8 +11,7 @@ use crate::{
     node::{
         flow_ctrl::cmds::Cmd,
         messaging::{OutgoingMsg, Peers},
-        Error, Event, MembershipEvent, MyNode, Proposal as CoreProposal, Result,
-        MIN_LEVEL_WHEN_FULL,
+        Event, MembershipEvent, MyNode, Proposal as CoreProposal, Result, MIN_LEVEL_WHEN_FULL,
     },
     storage::Error as StorageError,
 };
@@ -27,7 +26,7 @@ use sn_interface::{
     messaging::{
         data::StorageLevel,
         system::{JoinResponse, NodeCmd, NodeEvent, NodeMsg, NodeQuery, Proposal as ProposalMsg},
-        MsgId, NodeMsgAuthority,
+        MsgId,
     },
     network_knowledge::NetworkKnowledge,
     types::{log_markers::LogMarker, Keypair, Peer, PublicKey},
@@ -74,7 +73,6 @@ impl MyNode {
     pub(crate) async fn handle_valid_system_msg(
         node: Arc<RwLock<MyNode>>,
         msg_id: MsgId,
-        msg_authority: NodeMsgAuthority,
         msg: NodeMsg,
         sender: Peer,
         comm: &Comm,
@@ -512,25 +510,19 @@ impl MyNode {
                     LogMarker::ChunkQueryResponseReceviedFromAdult,
                 );
 
-                match msg_authority {
-                    NodeMsgAuthority::Node(auth) => {
-                        let sending_nodes_pk = PublicKey::from(auth.into_inner().node_ed_pk);
-                        Ok(node
-                            .handle_data_query_response_at_elder(
-                                correlation_id,
-                                response,
-                                user,
-                                sending_nodes_pk,
-                                op_id,
-                                #[cfg(feature = "traceroute")]
-                                traceroute,
-                            )
-                            .await
-                            .into_iter()
-                            .collect())
-                    }
-                    _ => Err(Error::InvalidQueryResponseAuthority),
-                }
+                Ok(node
+                    .handle_data_query_response_at_elder(
+                        correlation_id,
+                        response,
+                        user,
+                        sender.name(),
+                        op_id,
+                        #[cfg(feature = "traceroute")]
+                        traceroute,
+                    )
+                    .await
+                    .into_iter()
+                    .collect())
             }
         }
     }


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

Remove signatures from node messages
- remove `msg_authority` from `MsgType::Node`
- remove the `NodeMsgAuthority` type altogether