### PR TITLE
tests: DKG tests + test utils refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,12 +2531,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
-
-[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,15 +3415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_termios"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
-dependencies = [
- "redox_syscall",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3518,17 +3503,6 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
-]
-
-[[package]]
-name = "resource_proof"
-version = "1.0.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e67c3c4a88195d906d92d90fcf35902f5820d44cbaffb7535c2cf9348cf36fd"
-dependencies = [
- "clap 3.2.22",
- "termion",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -4267,7 +4241,6 @@ dependencies = [
  "rand 0.7.3",
  "rand 0.8.5",
  "rayon",
- "resource_proof",
  "rmp-serde",
  "self_encryption",
  "self_update",
@@ -4480,18 +4453,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "termion"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
-dependencies = [
- "libc",
- "numtoa",
- "redox_syscall",
- "redox_termios",
 ]
 
 [[package]]

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -657,8 +657,8 @@ impl Session {
 mod tests {
     use super::*;
     use sn_interface::{
-        network_knowledge::{test_utils::section_signed, SectionTree},
-        test_utils::TestSAP,
+        network_knowledge::SectionTree,
+        test_utils::{TestKeys, TestSAP},
     };
 
     use eyre::{eyre, Result};
@@ -689,7 +689,7 @@ mod tests {
 
         let prefix = prefix("0")?;
         let (section_auth, _, secret_key_set) = TestSAP::random_sap(prefix, elders_len, 0, None);
-        let sap0 = section_signed(&secret_key_set.secret_key(), section_auth)?;
+        let sap0 = TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth)?;
         let (mut network_contacts, _genesis_sk, _) = new_network_network_contacts();
         assert!(network_contacts.insert_without_chain(sap0));
 

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -688,7 +688,8 @@ mod tests {
         let elders_len = 5;
 
         let prefix = prefix("0")?;
-        let (section_auth, _, secret_key_set) = TestSAP::random_sap(prefix, elders_len, 0, None);
+        let (section_auth, _, secret_key_set) =
+            TestSAP::random_sap(prefix, elders_len, 0, None, None);
         let sap0 = TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth)?;
         let (mut network_contacts, _genesis_sk, _) = new_network_network_contacts();
         assert!(network_contacts.insert_without_chain(sap0));

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -656,9 +656,9 @@ impl Session {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sn_interface::network_knowledge::{
-        test_utils::{random_sap, section_signed},
-        SectionTree,
+    use sn_interface::{
+        network_knowledge::{test_utils::section_signed, SectionTree},
+        test_utils::TestSAP,
     };
 
     use eyre::{eyre, Result};
@@ -688,7 +688,7 @@ mod tests {
         let elders_len = 5;
 
         let prefix = prefix("0")?;
-        let (section_auth, _, secret_key_set) = random_sap(prefix, elders_len, 0, None);
+        let (section_auth, _, secret_key_set) = TestSAP::random_sap(prefix, elders_len, 0, None);
         let sap0 = section_signed(&secret_key_set.secret_key(), section_auth)?;
         let (mut network_contacts, _genesis_sk, _) = new_network_network_contacts();
         assert!(network_contacts.insert_without_chain(sap0));

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -154,8 +154,8 @@ pub fn init_logger() {
 pub mod test_utils {
     pub use crate::{
         network_knowledge::{
-            section_authority_provider::test_utils::*, section_tree_test_utils::*, test_utils::*,
-            test_utils_nw::*,
+            section_authority_provider::test_utils::*, test_utils::*, test_utils_nw::*,
+            test_utils_st::*,
         },
         types::keys::test_utils::*,
     };

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -152,7 +152,10 @@ pub fn init_logger() {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils {
-    pub use crate::network_knowledge::{
-        section_authority_provider::test_utils::*, section_tree_test_utils::*, test_utils::*,
+    pub use crate::{
+        network_knowledge::{
+            section_authority_provider::test_utils::*, section_tree_test_utils::*, test_utils::*,
+        },
+        types::keys::test_utils::*,
     };
 }

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -149,3 +149,10 @@ pub fn init_logger() {
             .unwrap_or_else(|_| println!("Error initializing logger"));
     });
 }
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils {
+    pub use crate::network_knowledge::{
+        section_authority_provider::test_utils::*, section_tree_test_utils::*, test_utils::*,
+    };
+}

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -155,6 +155,7 @@ pub mod test_utils {
     pub use crate::{
         network_knowledge::{
             section_authority_provider::test_utils::*, section_tree_test_utils::*, test_utils::*,
+            test_utils_nw::*,
         },
         types::keys::test_utils::*,
     };

--- a/sn_interface/src/messaging/system/section_sig.rs
+++ b/sn_interface/src/messaging/system/section_sig.rs
@@ -6,12 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use serde::{Deserialize, Serialize};
-
 use crate::messaging::{
     signature_aggregator::{AggregatorError, SignatureAggregator},
     AuthorityProof,
 };
+use serde::{Deserialize, Serialize};
 
 /// Signature created when a quorum of the section elders has agreed on something.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -80,19 +79,14 @@ impl SectionSigShare {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::test_utils::TestKeys;
     use bls::SecretKey;
 
     #[test]
     fn verify_keyed_sig() {
         let sk = SecretKey::random();
-        let public_key = sk.public_key();
-        let data = "hello".to_string();
-        let signature = sk.sign(&data);
-        let sig = SectionSig {
-            public_key,
-            signature,
-        };
+        let data = "hello";
+        let sig = TestKeys::get_section_sig_bytes(&sk, data.as_bytes());
         assert!(sig.verify(data.as_bytes()));
     }
 }

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -17,7 +17,7 @@ mod sections_dag;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 #[cfg(any(test, feature = "test-utils"))]
-pub use section_tree::test_utils as section_tree_test_utils;
+pub use section_tree::test_utils as test_utils_st;
 
 pub use self::{
     errors::{Error, Result},

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -630,7 +630,7 @@ pub mod test_utils_nw {
         ) -> Result<(NetworkKnowledge, Vec<MyNodeInfo>)> {
             let pk_set = sk_set.public_keys();
             let (sap, node_infos) =
-                TestSAP::random_sap_with_key(prefix, elder_count, adult_count, sk_set);
+                TestSAP::random_sap_with_key(prefix, elder_count, adult_count, sk_set, None);
             let signed_sap = TestKeys::get_section_signed(&sk_set.secret_key(), sap)?;
             let section_tree_update =
                 super::SectionTreeUpdate::new(signed_sap, SectionsDAG::new(pk_set.public_key()));
@@ -730,7 +730,7 @@ mod tests {
         let (mut knowledge, _) = NetworkKnowledge::first_node(peer, sk_gen.clone())?;
 
         // section 1
-        let (sap1, _, sk_1) = TestSAP::random_sap(prefix("1")?, 0, 0, None);
+        let (sap1, _, sk_1) = TestSAP::random_sap(prefix("1")?, 0, 0, None, None);
         let sap1 = TestKeys::get_section_signed(&sk_1.secret_key(), sap1)?;
         let our_node_name_prefix_1 = sap1.prefix().name();
         let proof_chain = knowledge.section_chain();
@@ -744,7 +744,7 @@ mod tests {
         assert_eq!(knowledge.signed_sap, sap1);
 
         // section with different prefix (0) and our node name doesn't match
-        let (sap0, _, sk_0) = TestSAP::random_sap(prefix("0")?, 0, 0, None);
+        let (sap0, _, sk_0) = TestSAP::random_sap(prefix("0")?, 0, 0, None, None);
         let sap0 = TestKeys::get_section_signed(&sk_0.secret_key(), sap0)?;
         let section_tree_update =
             TestSectionTree::get_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key())?;

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -607,7 +607,7 @@ fn create_first_sig<T: Serialize>(
 mod tests {
     use super::{supermajority, NetworkKnowledge};
     use crate::{
-        test_utils::{gen_addr, gen_section_tree_update, prefix, section_signed, TestSAP},
+        test_utils::{gen_addr, gen_section_tree_update, prefix, TestKeys, TestSAP},
         types::Peer,
     };
     use bls::SecretKeySet;
@@ -650,7 +650,7 @@ mod tests {
 
         // section 1
         let (sap1, _, sk_1) = TestSAP::random_sap(prefix("1")?, 0, 0, None);
-        let sap1 = section_signed(&sk_1.secret_key(), sap1)?;
+        let sap1 = TestKeys::get_section_signed(&sk_1.secret_key(), sap1)?;
         let our_node_name_prefix_1 = sap1.prefix().name();
         let proof_chain = knowledge.section_chain();
         let section_tree_update =
@@ -664,7 +664,7 @@ mod tests {
 
         // section with different prefix (0) and our node name doesn't match
         let (sap0, _, sk_0) = TestSAP::random_sap(prefix("0")?, 0, 0, None);
-        let sap0 = section_signed(&sk_0.secret_key(), sap0)?;
+        let sap0 = TestKeys::get_section_signed(&sk_0.secret_key(), sap0)?;
         let section_tree_update =
             gen_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key())?;
         // our node is still in prefix1

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -14,9 +14,10 @@ pub mod section_keys;
 mod section_peers;
 mod section_tree;
 mod sections_dag;
-
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
+#[cfg(any(test, feature = "test-utils"))]
+pub use section_tree::test_utils as section_tree_test_utils;
 
 pub use self::{
     errors::{Error, Result},
@@ -604,12 +605,11 @@ fn create_first_sig<T: Serialize>(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        supermajority,
-        test_utils::{gen_addr, prefix, random_sap, section_signed},
-        NetworkKnowledge,
+    use super::{supermajority, NetworkKnowledge};
+    use crate::{
+        test_utils::{gen_addr, gen_section_tree_update, prefix, section_signed, TestSAP},
+        types::Peer,
     };
-    use crate::{network_knowledge::test_utils::gen_section_tree_update, types::Peer};
     use bls::SecretKeySet;
     use eyre::Result;
     use proptest::prelude::*;
@@ -649,7 +649,7 @@ mod tests {
         let (mut knowledge, _) = NetworkKnowledge::first_node(peer, sk_gen.clone())?;
 
         // section 1
-        let (sap1, _, sk_1) = random_sap(prefix("1")?, 0, 0, None);
+        let (sap1, _, sk_1) = TestSAP::random_sap(prefix("1")?, 0, 0, None);
         let sap1 = section_signed(&sk_1.secret_key(), sap1)?;
         let our_node_name_prefix_1 = sap1.prefix().name();
         let proof_chain = knowledge.section_chain();
@@ -663,7 +663,7 @@ mod tests {
         assert_eq!(knowledge.signed_sap, sap1);
 
         // section with different prefix (0) and our node name doesn't match
-        let (sap0, _, sk_0) = random_sap(prefix("0")?, 0, 0, None);
+        let (sap0, _, sk_0) = TestSAP::random_sap(prefix("0")?, 0, 0, None);
         let sap0 = section_signed(&sk_0.secret_key(), sap0)?;
         let section_tree_update =
             gen_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key())?;

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -605,16 +605,9 @@ fn create_first_sig<T: Serialize>(
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils_nw {
-    use super::{
-        MyNodeInfo, NetworkKnowledge, NodeState, SectionKeyShare, SectionTree, SectionTreeUpdate,
-        SectionsDAG,
-    };
-    use crate::{
-        test_utils::{TestSAP, TestSectionTree},
-        types::keys::test_utils::TestKeys,
-        SectionAuthorityProvider,
-    };
-    use eyre::{eyre, Result};
+    use super::{MyNodeInfo, NetworkKnowledge, NodeState, SectionTree, SectionsDAG};
+    use crate::{test_utils::TestSAP, types::keys::test_utils::TestKeys};
+    use eyre::Result;
     use xor_name::Prefix;
 
     /// `NetworkKnowledge` related utils for testing
@@ -644,42 +637,6 @@ pub mod test_utils_nw {
                 let _changed = network_knowledge.section_peers.update(signed_state);
             }
             Ok((network_knowledge, node_infos))
-        }
-
-        pub fn do_create_section(
-            section_auth: &SectionAuthorityProvider,
-            genesis_ks: &bls::SecretKeySet,
-            other_section_keys: Option<Vec<bls::SecretKey>>,
-            parent_section_tree: Option<SectionTree>,
-        ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
-            let (section_chain, last_sk, share_index) =
-                if let Some(other_section_keys) = other_section_keys {
-                    let section_chain = TestSectionTree::gen_proof_chain(
-                        &genesis_ks.secret_key(),
-                        &other_section_keys,
-                    )?;
-                    let last_key = other_section_keys
-                        .last()
-                        .ok_or_else(|| eyre!("The section keys list must be populated"))?;
-                    let share_index = other_section_keys.len() - 1;
-                    (section_chain, last_key.clone(), share_index)
-                } else {
-                    let section_chain = SectionsDAG::new(genesis_ks.public_keys().public_key());
-                    (section_chain, genesis_ks.secret_key(), 0)
-                };
-
-            let signed_sap = TestKeys::get_section_signed(&last_sk, section_auth.clone())?;
-            let section_tree_update = SectionTreeUpdate::new(signed_sap, section_chain);
-            let section_tree = if let Some(parent_section_tree) = parent_section_tree {
-                parent_section_tree
-            } else {
-                SectionTree::new(genesis_ks.public_keys().public_key())
-            };
-            let section = NetworkKnowledge::new(section_tree, section_tree_update)?;
-
-            let sks = bls::SecretKeySet::from_bytes(last_sk.to_bytes().to_vec())?;
-            let section_key_share = TestKeys::get_section_key_share(&sks, share_index);
-            Ok((section, section_key_share))
         }
     }
 }

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -198,7 +198,7 @@ pub mod test_utils {
     use crate::{
         messaging::system::SectionSigned,
         network_knowledge::{MyNodeInfo, NodeState, SectionAuthorityProvider},
-        test_utils::{gen_sorted_nodes, section_signed},
+        test_utils::{gen_sorted_nodes, TestKeys},
     };
     use eyre::{Context, Result};
     use rand::RngCore;
@@ -211,7 +211,7 @@ pub mod test_utils {
             prefix: Prefix,
         ) -> Result<(SectionSigned<SectionAuthorityProvider>, bls::SecretKey)> {
             let (section_auth, _, secret_key_set) = Self::random_sap(prefix, 5, 0, None);
-            let sap = section_signed(&secret_key_set.secret_key(), section_auth)
+            let sap = TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth)
                 .context(format!("Failed to generate SAP for prefix {:?}", prefix))?;
             Ok((sap, secret_key_set.secret_key()))
         }

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -200,27 +200,21 @@ pub mod test_utils {
         network_knowledge::{MyNodeInfo, NodeState, SectionAuthorityProvider},
         test_utils::{gen_sorted_nodes, TestKeys},
     };
-    use eyre::{Context, Result};
+    use eyre::Result;
     use rand::RngCore;
     use xor_name::Prefix;
 
+    /// `SectionAuthorityProvider` related utils for testing
     pub struct TestSAP {}
 
     impl TestSAP {
-        pub fn gen_section_auth(
-            prefix: Prefix,
-        ) -> Result<(SectionSigned<SectionAuthorityProvider>, bls::SecretKey)> {
-            let (section_auth, _, secret_key_set) = Self::random_sap(prefix, 5, 0, None);
-            let sap = TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth)
-                .context(format!("Failed to generate SAP for prefix {:?}", prefix))?;
-            Ok((sap, secret_key_set.secret_key()))
-        }
-
         /// Generate a random `SectionAuthorityProvider` for testing.
         ///
         /// The total number of members in the section will be `elder_count` + `adult_count`. A lot of
         /// tests don't require adults in the section, so zero is an acceptable value for
         /// `adult_count`.
+        ///
+        /// The rng is used to generate the `SecretKeySet`
         ///
         /// An optional `sk_threshold_size` can be passed to specify the threshold when the secret key
         /// set is generated for the section key. Some tests require a low threshold.
@@ -241,6 +235,9 @@ pub mod test_utils {
             (section_auth, nodes, sks)
         }
 
+        /// Generate a random `SectionAuthorityProvider` for testing.
+        ///
+        /// Same as `random_sap_with_rng` but with `thread_rng`.
         pub fn random_sap(
             prefix: Prefix,
             elder_count: usize,
@@ -272,6 +269,25 @@ pub mod test_utils {
             let section_auth =
                 SectionAuthorityProvider::new(elders, prefix, members, sk_set.public_keys(), 0);
             (section_auth, nodes)
+        }
+
+        /// Generate a random `SectionAuthorityProvider` which is signed by itself
+        pub fn random_signed_sap(
+            prefix: Prefix,
+            elder_count: usize,
+            adult_count: usize,
+            sk_threshold_size: Option<usize>,
+        ) -> Result<(
+            SectionSigned<SectionAuthorityProvider>,
+            Vec<MyNodeInfo>,
+            bls::SecretKey,
+        )> {
+            let (section_auth, nodes, secret_key_set) =
+                Self::random_sap(prefix, elder_count, adult_count, sk_threshold_size);
+            let signed_sap =
+                TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth)?;
+
+            Ok((signed_sap, nodes, secret_key_set.secret_key()))
         }
     }
 }

--- a/sn_interface/src/network_knowledge/section_peers.rs
+++ b/sn_interface/src/network_knowledge/section_peers.rs
@@ -120,10 +120,8 @@ mod tests {
     use super::{SectionPeers, SectionsDAG};
     use crate::{
         messaging::system::SectionSigned,
-        network_knowledge::{
-            test_utils::{assert_lists, gen_addr, section_signed},
-            MembershipState, NodeState, RelocateDetails,
-        },
+        network_knowledge::{MembershipState, NodeState, RelocateDetails},
+        test_utils::{assert_lists, gen_addr, TestKeys},
         types::Peer,
     };
     use eyre::Result;
@@ -162,7 +160,7 @@ mod tests {
         nodes_2.iter().for_each(|node| {
             section_peers.update(node.clone());
         });
-        let sig = bincode::serialize(&sk_2.public_key()).map(|bytes| sk_1.sign(&bytes))?;
+        let sig = TestKeys::sign(&sk_1, &sk_2.public_key())?;
         proof_chain.insert(&sk_1.public_key(), sk_2.public_key(), sig)?;
         // 1 -> 2 should be retained
         section_peers.prune_members_archive(&proof_chain, &sk_2.public_key())?;
@@ -177,7 +175,7 @@ mod tests {
         nodes_3.iter().for_each(|node| {
             section_peers.update(node.clone());
         });
-        let sig = bincode::serialize(&sk_3.public_key()).map(|bytes| sk_2.sign(&bytes))?;
+        let sig = TestKeys::sign(&sk_2, &sk_3.public_key())?;
         proof_chain.insert(&sk_2.public_key(), sk_3.public_key(), sig)?;
         // 1 -> 2 -> 3 should be retained
         section_peers.prune_members_archive(&proof_chain, &sk_3.public_key())?;
@@ -192,7 +190,7 @@ mod tests {
         nodes_4.iter().for_each(|node| {
             section_peers.update(node.clone());
         });
-        let sig = bincode::serialize(&sk_4.public_key()).map(|bytes| sk_3.sign(&bytes))?;
+        let sig = TestKeys::sign(&sk_3, &sk_4.public_key())?;
         proof_chain.insert(&sk_3.public_key(), sk_4.public_key(), sig)?;
         //  2 -> 3 -> 4 should be retained
         section_peers.prune_members_archive(&proof_chain, &sk_4.public_key())?;
@@ -210,7 +208,7 @@ mod tests {
         nodes_5.iter().for_each(|node| {
             section_peers.update(node.clone());
         });
-        let sig = bincode::serialize(&sk_5.public_key()).map(|bytes| sk_3.sign(&bytes))?;
+        let sig = TestKeys::sign(&sk_3, &sk_5.public_key())?;
         proof_chain.insert(&sk_3.public_key(), sk_5.public_key(), sig)?;
         // 2 -> 3 -> 5 should be retained
         section_peers.prune_members_archive(&proof_chain, &sk_5.public_key())?;
@@ -242,9 +240,10 @@ mod tests {
         assert!(section_peers.update(node_left.clone()));
         assert!(section_peers.update(node_relocated.clone()));
 
-        let node_left_joins = section_signed(&sk, NodeState::joined(*node_left.peer(), None))?;
+        let node_left_joins =
+            TestKeys::get_section_signed(&sk, NodeState::joined(*node_left.peer(), None))?;
         let node_relocated_joins =
-            section_signed(&sk, NodeState::joined(*node_relocated.peer(), None))?;
+            TestKeys::get_section_signed(&sk, NodeState::joined(*node_relocated.peer(), None))?;
         assert!(!section_peers.update(node_left_joins));
         assert!(!section_peers.update(node_relocated_joins));
 
@@ -274,9 +273,9 @@ mod tests {
         assert!(section_peers.update(node_2.clone()));
 
         let node_1 = NodeState::left(*node_1.peer(), Some(node_1.name()));
-        let node_1 = section_signed(&sk, node_1)?;
+        let node_1 = TestKeys::get_section_signed(&sk, node_1)?;
         let node_2 = NodeState::left(*node_2.peer(), Some(node_2.name()));
-        let node_2 = section_signed(&sk, node_2)?;
+        let node_2 = TestKeys::get_section_signed(&sk, node_2)?;
         assert!(section_peers.update(node_1.clone()));
         assert!(section_peers.update(node_2.clone()));
 
@@ -305,7 +304,7 @@ mod tests {
                     NodeState::relocated(peer, None, (**details).clone())
                 }
             };
-            let sig = section_signed(secret_key, node_state)?;
+            let sig = TestKeys::get_section_signed(secret_key, node_state)?;
             signed_node_states.push(sig);
         }
         Ok(signed_node_states)

--- a/sn_interface/src/network_knowledge/section_peers.rs
+++ b/sn_interface/src/network_knowledge/section_peers.rs
@@ -124,7 +124,7 @@ mod tests {
             test_utils::{assert_lists, gen_addr, section_signed},
             MembershipState, NodeState, RelocateDetails,
         },
-        types::{Peer, SecretKeySet},
+        types::Peer,
     };
     use eyre::Result;
     use rand::thread_rng;
@@ -136,7 +136,7 @@ mod tests {
         let mut section_peers = SectionPeers::default();
 
         // adding node set 1
-        let sk_1 = SecretKeySet::random(None).secret_key().clone();
+        let sk_1 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_1 = gen_random_signed_node_states(1, MembershipState::Left, &sk_1)?;
         nodes_1.iter().for_each(|node| {
             section_peers.update(node.clone());
@@ -147,7 +147,7 @@ mod tests {
         assert_lists(section_peers.archive.values(), &nodes_1);
 
         // adding node set 2 as MembershipState::Relocated
-        let sk_2 = SecretKeySet::random(None).secret_key().clone();
+        let sk_2 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let relocate = RelocateDetails {
             previous_name: XorName::random(&mut rng),
             dst: XorName::random(&mut rng),
@@ -172,7 +172,7 @@ mod tests {
         );
 
         // adding node set 3
-        let sk_3 = SecretKeySet::random(None).secret_key().clone();
+        let sk_3 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_3 = gen_random_signed_node_states(1, MembershipState::Left, &sk_3)?;
         nodes_3.iter().for_each(|node| {
             section_peers.update(node.clone());
@@ -187,7 +187,7 @@ mod tests {
         );
 
         // adding node set 4
-        let sk_4 = SecretKeySet::random(None).secret_key().clone();
+        let sk_4 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_4 = gen_random_signed_node_states(1, MembershipState::Left, &sk_4)?;
         nodes_4.iter().for_each(|node| {
             section_peers.update(node.clone());
@@ -205,7 +205,7 @@ mod tests {
         // 1 -> 2 -> 3 -> 4
         //              |
         //              -> 5
-        let sk_5 = SecretKeySet::random(None).secret_key().clone();
+        let sk_5 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_5 = gen_random_signed_node_states(1, MembershipState::Left, &sk_5)?;
         nodes_5.iter().for_each(|node| {
             section_peers.update(node.clone());
@@ -226,7 +226,7 @@ mod tests {
     fn archived_members_should_not_be_moved_to_members_list() -> Result<()> {
         let mut rng = thread_rng();
         let mut section_peers = SectionPeers::default();
-        let sk = SecretKeySet::random(None).secret_key().clone();
+        let sk = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let node_left = gen_random_signed_node_states(1, MembershipState::Left, &sk)?[0].clone();
         let relocate = RelocateDetails {
             previous_name: XorName::random(&mut rng),
@@ -257,7 +257,7 @@ mod tests {
     fn members_should_be_archived_if_they_leave_or_relocate() -> Result<()> {
         let mut rng = thread_rng();
         let mut section_peers = SectionPeers::default();
-        let sk = SecretKeySet::random(None).secret_key().clone();
+        let sk = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
 
         let node_1 = gen_random_signed_node_states(1, MembershipState::Joined, &sk)?[0].clone();
         let relocate = RelocateDetails {

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -488,7 +488,7 @@ impl SectionsDAG {
 }
 
 #[cfg(test)]
-pub(super) mod tests {
+pub(crate) mod tests {
     use super::{Error, SectionInfo, SectionsDAG};
     use crate::{
         messaging::system::SectionSigned,
@@ -1162,7 +1162,7 @@ pub(super) mod tests {
     }
 
     // Generate a random `SectionsDAG` and the SAP for each of the section key
-    pub(super) fn gen_random_sections_dag(
+    fn gen_random_sections_dag(
         seed: Option<u64>,
         n_sections: usize,
     ) -> Result<(

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -495,13 +495,12 @@ pub(super) mod tests {
         network_knowledge::test_utils::{
             assert_lists, prefix, random_sap_with_rng, section_signed,
         },
-        types::SecretKeySet,
         SectionAuthorityProvider,
     };
     use crdts::CmRDT;
     use eyre::{eyre, Result};
     use proptest::prelude::{any, proptest, ProptestConfig, Strategy};
-    use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
+    use rand::{rngs::StdRng, thread_rng, Rng, RngCore, SeedableRng};
     use std::collections::{BTreeMap, BTreeSet};
     use xor_name::Prefix;
 
@@ -1073,7 +1072,7 @@ pub(super) mod tests {
 
     // Test helpers
     fn gen_keypair() -> (bls::SecretKey, bls::PublicKey) {
-        let sk_set = SecretKeySet::random(None);
+        let sk_set = bls::SecretKeySet::random(0, &mut thread_rng());
         let sk = sk_set.secret_key();
         (sk.clone(), sk.public_key())
     }

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -492,9 +492,7 @@ pub(super) mod tests {
     use super::{Error, SectionInfo, SectionsDAG};
     use crate::{
         messaging::system::SectionSigned,
-        network_knowledge::test_utils::{
-            assert_lists, prefix, random_sap_with_rng, section_signed,
-        },
+        test_utils::{assert_lists, prefix, section_signed, TestSAP},
         SectionAuthorityProvider,
     };
     use crdts::CmRDT;
@@ -1182,7 +1180,8 @@ pub(super) mod tests {
             None => StdRng::from_entropy(),
         };
 
-        let (sap_gen, _, sk_gen) = random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None);
+        let (sap_gen, _, sk_gen) =
+            TestSAP::random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None);
         let sk_gen = sk_gen.secret_key();
         let sap_gen = section_signed(&sk_gen, sap_gen)?;
         let pk_gen = sap_gen.public_key_set().public_key();
@@ -1210,7 +1209,7 @@ pub(super) mod tests {
             >,
             dag: &mut SectionsDAG,
         ) -> Result<()> {
-            let (sap, _, sk_set) = random_sap_with_rng(rng, prefix, 0, 0, None);
+            let (sap, _, sk_set) = TestSAP::random_sap_with_rng(rng, prefix, 0, 0, None);
             let sap = section_signed(&sk_set.secret_key(), sap)?;
             let key = sap.public_key_set().public_key();
             let sig = sign(parent_sk, &key);

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -1175,7 +1175,7 @@ pub(crate) mod tests {
         };
 
         let (sap_gen, _, sk_gen) =
-            TestSAP::random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None);
+            TestSAP::random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None, None);
         let sk_gen = sk_gen.secret_key();
         let sap_gen = TestKeys::get_section_signed(&sk_gen, sap_gen)?;
         let pk_gen = sap_gen.public_key_set().public_key();
@@ -1203,7 +1203,7 @@ pub(crate) mod tests {
             >,
             dag: &mut SectionsDAG,
         ) -> Result<()> {
-            let (sap, _, sk_set) = TestSAP::random_sap_with_rng(rng, prefix, 0, 0, None);
+            let (sap, _, sk_set) = TestSAP::random_sap_with_rng(rng, prefix, 0, 0, None, None);
             let sap = TestKeys::get_section_signed(&sk_set.secret_key(), sap)?;
             let key = sap.public_key_set().public_key();
             let sig = TestKeys::sign(parent_sk, &key).expect("Failed to sign public key");

--- a/sn_interface/src/network_knowledge/test_utils.rs
+++ b/sn_interface/src/network_knowledge/test_utils.rs
@@ -79,7 +79,8 @@ pub fn gen_sorted_nodes(
                 gen_addr(),
             )
         }))
-        .sorted_by_key(|node| node.name())
+        .sorted_by_key(|node| node.age())
+        .rev()
         .collect()
 }
 

--- a/sn_interface/src/types/keys/secret_key.rs
+++ b/sn_interface/src/types/keys/secret_key.rs
@@ -84,16 +84,3 @@ impl Display for SecretKey {
         Debug::fmt(self, formatter)
     }
 }
-
-#[cfg(any(test, feature = "test-utils"))]
-pub(crate) mod test_utils {
-    use crate::messaging::system::SectionSig;
-
-    /// Create signature for the given bytes using the given secret key.
-    pub fn keyed_signed(secret_key: &bls::SecretKey, bytes: &[u8]) -> SectionSig {
-        SectionSig {
-            public_key: secret_key.public_key(),
-            signature: secret_key.sign(bytes),
-        }
-    }
-}

--- a/sn_interface/src/types/keys/secret_key.rs
+++ b/sn_interface/src/types/keys/secret_key.rs
@@ -88,49 +88,6 @@ impl Display for SecretKey {
 #[cfg(any(test, feature = "test-utils"))]
 pub(crate) mod test_utils {
     use crate::messaging::system::SectionSig;
-    use crate::network_knowledge::{elder_count, supermajority};
-    use rand::RngCore;
-    use std::ops::Deref;
-
-    fn threshold() -> usize {
-        supermajority(elder_count()) - 1
-    }
-
-    // Wrapper for `bls::SecretKeySet` that also allows to retrieve the corresponding `bls::SecretKey`.
-    // Note: `bls::SecretKeySet` does have a `secret_key` method, but it's test-only and not available
-    // for the consumers of the crate.
-    #[derive(Clone)]
-    pub struct SecretKeySet {
-        set: bls::SecretKeySet,
-        key: bls::SecretKey,
-    }
-
-    impl SecretKeySet {
-        pub fn random(threshold_size: Option<usize>) -> Self {
-            Self::random_with_rng(&mut rand::thread_rng(), threshold_size)
-        }
-
-        pub fn random_with_rng<R: RngCore>(rng: &mut R, threshold_size: Option<usize>) -> Self {
-            let threshold_size = threshold_size.unwrap_or_else(threshold);
-            let poly = bls::poly::Poly::random(threshold_size, rng);
-            let key = bls::SecretKey::from_mut(&mut poly.evaluate(0));
-            let set = bls::SecretKeySet::from(poly);
-
-            Self { set, key }
-        }
-
-        pub fn secret_key(&self) -> &bls::SecretKey {
-            &self.key
-        }
-    }
-
-    impl Deref for SecretKeySet {
-        type Target = bls::SecretKeySet;
-
-        fn deref(&self) -> &Self::Target {
-            &self.set
-        }
-    }
 
     /// Create signature for the given bytes using the given secret key.
     pub fn keyed_signed(secret_key: &bls::SecretKey, bytes: &[u8]) -> SectionSig {

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -44,9 +44,6 @@ pub use peer::Peer;
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
-#[cfg(any(test, feature = "test-utils"))]
-pub use keys::secret_key::test_utils::keyed_signed;
-
 // TODO: temporary type tag for spentbook since its underlying data type is
 // still not implemented, it uses a Public Register for now.
 pub const SPENTBOOK_TYPE_TAG: u64 = 0;

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
 #[cfg(any(test, feature = "test-utils"))]
-pub use keys::secret_key::test_utils::{keyed_signed, SecretKeySet};
+pub use keys::secret_key::test_utils::keyed_signed;
 
 // TODO: temporary type tag for spentbook since its underlying data type is
 // still not implemented, it uses a Public Register for now.

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -62,7 +62,6 @@ qp2p = "~0.30.0"
 rand = "~0.8"
 rand-07 = { package = "rand", version = "~0.7.3" }
 rayon = "1.5.1"
-resource_proof = "1.0.39"
 rmp-serde = "1.0.0"
 self_encryption = "~0.27.5"
 sn_consensus = "3.1.2"

--- a/sn_node/benches/data_storage.rs
+++ b/sn_node/benches/data_storage.rs
@@ -8,9 +8,10 @@
 
 use sn_interface::{
     messaging::data::{CreateRegister, SignedRegisterCreate},
+    test_utils::TestKeys,
     types::{
         register::{Policy, User},
-        Chunk, Keypair, PublicKey, RegisterCmd, ReplicatedData,
+        Chunk, Keypair, PublicKey, RegisterCmd, ReplicatedData, SectionSig,
     },
 };
 use sn_node::{
@@ -212,17 +213,9 @@ fn bench_data_storage_reads(c: &mut Criterion) -> Result<()> {
     Ok(())
 }
 
-fn section_sig() -> sn_interface::messaging::SectionSig {
-    use sn_interface::messaging::system::SectionSig;
-
+fn section_sig() -> SectionSig {
     let sk = bls::SecretKey::random();
-    let public_key = sk.public_key();
-    let data = "hello".to_string();
-    let signature = sk.sign(&data);
-    SectionSig {
-        public_key,
-        signature,
-    }
+    TestKeys::get_section_sig_bytes(&sk, "hello".as_bytes())
 }
 
 fn custom_criterion() -> Criterion {

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -452,7 +452,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone())?;
+        let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone())?;
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -466,7 +466,7 @@ mod tests {
 
         let next_section_key = next_sk_set.public_keys().public_key();
         let section_tree_update = gen_section_tree_update(
-            &section_signed(&next_sk_set.secret_key(), next_sap.clone())?,
+            &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap.clone())?,
             &SectionsDAG::new(genesis_pk),
             &genesis_sk,
         )?;
@@ -559,7 +559,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone())?;
+        let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone())?;
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -637,7 +637,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone())?;
+        let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone())?;
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -715,7 +715,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone())?;
+        let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone())?;
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -773,7 +773,7 @@ mod tests {
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone())?;
+        let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone())?;
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap.clone()));
 
@@ -812,7 +812,7 @@ mod tests {
                 TestSAP::random_sap(Prefix::default(), 1, 0, None);
             let next_section_key = next_sk_set.public_keys().public_key();
             let section_tree_update = gen_section_tree_update(
-                &section_signed(&next_sk_set.secret_key(), next_sap)?,
+                &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap)?,
                 &SectionsDAG::new(genesis_pk),
                 &genesis_sk,
             )?;

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -443,7 +443,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(10);
 
         let (genesis_sap, _genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -462,7 +462,7 @@ mod tests {
         let bootstrap = async move { state.try_join(join_timeout).await.map_err(Error::from) };
 
         let (next_sap, next_elders, next_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
 
         let next_section_key = next_sk_set.public_keys().public_key();
         let section_tree_update = TestSectionTree::get_section_tree_update(
@@ -550,7 +550,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -579,7 +579,8 @@ mod tests {
                     assert_matches!(msg, NodeMsg::JoinRequest{..}));
 
             // Send JoinResponse::Redirect
-            let (new_sap, _, _) = TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            let (new_sap, _, _) =
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
 
             send_response(
                 &recv_tx,
@@ -628,7 +629,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -654,7 +655,7 @@ mod tests {
             assert_matches!(msg, NodeMsg::JoinRequest{..}));
 
             let (new_sap, _, new_sk_set) =
-                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
             let new_pk_set = new_sk_set.public_keys();
 
             send_response(
@@ -706,7 +707,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -769,7 +770,7 @@ mod tests {
         let bad_prefix = Prefix::default().pushed(!first_bit);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), 1, 0, None);
+            TestSAP::random_sap(Prefix::default(), 1, 0, None, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -792,7 +793,7 @@ mod tests {
 
             // Send `Retry` with bad prefix
             let bad_section_tree_update = {
-                let (bad_sap, _, _) = TestSAP::random_sap(bad_prefix, 1, 0, None);
+                let (bad_sap, _, _) = TestSAP::random_sap(bad_prefix, 1, 0, None, None);
                 let mut bad_signed_sap = signed_genesis_sap.clone();
                 bad_signed_sap.value = bad_sap;
                 SectionTreeUpdate::new(bad_signed_sap, proof_chain.clone())
@@ -809,7 +810,7 @@ mod tests {
 
             // Send `Retry` with valid update
             let (next_sap, next_elders, next_sk_set) =
-                TestSAP::random_sap(Prefix::default(), 1, 0, None);
+                TestSAP::random_sap(Prefix::default(), 1, 0, None, None);
             let next_section_key = next_sk_set.public_keys().public_key();
             let section_tree_update = TestSectionTree::get_section_tree_update(
                 &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap)?,

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -465,7 +465,7 @@ mod tests {
             TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
 
         let next_section_key = next_sk_set.public_keys().public_key();
-        let section_tree_update = gen_section_tree_update(
+        let section_tree_update = TestSectionTree::get_section_tree_update(
             &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap.clone())?,
             &SectionsDAG::new(genesis_pk),
             &genesis_sk,
@@ -811,7 +811,7 @@ mod tests {
             let (next_sap, next_elders, next_sk_set) =
                 TestSAP::random_sap(Prefix::default(), 1, 0, None);
             let next_section_key = next_sk_set.public_keys().public_key();
-            let section_tree_update = gen_section_tree_update(
+            let section_tree_update = TestSectionTree::get_section_tree_update(
                 &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap)?,
                 &SectionsDAG::new(genesis_pk),
                 &genesis_sk,

--- a/sn_node/src/node/bootstrap/relocate.rs
+++ b/sn_node/src/node/bootstrap/relocate.rs
@@ -249,10 +249,8 @@ mod tests {
     use sn_interface::{
         elder_count,
         messaging::system::{JoinAsRelocatedResponse, NodeMsg},
-        network_knowledge::{
-            test_utils::{gen_addr, section_signed},
-            MyNodeInfo, NodeState, SectionAuthorityProvider, MIN_ADULT_AGE,
-        },
+        network_knowledge::{MyNodeInfo, NodeState, SectionAuthorityProvider, MIN_ADULT_AGE},
+        test_utils::{gen_addr, TestKeys},
         types::{keys::ed25519, Peer},
     };
     use std::{collections::BTreeSet, net::SocketAddr};
@@ -268,7 +266,8 @@ mod tests {
             gen_addr(),
         );
         let node_state = NodeState::joined(node.peer(), None);
-        let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state)?;
+        let signed_node_state =
+            TestKeys::get_section_signed(&from_sk_set.secret_key(), node_state)?;
         // to_sap
         let (to_sap, _) = generate_sap();
 
@@ -315,7 +314,8 @@ mod tests {
                 gen_addr(),
             );
             let node_state = NodeState::joined(node.peer(), None);
-            let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state)?;
+            let signed_node_state =
+                TestKeys::get_section_signed(&from_sk_set.secret_key(), node_state)?;
             // to_sap
             let (to_sap, to_sk_set) = generate_sap();
 
@@ -380,7 +380,8 @@ mod tests {
                 gen_addr(),
             );
             let node_state = NodeState::joined(node.peer(), None);
-            let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state)?;
+            let signed_node_state =
+                TestKeys::get_section_signed(&from_sk_set.secret_key(), node_state)?;
             // to_sap
             let (to_sap, to_sk_set) = generate_sap();
 

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -19,7 +19,7 @@ use sn_interface::{
     network_knowledge::{
         test_utils::*, MembershipState, NodeState, RelocateDetails, SectionAuthorityProvider,
     },
-    types::{Keypair, Peer, ReplicatedData, SecretKeySet},
+    types::{Keypair, Peer, ReplicatedData},
 };
 use std::collections::BTreeSet;
 

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -14,7 +14,7 @@ use sn_interface::{
         data::{ClientMsg, Error as MessagingDataError},
         serialisation::WireMsg,
         system::{JoinResponse, NodeCmd, NodeMsg},
-        AuthorityProof, ClientAuth, MsgId, MsgType,
+        AuthorityProof, ClientAuth, MsgId,
     },
     network_knowledge::{
         test_utils::*, MembershipState, NodeState, RelocateDetails, SectionAuthorityProvider,

--- a/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
@@ -1,18 +1,11 @@
-use crate::node::{api::gen_genesis_dbc, flow_ctrl::dispatcher::Dispatcher};
+use crate::node::api::gen_genesis_dbc;
 use eyre::{eyre, Result};
 use sn_dbc::{
-    get_public_commitments_from_transaction, Commitment, Dbc, Hash, IndexedSignatureShare,
-    KeyImage, Owner, OwnerOnce, PublicKey, RingCtTransaction, Signature, SpentProof,
-    SpentProofContent, SpentProofShare, Token, TransactionBuilder,
+    Dbc, KeyImage, Owner, OwnerOnce, RingCtTransaction, SpentProof, SpentProofShare, Token,
+    TransactionBuilder,
 };
-use sn_interface::network_knowledge::section_keys::build_spent_proof_share;
-use sn_interface::{
-    messaging::data::{ClientMsg, DataCmd, RegisterCmd, SpentbookCmd},
-    network_knowledge::{SectionAuthorityProvider, SectionKeysProvider},
-    types::{Peer, ReplicatedData},
-};
+use sn_interface::{messaging::data::RegisterCmd, types::ReplicatedData};
 use std::collections::BTreeSet;
-use std::str::FromStr;
 
 /// Get the spent proof share that's packaged inside the data that's to be replicated to the adults
 /// in the section.

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -41,11 +41,12 @@ use sn_interface::{
         Dst, MsgId, MsgType, WireMsg,
     },
     network_knowledge::{
-        recommended_section_size, supermajority, test_utils::*, Error as NetworkKnowledgeError,
-        MembershipState, MyNodeInfo, NetworkKnowledge, NodeState, RelocateDetails,
-        SectionAuthorityProvider, SectionKeyShare, SectionKeysProvider, SectionTree,
-        SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
+        recommended_section_size, supermajority, Error as NetworkKnowledgeError, MembershipState,
+        MyNodeInfo, NetworkKnowledge, NodeState, RelocateDetails, SectionAuthorityProvider,
+        SectionKeyShare, SectionKeysProvider, SectionTree, SectionTreeUpdate, SectionsDAG,
+        MIN_ADULT_AGE,
     },
+    test_utils::*,
     types::{keyed_signed, keys::ed25519, Peer, PublicKey, ReplicatedData},
 };
 
@@ -650,7 +651,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
                 RelocatedPeerRole::Elder => elder_count(),
                 RelocatedPeerRole::NonElder => recommended_section_size(),
             };
-            let (section_auth, mut nodes, sk_set) = random_sap(prefix, elder_count(), 0, None);
+            let (section_auth, mut nodes, sk_set) = TestSAP::random_sap(prefix, elder_count(), 0, None);
             let (mut section, section_key_share) =
                 network_utils::create_section(&sk_set, &section_auth, None, None)?;
 

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -171,7 +171,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
 
             // Creates nodes where everybody has age 6 except one has 5.
             let mut nodes: Vec<_> =
-                gen_sorted_nodes(&Prefix::default(), elder_count(), 0, Some(&[6, 5]));
+                gen_sorted_nodes(&Prefix::default(), elder_count(), 0, Some(&[5, 6]));
 
             let elders = nodes.iter().map(MyNodeInfo::peer);
             let members = nodes.iter().map(|n| NodeState::joined(n.peer(), None));

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -382,7 +382,8 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async move {
-            let (section_auth, mut nodes, sk_set) = network_utils::create_section_auth();
+            let (section_auth, mut nodes, sk_set) =
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
 
             let (mut section, _) =
                 network_utils::create_section(&sk_set, &section_auth, None, None)?;
@@ -450,7 +451,8 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
             let sk0 = bls::SecretKey::random();
             let pk0 = sk0.public_key();
 
-            let (old_sap, mut nodes, sk_set1) = network_utils::create_section_auth();
+            let (old_sap, mut nodes, sk_set1) =
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
             let members =
                 BTreeSet::from_iter(nodes.iter().map(|n| NodeState::joined(n.peer(), None)));
             let pk1 = sk_set1.secret_key().public_key();

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -19,7 +19,7 @@ use sn_interface::{
         test_utils::*, MyNodeInfo, NetworkKnowledge, NodeState, SectionAuthorityProvider,
         SectionKeyShare, SectionTree, SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
     },
-    types::{keys::ed25519, Peer, SecretKeySet},
+    types::{keys::ed25519, Peer},
 };
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
@@ -296,7 +296,7 @@ impl TestNodeBuilder {
 
 pub(crate) fn create_section_with_key(
     prefix: Prefix,
-    sk_set: &SecretKeySet,
+    sk_set: &bls::SecretKeySet,
 ) -> Result<(NetworkKnowledge, SectionAuthorityProvider)> {
     let (sap, _) = random_sap_with_key(prefix, elder_count(), 0, sk_set);
     let (section, _) = create_section(sk_set, &sap, None, None)?;
@@ -326,13 +326,13 @@ pub(crate) fn create_section(
 ///
 /// Some tests require the condition where only the elders were marked as joined members.
 pub(crate) fn create_section_with_elders(
-    sk_set: &SecretKeySet,
+    sk_set: &bls::SecretKeySet,
     sap: &SectionAuthorityProvider,
 ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
     let (mut section, section_key_share) = do_create_section(sap, sk_set, None, None)?;
     for peer in sap.elders() {
         let node_state = NodeState::joined(*peer, None);
-        let node_state = section_signed(sk_set.secret_key(), node_state)?;
+        let node_state = section_signed(&sk_set.secret_key(), node_state)?;
         let _updated = section.update_member(node_state);
     }
     Ok((section, section_key_share))

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -348,8 +348,7 @@ pub(crate) fn create_section_with_elders(
     sk_set: &bls::SecretKeySet,
     sap: &SectionAuthorityProvider,
 ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
-    let (mut section, section_key_share) =
-        TestNetworkKnowledge::do_create_section(sap, sk_set, None, None)?;
+    let (mut section, section_key_share) = do_create_section(sap, sk_set, None, None)?;
     for peer in sap.elders() {
         let node_state = NodeState::joined(*peer, None);
         let node_state = TestKeys::get_section_signed(&sk_set.secret_key(), node_state)?;

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -444,10 +444,8 @@ mod tests {
     use sn_interface::{
         elder_count,
         messaging::{Dst, MsgId, MsgKind},
-        network_knowledge::{
-            test_utils::{gen_addr, random_sap, section_signed},
-            MyNodeInfo, SectionKeyShare, SectionKeysProvider, SectionsDAG,
-        },
+        network_knowledge::{MyNodeInfo, SectionKeyShare, SectionKeysProvider, SectionsDAG},
+        test_utils::{gen_addr, section_signed, TestSAP},
         types::keys::ed25519,
     };
 
@@ -645,7 +643,8 @@ mod tests {
             let prefix1 = Prefix::default().pushed(true);
 
             // generate a SAP for prefix0
-            let (sap, mut nodes, secret_key_set) = random_sap(prefix0, elder_count(), 0, None);
+            let (sap, mut nodes, secret_key_set) =
+                TestSAP::random_sap(prefix0, elder_count(), 0, None);
             let info = nodes.remove(0);
             let sap_sk = secret_key_set.secret_key();
             let signed_sap = section_signed(&sap_sk, sap)?;
@@ -679,7 +678,8 @@ mod tests {
             let _ = node.update_network_knowledge(section_tree_update, None)?;
 
             // generate other SAP for prefix1
-            let (other_sap, _, secret_key_set) = random_sap(prefix1, elder_count(), 0, None);
+            let (other_sap, _, secret_key_set) =
+                TestSAP::random_sap(prefix1, elder_count(), 0, None);
             let other_sap_sk = secret_key_set.secret_key();
             let other_sap = section_signed(&other_sap_sk, other_sap)?;
             // generate a proof chain for this other SAP

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -645,7 +645,7 @@ mod tests {
 
             // generate a SAP for prefix0
             let (sap, mut nodes, secret_key_set) =
-                TestSAP::random_sap(prefix0, elder_count(), 0, None);
+                TestSAP::random_sap(prefix0, elder_count(), 0, None, None);
             let info = nodes.remove(0);
             let sap_sk = secret_key_set.secret_key();
             let signed_sap = TestKeys::get_section_signed(&sap_sk, sap)?;
@@ -680,7 +680,7 @@ mod tests {
 
             // generate other SAP for prefix1
             let (other_sap, _, secret_key_set) =
-                TestSAP::random_sap(prefix1, elder_count(), 0, None);
+                TestSAP::random_sap(prefix1, elder_count(), 0, None, None);
             let other_sap_sk = secret_key_set.secret_key();
             let other_sap = TestKeys::get_section_signed(&other_sap_sk, other_sap)?;
             // generate a proof chain for this other SAP

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -809,7 +809,8 @@ mod tests {
             system::{DkgSessionId, NodeMsg},
             MsgId, Traceroute,
         },
-        network_knowledge::{test_utils::gen_network_knowledge_with_key, SectionKeyShare},
+        network_knowledge::SectionKeyShare,
+        test_utils::TestNetworkKnowledge,
         types::Peer,
     };
     use std::{
@@ -1019,8 +1020,12 @@ mod tests {
             SecretKeySet::from(poly)
         };
 
-        let (network_knowledge, node_infos) =
-            gen_network_knowledge_with_key(Prefix::default(), elders, 0, &gen_section_key_set)?;
+        let (network_knowledge, node_infos) = TestNetworkKnowledge::random_section_with_key(
+            Prefix::default(),
+            elders,
+            0,
+            &gen_section_key_set,
+        )?;
 
         for (idx, info) in node_infos.into_iter().enumerate() {
             let comm = create_comm().await?;

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -799,37 +799,37 @@ mod tests {
         },
         UsedSpace,
     };
+    use assert_matches::assert_matches;
     use bls::SecretKeySet;
     use eyre::{eyre, Result};
-    use rand::{rngs::StdRng, RngCore, SeedableRng};
+    use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
     use sn_interface::{
         init_logger,
         messaging::{
             signature_aggregator::SignatureAggregator,
-            system::{DkgSessionId, NodeMsg},
-            MsgId, Traceroute,
+            system::{DkgSessionId, NodeMsg, Proposal, SectionSigned},
+            MsgId, SectionSigShare, Traceroute,
         },
-        network_knowledge::SectionKeyShare,
-        test_utils::TestNetworkKnowledge,
+        network_knowledge::{
+            supermajority, NodeState, SectionAuthUtils, SectionKeyShare, SectionsDAG,
+        },
+        test_utils::{TestKeys, TestNetworkKnowledge, TestSectionTree},
         types::Peer,
+        SectionAuthorityProvider,
     };
     use std::{
         collections::{BTreeMap, BTreeSet},
         sync::Arc,
     };
     use tokio::sync::RwLock;
-    use xor_name::Prefix;
+    use xor_name::{Prefix, XorName};
 
-    #[tokio::test]
-    async fn gg() {
-        let loc = tokio::task::LocalSet::new();
-        loc.run_until(async {
-            let mut rng = rand::thread_rng();
-            let _gg = generate_working_nodes(5, &mut rng).await;
-        })
-        .await;
-    }
-
+    /// Simulate an entire round of dkg till termination; The dkg round just creates a new keyshare
+    /// but without any elder change (i.e., the dkg is between the same set of elders). The test
+    /// collect the `NodeMsg`s and passes them to the recipient nodes directly instead of using the
+    /// comm module.
+    /// TODO: implement elder change, i.e., a new node with higher age joins, now all 8 nodes should
+    /// handle the messages.
     #[tokio::test]
     async fn simulate_dkg_round() -> Result<()> {
         init_logger();
@@ -837,186 +837,374 @@ mod tests {
         let loc = tokio::task::LocalSet::new();
 
         loc.run_until(async {
-            // let mut rng_for_seed = rand::thread_rng();
-            // let seed = rng_for_seed.gen();
-            let seed = 123;
+            let mut rng_for_seed = rand::thread_rng();
+            let seed = rng_for_seed.gen();
+            let node_count = 7;
             let mut rng = StdRng::seed_from_u64(seed);
             let traceroute = Traceroute(vec![]);
-            let (nodes, comm) = generate_working_nodes(7, &mut rng).await?;
+            let (mut node_instances, initial_sk_set) =
+                MyNodeInstance::new_instances(node_count, &mut rng).await?;
 
-            let elders = nodes
-                .iter()
-                .map(|node| (node.name(), node.addr))
-                .collect::<BTreeMap<_, _>>();
-            let session_id = DkgSessionId {
-                prefix: Prefix::default(),
-                elders,
-                section_chain_len: 1,
-                bootstrap_members: BTreeSet::new(),
-                membership_gen: 0,
-            };
+            // let current set of elders start the dkg round and capture the msgs that are outbound to the other nodes
+            MyNodeInstance::start_dkg(&mut node_instances).await?;
 
-            let mut node_instances = nodes
-                .into_iter()
-                .zip(comm.into_iter())
-                .map(|(node, comm)| {
-                    let peer = Peer::new(node.name(), node.addr);
-                    let mock = MyNodeInstance {
-                        node: Arc::new(RwLock::new(node)),
-                        comm,
-                        msg_queue: Vec::new(),
-                    };
-                    (peer, mock)
-                })
-                .collect::<BTreeMap<_, _>>();
-
-            // let a random node start dkg
-            let random_node = node_instances
-                .values()
-                .next()
-                .ok_or_else(|| eyre!("Have atleast 1 node"))?
-                .node
-                .clone();
-            let original_tree = random_node
-                .read()
-                .await
-                .network_knowledge()
-                .section_tree()
-                .clone();
-            let cmds = random_node.write().await.send_dkg_start(session_id)?;
-
-            // random node should process cmds => assuming they are SendMsgs for now
-            let mut msgs_to_other_nodes = Vec::new();
-            for cmd in cmds {
-                let msg = random_node
-                    .read()
-                    .await
-                    .mock_process_send_msg(cmd)?
-                    .ok_or_else(|| eyre!("send_dkg_start will send msgs to other nodes"))?;
-                println!("random_node cmd output: {}", msg.0 .1);
-                msgs_to_other_nodes.push(msg);
-            }
-            // add the msgs to the recipients queue
-            msgs_to_other_nodes
-                .into_iter()
-                .try_for_each(|(system_msg, recipients)| {
-                    recipients.iter().try_for_each(|recp| -> Result<()> {
-                        node_instances
-                            .get_mut(recp)
-                            .ok_or_else(|| eyre!("recp is present in node_instances"))?
-                            .msg_queue
-                            .push(system_msg.clone());
-                        Ok(())
-                    })
-                })?;
-
+            let mut new_secret_key_shares = BTreeMap::new();
             let mut done = false;
             while !done {
-                // let the nodes process the 1. SystemMsg -> 2. Process Cmd from prev step -> 3. add the system msg to queue
+                // For each of the node instances and for each of the msg in their `msg_queue`, 1) handle the msg and
+                // the cmds 2) handle the cmds 3) if the cmds produce more msgs, add them to the `msg_queue` of the
+                // respective nodes
                 let mut msgs_to_other_nodes = Vec::new();
-                for mock_node in node_instances.values_mut() {
+                for mock_node in node_instances.values() {
                     let node = mock_node.node.clone();
-                    let comm = &mock_node.comm;
-                    println!("\n\n NODE: {}", node.read().await.name());
-                    while let Some((msg_id, msg, sender)) = mock_node.msg_queue.pop() {
+                    debug!("\n\n NODE: {}", node.read().await.name());
+                    while let Some((msg_id, msg, sender)) = mock_node.msg_queue.write().await.pop()
+                    {
                         let cmds = MyNode::handle_valid_system_msg(
                             node.clone(),
                             msg_id,
                             msg,
                             sender,
-                            comm,
+                            &mock_node.comm,
                             traceroute.clone(),
                         )
                         .await?;
 
                         for cmd in cmds {
-                            println!("Got cmd {}", cmd);
-                            if let Some(new_msgs) =
-                                node.write().await.mock_process_send_msg(cmd.clone())?
-                            {
-                                println!("Cmd output {}", new_msgs.0 .2);
-                                msgs_to_other_nodes.push(new_msgs);
-                            } else {
-                                let cmds = node.write().await.mock_process_dkg_outcome(cmd).await?;
-                                for cmd in cmds {
-                                    let mut new_msgs = node
-                                        .read()
-                                        .await
-                                        .mock_process_send_msg(cmd.clone())?
-                                        .ok_or_else(|| {
-                                            eyre!("dkg_outcome will send msgs to other nodes")
-                                        })?;
-
-                                    // if no recepients, lets handle it (because we get a proposal here, not sure what to do wwith it)
-                                    if new_msgs.1.is_empty() {
-                                        let n = node.read().await;
-                                        new_msgs.1 = vec![Peer::new(n.name(), n.addr)];
-                                    }
-                                    println!("Cmd output after dkg outcome {}", new_msgs.0 .2);
+                            debug!("Got cmd {}", cmd);
+                            match cmd {
+                                Cmd::SendMsg {
+                                    msg,
+                                    msg_id,
+                                    recipients,
+                                    ..
+                                } => {
+                                    let new_msgs =
+                                        node.read().await.mock_send_msg(msg, msg_id, recipients)?;
                                     msgs_to_other_nodes.push(new_msgs);
                                 }
+                                Cmd::HandleDkgOutcome {
+                                    section_auth,
+                                    outcome,
+                                } => {
+                                    // capture the sk_share here as we don't proceed with the SAP update
+                                    let _ = new_secret_key_shares
+                                        .insert(node.read().await.name(), outcome.clone());
+                                    let ((_, msg, _), _) = node
+                                        .write()
+                                        .await
+                                        .mock_dkg_outcome_proposal(section_auth, outcome)
+                                        .await?;
+                                    assert_matches!(msg, NodeMsg::Propose { proposal, .. } => {
+                                        assert_matches!(proposal, Proposal::SectionInfo(_))
+                                    });
+                                }
+                                _ => panic!("got a different cmd {:?}", cmd),
                             }
                         }
                     }
                 }
 
-                msgs_to_other_nodes
-                    .into_iter()
-                    .try_for_each(|(system_msg, recipients)| {
-                        recipients.iter().try_for_each(|recp| -> Result<()> {
-                            node_instances
-                                .get_mut(recp)
-                                .ok_or_else(|| eyre!("recp is present in node_instances"))?
-                                .msg_queue
-                                .push(system_msg.clone());
-                            Ok(())
-                        })
-                    })?;
+                // add the msgs to the msg_queue of each node
+                MyNodeInstance::add_msgs_to_queue(&mut node_instances, msgs_to_other_nodes).await?;
 
                 // done if the queues are empty
-                done = node_instances
-                    .values()
-                    .all(|node| node.msg_queue.is_empty());
+                done = MyNodeInstance::is_msg_queue_empty(&node_instances).await;
             }
 
-            // dkg done, make sure the key is valid
-            let mut pub_key_set = BTreeSet::new();
-            // let mut sig_shares = Vec::new();
-            let _agg = SignatureAggregator::default();
-            println!("\n\n{original_tree:?}");
-            for node in node_instances.values() {
-                let key_share = node.node.read().await.key_share()?;
-                let _ = pub_key_set.insert(key_share.public_key_set);
-
-                // agg.try_aggregate("msg".as_bytes(), key_share.secret_key_share.sign("msg"))?;
-            }
-
-            assert_eq!(pub_key_set.len(), 1);
+            // dkg done, make sure the new key share is valid
+            MyNodeInstance::verify_new_key(
+                &node_instances,
+                &initial_sk_set,
+                &new_secret_key_shares,
+                node_count,
+            )
+            .await?;
 
             Ok(())
         })
         .await
     }
 
-    /// Generate a random `SectionAuthorityProvider` for testing.
-    ///
-    /// The total number of members in the section will be `elder_count` + `adult_count`. A lot of
-    /// tests don't require adults in the section, so zero is an acceptable value for
-    /// `adult_count`.
-    ///
-    /// An optional `sk_threshold_size` can be passed to specify the threshold when the secret key
-    /// set is generated for the section key. Some tests require a low threshold.
+    /// If a node already has the new SAP in its `SectionTree`, then it should not propose `SectionInfo`
+    #[tokio::test]
+    async fn lagging_node_should_not_propose_new_section_info() -> Result<()> {
+        init_logger();
+        // Construct a local task set that can run `!Send` futures.
+        let loc = tokio::task::LocalSet::new();
+
+        loc.run_until(async {
+            let mut rng = rand::thread_rng();
+            let node_count = 7;
+            let traceroute = Traceroute(vec![]);
+            let (mut node_instances, initial_sk_set) =
+                MyNodeInstance::new_instances(node_count, &mut rng).await?;
+
+            // let current set of elders start the dkg round and capture the msgs that are outbound to the other nodes
+            MyNodeInstance::start_dkg(&mut node_instances).await?;
+
+            let mut new_secret_key_shares: BTreeMap<XorName, SectionKeyShare> = BTreeMap::new();
+            let mut new_sap: BTreeSet<SectionAuthorityProvider> = BTreeSet::new();
+            let mut lagging = false;
+            let mut done = false;
+            while !done {
+                // For each of the node instances and for each of the msg in their `msg_queue`, 1) handle the msg and
+                // the cmds 2) handle the cmds 3) if the cmds produce more msgs, add them to the `msg_queue` of the
+                // respective nodes
+                let mut msgs_to_other_nodes = Vec::new();
+                for mock_node in node_instances.values() {
+                    let node = mock_node.node.clone();
+                    let name = node.read().await.name();
+                    debug!("\n\n NODE: {}", name);
+                    while let Some((msg_id, msg, sender)) = mock_node.msg_queue.write().await.pop()
+                    {
+                        let cmds = MyNode::handle_valid_system_msg(
+                            node.clone(),
+                            msg_id,
+                            msg,
+                            sender,
+                            &mock_node.comm,
+                            traceroute.clone(),
+                        )
+                        .await?;
+
+                        // if we have the supermajority of the sk_shares, sign the sap and insert it into the remaining node's
+                        // section tree. Now these nodes should not trigger the `Proposal::SectionInfo`
+                        if !lagging && new_secret_key_shares.len() >= supermajority(node_count) {
+                            assert_eq!(new_sap.len(), 1);
+                            let new_sap = new_sap
+                                .clone()
+                                .into_iter()
+                                .next()
+                                .ok_or_else(|| eyre!("should contain 1"))?;
+                            let serialized_new_sap = bincode::serialize(&new_sap.clone())?;
+                            // sign the sap using the new_key to get the signed sap
+                            let mut sig_shares = Vec::new();
+                            for share in new_secret_key_shares.values() {
+                                let sig_share = SectionSigShare::new(
+                                    share.public_key_set.clone(),
+                                    share.index,
+                                    &share.secret_key_share,
+                                    &serialized_new_sap,
+                                );
+                                sig_shares.push(sig_share);
+                            }
+                            let mut agg = SignatureAggregator::default();
+                            for sig_share in &sig_shares {
+                                // try_aggregate will return Some<_> only once;
+                                if let Some(section_sig) =
+                                    agg.try_aggregate(&serialized_new_sap, sig_share.clone())?
+                                {
+                                    let signed_sap =
+                                        SectionSigned::new(new_sap.clone(), section_sig);
+                                    let proof_chain = {
+                                        let parent = initial_sk_set.public_keys().public_key();
+                                        let mut dag = SectionsDAG::new(parent);
+                                        let sig = TestKeys::sign(
+                                            &initial_sk_set.secret_key(),
+                                            &new_sap.section_key(),
+                                        )?;
+                                        dag.insert(&parent, new_sap.section_key(), sig)?;
+                                        dag
+                                    };
+                                    let update = TestSectionTree::get_section_tree_update(
+                                        &signed_sap,
+                                        &proof_chain,
+                                        &initial_sk_set.secret_key(),
+                                    )?;
+
+                                    // find all the lagging nodes; i.e., ones that are yet to handle the dkg_outcome
+                                    let lagging_nodes = node_instances
+                                        .keys()
+                                        .filter(|node| !new_secret_key_shares.contains_key(node))
+                                        .cloned()
+                                        .collect::<Vec<_>>();
+                                    debug!("Lagging node {lagging_nodes:?}");
+                                    // update them
+                                    for lag in lagging_nodes {
+                                        let _updated = node_instances
+                                            .get(&lag)
+                                            .ok_or_else(|| eyre!("node will be present"))?
+                                            .node
+                                            .write()
+                                            .await
+                                            .network_knowledge
+                                            .update_knowledge_if_valid(
+                                                update.clone(),
+                                                None,
+                                                &name,
+                                            )?;
+                                        debug!("nw update: {_updated} for {lag} ");
+                                    }
+                                    // successfully simulated lagging nodes
+                                    lagging = true;
+                                }
+                            }
+
+                            // if we have passed the supermajority check, then we should enter the aggregate block; else
+                            // something went wrong
+                            if !lagging {
+                                panic!("sig aggregation did not complete")
+                            }
+                        }
+
+                        for cmd in cmds {
+                            debug!("Got cmd {}", cmd);
+                            match cmd {
+                                Cmd::SendMsg {
+                                    msg,
+                                    msg_id,
+                                    recipients,
+                                    ..
+                                } => {
+                                    let new_msgs =
+                                        node.read().await.mock_send_msg(msg, msg_id, recipients)?;
+                                    msgs_to_other_nodes.push(new_msgs);
+                                }
+                                Cmd::HandleDkgOutcome {
+                                    section_auth,
+                                    outcome,
+                                } => {
+                                    let _ = new_secret_key_shares
+                                        .insert(node.read().await.name(), outcome.clone());
+                                    let _ = new_sap.insert(section_auth.clone());
+                                    if !lagging {
+                                        let ((_, msg, _), _) = node
+                                            .write()
+                                            .await
+                                            .mock_dkg_outcome_proposal(section_auth, outcome)
+                                            .await?;
+                                        assert_matches!(msg, NodeMsg::Propose { proposal, .. } => {
+                                            assert_matches!(proposal, Proposal::SectionInfo(_))
+                                        });
+                                    } else {
+                                        // Since the dkg session is for the same prefix, the
+                                        // lagging node just returns a empty cmd list. There are
+                                        // multiple paths here and testing them here is not a wise
+                                        // choice, instead we can test them where the logic is
+                                        // defined.
+                                        let cmds = node
+                                            .write()
+                                            .await
+                                            .handle_dkg_outcome(section_auth, outcome)
+                                            .await?;
+                                        assert_eq!(cmds.len(), 0);
+                                    }
+                                }
+                                _ => panic!("got a different cmd {:?}", cmd),
+                            }
+                        }
+                    }
+                }
+
+                // add the msgs to the msg_queue of each node
+                MyNodeInstance::add_msgs_to_queue(&mut node_instances, msgs_to_other_nodes).await?;
+
+                // done if the queues are empty
+                done = MyNodeInstance::is_msg_queue_empty(&node_instances).await;
+            }
+
+            // dkg done, make sure the new key share is valid
+            MyNodeInstance::verify_new_key(
+                &node_instances,
+                &initial_sk_set,
+                &new_secret_key_shares,
+                node_count,
+            )
+            .await?;
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn total_participation_is_required_for_dkg_votes() -> Result<()> {
+        init_logger();
+        // Construct a local task set that can run `!Send` futures.
+        let loc = tokio::task::LocalSet::new();
+
+        loc.run_until(async {
+            let mut rng = rand::thread_rng();
+            let node_count = 7;
+            let traceroute = Traceroute(vec![]);
+            let (mut node_instances, _initial_sk_set) =
+                MyNodeInstance::new_instances(node_count, &mut rng).await?;
+
+            MyNodeInstance::start_dkg(&mut node_instances).await?;
+
+            let dead_node = node_instances
+                .keys()
+                .next()
+                .cloned()
+                .ok_or_else(|| eyre!("node_instances is not empty"))?;
+            let mut done = false;
+            while !done {
+                let mut msgs_to_other_nodes = Vec::new();
+                for mock_node in node_instances.values() {
+                    let node = mock_node.node.clone();
+                    debug!("\n\n NODE: {}", node.read().await.name());
+                    while let Some((msg_id, msg, sender)) = mock_node.msg_queue.write().await.pop()
+                    {
+                        let cmds = MyNode::handle_valid_system_msg(
+                            node.clone(),
+                            msg_id,
+                            msg,
+                            sender,
+                            &mock_node.comm,
+                            traceroute.clone(),
+                        )
+                        .await?;
+
+                        for cmd in cmds {
+                            debug!("Got cmd {}", cmd);
+                            match cmd {
+                                Cmd::SendMsg {
+                                    msg,
+                                    msg_id,
+                                    recipients,
+                                    ..
+                                } => {
+                                    let mut new_msgs =
+                                        node.read().await.mock_send_msg(msg, msg_id, recipients)?;
+                                    // dead_node will not recieve the msg
+                                    new_msgs.1.retain(|peer| peer.name() != dead_node);
+                                    msgs_to_other_nodes.push(new_msgs);
+                                }
+                                _ => panic!("got a different cmd {:?}", cmd),
+                            }
+                        }
+                    }
+                }
+
+                // add the msgs to the msg_queue of each node
+                MyNodeInstance::add_msgs_to_queue(&mut node_instances, msgs_to_other_nodes).await?;
+
+                // done if the queues are empty
+                done = MyNodeInstance::is_msg_queue_empty(&node_instances).await;
+            }
+
+            // all the msgs are processed and we counldn't reach dkg termination
+            Ok(())
+        })
+        .await
+    }
+
+    // Test helpers
+
+    /// TODO: integrate this into `NodeTestBuilder` which only creates a single working node for now
+    /// Generate a set of working node instances (no dispatcher)
     async fn generate_working_nodes<R: RngCore>(
         elders: usize,
         rng: &mut R,
-    ) -> Result<(Vec<MyNode>, Vec<Comm>)> {
+    ) -> Result<(Vec<MyNode>, Vec<Comm>, SecretKeySet)> {
         let mut nodes = Vec::new();
         let mut comms = Vec::new();
         let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
 
         let gen_section_key_set = {
             // sk_share for each elder
-            let poly = bls::poly::Poly::random(elders, rng);
+            let poly = bls::poly::Poly::random(supermajority(elders), rng);
             SecretKeySet::from(poly)
         };
 
@@ -1029,11 +1217,7 @@ mod tests {
 
         for (idx, info) in node_infos.into_iter().enumerate() {
             let comm = create_comm().await?;
-            let section_key_share = SectionKeyShare {
-                public_key_set: gen_section_key_set.public_keys(),
-                index: idx,
-                secret_key_share: gen_section_key_set.secret_key_share(idx),
-            };
+            let section_key_share = TestKeys::get_section_key_share(&gen_section_key_set, idx);
             let node = MyNode::new(
                 comm.socket_addr(),
                 info.keypair.clone(),
@@ -1047,7 +1231,7 @@ mod tests {
             nodes.push(node);
             comms.push(comm);
         }
-        Ok((nodes, comms))
+        Ok((nodes, comms, gen_section_key_set))
     }
 
     type MockSystemMsg = (MsgId, NodeMsg, Peer);
@@ -1055,47 +1239,191 @@ mod tests {
     struct MyNodeInstance {
         node: Arc<RwLock<MyNode>>,
         comm: Comm,
-        msg_queue: Vec<MockSystemMsg>,
+        // might need to modify the queue when we are iterating through `Vec<MyNodeInstance>`, hence the rwlock
+        msg_queue: RwLock<Vec<MockSystemMsg>>,
+    }
+
+    impl MyNodeInstance {
+        // Creates a set of MyNodeInstances. The network contains a genesis section with all the
+        // node_count present in it. The gen_sk_set is also returned
+        async fn new_instances<R: RngCore>(
+            node_count: usize,
+            rng: &mut R,
+        ) -> Result<(BTreeMap<XorName, MyNodeInstance>, SecretKeySet)> {
+            let (nodes, comm, sk_set) = generate_working_nodes(node_count, rng).await?;
+
+            let node_instances = nodes
+                .into_iter()
+                .zip(comm.into_iter())
+                .map(|(node, comm)| {
+                    let name = node.name();
+                    let mock = MyNodeInstance {
+                        node: Arc::new(RwLock::new(node)),
+                        comm,
+                        msg_queue: RwLock::new(Vec::new()),
+                    };
+                    (name, mock)
+                })
+                .collect::<BTreeMap<_, _>>();
+            Ok((node_instances, sk_set))
+        }
+
+        // Each node sends out DKG start msg and they are added to the msg queue for the other nodes
+        async fn start_dkg(nodes: &mut BTreeMap<XorName, MyNodeInstance>) -> Result<()> {
+            let mut elders = BTreeMap::new();
+            for (name, node) in nodes.iter() {
+                let _ = elders.insert(*name, node.node.read().await.addr);
+            }
+            let bootstrap_members = elders
+                .iter()
+                .map(|(name, addr)| {
+                    let peer = Peer::new(*name, *addr);
+                    NodeState::joined(peer, None)
+                })
+                .collect::<BTreeSet<_>>();
+            // A DKG session which just creates a new key for the same set of eleders
+            let session_id = DkgSessionId {
+                prefix: Prefix::default(),
+                elders,
+                section_chain_len: 1,
+                bootstrap_members,
+                membership_gen: 0,
+            };
+            let mut msgs_to_other_nodes = Vec::new();
+            for node in nodes.values() {
+                let mut node = node.node.write().await;
+                let mut cmd = node.send_dkg_start(session_id.clone())?;
+                assert_eq!(cmd.len(), 1);
+                let msg = assert_matches!(cmd.remove(0), Cmd::SendMsg { msg, msg_id, recipients, .. } => (msg, msg_id, recipients));
+                let msg = node.mock_send_msg(msg.0, msg.1, msg.2)?;
+                msgs_to_other_nodes.push(msg);
+            }
+            // add the msgs to the msg_queue of each node
+            Self::add_msgs_to_queue(nodes, msgs_to_other_nodes).await
+        }
+
+        // Given a list of node instances and a lit of NodeMsgs, add the msgs to the message queue of the recipients
+        async fn add_msgs_to_queue(
+            nodes: &mut BTreeMap<XorName, MyNodeInstance>,
+            msgs: Vec<(MockSystemMsg, Vec<Peer>)>,
+        ) -> Result<()> {
+            for (system_msg, recipients) in msgs {
+                for recp in recipients {
+                    nodes
+                        .get(&recp.name())
+                        .ok_or_else(|| eyre!("recp is present in node_instances"))?
+                        .msg_queue
+                        .write()
+                        .await
+                        .push(system_msg.clone());
+                }
+            }
+            Ok(())
+        }
+
+        async fn is_msg_queue_empty(nodes: &BTreeMap<XorName, MyNodeInstance>) -> bool {
+            let mut not_empty = false;
+            for node in nodes.values() {
+                if !node.msg_queue.read().await.is_empty() {
+                    not_empty = true;
+                }
+            }
+            !not_empty
+        }
+
+        async fn verify_new_key(
+            nodes: &BTreeMap<XorName, MyNodeInstance>,
+            previous_sk_set: &SecretKeySet,
+            new_secret_key_shares: &BTreeMap<XorName, SectionKeyShare>,
+            node_count: usize,
+        ) -> Result<()> {
+            let mut pub_key_set = BTreeSet::new();
+            let mut sig_shares = Vec::new();
+            for node in nodes.values() {
+                let node = node.node.read().await;
+                let old_pk = node
+                    .section_keys_provider
+                    .key_share(&previous_sk_set.secret_key().public_key())?
+                    .public_key_set
+                    .public_key();
+                // new key
+                // a node can be absent if it did not terminate
+                let key_share = if let Some(share) = new_secret_key_shares.get(&node.name()) {
+                    share
+                } else {
+                    continue;
+                };
+                let pk = key_share.public_key_set.public_key();
+                assert_ne!(old_pk, pk);
+                let _ = pub_key_set.insert(pk);
+
+                let sig_share = SectionSigShare::new(
+                    key_share.public_key_set.clone(),
+                    key_share.index,
+                    &key_share.secret_key_share,
+                    "msg".as_bytes(),
+                );
+                sig_shares.push(sig_share);
+            }
+            assert_eq!(pub_key_set.len(), 1);
+            let mut agg = SignatureAggregator::default();
+            let mut sig_count = 1;
+            for sig_share in sig_shares {
+                // sup(7) = 5 i.e, we need 5 shares to gen the complete sig; Thus the first 4 return None, and 5th one
+                // gives us the complete sig;
+                if sig_count < supermajority(node_count) || sig_count > supermajority(node_count) {
+                    assert!(agg.try_aggregate("msg".as_bytes(), sig_share)?.is_none());
+                } else if sig_count == supermajority(node_count) {
+                    assert!(agg.try_aggregate("msg".as_bytes(), sig_share)?.is_some());
+                }
+                sig_count += 1;
+            }
+            Ok(())
+        }
     }
 
     impl MyNode {
-        fn mock_process_send_msg(&self, cmd: Cmd) -> Result<Option<(MockSystemMsg, Vec<Peer>)>> {
-            match cmd {
-                Cmd::SendMsg {
-                    msg,
-                    msg_id,
-                    recipients,
-                    ..
-                } => {
-                    if let OutgoingMsg::Node(msg) = msg {
-                        let current_node = Peer::new(self.name(), self.addr);
+        fn mock_send_msg(
+            &self,
+            msg: OutgoingMsg,
+            msg_id: MsgId,
+            recipients: Peers,
+        ) -> Result<(MockSystemMsg, Vec<Peer>)> {
+            trace!("msg: {msg:?} msg_id {msg_id:?}, recipients {recipients:?}");
+            if let OutgoingMsg::Node(msg) = msg {
+                let current_node = Peer::new(self.name(), self.addr);
 
-                        let recipients = match recipients {
-                            Peers::Single(peer) => vec![peer],
-                            Peers::Multiple(peers) => peers.into_iter().collect(),
-                        };
-                        let mock_system_msg: MockSystemMsg = (msg_id, msg, current_node);
-                        Ok(Some((mock_system_msg, recipients)))
-                    } else {
-                        Err(eyre!("Should be OutgoingMsg::Node"))
-                    }
-                }
-                Cmd::HandleDkgOutcome { .. } => Ok(None),
-                _ => Err(eyre!("Should be Cmd::SendMsg")),
+                let recipients = match recipients {
+                    Peers::Single(peer) => vec![peer],
+                    Peers::Multiple(peers) => peers.into_iter().collect(),
+                };
+                let mock_system_msg: MockSystemMsg = (msg_id, msg, current_node);
+                debug!("SendMsg output {}", mock_system_msg.2);
+                Ok((mock_system_msg, recipients))
+            } else {
+                Err(eyre!("Should be OutgoingMsg::Node"))
             }
         }
 
-        // can lead to more cmds for self unlike the above.. (these cmds give SendMsgs again)
-        async fn mock_process_dkg_outcome(&mut self, cmd: Cmd) -> Result<Vec<Cmd>> {
-            match cmd {
-                Cmd::HandleDkgOutcome {
-                    section_auth,
-                    outcome,
-                } => {
-                    println!("proposed sap {section_auth:?}");
-                    Ok(self.handle_dkg_outcome(section_auth, outcome).await?)
-                }
-                _ => Err(eyre!("Should be Cmd::HandleDkgOutcome")),
+        // if SectionInfo proposal is triggered, it will send out msgs to other nodes
+        async fn mock_dkg_outcome_proposal(
+            &mut self,
+            sap: SectionAuthorityProvider,
+            key_share: SectionKeyShare,
+        ) -> Result<(MockSystemMsg, Vec<Peer>)> {
+            let mut cmds = self.handle_dkg_outcome(sap, key_share).await?;
+            // contains only the SendMsg for SectionInfo proposal
+            assert_eq!(cmds.len(), 1);
+            if let Cmd::SendMsg {
+                msg,
+                msg_id,
+                recipients,
+                ..
+            } = cmds.remove(0)
+            {
+                self.mock_send_msg(msg, msg_id, recipients)
+            } else {
+                Err(eyre!("Should be Cmd::SendMsg"))
             }
         }
     }

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -62,7 +62,7 @@ impl Proposal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sn_interface::test_utils::TestSAP;
+    use sn_interface::test_utils::{TestKeys, TestSAP};
 
     use eyre::Result;
     use serde::Serialize;
@@ -79,8 +79,7 @@ mod tests {
         // Proposal::NewElders
         let new_sk = bls::SecretKey::random();
         let new_pk = new_sk.public_key();
-        let section_signed_auth =
-            sn_interface::network_knowledge::test_utils::section_signed(&new_sk, section_auth)?;
+        let section_signed_auth = TestKeys::get_section_signed(&new_sk, section_auth)?;
         let proposal = Proposal::NewElders(section_signed_auth);
         verify_serialize_for_signing(&proposal, &new_pk)?;
 

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn serialize_for_signing() -> Result<()> {
         // Proposal::SectionInfo
-        let (section_auth, _, _) = TestSAP::random_sap(Prefix::default(), 4, 0, None);
+        let (section_auth, _, _) = TestSAP::random_sap(Prefix::default(), 4, 0, None, None);
         let proposal = Proposal::SectionInfo(section_auth.clone());
         verify_serialize_for_signing(&proposal, &section_auth)?;
 

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -62,7 +62,7 @@ impl Proposal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sn_interface::network_knowledge::test_utils::random_sap;
+    use sn_interface::test_utils::TestSAP;
 
     use eyre::Result;
     use serde::Serialize;
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn serialize_for_signing() -> Result<()> {
         // Proposal::SectionInfo
-        let (section_auth, _, _) = random_sap(Prefix::default(), 4, 0, None);
+        let (section_auth, _, _) = TestSAP::random_sap(Prefix::default(), 4, 0, None);
         let proposal = Proposal::SectionInfo(section_auth.clone());
         verify_serialize_for_signing(&proposal, &section_auth)?;
 

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -124,9 +124,9 @@ mod tests {
     use sn_interface::{
         elder_count,
         network_knowledge::{
-            test_utils::section_signed, SectionAuthorityProvider, SectionTreeUpdate, SectionsDAG,
-            MIN_ADULT_AGE,
+            SectionAuthorityProvider, SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
         },
+        test_utils::TestKeys,
         types::Peer,
     };
 
@@ -183,7 +183,7 @@ mod tests {
             0,
         );
         let section_tree_update = {
-            let signed_sap = section_signed(&sk, section_auth)?;
+            let signed_sap = TestKeys::get_section_signed(&sk, section_auth)?;
             SectionTreeUpdate::new(signed_sap, SectionsDAG::new(genesis_pk))
         };
 
@@ -192,7 +192,7 @@ mod tests {
 
         for peer in &peers {
             let info = NodeState::joined(*peer, None);
-            let info = section_signed(&sk, info)?;
+            let info = TestKeys::get_section_signed(&sk, info)?;
 
             assert!(network_knowledge.update_member(info));
         }

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -253,17 +253,18 @@ fn list_files_in(path: &Path) -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{DataStorage, Error, UsedSpace};
-
     use sn_interface::{
         init_logger,
         messaging::{
             data::{CreateRegister, DataQueryVariant, SignedRegisterCreate},
             system::NodeQueryResponse,
         },
+        test_utils::TestKeys,
         types::{
             register::{Policy, User},
             utils::random_bytes,
             Chunk, ChunkAddress, DataAddress, Keypair, PublicKey, RegisterCmd, ReplicatedData,
+            SectionSig,
         },
     };
 
@@ -368,16 +369,9 @@ mod tests {
         Ok(())
     }
 
-    use sn_interface::messaging::system::SectionSig;
     fn section_sig() -> SectionSig {
         let sk = bls::SecretKey::random();
-        let public_key = sk.public_key();
-        let data = "hello".to_string();
-        let signature = sk.sign(&data);
-        SectionSig {
-            public_key,
-            signature,
-        }
+        TestKeys::get_section_sig_bytes(&sk, "hello".as_bytes())
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Removes a test utility wrapper for `bls::SecretKeySet` . It was previously wrapped because there was no way to get `SecretKey` from the set. The current version of `bls::SecretKeySet` provides a method to do so.
- Organizes test utility functions into their own structs, e.g., `TestKeys` for all the key related utils, etc,. 
- Removes unused dependency from `flow_ctrl/tests/`
- Tests for `dkg` using working set of 7 nodes. Bypasses the communication module by manually passing around the `SendMsg` messages.