### PR TITLE
refactor(client): test helper function for sleeping before querying published Register ops

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -28,7 +28,7 @@ jobs:
       - cargo-deny
       - e2e
       - api
-      # - cli
+      - cli
       # - e2e-split
       - unit
       - checks
@@ -134,7 +134,7 @@ jobs:
           sharedKey: ${{github.run_id}}-unit
 
       - name: Build sn_interface tests before running
-        run: cd sn_interface &&  cargo test --no-run --release
+        run: cd sn_interface && cargo test --no-run --release
         timeout-minutes: 50
 
       - name: Run sn_interface tests
@@ -142,7 +142,7 @@ jobs:
         run: cd sn_interface && cargo test --release
 
       - name: Build sn_dysfunction tests before running
-        run: cd sn_dysfunction &&  cargo test --no-run --release
+        run: cd sn_dysfunction && cargo test --no-run --release
         timeout-minutes: 50
 
       - name: Run sn_dysfunction tests
@@ -207,7 +207,7 @@ jobs:
         timeout-minutes: 60
 
       - name: Build testnet
-        run: cd testnet && cargo build  --release --bin testnet
+        run: cd testnet && cargo build --release --bin testnet
         timeout-minutes: 60
 
       # - name: Build log_cmds_inspector
@@ -218,7 +218,7 @@ jobs:
         run: ./target/release/testnet --interval 30000
         id: section-startup
         env:
-          RUST_LOG: "sn_node,sn_api,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
+          RUST_LOG: "sn_node,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
 
       - name: Wait for all nodes to join
         shell: bash
@@ -603,14 +603,14 @@ jobs:
         timeout-minutes: 60
 
       - name: Build testnet
-        run: cd testnet && cargo build  --release --bin testnet
+        run: cd testnet && cargo build --release --bin testnet
         timeout-minutes: 60
 
       - name: Start the network
         run: ./target/release/testnet --interval 30000
         id: section-startup
         env:
-          RUST_LOG: "sn_node,sn_api,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
+          RUST_LOG: "sn_node,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
 
       - name: Wait for all nodes to join
         shell: bash

--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -561,114 +561,112 @@ jobs:
         if: failure()
         continue-on-error: true
 
-  # cli:
-  #   if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
-  #   name: Run CLI tests
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   steps:
-  #     - uses: actions/checkout@v2
+  cli:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
+    name: Run CLI tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - name: Install Rust
-  #       id: toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: stable
-  #         override: true
+      - name: Install Rust
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
-  #     - uses: Swatinem/rust-cache@v1
-  #       continue-on-error: true
-  #       with:
-  #         cache-on-failure: true
-  #         sharedKey: ${{github.run_id}}
+      - uses: Swatinem/rust-cache@v1
+        continue-on-error: true
+        with:
+          cache-on-failure: true
+          sharedKey: ${{github.run_id}}
 
-  #     - name: install ripgrep ubuntu
-  #       run: sudo apt-get install ripgrep
-  #       if: matrix.os == 'ubuntu-latest'
+      - name: install ripgrep ubuntu
+        run: sudo apt-get install ripgrep
+        if: matrix.os == 'ubuntu-latest'
 
-  #     - name: install ripgrep mac
-  #       run: brew install ripgrep
-  #       if: matrix.os == 'macos-latest'
+      - name: install ripgrep mac
+        run: brew install ripgrep
+        if: matrix.os == 'macos-latest'
 
-  #     - name: install ripgrep windows
-  #       run: choco install ripgrep
-  #       if: matrix.os == 'windows-latest'
+      - name: install ripgrep windows
+        run: choco install ripgrep
+        if: matrix.os == 'windows-latest'
 
-  #     - name: Build sn bins
-  #       run: cd sn_node && cargo build --release --bins
-  #       timeout-minutes: 60
+      - name: Build sn bins
+        run: cd sn_node && cargo build --release --bins
+        timeout-minutes: 60
 
-  #     - name: Build testnet
-  #       run: cd testnet && cargo build  --release --bin testnet
-  #       timeout-minutes: 60
+      - name: Build testnet
+        run: cd testnet && cargo build  --release --bin testnet
+        timeout-minutes: 60
 
-  #     - name: Start the network
-  #       run: ./target/release/testnet --interval 30000
-  #       id: section-startup
-  #       env:
-  #         RUST_LOG: "sn_node,sn_api,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
+      - name: Start the network
+        run: ./target/release/testnet --interval 30000
+        id: section-startup
+        env:
+          RUST_LOG: "sn_node,sn_api,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
 
-  #     - name: Wait for all nodes to join
-  #       shell: bash
-  #       run: ./resources/scripts/wait_for_nodes_to_join.sh
-  #       timeout-minutes: 5
+      - name: Wait for all nodes to join
+        shell: bash
+        run: ./resources/scripts/wait_for_nodes_to_join.sh
+        timeout-minutes: 5
 
-  #     - name: Generate keys for test run
-  #       run: cargo run --package sn_cli --release -- keys create --for-cli
+      - name: Generate keys for test run
+        run: cargo run --package sn_cli --release -- keys create --for-cli
 
-  #     - name: Build all tests before running
-  #       run: cd sn_cli && cargo test --no-run --release
-  #       timeout-minutes: 50
+      - name: Build all tests before running
+        run: cd sn_cli && cargo test --no-run --release
+        timeout-minutes: 50
 
-  #     - name: Run CLI tests
-  #       run: cd sn_cli && cargo test --release -- --test-threads=1
-  #       env:
-  #         RUST_LOG: "sn_client=trace"
-  #       timeout-minutes: 50
+      - name: Run CLI tests
+        run: cd sn_cli && cargo test --release -- --test-threads=1
+        timeout-minutes: 50
 
-  #     - name: Are nodes still running...?
-  #       shell: bash
-  #       timeout-minutes: 1
-  #       if: failure() && matrix.os
-  #       run: |
-  #         echo "$(pgrep sn_node | wc -l) nodes still running"
-  #         ls $HOME/.safe/node/local-test-network
+      - name: Are nodes still running...?
+        shell: bash
+        timeout-minutes: 1
+        if: failure() && matrix.os
+        run: |
+          echo "$(pgrep sn_node | wc -l) nodes still running"
+          ls $HOME/.safe/node/local-test-network
 
-  #     - name: Ensure no nodes have left during test runs
-  #       timeout-minutes: 1
-  #       shell: bash
-  #       if: matrix.os != 'windows-latest'
-  #       # we just want to print out the info. If there is none, an exit code of 1 is returned, so here we return true
-  #       run: rg "Membership - decided" $HOME/.safe/node/local-test-network | rg Left || true
+      - name: Ensure no nodes have left during test runs
+        timeout-minutes: 1
+        shell: bash
+        if: matrix.os != 'windows-latest'
+        # we just want to print out the info. If there is none, an exit code of 1 is returned, so here we return true
+        run: rg "Membership - decided" $HOME/.safe/node/local-test-network | rg Left || true
 
-  #     - name: Generate StateMap
-  #       shell: bash
-  #       continue-on-error: true
-  #       run: |
-  #         cargo install --git https://github.com/TritonDataCenter/statemap.git
-  #         ./resources/scripts/statemap-preprocess.sh --run-statemap > safe_statemap.svg
+      - name: Generate StateMap
+        shell: bash
+        continue-on-error: true
+        run: |
+          cargo install --git https://github.com/TritonDataCenter/statemap.git
+          ./resources/scripts/statemap-preprocess.sh --run-statemap > safe_statemap.svg
 
-  #     - name: Upload StateMap
-  #       uses: actions/upload-artifact@main
-  #       with:
-  #         name: statemap_cli_${{matrix.os}}.svg
-  #         path: safe_statemap.svg
-  #       continue-on-error: true
+      - name: Upload StateMap
+        uses: actions/upload-artifact@main
+        with:
+          name: statemap_cli_${{matrix.os}}.svg
+          path: safe_statemap.svg
+        continue-on-error: true
 
-  #     - name: Tar log files
-  #       shell: bash
-  #       continue-on-error: true
-  #       run: find ~/.safe/node/local-test-network -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
-  #       if: failure()
+      - name: Tar log files
+        shell: bash
+        continue-on-error: true
+        run: find ~/.safe/node/local-test-network -iname '*.log*' | tar -zcvf log_files.tar.gz --files-from -
+        if: failure()
 
-  #     - name: Upload Node Logs
-  #       uses: actions/upload-artifact@main
-  #       with:
-  #         name: sn_node_logs_cli_${{matrix.os}}
-  #         path: log_files.tar.gz
-  #       if: failure()
-  #       continue-on-error: true
+      - name: Upload Node Logs
+        uses: actions/upload-artifact@main
+        with:
+          name: sn_node_logs_cli_${{matrix.os}}
+          path: log_files.tar.gz
+        if: failure()
+        continue-on-error: true

--- a/sn_cli/tests/cli_node.rs
+++ b/sn_cli/tests/cli_node.rs
@@ -42,6 +42,7 @@ fn node_install_should_install_the_latest_version() -> Result<()> {
 }
 
 #[test]
+#[ignore = "reenable when aws setup once more"]
 fn node_install_should_install_a_specific_version() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let safe_dir = temp_dir.child(".safe");
@@ -66,6 +67,7 @@ fn node_install_should_install_a_specific_version() -> Result<()> {
 }
 
 #[test]
+#[ignore = "reenable when aws setup once more"]
 fn node_install_should_install_to_a_specific_location() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let safe_dir = temp_dir.child(".safe");

--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -260,7 +260,6 @@ fn section_sig() -> sn_interface::messaging::SectionSig {
 #[cfg(test)]
 mod tests {
     use crate::{
-        retry_loop_for_pattern,
         utils::test_utils::{create_test_client, init_logger},
         Error,
     };
@@ -280,7 +279,17 @@ mod tests {
         collections::{BTreeMap, BTreeSet},
         time::Instant,
     };
+    use tokio::time::{sleep, Duration};
     use tracing::Instrument;
+
+    // Helper function used by all tests to always wait the same amount of time
+    // before trying to query for published Register ops. The amount of secs shall
+    // be based or directly determined by how much we are stressing the testnet, e.g. if we
+    // are using many test-threads we may need to sleep for a longer period of time.
+    async fn delay_before_we_query_pubished_data() {
+        let duration = Duration::from_secs(1);
+        sleep(duration).await;
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_register_batching() -> Result<()> {
@@ -288,7 +297,6 @@ mod tests {
         let _outer_span = tracing::info_span!("test__register_batching").entered();
 
         let client = create_test_client().await?;
-        let one_sec = tokio::time::Duration::from_secs(1);
         let name = xor_name::rand::random();
         let tag = 15000;
         let owner = User::Key(client.public_key());
@@ -304,7 +312,7 @@ mod tests {
 
         // publish that batch to the network
         client.publish_register_ops(batch).await?;
-        tokio::time::sleep(one_sec).await;
+        delay_before_we_query_pubished_data().await;
 
         // check they're both there
         let register1 = client.get_register(address).await?;
@@ -333,12 +341,10 @@ mod tests {
         let network_assert_delay: u64 = std::env::var("NETWORK_ASSERT_DELAY")
             .unwrap_or_else(|_| "3".to_string())
             .parse()?;
-
-        let client = create_test_client().await?;
-
-        let delay = tokio::time::Duration::from_secs(network_assert_delay);
+        let delay = Duration::from_secs(network_assert_delay);
         debug!("Running network asserts with delay of {:?}", delay);
 
+        let client = create_test_client().await?;
         let name = xor_name::rand::random();
         let tag = 15000;
         let owner = User::Key(client.public_key());
@@ -347,8 +353,8 @@ mod tests {
         let (_address, batch) = client.create_register(name, tag, policy(owner)).await?;
         client.publish_register_ops(batch).await?;
 
-        // small delay to ensure logs have written
-        tokio::time::sleep(delay).await;
+        // small delay to ensure logs have written by the nodes
+        sleep(delay).await;
 
         // All elders should have been written to
         the_logs.assert_count(LogMarker::RegisterWrite, 7)?;
@@ -407,9 +413,7 @@ mod tests {
         // store a Register
         let (address, batch) = client.create_register(name, tag, policy(owner)).await?;
         client.publish_register_ops(batch).await?;
-
-        let delay = tokio::time::Duration::from_secs(1);
-        tokio::time::sleep(delay).await;
+        delay_before_we_query_pubished_data().await;
 
         let register = client.get_register(address).await?;
 
@@ -421,8 +425,8 @@ mod tests {
         // store a second Register
         let (address, batch) = client.create_register(name, tag, policy(owner)).await?;
         client.publish_register_ops(batch).await?;
+        delay_before_we_query_pubished_data().await;
 
-        tokio::time::sleep(delay).await;
         let register = client.get_register(address).await?;
 
         assert_eq!(*register.name(), name);
@@ -451,8 +455,8 @@ mod tests {
             .publish_register_ops(batch)
             .await
             .context("publish ops failed")?;
+        delay_before_we_query_pubished_data().await;
 
-        // keep retrying until ok
         let permissions = client
             .get_register_permissions_for_user(address, owner)
             .instrument(tracing::info_span!("get owner perms"))
@@ -494,6 +498,7 @@ mod tests {
 
         let (address, batch) = client.create_register(name, tag, policy(owner)).await?;
         client.publish_register_ops(batch).await?;
+        delay_before_we_query_pubished_data().await;
 
         let value_1 = random_register_entry();
 
@@ -556,9 +561,10 @@ mod tests {
             .write_to_local_register(address, value_1.clone(), BTreeSet::new())
             .await?;
         client.publish_register_ops(batch).await?;
+        delay_before_we_query_pubished_data().await;
 
         // now check last entry
-        let hashes = retry_loop_for_pattern!(client.read_register(address), Ok(hashes) if !hashes.is_empty())?;
+        let hashes = client.read_register(address).await?;
 
         assert_eq!(1, hashes.len());
         let current = hashes.iter().next();
@@ -578,16 +584,14 @@ mod tests {
         assert!(batch.len() == 1);
 
         client.publish_register_ops(batch).await?;
+        delay_before_we_query_pubished_data().await;
 
         // and then lets check all entries are returned
-        // NB: these will not be ordered according to insertion order, but according to the hashes of the values.
-        let hashes =
-            retry_loop_for_pattern!(client.read_register(address), Ok(hashes) if hashes.len() > 1)?;
+        // NB: these will not be ordered according to insertion order,
+        // but according to the hashes of the values.
+        let hashes = client.read_register(address).await?;
 
         assert_eq!(2, hashes.len());
-
-        let delay = tokio::time::Duration::from_secs(1);
-        tokio::time::sleep(delay).await;
 
         // get_register_entry
         let retrieved_value_1 = client
@@ -595,8 +599,6 @@ mod tests {
             .instrument(tracing::info_span!("get_value_1"))
             .await?;
         assert_eq!(retrieved_value_1, value_1);
-
-        tokio::time::sleep(delay).await;
 
         let retrieved_value_2 = client
             .get_register_entry(address, value2_hash)
@@ -637,6 +639,7 @@ mod tests {
 
         let (address, batch) = client.create_register(name, tag, policy(owner)).await?;
         client.publish_register_ops(batch).await?;
+        delay_before_we_query_pubished_data().await;
 
         // Assert that the data is stored.
         let current_owner = client.get_register_owner(address).await?;
@@ -667,6 +670,7 @@ mod tests {
             .publish_register_ops(batch)
             .await
             .context("publishing reg failed")?;
+        delay_before_we_query_pubished_data().await;
 
         let _register = client
             .get_register(address)

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -58,7 +58,7 @@ impl Session {
         resp_tx: mpsc::Sender<MsgResponse>,
     ) {
         let addr = peer.addr();
-        debug!("Waiting for incoming msg on bi-stream from {peer:?}");
+        debug!("Waiting for response msg on bi-stream from {peer:?} for {msg_id:?}");
 
         let _handle = tokio::spawn(async move {
             match Self::read_msg_from_recvstream(&mut recv_stream).await {
@@ -86,22 +86,6 @@ impl Session {
         })
         .in_current_span();
     }
-
-    // #[instrument(skip_all, level = "debug")]
-    // pub(crate) async fn handle_msg(
-    //     msg: MsgType,
-    //     src_peer: Peer,
-    //     mut session: Self,
-    //     resp_tx: mpsc::Sender<MsgResponse>,
-
-    // ) -> Result<(), Error> {
-    //     match msg.clone() {
-    //         MsgType::Client { msg_id, msg, .. } => {
-    //             Self::handle_client_msg(msg_id, msg, src_peer.addr(), resp_tx).await
-    //         }
-    //         MsgType::Node { msg, .. } => session.handle_system_msg(msg, src_peer, resp_tx).await?,
-    //     }
-    // }
 
     async fn handle_system_msg(
         &mut self,

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -32,7 +32,7 @@ pub enum Error {
     NetworkContacts(String),
     /// InsufficientAcksReceived
     #[error(
-        "Did not receive sufficient ACK messages from elders to be sure this cmd ({msg_id:?}) \
+        "Did not receive sufficient ACK messages from Elders to be sure this cmd ({msg_id:?}) \
         passed, expected: {expected}, received {received}."
     )]
     InsufficientAcksReceived {
@@ -43,9 +43,6 @@ pub enum Error {
         /// Number of received ACKs
         received: usize,
     },
-    /// Message auth checks failed
-    #[error("Message's authority could not be trusted, unknown section key: {0:?}.")]
-    UntrustedMessage(PublicKey),
     /// Initial network contact failed
     #[error("Initial network contact probe failed. Attempted contacts: {0:?}")]
     NetworkContact(Vec<Peer>),
@@ -119,9 +116,6 @@ pub enum Error {
     /// Timeout when awaiting command ACK from Elders.
     #[error("Timeout when awaiting command ACK from Elders for data address {0}")]
     CmdAckValidationTimeout(XorName),
-    /// No operation Id could be found
-    #[error("Could not retrieve the operation id of a query or response")]
-    UnknownOperationId,
     /// Unexpected query response received
     #[error("Unexpected response received for {query:?}. Received: {response:?}")]
     UnexpectedQueryResponse {
@@ -201,8 +195,8 @@ pub enum Error {
     #[error("A signed section authority provider was not found for section key {0:?}")]
     SignedSapNotFound(PublicKey),
     /// Occurs if a DBC spend command eventually fails after a number of retry attempts.
-    #[error("The DBC spend request failed after several retry attempts")]
-    DbcSpendRetryAttemptsExceeded,
+    #[error("The DBC spend request failed after {0} attempts")]
+    DbcSpendRetryAttemptsExceeded(u8),
     /// Occurs if a section key is not found when searching the sections DAG.
     #[error("Section key {0:?} was not found in the sections DAG")]
     SectionsDagKeyNotFound(PublicKey),

--- a/sn_client/src/utils/test_utils/mod.rs
+++ b/sn_client/src/utils/test_utils/mod.rs
@@ -24,20 +24,6 @@ pub use sn_interface::init_logger;
 
 #[cfg(test)]
 #[macro_export]
-/// Helper for tests to retry an operation awaiting for a successful response result
-macro_rules! retry_loop {
-    ($async_func:expr) => {
-        loop {
-            match $async_func.await {
-                Ok(val) => break val,
-                Err(_) => tokio::time::sleep(std::time::Duration::from_secs(2)).await,
-            }
-        }
-    };
-}
-
-#[cfg(test)]
-#[macro_export]
 /// Helper for tests to retry an operation awaiting for a specific result
 macro_rules! retry_loop_for_pattern {
     ($async_func:expr, $pattern:pat $(if $cond:expr)?) => {
@@ -47,8 +33,8 @@ macro_rules! retry_loop_for_pattern {
                 $pattern $(if $cond)? => break result,
                 Ok(_) | Err(_) => {
                     debug!("waiting before retying.....");
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await}
-                    ,
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await
+                }
             }
         }
     };

--- a/sn_cmd_test_utilities/src/lib.rs
+++ b/sn_cmd_test_utilities/src/lib.rs
@@ -342,7 +342,7 @@ pub mod util {
     pub fn parse_files_put_or_sync_output(output: &str) -> Result<(String, ProcessedFiles)> {
         serde_json::from_str(output).map_err(|_| {
             eyre!(
-                "Failed to parse output of `safe files put/sync`: {}",
+                "Failed to parse output of `safe files put/sync` (Perhaps RUST_LOG is polluting output?): {}",
                 output
             )
         })
@@ -352,27 +352,31 @@ pub mod util {
         output: &str,
     ) -> Result<(String, SafeUrl, (String, String, String))> {
         serde_json::from_str(output)
-            .map_err(|_| eyre!("Failed to parse output of `safe nrs register`: {}", output))
+            .map_err(|_| eyre!("Failed to parse output of `safe nrs register` (Perhaps RUST_LOG is polluting output?): {}", output))
     }
 
     pub fn parse_wallet_create_output(output: &str) -> Result<String> {
         serde_json::from_str(output)
-            .map_err(|_| eyre!("Failed to parse output of `safe wallet create`: {}", output))
+            .map_err(|_| eyre!("Failed to parse output of `safe wallet create` (Perhaps RUST_LOG is polluting output?): {}", output))
     }
 
     pub fn parse_xorurl_output(output: &str) -> Result<Vec<(String, String)>> {
         serde_json::from_str(output)
-            .map_err(|_| eyre!("Failed to parse output of `safe xorurl`: {}", output))
+            .map_err(|_| eyre!("Failed to parse output of `safe xorurl` (Perhaps RUST_LOG is polluting output?): {}", output))
     }
 
     pub fn parse_dog_output(output: &str) -> Result<(String, Vec<SafeData>)> {
-        serde_json::from_str(output)
-            .map_err(|_| eyre!("Failed to parse output of `safe dog`: {}", output))
+        serde_json::from_str(output).map_err(|_| {
+            eyre!(
+                "Failed to parse output of `safe dog` (Perhaps RUST_LOG is polluting output?): {}",
+                output
+            )
+        })
     }
 
     pub fn parse_keys_create_output(output: &str) -> Result<(String, String)> {
         serde_json::from_str(output)
-            .map_err(|_| eyre!("Failed to parse output of `safe keys create`: {}", output))
+            .map_err(|_| eyre!("Failed to parse output of `safe keys create` (Perhaps RUST_LOG is polluting output?): {}", output))
     }
 
     /// Runs safe with the arguments specified, with the option to assert on the exit code.


### PR DESCRIPTION
- Also removing unused test utilty from sn_api and unused sn_client::Error types.
- Disabling log instrumentation for large args of `spend_dbc` API.
- Re-enable CLI tests, single-threaded mode, disabling RUST_LOG. Also adds a note about this to errors.