### PR TITLE
Cleanup around DKG/Handover, remove Proposal duplication

### DIFF
--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -6,19 +6,21 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-mod agreement;
+mod dkg;
 mod join;
 mod join_as_relocated;
 mod node_msgs;
+mod proposal;
 mod section_sig;
 
 use crate::messaging::{AuthorityProof, EndUser, MsgId};
 use crate::network_knowledge::{NodeState, SapCandidate, SectionTreeUpdate};
-pub use agreement::{DkgSessionId, Proposal, SectionSigned};
+pub use dkg::DkgSessionId;
 pub use join::{JoinRejectionReason, JoinRequest, JoinResponse};
 pub use join_as_relocated::{JoinAsRelocatedRequest, JoinAsRelocatedResponse};
 pub use node_msgs::{NodeCmd, NodeEvent, NodeQuery, NodeQueryResponse};
-pub use section_sig::{SectionSig, SectionSigShare};
+pub use proposal::Proposal;
+pub use section_sig::{SectionSig, SectionSigShare, SectionSigned};
 
 use bls::PublicKey as BlsPublicKey;
 use ed25519::Signature;

--- a/sn_interface/src/messaging/system/proposal.rs
+++ b/sn_interface/src/messaging/system/proposal.rs
@@ -15,7 +15,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 /// A Proposal about the state of the section
-/// This can be a result of seeing a node come online, go offline, changes to section info etc.
+/// This can be a result of seeing a node go offline, changes to section info etc.
 /// Anything where we need section authority before action can be taken
 /// Proposals sent by elders or elder candidates, to elders or elder candidates
 #[allow(clippy::large_enum_variant)]

--- a/sn_interface/src/messaging/system/proposal.rs
+++ b/sn_interface/src/messaging/system/proposal.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use serde::{Deserialize, Serialize};
 
-/// A Proposal about the state of the network
+/// A Proposal about the state of the section
 /// This can be a result of seeing a node come online, go offline, changes to section info etc.
 /// Anything where we need section authority before action can be taken
 /// Proposals sent by elders or elder candidates, to elders or elder candidates

--- a/sn_interface/src/messaging/system/section_sig.rs
+++ b/sn_interface/src/messaging/system/section_sig.rs
@@ -7,6 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use serde::{Deserialize, Serialize};
+use std::{borrow::Borrow, ops::Deref};
+use xor_name::Prefix;
 
 use crate::messaging::{
     signature_aggregator::{AggregatorError, SignatureAggregator},
@@ -75,6 +77,32 @@ impl SectionSigShare {
         self.public_key_set
             .public_key_share(self.index)
             .verify(&self.signature_share, payload)
+    }
+}
+
+/// A section signed piece of data
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+pub struct SectionSigned<T: Serialize> {
+    /// some value agreed upon by elders
+    pub value: T,
+    /// section signature over the value
+    pub sig: SectionSig,
+}
+
+impl<T> Borrow<Prefix> for SectionSigned<T>
+where
+    T: Borrow<Prefix> + Serialize,
+{
+    fn borrow(&self) -> &Prefix {
+        self.value.borrow()
+    }
+}
+
+impl<T: Serialize> Deref for SectionSigned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
     }
 }
 

--- a/sn_node/src/node/dkg/README.md
+++ b/sn_node/src/node/dkg/README.md
@@ -21,7 +21,7 @@ pub struct DkgSessionId {
 }
 ```
 
-When a node receives a `DkgStart` message, this DKG session starts.
+When a node receives a `DkgStart` message from at least supermajority of elders, this DKG session starts.
 
 ## Ephemeral bls Keys
 
@@ -86,7 +86,7 @@ Sometimes a node will receive a bunch of votes from another node (either from AE
 
 ## Going to Handover
 
-When DKG finishes, nodes generate their key shares and send out a signed (with that new key share) `Proposal::SectionInfo(SectionAuthorityProvider)` to the elders. Once the elders receive super-majority of those, they know they can propose those in a `Handover` consensus round.
+When DKG finishes, nodes generate their key shares and send out a signed (with that new key share) `Proposal::RequestHandover(SectionAuthorityProvider)` to the elders. Once the elders receive super-majority of those, they know they can propose those in a `Handover` consensus round.
 
 ## Links
 

--- a/sn_node/src/node/dkg/mod.rs
+++ b/sn_node/src/node/dkg/mod.rs
@@ -26,10 +26,15 @@ use std::sync::Arc;
 use std::time::Instant;
 use xor_name::XorName;
 
+/// A mapping of DKG participant XorName to their ephemeral bls public key along
+/// with their ed signature over it as proof that we can trust it
 pub(crate) type DkgPubKeys = BTreeMap<XorName, (BlsPublicKey, Signature)>;
 
+/// Ephemeral bls keys used for a single DKG session
 pub(crate) struct DkgEphemeralKeys {
+    /// our own generated secret key
     secret_key: BlsSecretKey,
+    /// the pub keys of other participants
     pub_keys: DkgPubKeys,
 }
 

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -29,7 +29,9 @@ impl MyNode {
             Proposal::VoteNodeOffline(node_state) => {
                 Ok(self.handle_offline_agreement(node_state, sig))
             }
-            Proposal::SectionInfo(sap) => self.handle_section_info_agreement(sap, sig).await,
+            Proposal::RequestHandover(sap) => {
+                self.handle_request_handover_agreement(sap, sig).await
+            }
             Proposal::NewElders(_) => {
                 error!("Elders agreement should be handled in a separate blocking fashion");
                 Ok(None)
@@ -51,7 +53,7 @@ impl MyNode {
     }
 
     #[instrument(skip(self), level = "trace")]
-    async fn handle_section_info_agreement(
+    async fn handle_request_handover_agreement(
         &mut self,
         sap: SectionAuthorityProvider,
         sig: SectionSig,
@@ -65,7 +67,7 @@ impl MyNode {
             // Other section. We shouln't be receiving or updating a SAP for
             // a remote section here, that is done with a AE msg response.
             debug!(
-                "Ignoring Proposal::SectionInfo since prefix doesn't match ours: {:?}",
+                "Ignoring Proposal::RequestHandover since prefix doesn't match ours: {:?}",
                 sap
             );
             return Ok(None);

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -780,7 +780,7 @@ impl MyNode {
         } else {
             // This proposal is sent to the current set of elders to be aggregated
             // and section signed.
-            let proposal = Proposal::SectionInfo(sap);
+            let proposal = Proposal::RequestHandover(sap);
             let recipients: Vec<_> = self.network_knowledge.section_auth().elders_vec();
             self.send_proposal_with(recipients, proposal, &key_share)
         }

--- a/sn_node/src/node/messaging/handover.rs
+++ b/sn_node/src/node/messaging/handover.rs
@@ -128,7 +128,7 @@ impl MyNode {
     /// Verifies the SAP signature and checks that the signature's public key matches the
     /// signature of the SAP, because SAP candidates are signed by the candidate section key
     fn check_sap_sig(&self, sap: &SectionSigned<SectionAuthorityProvider>) -> Result<()> {
-        let sap_bytes = Proposal::SectionInfo(sap.value.clone()).as_signable_bytes()?;
+        let sap_bytes = Proposal::RequestHandover(sap.value.clone()).as_signable_bytes()?;
         if !sap.sig.verify(&sap_bytes) {
             return Err(Error::InvalidSignature);
         }

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -11,7 +11,7 @@ use crate::{
     node::{
         flow_ctrl::cmds::Cmd,
         messaging::{OutgoingMsg, Peers},
-        Event, MembershipEvent, MyNode, Proposal as CoreProposal, Result, MIN_LEVEL_WHEN_FULL,
+        Event, MembershipEvent, MyNode, Result, MIN_LEVEL_WHEN_FULL,
     },
     storage::Error as StorageError,
 };
@@ -25,7 +25,7 @@ use sn_interface::messaging::Traceroute;
 use sn_interface::{
     messaging::{
         data::StorageLevel,
-        system::{JoinResponse, NodeCmd, NodeEvent, NodeMsg, NodeQuery, Proposal as ProposalMsg},
+        system::{JoinResponse, NodeCmd, NodeEvent, NodeMsg, NodeQuery},
         MsgId,
     },
     network_knowledge::NetworkKnowledge,
@@ -277,17 +277,7 @@ impl MyNode {
                     msg_id
                 );
 
-                // lets convert our message into a usable proposal for core
-                let core_proposal = match proposal {
-                    ProposalMsg::VoteNodeOffline(node_state) => {
-                        CoreProposal::VoteNodeOffline(node_state)
-                    }
-                    ProposalMsg::SectionInfo(sap) => CoreProposal::SectionInfo(sap),
-                    ProposalMsg::NewElders(sap) => CoreProposal::NewElders(sap),
-                    ProposalMsg::JoinsAllowed(allowed) => CoreProposal::JoinsAllowed(allowed),
-                };
-
-                node.handle_proposal(msg_id, core_proposal, sig_share, sender)
+                node.handle_proposal(msg_id, proposal, sig_share, sender)
             }
             NodeMsg::DkgStart(session_id, elder_sig) => {
                 trace!(

--- a/sn_node/src/node/messaging/proposal.rs
+++ b/sn_node/src/node/messaging/proposal.rs
@@ -58,7 +58,7 @@ impl MyNode {
 
         // Broadcast the proposal to the rest of the section elders.
         let msg = NodeMsg::Propose {
-            proposal: proposal.clone().into_msg(),
+            proposal: proposal.clone(),
             sig_share: sig_share.clone(),
         };
 
@@ -99,7 +99,7 @@ impl MyNode {
         let sig_share_pk = &sig_share.public_key_set.public_key();
         let our_prefix = self.network_knowledge.prefix();
         // Any other proposal than SectionInfo needs to be signed by a known section key.
-        if let Proposal::SectionInfo(sap) = &proposal {
+        if let Proposal::RequestHandover(sap) = &proposal {
             if sap.prefix() == our_prefix || sap.prefix().is_extension_of(&our_prefix) {
                 // This `SectionInfo` is proposed by the DKG participants and
                 // it's signed by the new key created by the DKG so we don't

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -25,7 +25,6 @@ mod messages;
 mod messaging;
 mod node_starter;
 mod node_test_api;
-mod proposal;
 mod relocation;
 
 use self::{
@@ -39,7 +38,6 @@ use self::{
         event::{CmdProcessEvent, Elders},
     },
     node_starter::CmdChannel,
-    proposal::Proposal,
 };
 pub use self::{
     cfg::config_handler::Config,
@@ -61,7 +59,10 @@ pub(crate) use relocation::{check as relocation_check, ChurnId};
 pub use sn_interface::network_knowledge::{
     FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
 };
-use sn_interface::{messaging::system::NodeMsg, types::Peer};
+use sn_interface::{
+    messaging::system::{NodeMsg, Proposal},
+    types::Peer,
+};
 
 pub use qp2p::{Config as NetworkConfig, SendStream};
 pub use xor_name::{Prefix, XorName, XOR_NAME_LEN}; // TODO remove pub on API update


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

- Renamed confusing/collisional `Proposal::SectionInfo` to clearer `Proposal::RequestHandover`
- Removed `agreement.rs` and put content in files that make more sense:
    - Moved `SectionSigned` to `section_sig.rs`
    - Moved `DkgSessionId` to `dkg.rs`
    - Moved `Proposal` to `proposal.rs`
- Updated docs around Dkg and Proposals
- Got rid of duplicate `Proposal` type in `sn_node` causing confusion/duplication and unnecessary conversions