### PR TITLE
chore(node): move conn acquisition off thread too.

### DIFF
--- a/sn_node/src/comm/link.rs
+++ b/sn_node/src/comm/link.rs
@@ -25,6 +25,7 @@ type ConnId = String;
 /// comms initiation between the peers, and so on.
 /// Unused connections will expire, so the Link is cheap to keep around.
 /// The Link is kept around as long as the peer is deemed worth to keep contact with.
+#[derive(Clone)]
 pub(crate) struct Link {
     peer: Peer,
     endpoint: Endpoint,


### PR DESCRIPTION
This was currently potentially a blocker if there'd been connection issues. And might prevent other messages being sent

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
