### PR TITLE
feat(join): remove age stepping in genesis sections

### DIFF
--- a/sn_cli/tests/cli_node.rs
+++ b/sn_cli/tests/cli_node.rs
@@ -42,6 +42,7 @@ fn node_install_should_install_the_latest_version() -> Result<()> {
 }
 
 #[test]
+#[ignore = "reenable when aws setup once more"]
 fn node_install_should_install_a_specific_version() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let safe_dir = temp_dir.child(".safe");
@@ -66,6 +67,7 @@ fn node_install_should_install_a_specific_version() -> Result<()> {
 }
 
 #[test]
+#[ignore = "reenable when aws setup once more"]
 fn node_install_should_install_to_a_specific_location() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let safe_dir = temp_dir.child(".safe");

--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -39,8 +39,6 @@ pub enum JoinResponse {
         /// The update to our NetworkKnowledge containing the current `SectionAuthorityProvider`
         /// and the section chain truncated from the section key found in the join request.
         section_tree_update: SectionTreeUpdate,
-        /// The age of the node as expected by the section.
-        expected_age: u8,
     },
     /// Response redirecting a joining peer to join a different section,
     /// containing addresses of nodes that are closer (than the recipient) to the

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -51,13 +51,6 @@ pub const GENESIS_DBC_SK: &str = "0c5152498fc5b2f9ed691ef875f2c16f1f950910391f7b
 /// The minimum age a node becomes an adult node.
 pub const MIN_ADULT_AGE: u8 = 5;
 
-/// During the first section, nodes can start at a range of age to avoid too many nodes having the
-/// same time get relocated at the same time.
-/// Defines the lower bound of this range.
-pub const FIRST_SECTION_MIN_AGE: u8 = MIN_ADULT_AGE + 1;
-/// Defines the higher bound of this range.
-pub const FIRST_SECTION_MAX_AGE: u8 = 98;
-
 const SN_ELDER_COUNT: &str = "SN_ELDER_COUNT";
 /// Number of elders per section.
 pub const DEFAULT_ELDER_COUNT: usize = 7;

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -44,8 +44,7 @@ use sn_interface::{
         recommended_section_size, supermajority, test_utils::*, Error as NetworkKnowledgeError,
         MembershipState, MyNodeInfo, NetworkKnowledge, NodeState, RelocateDetails,
         SectionAuthorityProvider, SectionKeyShare, SectionKeysProvider, SectionTree,
-        SectionTreeUpdate, SectionsDAG, FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE,
-        MIN_ADULT_AGE,
+        SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
     },
     types::{keyed_signed, keys::ed25519, Peer, PublicKey, ReplicatedData, SecretKeySet},
 };

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -58,9 +58,7 @@ pub use crate::storage::DataStorage;
 #[cfg(test)]
 pub(crate) use relocation::{check as relocation_check, ChurnId};
 
-pub use sn_interface::network_knowledge::{
-    FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE, MIN_ADULT_AGE,
-};
+pub use sn_interface::network_knowledge::MIN_ADULT_AGE;
 use sn_interface::{messaging::system::NodeMsg, types::Peer};
 
 pub use qp2p::{Config as NetworkConfig, SendStream};


### PR DESCRIPTION
There used to be a worry about too many nodes being relocated at the same time but that is no longer a concern there since we only relocate one node at a time.

This PR remove the age stepping logic so that the genesis sections do not have a special join process.