### PR TITLE
feat(client): try to reconnect once when the client lost a connection to a peer

### DIFF
--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -104,11 +104,10 @@ impl Client {
                 )
                 .await;
 
-            // In the next attempt, try the next adult, further away.
-            query.adult_index += 1;
-            // There should not be more than a certain amount of adults holding copies of the data. Retry the closest adult again.
-            if query.adult_index >= data_copy_count() {
-                // we dont want to retry beyond data_copy_count adults so
+            // There should not be more than a certain amount of adults holding
+            // copies of the data. Retry the closest adult again.
+            if query.adult_index >= data_copy_count() - 1 {
+                // we don't want to retry beyond data_copy_count Adults
                 return res;
             }
 
@@ -126,6 +125,8 @@ impl Client {
                     }
                 }
 
+                // In the next attempt, try the next adult, further away.
+                query.adult_index += 1;
                 debug!("Sleeping before trying query again: {delay:?} sleep for {query:?}");
                 sleep(delay).await;
             } else {

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -78,7 +78,10 @@ impl Client {
                 );
                 if attempts >= MAX_SPEND_DBC_ATTEMPS {
                     error!("DBC spend request failed after {attempts} attempts");
-                    return Err(Error::DbcSpendRetryAttemptsExceeded(attempts));
+                    return Err(Error::DbcSpendRetryAttemptsExceeded {
+                        attempts,
+                        key_image,
+                    });
                 }
                 let network = self.session.network.read().await;
                 let (proof_chain, _) = network

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -379,7 +379,10 @@ impl Session {
             }
         }
 
-        Err(Error::NoResponse(elders))
+        Err(Error::NoResponse {
+            msg_id,
+            peers: elders,
+        })
     }
 
     #[instrument(skip_all, level = "debug")]
@@ -626,7 +629,7 @@ impl Session {
                                 break Err(Error::ChoasSendFail)
                             }
                             Err(SendToOneError::Connection(error)) => {
-                                break Err(Error::QuicP2pConnection { peer, error });
+                                break Err(Error::QuicP2pConnection { peer, error, msg_id });
                             }
                             Err(SendToOneError::Send(error @ SendError::ConnectionLost(_))) => {
                                 warn!("Connection lost to {peer:?} (new link?: {force_new_link}): {error}");
@@ -634,7 +637,7 @@ impl Session {
                                 // Unless we were forcing a new link to the peer up front, let's
                                 // retry (only once) to reconnect to this peer and send the msg.
                                 if force_new_link {
-                                    break Err(Error::QuicP2pSend { peer, error });
+                                    break Err(Error::QuicP2pSend { peer, error, msg_id });
                                 } else {
                                     // let's retry once by forcing a new connection to this peer
                                     force_new_link = true;
@@ -646,7 +649,7 @@ impl Session {
                                 }
                             }
                             Err(SendToOneError::Send(error)) => {
-                                break Err(Error::QuicP2pSend { peer, error });
+                                break Err(Error::QuicP2pSend { peer, error, msg_id });
                             }
                         }
                     };

--- a/sn_interface/src/types/connections/mod.rs
+++ b/sn_interface/src/types/connections/mod.rs
@@ -137,6 +137,7 @@ impl PeerLinks {
         let links = self.links.read().await;
         links.get(id).cloned()
     }
+
     pub async fn get_peer_by_name(&self, name: &XorName) -> Option<Peer> {
         let links = self.links.read().await;
 


### PR DESCRIPTION
Also including additional contextual information for a few `sn_client::Error` types.
