### PR TITLE
Reenable cmd ids and child ids

### DIFF
--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -8,24 +8,20 @@
 
 use crate::node::flow_ctrl::{cmds::Cmd, dispatcher::Dispatcher};
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use tokio::sync::RwLock;
 use xor_name::XorName;
 
-/// A module for enhanced flow control.
-///
-/// Orders the incoming cmds (work) according to their priority,
-/// and executes them in a controlled way, taking into
-/// account the rate limits of our system load monitoring.
-///
-/// Stacking up direct method calls in the async runtime is sort of
-/// like saying to a node "do everything everyone is asking of you, now".
-/// We're now saying to a node "do as much as you can without choking,
-/// and start with the most important things first".
+/// Takes care of spawning a new task for the processing of a cmd,
+/// collecting resulting cmds from it, and sending it back to the calling context,
+/// all the while logging the correlation between incoming and resulting cmds.
 pub(crate) struct CmdCtrl {
     pub(crate) dispatcher: Arc<Dispatcher>,
     #[allow(dead_code)]
-    id_counter: usize,
+    id_counter: Arc<AtomicUsize>,
 }
 
 impl CmdCtrl {
@@ -35,7 +31,7 @@ impl CmdCtrl {
 
         Self {
             dispatcher: Arc::new(dispatcher),
-            id_counter: 0,
+            id_counter: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -43,37 +39,43 @@ impl CmdCtrl {
         self.dispatcher.node()
     }
 
-    /// Processes the next priority cmd
+    /// Processes the passed in cmd on a new task
     pub(crate) async fn process_cmd_job(
-        dispatcher: Arc<Dispatcher>,
+        &self,
         cmd: Cmd,
-        id: Option<usize>,
+        mut id: Vec<usize>,
         node_identifier: XorName,
-        cmd_process_api: tokio::sync::mpsc::Sender<(Cmd, Option<usize>)>,
+        cmd_process_api: tokio::sync::mpsc::Sender<(Cmd, Vec<usize>)>,
     ) {
-        trace!("about to spawn for processing cmd: {cmd:?}");
+        trace!("about to spawn task for processing cmd: {cmd:?}, id: {id:?}");
+        if id.is_empty() {
+            id.push(self.id_counter.fetch_add(1, Ordering::SeqCst));
+        }
+        let dispatcher = self.dispatcher.clone();
         let _ = tokio::task::spawn(async move {
-            debug!("> spawned process for cmd {cmd:?}");
+            debug!("> spawned process for cmd {cmd:?}, id: {id:?}");
 
             #[cfg(feature = "statemap")]
             sn_interface::statemap::log_state(node_identifier.to_string(), cmd.statemap_state());
 
-            debug!("* spawned process for cmd {cmd:?}, node read done");
             match dispatcher.process_cmd(cmd).await {
                 Ok(cmds) => {
-                    for cmd in cmds {
-                        match cmd_process_api.send((cmd, id)).await {
-                            Ok(_) => {
-                                //no issues
-                            }
+                    for (child_nr, cmd) in cmds.into_iter().enumerate() {
+                        // zero based, first child of first cmd => [0, 0], second child => [0, 1], first child of second child => [0, 1, 0]
+                        let child_id = [id.clone(), [child_nr].to_vec()].concat();
+                        match cmd_process_api.send((cmd, child_id)).await {
+                            Ok(_) => (), // no issues
                             Err(error) => {
-                                error!("Could not enqueue child Cmd: {:?}", error);
+                                let child_id = [id.clone(), [child_nr].to_vec()].concat();
+                                error!(
+                                    "Could not enqueue child cmd with id: {child_id:?}: {error:?}",
+                                );
                             }
                         }
                     }
                 }
                 Err(error) => {
-                    debug!("Error when processing command: {:?}", error);
+                    debug!("Error when processing cmd: {:?}", error);
                 }
             }
 

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -103,7 +103,7 @@ impl FlowCtrl {
         }
 
         for cmd in cmds {
-            if let Err(error) = self.cmd_sender_channel.send((cmd, None)).await {
+            if let Err(error) = self.cmd_sender_channel.send((cmd, vec![])).await {
                 error!("Error queuing std periodic check: {error:?}");
             }
         }
@@ -120,7 +120,7 @@ impl FlowCtrl {
         }
 
         for cmd in cmds {
-            if let Err(error) = self.cmd_sender_channel.send((cmd, None)).await {
+            if let Err(error) = self.cmd_sender_channel.send((cmd, vec![])).await {
                 error!("Error queuing adult periodic check: {error:?}");
             }
         }
@@ -196,7 +196,7 @@ impl FlowCtrl {
         debug!(" ----> all elder periodics cmds ready to push ");
 
         for cmd in cmds {
-            if let Err(error) = self.cmd_sender_channel.send((cmd, None)).await {
+            if let Err(error) = self.cmd_sender_channel.send((cmd, vec![])).await {
                 error!("Error queuing std periodic check: {error:?}");
             }
         }
@@ -344,7 +344,7 @@ impl FlowCtrl {
                     }
 
                     for cmd in cmds {
-                        if let Err(error) = cmd_channel.send((cmd, None)).await {
+                        if let Err(error) = cmd_channel.send((cmd, vec![])).await {
                             error!("Error sending DKG gossip msgs {error:?}");
                         }
                     }

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -49,7 +49,7 @@ const GENESIS_DBC_FILENAME: &str = "genesis_dbc";
 
 static EVENT_CHANNEL_SIZE: usize = 10_000;
 
-pub(crate) type CmdChannel = mpsc::Sender<(Cmd, Option<usize>)>;
+pub(crate) type CmdChannel = mpsc::Sender<(Cmd, Vec<usize>)>;
 
 /// Test only
 pub async fn new_test_api(

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -104,7 +104,7 @@ impl NodeTestApi {
     /// Messages sent here, either section to section or node to node.
     async fn send_cmd(&self, cmd: Cmd) -> Result<()> {
         self.cmd_channel
-            .send((cmd, None))
+            .send((cmd, vec![]))
             .await
             .map_err(|_| Error::CmdSendError)?;
 


### PR DESCRIPTION
Used for logging purposes.

***

The id of a cmd is a vec, where first entry represents the sequential nr of incoming cmds (does not increment by subsequent cmds - i.e. child cmds - spawned from such a cmd). 

I.e. `[0]` is the first cmd, `[235]` is the 235th cmd.

Second entry is the sequential nr of the child cmd spawned from the cmd at first entry, i.e. `[0, 2]` is the third child cmd of the first cmd, `[235, 0]` is the first child cmd of the 235th cmd.
And the first child cmd resulting from child `[235, 0]` would have the id `[235, 0, 0]`.

And so on. 

The trace back to the initial cmd is preserved, by entering the sequence nr of each child at every level of new children.