### PR TITLE
chore(ci): set nodes join interval to 30secs for testnet in sn-api tests job

### DIFF
--- a/.github/workflows/sn_pr_tests.yml
+++ b/.github/workflows/sn_pr_tests.yml
@@ -498,7 +498,7 @@ jobs:
         timeout-minutes: 60
 
       - name: Start the network
-        run: ./target/release/testnet --interval 3000
+        run: ./target/release/testnet --interval 30000
         id: section-startup
         env:
           RUST_LOG: "sn_node,sn_consensus,sn_dysfunction=trace,sn_interface=trace"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,9 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "qp2p"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab22c90a999c203fae9b4feb298932037e5d592ddd0e14cd917ca155ad53433"
+checksum = "da67ecd34bb2a9584cdb480048708a5234a66fcec61cdb5561afca59428b124a"
 dependencies = [
  "backoff 0.3.0",
  "bincode",
@@ -3070,7 +3070,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "webpki 0.21.4",
 ]
 
 [[package]]

--- a/sn_api/src/app/test_helpers.rs
+++ b/sn_api/src/app/test_helpers.rs
@@ -228,29 +228,11 @@ pub fn random_nrs_name() -> String {
 }
 
 #[macro_export]
-macro_rules! retry_loop {
-    ($n:literal, $async_func:expr) => {{
-        let mut retries: u64 = $n;
-        loop {
-            match $async_func.await {
-                Ok(val) => break val,
-                Err(_) if retries > 0 => {
-                    retries -= 1;
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                }
-                Err(e) => anyhow::bail!("Failed after {} retries: {:?}", $n, e),
-            }
-        }
-    }};
-    // Defaults to 10 retries if n is not provided
-    ($async_func:expr) => {{
-        retry_loop!(10, $async_func)
-    }};
-}
-
-#[macro_export]
 macro_rules! retry_loop_for_pattern {
     ($n:literal, $async_func:expr, $pattern:pat $(if $cond:expr)?) => {{
+        // initial delay as we usually call this right after the data was stored on the network
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
         let mut retries: u64 = $n;
         loop {
             let result = $async_func.await;

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -58,7 +58,8 @@ impl Session {
         resp_tx: mpsc::Sender<MsgResponse>,
     ) {
         let addr = peer.addr();
-        debug!("Waiting for response msg on bi-stream from {peer:?} for {msg_id:?}");
+        let stream_id = recv_stream.id();
+        debug!("Waiting for response msg on {stream_id} from {peer:?} for {msg_id:?}");
 
         let _handle = tokio::spawn(async move {
             match Self::read_msg_from_recvstream(&mut recv_stream).await {
@@ -68,14 +69,14 @@ impl Session {
                 Ok(MsgType::Node { msg, .. }) => {
                     if let Err(err) = session.handle_system_msg(msg, peer, resp_tx).await {
                         error!(
-                            "Error while handling incoming system msg on bi-stream \
+                            "Error while handling incoming system msg on {stream_id} \
                             from {addr:?} for {msg_id:?}: {err:?}"
                         );
                     }
                 }
                 Err(error) => {
                     error!(
-                        "Error while processing incoming msg on bi-stream \
+                        "Error while processing incoming msg on {stream_id} \
                         from {addr:?} in response to {msg_id:?}: {error:?}"
                     );
                 }

--- a/sn_client/src/utils/test_utils/mod.rs
+++ b/sn_client/src/utils/test_utils/mod.rs
@@ -21,21 +21,3 @@ pub use test_client::read_genesis_dbc_from_first_node;
 
 #[cfg(test)]
 pub use sn_interface::init_logger;
-
-#[cfg(test)]
-#[macro_export]
-/// Helper for tests to retry an operation awaiting for a specific result
-macro_rules! retry_loop_for_pattern {
-    ($async_func:expr, $pattern:pat $(if $cond:expr)?) => {
-        loop {
-            let result = $async_func.await;
-            match &result {
-                $pattern $(if $cond)? => break result,
-                Ok(_) | Err(_) => {
-                    debug!("waiting before retying.....");
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await
-                }
-            }
-        }
-    };
-}


### PR DESCRIPTION
- Upgrading qp2p to v0.30.1.
- Include bi-stream id in logs both on client and node sides.
- Removing unused sn_api and sn_client test helpers.
- Adding a 1sec delay in sn-api tests before querying uploaded data to potentially reduce the number of retrying queries.