### PR TITLE
chore: impl custom `Debug` trait to compact the logs

### DIFF
--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -33,16 +33,22 @@ use xor_name::XorName;
 /// List of peers of a section
 pub type SectionPeers = BTreeSet<SectionSigned<NodeState>>;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, custom_debug::Debug)]
 pub enum AntiEntropyKind {
     /// This AE message is sent to a peer when a message with outdated section
     /// information was received, attaching the bounced message so
     /// the peer can resend it with up to date destination information.
-    Retry { bounced_msg: UsrMsgBytes },
+    Retry {
+        #[debug(skip)]
+        bounced_msg: UsrMsgBytes,
+    },
     /// This AE message is sent to a peer when a message needs to be sent to a
     /// different and/or closest section, attaching the bounced message so the peer
     /// can resend it to the correct section with up to date destination information.
-    Redirect { bounced_msg: UsrMsgBytes },
+    Redirect {
+        #[debug(skip)]
+        bounced_msg: UsrMsgBytes,
+    },
     /// This AE message is sent to update a peer when we notice they are behind
     Update { members: SectionPeers },
 }

--- a/sn_interface/src/messaging/system/section_sig.rs
+++ b/sn_interface/src/messaging/system/section_sig.rs
@@ -6,20 +6,26 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use serde::{Deserialize, Serialize};
-
 use crate::messaging::{
     signature_aggregator::{AggregatorError, SignatureAggregator},
     AuthorityProof,
 };
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Debug, Formatter};
 
 /// Signature created when a quorum of the section elders has agreed on something.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct SectionSig {
     /// The BLS public key.
     pub public_key: bls::PublicKey,
     /// The BLS signature corresponding to the public key.
     pub signature: bls::Signature,
+}
+
+impl Debug for SectionSig {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_tuple("SectionSig").field(&self.public_key).finish()
+    }
 }
 
 impl SectionSig {

--- a/sn_interface/src/network_knowledge/node_state.rs
+++ b/sn_interface/src/network_knowledge/node_state.rs
@@ -14,6 +14,7 @@ use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::{Signature, Verifier};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::{self, Debug, Formatter};
 use std::net::SocketAddr;
 use xor_name::{Prefix, XorName};
 
@@ -29,7 +30,7 @@ pub enum MembershipState {
 }
 
 /// Information about a member of our section.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct NodeState {
     peer: Peer,
     /// Current state of the peer
@@ -38,6 +39,22 @@ pub struct NodeState {
     previous_name: Option<XorName>,
 }
 
+impl Debug for NodeState {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut f = f.debug_tuple("NodeState");
+        let f = f
+            .field(&self.name())
+            .field(&self.addr())
+            .field(&self.state());
+
+        let f = if let Some(prev_name) = self.previous_name() {
+            f.field(&format!("prev_name: {prev_name:?}"))
+        } else {
+            f
+        };
+        f.finish()
+    }
+}
 impl NodeState {
     // Creates a `NodeState` in the `Joined` state.
     pub fn joined(peer: Peer, previous_name: Option<XorName>) -> Self {


### PR DESCRIPTION
~~- Readable `AntiEntropyKind` debug messages; previously it printed out the entire binary~~
- `NodeState` is compacted to use half the characters
- `SectionAuthorityProvider` now provides more information while being compact