### PR TITLE
chore(node): Comm is clone. Dont close endpoint on drop.

### DIFF
--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -345,14 +345,6 @@ fn listen_for_incoming_msgs(
     });
 }
 
-impl Drop for Comm {
-    fn drop(&mut self) {
-        // Close all existing connections and stop accepting new ones.
-        // FIXME: this may be broken – `Comm` is clone, so this will break any clones?
-        self.our_endpoint.close();
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct MsgFromPeer {
     pub(crate) sender: Peer,


### PR DESCRIPTION
We are currently closing our endpoint when we dropp a comms instance. This could lead to closed connections and other unintended consequences if we drop a clone while another instance persists

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
