### PR TITLE
refactor: test utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,12 +2553,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
-
-[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,15 +3331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_termios"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
-dependencies = [
- "redox_syscall",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,17 +3419,6 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
-]
-
-[[package]]
-name = "resource_proof"
-version = "1.0.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e67c3c4a88195d906d92d90fcf35902f5820d44cbaffb7535c2cf9348cf36fd"
-dependencies = [
- "clap",
- "termion",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -4163,7 +4137,6 @@ dependencies = [
  "rand 0.7.3",
  "rand 0.8.5",
  "rayon",
- "resource_proof",
  "rmp-serde",
  "self_encryption",
  "self_update",
@@ -4399,18 +4372,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "termion"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
-dependencies = [
- "libc",
- "numtoa",
- "redox_syscall",
- "redox_termios",
 ]
 
 [[package]]

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -651,9 +651,12 @@ impl Session {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sn_interface::network_knowledge::{
-        test_utils::{prefix, random_sap, section_signed},
-        SectionTree,
+    use sn_interface::{
+        network_knowledge::{
+            test_utils::{prefix, section_signed},
+            SectionTree,
+        },
+        test_utils::TestSAP,
     };
 
     use eyre::Result;
@@ -674,7 +677,7 @@ mod tests {
         let elders_len = 5;
 
         let prefix = prefix("0");
-        let (section_auth, _, secret_key_set) = random_sap(prefix, elders_len, 0, None);
+        let (section_auth, _, secret_key_set) = TestSAP::random_sap(prefix, elders_len, 0, None);
         let sap0 = section_signed(&secret_key_set.secret_key(), section_auth);
         let (mut network_contacts, _genesis_sk, _) = new_network_network_contacts();
         assert!(network_contacts.insert_without_chain(sap0));

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -674,7 +674,8 @@ mod tests {
         let elders_len = 5;
 
         let prefix = prefix("0");
-        let (section_auth, _, secret_key_set) = TestSAP::random_sap(prefix, elders_len, 0, None);
+        let (section_auth, _, secret_key_set) =
+            TestSAP::random_sap(prefix, elders_len, 0, None, None);
         let sap0 = TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth);
         let (mut network_contacts, _genesis_sk, _) = new_network_network_contacts();
         assert!(network_contacts.insert_without_chain(sap0));

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -652,11 +652,8 @@ impl Session {
 mod tests {
     use super::*;
     use sn_interface::{
-        network_knowledge::{
-            test_utils::{prefix, section_signed},
-            SectionTree,
-        },
-        test_utils::TestSAP,
+        network_knowledge::SectionTree,
+        test_utils::{prefix, TestKeys, TestSAP},
     };
 
     use eyre::Result;
@@ -678,7 +675,7 @@ mod tests {
 
         let prefix = prefix("0");
         let (section_auth, _, secret_key_set) = TestSAP::random_sap(prefix, elders_len, 0, None);
-        let sap0 = section_signed(&secret_key_set.secret_key(), section_auth);
+        let sap0 = TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth);
         let (mut network_contacts, _genesis_sk, _) = new_network_network_contacts();
         assert!(network_contacts.insert_without_chain(sap0));
 

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -154,8 +154,8 @@ pub fn init_logger() {
 pub mod test_utils {
     pub use crate::{
         network_knowledge::{
-            section_authority_provider::test_utils::*, section_tree_test_utils::*, test_utils::*,
-            test_utils_nw::*,
+            section_authority_provider::test_utils::*, test_utils::*, test_utils_nw::*,
+            test_utils_st::*,
         },
         types::keys::test_utils::*,
     };

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -152,7 +152,10 @@ pub fn init_logger() {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils {
-    pub use crate::network_knowledge::{
-        section_authority_provider::test_utils::*, section_tree_test_utils::*, test_utils::*,
+    pub use crate::{
+        network_knowledge::{
+            section_authority_provider::test_utils::*, section_tree_test_utils::*, test_utils::*,
+        },
+        types::keys::test_utils::*,
     };
 }

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -149,3 +149,10 @@ pub fn init_logger() {
             .unwrap_or_else(|_| println!("Error initializing logger"));
     });
 }
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils {
+    pub use crate::network_knowledge::{
+        section_authority_provider::test_utils::*, section_tree_test_utils::*, test_utils::*,
+    };
+}

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -155,6 +155,7 @@ pub mod test_utils {
     pub use crate::{
         network_knowledge::{
             section_authority_provider::test_utils::*, section_tree_test_utils::*, test_utils::*,
+            test_utils_nw::*,
         },
         types::keys::test_utils::*,
     };

--- a/sn_interface/src/messaging/system/section_sig.rs
+++ b/sn_interface/src/messaging/system/section_sig.rs
@@ -86,19 +86,14 @@ impl SectionSigShare {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::test_utils::TestKeys;
     use bls::SecretKey;
 
     #[test]
     fn verify_keyed_sig() {
         let sk = SecretKey::random();
-        let public_key = sk.public_key();
-        let data = "hello".to_string();
-        let signature = sk.sign(&data);
-        let sig = SectionSig {
-            public_key,
-            signature,
-        };
+        let data = "hello";
+        let sig = TestKeys::get_section_sig_bytes(&sk, data.as_bytes());
         assert!(sig.verify(data.as_bytes()));
     }
 }

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -603,11 +603,92 @@ fn create_first_sig<T: Serialize>(
     })
 }
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils_nw {
+    use super::{
+        MyNodeInfo, NetworkKnowledge, NodeState, SectionKeyShare, SectionTree, SectionTreeUpdate,
+        SectionsDAG,
+    };
+    use crate::{
+        test_utils::{TestSAP, TestSectionTree},
+        types::keys::test_utils::TestKeys,
+        SectionAuthorityProvider,
+    };
+    use eyre::{eyre, Result};
+    use xor_name::Prefix;
+
+    /// `NetworkKnowledge` related utils for testing
+    pub struct TestNetworkKnowledge {}
+
+    impl TestNetworkKnowledge {
+        /// Generate a random `NetworkKnowledge` (section) for testing.
+        pub fn random_section_with_key(
+            prefix: Prefix,
+            elder_count: usize,
+            adult_count: usize,
+            sk_set: &bls::SecretKeySet,
+        ) -> (NetworkKnowledge, Vec<MyNodeInfo>) {
+            let pk_set = sk_set.public_keys();
+            let (sap, node_infos) =
+                TestSAP::random_sap_with_key(prefix, elder_count, adult_count, sk_set);
+            let signed_sap = TestKeys::get_section_signed(&sk_set.secret_key(), sap);
+            let section_tree_update =
+                super::SectionTreeUpdate::new(signed_sap, SectionsDAG::new(pk_set.public_key()));
+            let mut network_knowledge =
+                NetworkKnowledge::new(SectionTree::new(pk_set.public_key()), section_tree_update)
+                    .expect("Failed to create NetworkKnowledge");
+
+            // update the sap members
+            for peer in network_knowledge.signed_sap.elders() {
+                let node_state = NodeState::joined(*peer, None);
+                let signed_state = TestKeys::get_section_signed(&sk_set.secret_key(), node_state);
+                let _changed = network_knowledge.section_peers.update(signed_state);
+            }
+            (network_knowledge, node_infos)
+        }
+
+        pub fn do_create_section(
+            section_auth: &SectionAuthorityProvider,
+            genesis_ks: &bls::SecretKeySet,
+            other_section_keys: Option<Vec<bls::SecretKey>>,
+            parent_section_tree: Option<SectionTree>,
+        ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
+            let (section_chain, last_sk, share_index) = if let Some(other_section_keys) =
+                other_section_keys
+            {
+                let section_chain =
+                    TestSectionTree::gen_proof_chain(&genesis_ks.secret_key(), &other_section_keys);
+                let last_key = other_section_keys
+                    .last()
+                    .ok_or_else(|| eyre!("The section keys list must be populated"))?;
+                let share_index = other_section_keys.len() - 1;
+                (section_chain, last_key.clone(), share_index)
+            } else {
+                let section_chain = SectionsDAG::new(genesis_ks.public_keys().public_key());
+                (section_chain, genesis_ks.secret_key(), 0)
+            };
+
+            let signed_sap = TestKeys::get_section_signed(&last_sk, section_auth.clone());
+            let section_tree_update = SectionTreeUpdate::new(signed_sap, section_chain);
+            let section_tree = if let Some(parent_section_tree) = parent_section_tree {
+                parent_section_tree
+            } else {
+                SectionTree::new(genesis_ks.public_keys().public_key())
+            };
+            let section = NetworkKnowledge::new(section_tree, section_tree_update)?;
+
+            let sks = bls::SecretKeySet::from_bytes(last_sk.to_bytes().to_vec())?;
+            let section_key_share = TestKeys::get_section_key_share(&sks, share_index);
+            Ok((section, section_key_share))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{supermajority, NetworkKnowledge};
     use crate::{
-        test_utils::{gen_addr, gen_section_tree_update, prefix, TestKeys, TestSAP},
+        test_utils::{gen_addr, prefix, TestKeys, TestSAP, TestSectionTree},
         types::Peer,
     };
     use bls::SecretKeySet;
@@ -654,7 +735,7 @@ mod tests {
         let our_node_name_prefix_1 = sap1.prefix().name();
         let proof_chain = knowledge.section_chain();
         let section_tree_update =
-            gen_section_tree_update(&sap1, &proof_chain, &sk_gen.secret_key());
+            TestSectionTree::get_section_tree_update(&sap1, &proof_chain, &sk_gen.secret_key());
         assert!(knowledge.update_knowledge_if_valid(
             section_tree_update,
             None,
@@ -666,7 +747,7 @@ mod tests {
         let (sap0, _, sk_0) = TestSAP::random_sap(prefix("0"), 0, 0, None);
         let sap0 = TestKeys::get_section_signed(&sk_0.secret_key(), sap0);
         let section_tree_update =
-            gen_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key());
+            TestSectionTree::get_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key());
         // our node is still in prefix1
         assert!(knowledge.update_knowledge_if_valid(
             section_tree_update,

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -17,7 +17,7 @@ mod sections_dag;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 #[cfg(any(test, feature = "test-utils"))]
-pub use section_tree::test_utils as section_tree_test_utils;
+pub use section_tree::test_utils as test_utils_st;
 
 pub use self::{
     errors::{Error, Result},
@@ -605,16 +605,8 @@ fn create_first_sig<T: Serialize>(
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils_nw {
-    use super::{
-        MyNodeInfo, NetworkKnowledge, NodeState, SectionKeyShare, SectionTree, SectionTreeUpdate,
-        SectionsDAG,
-    };
-    use crate::{
-        test_utils::{TestSAP, TestSectionTree},
-        types::keys::test_utils::TestKeys,
-        SectionAuthorityProvider,
-    };
-    use eyre::{eyre, Result};
+    use super::{MyNodeInfo, NetworkKnowledge, NodeState, SectionTree, SectionsDAG};
+    use crate::{test_utils::TestSAP, types::keys::test_utils::TestKeys};
     use xor_name::Prefix;
 
     /// `NetworkKnowledge` related utils for testing
@@ -645,41 +637,6 @@ pub mod test_utils_nw {
                 let _changed = network_knowledge.section_peers.update(signed_state);
             }
             (network_knowledge, node_infos)
-        }
-
-        pub fn do_create_section(
-            section_auth: &SectionAuthorityProvider,
-            genesis_ks: &bls::SecretKeySet,
-            other_section_keys: Option<Vec<bls::SecretKey>>,
-            parent_section_tree: Option<SectionTree>,
-        ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
-            let (section_chain, last_sk, share_index) = if let Some(other_section_keys) =
-                other_section_keys
-            {
-                let section_chain =
-                    TestSectionTree::gen_proof_chain(&genesis_ks.secret_key(), &other_section_keys);
-                let last_key = other_section_keys
-                    .last()
-                    .ok_or_else(|| eyre!("The section keys list must be populated"))?;
-                let share_index = other_section_keys.len() - 1;
-                (section_chain, last_key.clone(), share_index)
-            } else {
-                let section_chain = SectionsDAG::new(genesis_ks.public_keys().public_key());
-                (section_chain, genesis_ks.secret_key(), 0)
-            };
-
-            let signed_sap = TestKeys::get_section_signed(&last_sk, section_auth.clone());
-            let section_tree_update = SectionTreeUpdate::new(signed_sap, section_chain);
-            let section_tree = if let Some(parent_section_tree) = parent_section_tree {
-                parent_section_tree
-            } else {
-                SectionTree::new(genesis_ks.public_keys().public_key())
-            };
-            let section = NetworkKnowledge::new(section_tree, section_tree_update)?;
-
-            let sks = bls::SecretKeySet::from_bytes(last_sk.to_bytes().to_vec())?;
-            let section_key_share = TestKeys::get_section_key_share(&sks, share_index);
-            Ok((section, section_key_share))
         }
     }
 }

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -14,9 +14,10 @@ pub mod section_keys;
 mod section_peers;
 mod section_tree;
 mod sections_dag;
-
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
+#[cfg(any(test, feature = "test-utils"))]
+pub use section_tree::test_utils as section_tree_test_utils;
 
 pub use self::{
     errors::{Error, Result},
@@ -604,12 +605,11 @@ fn create_first_sig<T: Serialize>(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        supermajority,
-        test_utils::{gen_addr, prefix, random_sap, section_signed},
-        NetworkKnowledge,
+    use super::{supermajority, NetworkKnowledge};
+    use crate::{
+        test_utils::{gen_addr, gen_section_tree_update, prefix, section_signed, TestSAP},
+        types::Peer,
     };
-    use crate::{network_knowledge::test_utils::gen_section_tree_update, types::Peer};
     use bls::SecretKeySet;
     use eyre::Result;
     use proptest::prelude::*;
@@ -649,7 +649,7 @@ mod tests {
         let (mut knowledge, _) = NetworkKnowledge::first_node(peer, sk_gen.clone())?;
 
         // section 1
-        let (sap1, _, sk_1) = random_sap(prefix("1"), 0, 0, None);
+        let (sap1, _, sk_1) = TestSAP::random_sap(prefix("1"), 0, 0, None);
         let sap1 = section_signed(&sk_1.secret_key(), sap1);
         let our_node_name_prefix_1 = sap1.prefix().name();
         let proof_chain = knowledge.section_chain();
@@ -663,7 +663,7 @@ mod tests {
         assert_eq!(knowledge.signed_sap, sap1);
 
         // section with different prefix (0) and our node name doesn't match
-        let (sap0, _, sk_0) = random_sap(prefix("0"), 0, 0, None);
+        let (sap0, _, sk_0) = TestSAP::random_sap(prefix("0"), 0, 0, None);
         let sap0 = section_signed(&sk_0.secret_key(), sap0);
         let section_tree_update =
             gen_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key());

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -607,7 +607,7 @@ fn create_first_sig<T: Serialize>(
 mod tests {
     use super::{supermajority, NetworkKnowledge};
     use crate::{
-        test_utils::{gen_addr, gen_section_tree_update, prefix, section_signed, TestSAP},
+        test_utils::{gen_addr, gen_section_tree_update, prefix, TestKeys, TestSAP},
         types::Peer,
     };
     use bls::SecretKeySet;
@@ -650,7 +650,7 @@ mod tests {
 
         // section 1
         let (sap1, _, sk_1) = TestSAP::random_sap(prefix("1"), 0, 0, None);
-        let sap1 = section_signed(&sk_1.secret_key(), sap1);
+        let sap1 = TestKeys::get_section_signed(&sk_1.secret_key(), sap1);
         let our_node_name_prefix_1 = sap1.prefix().name();
         let proof_chain = knowledge.section_chain();
         let section_tree_update =
@@ -664,7 +664,7 @@ mod tests {
 
         // section with different prefix (0) and our node name doesn't match
         let (sap0, _, sk_0) = TestSAP::random_sap(prefix("0"), 0, 0, None);
-        let sap0 = section_signed(&sk_0.secret_key(), sap0);
+        let sap0 = TestKeys::get_section_signed(&sk_0.secret_key(), sap0);
         let section_tree_update =
             gen_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key());
         // our node is still in prefix1

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -630,7 +630,7 @@ pub mod test_utils_nw {
         ) -> (NetworkKnowledge, Vec<MyNodeInfo>) {
             let pk_set = sk_set.public_keys();
             let (sap, node_infos) =
-                TestSAP::random_sap_with_key(prefix, elder_count, adult_count, sk_set);
+                TestSAP::random_sap_with_key(prefix, elder_count, adult_count, sk_set, None);
             let signed_sap = TestKeys::get_section_signed(&sk_set.secret_key(), sap);
             let section_tree_update =
                 super::SectionTreeUpdate::new(signed_sap, SectionsDAG::new(pk_set.public_key()));
@@ -730,7 +730,7 @@ mod tests {
         let (mut knowledge, _) = NetworkKnowledge::first_node(peer, sk_gen.clone())?;
 
         // section 1
-        let (sap1, _, sk_1) = TestSAP::random_sap(prefix("1"), 0, 0, None);
+        let (sap1, _, sk_1) = TestSAP::random_sap(prefix("1"), 0, 0, None, None);
         let sap1 = TestKeys::get_section_signed(&sk_1.secret_key(), sap1);
         let our_node_name_prefix_1 = sap1.prefix().name();
         let proof_chain = knowledge.section_chain();
@@ -744,7 +744,7 @@ mod tests {
         assert_eq!(knowledge.signed_sap, sap1);
 
         // section with different prefix (0) and our node name doesn't match
-        let (sap0, _, sk_0) = TestSAP::random_sap(prefix("0"), 0, 0, None);
+        let (sap0, _, sk_0) = TestSAP::random_sap(prefix("0"), 0, 0, None, None);
         let sap0 = TestKeys::get_section_signed(&sk_0.secret_key(), sap0);
         let section_tree_update =
             TestSectionTree::get_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key());

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -236,24 +236,29 @@ pub mod test_utils {
     pub struct TestSAP {}
 
     impl TestSAP {
-        /// Generate a random `SectionAuthorityProvider` for testing.
+        /// Generate a random `SectionAuthorityProvider` for testing with the `SectionKeySet` created using the rng.
         ///
         /// The total number of members in the section will be `elder_count` + `adult_count`. A lot of
         /// tests don't require adults in the section, so zero is an acceptable value for
         /// `adult_count`.
         ///
-        /// The rng is used to generate the `SecretKeySet`
+        /// Optionally provide `age_pattern` to create elders with specific ages.
+        /// If None = elder's age is set to `MIN_ADULT_AGE`
+        /// If age_pattern.len() == elder, then apply the respective ages to each node
+        /// If age_pattern.len() < elder, then the last element's value is taken as the age for the remaining nodes.
+        /// If age_pattern.len() > elder, then the extra elements after `count` are ignored.
         ///
-        /// An optional `sk_threshold_size` can be passed to specify the threshold when the secret key
+        /// Also an optional `sk_threshold_size` can be passed to specify the threshold when the secret key
         /// set is generated for the section key. Some tests require a low threshold.
         pub fn random_sap_with_rng<R: RngCore>(
             rng: &mut R,
             prefix: Prefix,
             elder_count: usize,
             adult_count: usize,
+            elder_age_pattern: Option<&[u8]>,
             sk_threshold_size: Option<usize>,
         ) -> (SectionAuthorityProvider, Vec<MyNodeInfo>, bls::SecretKeySet) {
-            let nodes = gen_sorted_nodes(&prefix, elder_count + adult_count, false);
+            let nodes = gen_sorted_nodes(&prefix, elder_count, adult_count, elder_age_pattern);
             let elders = nodes.iter().map(MyNodeInfo::peer).take(elder_count);
             let members = nodes.iter().map(|i| NodeState::joined(i.peer(), None));
             let poly = bls::poly::Poly::random(sk_threshold_size.unwrap_or(0), rng);
@@ -270,6 +275,7 @@ pub mod test_utils {
             prefix: Prefix,
             elder_count: usize,
             adult_count: usize,
+            elder_age_pattern: Option<&[u8]>,
             sk_threshold_size: Option<usize>,
         ) -> (SectionAuthorityProvider, Vec<MyNodeInfo>, bls::SecretKeySet) {
             Self::random_sap_with_rng(
@@ -277,6 +283,7 @@ pub mod test_utils {
                 prefix,
                 elder_count,
                 adult_count,
+                elder_age_pattern,
                 sk_threshold_size,
             )
         }
@@ -290,8 +297,9 @@ pub mod test_utils {
             elder_count: usize,
             adult_count: usize,
             sk_set: &bls::SecretKeySet,
+            elder_age_pattern: Option<&[u8]>,
         ) -> (SectionAuthorityProvider, Vec<MyNodeInfo>) {
-            let nodes = gen_sorted_nodes(&prefix, elder_count + adult_count, false);
+            let nodes = gen_sorted_nodes(&prefix, elder_count, adult_count, elder_age_pattern);
             let elders = nodes.iter().map(MyNodeInfo::peer).take(elder_count);
             let members = nodes.iter().map(|i| NodeState::joined(i.peer(), None));
             let section_auth =
@@ -311,7 +319,7 @@ pub mod test_utils {
             bls::SecretKey,
         ) {
             let (section_auth, nodes, secret_key_set) =
-                Self::random_sap(prefix, elder_count, adult_count, sk_threshold_size);
+                Self::random_sap(prefix, elder_count, adult_count, None, sk_threshold_size);
             let signed_sap =
                 TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth);
 

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -227,7 +227,7 @@ pub mod test_utils {
     use crate::{
         messaging::system::SectionSigned,
         network_knowledge::{MyNodeInfo, NodeState, SectionAuthorityProvider},
-        test_utils::{gen_sorted_nodes, section_signed},
+        test_utils::{gen_sorted_nodes, TestKeys},
     };
     use rand::RngCore;
     use xor_name::Prefix;
@@ -239,7 +239,7 @@ pub mod test_utils {
             prefix: Prefix,
         ) -> (SectionSigned<SectionAuthorityProvider>, bls::SecretKey) {
             let (section_auth, _, secret_key_set) = Self::random_sap(prefix, 5, 0, None);
-            let sap = section_signed(&secret_key_set.secret_key(), section_auth);
+            let sap = TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth);
             (sap, secret_key_set.secret_key())
         }
 

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -232,22 +232,17 @@ pub mod test_utils {
     use rand::RngCore;
     use xor_name::Prefix;
 
+    /// `SectionAuthorityProvider` related utils for testing
     pub struct TestSAP {}
 
     impl TestSAP {
-        pub fn gen_section_auth(
-            prefix: Prefix,
-        ) -> (SectionSigned<SectionAuthorityProvider>, bls::SecretKey) {
-            let (section_auth, _, secret_key_set) = Self::random_sap(prefix, 5, 0, None);
-            let sap = TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth);
-            (sap, secret_key_set.secret_key())
-        }
-
         /// Generate a random `SectionAuthorityProvider` for testing.
         ///
         /// The total number of members in the section will be `elder_count` + `adult_count`. A lot of
         /// tests don't require adults in the section, so zero is an acceptable value for
         /// `adult_count`.
+        ///
+        /// The rng is used to generate the `SecretKeySet`
         ///
         /// An optional `sk_threshold_size` can be passed to specify the threshold when the secret key
         /// set is generated for the section key. Some tests require a low threshold.
@@ -268,6 +263,9 @@ pub mod test_utils {
             (section_auth, nodes, sks)
         }
 
+        /// Generate a random `SectionAuthorityProvider` for testing.
+        ///
+        /// Same as `random_sap_with_rng` but with `thread_rng`.
         pub fn random_sap(
             prefix: Prefix,
             elder_count: usize,
@@ -299,6 +297,25 @@ pub mod test_utils {
             let section_auth =
                 SectionAuthorityProvider::new(elders, prefix, members, sk_set.public_keys(), 0);
             (section_auth, nodes)
+        }
+
+        /// Generate a random `SectionAuthorityProvider` which is signed by itself
+        pub fn random_signed_sap(
+            prefix: Prefix,
+            elder_count: usize,
+            adult_count: usize,
+            sk_threshold_size: Option<usize>,
+        ) -> (
+            SectionSigned<SectionAuthorityProvider>,
+            Vec<MyNodeInfo>,
+            bls::SecretKey,
+        ) {
+            let (section_auth, nodes, secret_key_set) =
+                Self::random_sap(prefix, elder_count, adult_count, sk_threshold_size);
+            let signed_sap =
+                TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth);
+
+            (signed_sap, nodes, secret_key_set.secret_key())
         }
     }
 }

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -221,3 +221,84 @@ impl SectionAuthorityProvider {
         self.public_key_set.public_key()
     }
 }
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils {
+    use crate::{
+        messaging::system::SectionSigned,
+        network_knowledge::{MyNodeInfo, NodeState, SectionAuthorityProvider},
+        test_utils::{gen_sorted_nodes, section_signed},
+    };
+    use rand::RngCore;
+    use xor_name::Prefix;
+
+    pub struct TestSAP {}
+
+    impl TestSAP {
+        pub fn gen_section_auth(
+            prefix: Prefix,
+        ) -> (SectionSigned<SectionAuthorityProvider>, bls::SecretKey) {
+            let (section_auth, _, secret_key_set) = Self::random_sap(prefix, 5, 0, None);
+            let sap = section_signed(&secret_key_set.secret_key(), section_auth);
+            (sap, secret_key_set.secret_key())
+        }
+
+        /// Generate a random `SectionAuthorityProvider` for testing.
+        ///
+        /// The total number of members in the section will be `elder_count` + `adult_count`. A lot of
+        /// tests don't require adults in the section, so zero is an acceptable value for
+        /// `adult_count`.
+        ///
+        /// An optional `sk_threshold_size` can be passed to specify the threshold when the secret key
+        /// set is generated for the section key. Some tests require a low threshold.
+        pub fn random_sap_with_rng<R: RngCore>(
+            rng: &mut R,
+            prefix: Prefix,
+            elder_count: usize,
+            adult_count: usize,
+            sk_threshold_size: Option<usize>,
+        ) -> (SectionAuthorityProvider, Vec<MyNodeInfo>, bls::SecretKeySet) {
+            let nodes = gen_sorted_nodes(&prefix, elder_count + adult_count, false);
+            let elders = nodes.iter().map(MyNodeInfo::peer).take(elder_count);
+            let members = nodes.iter().map(|i| NodeState::joined(i.peer(), None));
+            let poly = bls::poly::Poly::random(sk_threshold_size.unwrap_or(0), rng);
+            let sks = bls::SecretKeySet::from(poly);
+            let section_auth =
+                SectionAuthorityProvider::new(elders, prefix, members, sks.public_keys(), 0);
+            (section_auth, nodes, sks)
+        }
+
+        pub fn random_sap(
+            prefix: Prefix,
+            elder_count: usize,
+            adult_count: usize,
+            sk_threshold_size: Option<usize>,
+        ) -> (SectionAuthorityProvider, Vec<MyNodeInfo>, bls::SecretKeySet) {
+            Self::random_sap_with_rng(
+                &mut rand::thread_rng(),
+                prefix,
+                elder_count,
+                adult_count,
+                sk_threshold_size,
+            )
+        }
+
+        /// Generate a random `SectionAuthorityProvider` for testing.
+        ///
+        /// Same as `random_sap`, but instead the secret key is provided. This can be useful for
+        /// creating a section to share the same genesis key as another one.
+        pub fn random_sap_with_key(
+            prefix: Prefix,
+            elder_count: usize,
+            adult_count: usize,
+            sk_set: &bls::SecretKeySet,
+        ) -> (SectionAuthorityProvider, Vec<MyNodeInfo>) {
+            let nodes = gen_sorted_nodes(&prefix, elder_count + adult_count, false);
+            let elders = nodes.iter().map(MyNodeInfo::peer).take(elder_count);
+            let members = nodes.iter().map(|i| NodeState::joined(i.peer(), None));
+            let section_auth =
+                SectionAuthorityProvider::new(elders, prefix, members, sk_set.public_keys(), 0);
+            (section_auth, nodes)
+        }
+    }
+}

--- a/sn_interface/src/network_knowledge/section_peers.rs
+++ b/sn_interface/src/network_knowledge/section_peers.rs
@@ -124,7 +124,7 @@ mod tests {
             test_utils::{assert_lists, gen_addr, section_signed},
             MembershipState, NodeState, RelocateDetails,
         },
-        types::{Peer, SecretKeySet},
+        types::Peer,
     };
     use eyre::Result;
     use rand::thread_rng;
@@ -136,7 +136,7 @@ mod tests {
         let mut section_peers = SectionPeers::default();
 
         // adding node set 1
-        let sk_1 = SecretKeySet::random(None).secret_key().clone();
+        let sk_1 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_1 = gen_random_signed_node_states(1, MembershipState::Left, &sk_1);
         nodes_1.iter().for_each(|node| {
             section_peers.update(node.clone());
@@ -147,7 +147,7 @@ mod tests {
         assert_lists(section_peers.archive.values(), &nodes_1);
 
         // adding node set 2 as MembershipState::Relocated
-        let sk_2 = SecretKeySet::random(None).secret_key().clone();
+        let sk_2 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let relocate = RelocateDetails {
             previous_name: XorName::random(&mut rng),
             dst: XorName::random(&mut rng),
@@ -169,7 +169,7 @@ mod tests {
         );
 
         // adding node set 3
-        let sk_3 = SecretKeySet::random(None).secret_key().clone();
+        let sk_3 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_3 = gen_random_signed_node_states(1, MembershipState::Left, &sk_3);
         nodes_3.iter().for_each(|node| {
             section_peers.update(node.clone());
@@ -184,7 +184,7 @@ mod tests {
         );
 
         // adding node set 4
-        let sk_4 = SecretKeySet::random(None).secret_key().clone();
+        let sk_4 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_4 = gen_random_signed_node_states(1, MembershipState::Left, &sk_4);
         nodes_4.iter().for_each(|node| {
             section_peers.update(node.clone());
@@ -202,7 +202,7 @@ mod tests {
         // 1 -> 2 -> 3 -> 4
         //              |
         //              -> 5
-        let sk_5 = SecretKeySet::random(None).secret_key().clone();
+        let sk_5 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_5 = gen_random_signed_node_states(1, MembershipState::Left, &sk_5);
         nodes_5.iter().for_each(|node| {
             section_peers.update(node.clone());
@@ -223,7 +223,7 @@ mod tests {
     fn archived_members_should_not_be_moved_to_members_list() {
         let mut rng = thread_rng();
         let mut section_peers = SectionPeers::default();
-        let sk = SecretKeySet::random(None).secret_key().clone();
+        let sk = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let node_left = gen_random_signed_node_states(1, MembershipState::Left, &sk)[0].clone();
         let relocate = RelocateDetails {
             previous_name: XorName::random(&mut rng),
@@ -253,7 +253,7 @@ mod tests {
     fn members_should_be_archived_if_they_leave_or_relocate() {
         let mut rng = thread_rng();
         let mut section_peers = SectionPeers::default();
-        let sk = SecretKeySet::random(None).secret_key().clone();
+        let sk = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
 
         let node_1 = gen_random_signed_node_states(1, MembershipState::Joined, &sk)[0].clone();
         let relocate = RelocateDetails {

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -464,10 +464,12 @@ pub mod test_utils {
     use super::{SectionTree, SectionTreeUpdate, SectionsDAG};
     use crate::{messaging::system::SectionSigned, test_utils::TestKeys, SectionAuthorityProvider};
 
+    /// `SectionTree` related utils for testing
     pub struct TestSectionTree {}
 
     impl TestSectionTree {
-        pub fn random() -> (SectionTree, bls::SecretKey) {
+        /// Get a random `SectionTree`
+        pub fn random_tree() -> (SectionTree, bls::SecretKey) {
             let genesis_sk = bls::SecretKey::random();
             let tree = SectionTree::new(genesis_sk.public_key());
 
@@ -516,17 +518,17 @@ mod tests {
     use super::*;
     use crate::{
         network_knowledge::sections_dag::tests::arb_sections_dag_and_proof_chains,
-        test_utils::{assert_lists, gen_section_tree_update, prefix, TestSAP, TestSectionTree},
+        test_utils::{assert_lists, prefix, TestSAP, TestSectionTree},
     };
     use eyre::Result;
     use proptest::{prelude::ProptestConfig, prop_assert_eq, proptest};
 
     #[test]
     fn insert_existing_prefix() {
-        let (mut tree, _) = TestSectionTree::random();
+        let (mut tree, _) = TestSectionTree::random_tree();
         let p0 = prefix("0");
-        let (sap0, _) = TestSAP::gen_section_auth(p0);
-        let (new_sap0, _) = TestSAP::gen_section_auth(p0);
+        let (sap0, _) = random_signed_sap(p0);
+        let (new_sap0, _) = random_signed_sap(p0);
         assert_ne!(sap0, new_sap0);
 
         assert!(tree.insert(sap0));
@@ -536,16 +538,16 @@ mod tests {
 
     #[test]
     fn insert_direct_descendants_of_existing_prefix() {
-        let (mut tree, _) = TestSectionTree::random();
+        let (mut tree, _) = TestSectionTree::random_tree();
         let p0 = prefix("0");
         let p00 = prefix("00");
         let p01 = prefix("01");
 
-        let (sap0, _) = TestSAP::gen_section_auth(p0);
+        let (sap0, _) = random_signed_sap(p0);
         assert!(tree.insert(sap0));
 
         // Insert the first sibling. Parent get pruned in the map.
-        let (sap00, _) = TestSAP::gen_section_auth(p00);
+        let (sap00, _) = random_signed_sap(p00);
         assert!(tree.insert(sap00.clone()));
 
         assert_eq!(tree.get(&p00), Some(sap00.value.clone()));
@@ -553,7 +555,7 @@ mod tests {
         assert_eq!(tree.get(&p0), None);
 
         // Insert the other sibling.
-        let (sap3, _) = TestSAP::gen_section_auth(p01);
+        let (sap3, _) = random_signed_sap(p01);
         assert!(tree.insert(sap3.clone()));
 
         assert_eq!(tree.get(&p00), Some(sap00.value));
@@ -563,11 +565,11 @@ mod tests {
 
     #[test]
     fn return_opposite_prefix_if_none_matching() -> Result<()> {
-        let (mut tree, _) = TestSectionTree::random();
+        let (mut tree, _) = TestSectionTree::random_tree();
         let p0 = prefix("0");
         let p1 = prefix("1");
 
-        let (sap0, _) = TestSAP::gen_section_auth(p0);
+        let (sap0, _) = random_signed_sap(p0);
 
         let _changed = tree.insert(sap0.clone());
 
@@ -595,17 +597,17 @@ mod tests {
 
     #[test]
     fn insert_indirect_descendants_of_existing_prefix() {
-        let (mut tree, _) = TestSectionTree::random();
+        let (mut tree, _) = TestSectionTree::random_tree();
         let p0 = prefix("0");
         let p000 = prefix("000");
         let p001 = prefix("001");
         let p00 = prefix("00");
         let p01 = prefix("01");
 
-        let (sap0, _) = TestSAP::gen_section_auth(p0);
-        let (sap01, _) = TestSAP::gen_section_auth(p01);
-        let (sap000, _) = TestSAP::gen_section_auth(p000);
-        let (sap001, _) = TestSAP::gen_section_auth(p001);
+        let (sap0, _) = random_signed_sap(p0);
+        let (sap01, _) = random_signed_sap(p01);
+        let (sap000, _) = random_signed_sap(p000);
+        let (sap001, _) = random_signed_sap(p001);
 
         assert!(tree.insert(sap0));
 
@@ -633,12 +635,12 @@ mod tests {
 
     #[test]
     fn insert_ancestor_of_existing_prefix() {
-        let (mut tree, _) = TestSectionTree::random();
+        let (mut tree, _) = TestSectionTree::random_tree();
         let p0 = prefix("0");
         let p00 = prefix("00");
 
-        let (sap0, _) = TestSAP::gen_section_auth(p0);
-        let (sap00, _) = TestSAP::gen_section_auth(p00);
+        let (sap0, _) = random_signed_sap(p0);
+        let (sap00, _) = random_signed_sap(p00);
         let _changed = tree.insert(sap00.clone());
 
         assert!(!tree.insert(sap0));
@@ -648,16 +650,16 @@ mod tests {
 
     #[test]
     fn get_matching() -> Result<()> {
-        let (mut tree, _) = TestSectionTree::random();
+        let (mut tree, _) = TestSectionTree::random_tree();
         let p = prefix("");
         let p0 = prefix("0");
         let p1 = prefix("1");
         let p10 = prefix("10");
 
-        let (sap, _) = TestSAP::gen_section_auth(p);
-        let (sap0, _) = TestSAP::gen_section_auth(p0);
-        let (sap1, _) = TestSAP::gen_section_auth(p1);
-        let (sap10, _) = TestSAP::gen_section_auth(p10);
+        let (sap, _) = random_signed_sap(p);
+        let (sap0, _) = random_signed_sap(p0);
+        let (sap1, _) = random_signed_sap(p1);
+        let (sap10, _) = random_signed_sap(p10);
 
         let _changed = tree.insert(sap.clone());
 
@@ -697,14 +699,14 @@ mod tests {
 
     #[test]
     fn get_matching_prefix() -> Result<()> {
-        let (mut tree, _) = TestSectionTree::random();
+        let (mut tree, _) = TestSectionTree::random_tree();
         let p0 = prefix("0");
         let p1 = prefix("1");
         let p10 = prefix("10");
 
-        let (sap0, _) = TestSAP::gen_section_auth(p0);
-        let (sap1, _) = TestSAP::gen_section_auth(p1);
-        let (sap10, _) = TestSAP::gen_section_auth(p10);
+        let (sap0, _) = random_signed_sap(p0);
+        let (sap1, _) = random_signed_sap(p1);
+        let (sap10, _) = random_signed_sap(p10);
 
         let _changed = tree.insert(sap0.clone());
         let _changed = tree.insert(sap1);
@@ -725,18 +727,20 @@ mod tests {
     #[test]
     fn closest() -> Result<()> {
         // Create map containing sections (00), (01) and (10)
-        let (mut tree, genesis_sk) = TestSectionTree::random();
+        let (mut tree, genesis_sk) = TestSectionTree::random_tree();
         let dag = SectionsDAG::new(genesis_sk.public_key());
         let p01 = prefix("01");
         let p10 = prefix("10");
         let p11 = prefix("11");
 
-        let (sap01, _) = TestSAP::gen_section_auth(p01);
-        let section_tree_update = gen_section_tree_update(&sap01, &dag, &genesis_sk);
+        let (sap01, _) = random_signed_sap(p01);
+        let section_tree_update =
+            TestSectionTree::get_section_tree_update(&sap01, &dag, &genesis_sk);
         assert!(tree.update(section_tree_update)?);
 
-        let (sap10, _) = TestSAP::gen_section_auth(p10);
-        let section_tree_update = gen_section_tree_update(&sap10, &dag, &genesis_sk);
+        let (sap10, _) = random_signed_sap(p10);
+        let section_tree_update =
+            TestSectionTree::get_section_tree_update(&sap10, &dag, &genesis_sk);
         assert!(tree.update(section_tree_update)?);
 
         let n01 = p01.substituted_in(xor_name::rand::random());
@@ -752,16 +756,18 @@ mod tests {
 
     #[test]
     fn proof_chain_should_contain_a_single_branch_during_update() -> Result<()> {
-        let (mut tree, genesis_sk) = TestSectionTree::random();
+        let (mut tree, genesis_sk) = TestSectionTree::random_tree();
 
-        let (sap0, _) = TestSAP::gen_section_auth(prefix("0"));
-        let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
+        let (sap0, _) = random_signed_sap(prefix("0"));
+        let tree_update =
+            TestSectionTree::get_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
         assert!(tree.update(tree_update)?);
 
-        let (sap1, _) = TestSAP::gen_section_auth(prefix("1"));
+        let (sap1, _) = random_signed_sap(prefix("1"));
         // instead of constructing a proof_chain from gen -> 1; we also include the branch '0'
         // which will result in an error while updating the SectionTree
-        let tree_update = gen_section_tree_update(&sap1, tree.get_sections_dag(), &genesis_sk);
+        let tree_update =
+            TestSectionTree::get_section_tree_update(&sap1, tree.get_sections_dag(), &genesis_sk);
         assert!(matches!(
             tree.update(tree_update),
             Err(Error::MultipleBranchError)
@@ -772,11 +778,12 @@ mod tests {
 
     #[test]
     fn updating_with_same_sap_should_return_false() -> Result<()> {
-        let (mut tree, genesis_sk) = TestSectionTree::random();
+        let (mut tree, genesis_sk) = TestSectionTree::random_tree();
 
         // node updated with sap0
-        let (sap0, _) = TestSAP::gen_section_auth(prefix("0"));
-        let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
+        let (sap0, _) = random_signed_sap(prefix("0"));
+        let tree_update =
+            TestSectionTree::get_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
         let tree_update_same = tree_update.clone();
         assert!(tree.update(tree_update)?);
 
@@ -788,17 +795,19 @@ mod tests {
 
     #[test]
     fn sap_with_same_parent_and_prefix_should_result_in_error_during_update() -> Result<()> {
-        let (mut tree, genesis_sk) = TestSectionTree::random();
+        let (mut tree, genesis_sk) = TestSectionTree::random_tree();
 
         // node updated with sap0
-        let (sap0, _) = TestSAP::gen_section_auth(prefix("0"));
+        let (sap0, _) = random_signed_sap(prefix("0"));
         let proof_chain = tree.get_sections_dag().clone();
-        let tree_update = gen_section_tree_update(&sap0, &proof_chain, &genesis_sk);
+        let tree_update =
+            TestSectionTree::get_section_tree_update(&sap0, &proof_chain, &genesis_sk);
         assert!(tree.update(tree_update)?);
 
         // node tries to update with sap signed by same parent for the same prefix
-        let (sap0_same, _) = TestSAP::gen_section_auth(prefix("0"));
-        let tree_update = gen_section_tree_update(&sap0_same, &proof_chain, &genesis_sk);
+        let (sap0_same, _) = random_signed_sap(prefix("0"));
+        let tree_update =
+            TestSectionTree::get_section_tree_update(&sap0_same, &proof_chain, &genesis_sk);
         assert!(matches!(
             tree.update(tree_update),
             Err(Error::UntrustedProofChain(_))
@@ -809,17 +818,19 @@ mod tests {
 
     #[test]
     fn outdated_sap_for_the_same_prefix_should_result_in_error_during_update() -> Result<()> {
-        let (mut tree, genesis_sk) = TestSectionTree::random();
+        let (mut tree, genesis_sk) = TestSectionTree::random_tree();
 
         // node updated with sap0
-        let (sap0, sk0) = TestSAP::gen_section_auth(prefix("0"));
-        let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
+        let (sap0, sk0) = random_signed_sap(prefix("0"));
+        let tree_update =
+            TestSectionTree::get_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
         let tree_update_outdated = tree_update.clone();
         assert!(tree.update(tree_update)?);
 
         // node updated with sap1 with same prefix
-        let (sap1, _) = TestSAP::gen_section_auth(prefix("0"));
-        let tree_update = gen_section_tree_update(&sap1, tree.get_sections_dag(), &sk0);
+        let (sap1, _) = random_signed_sap(prefix("0"));
+        let tree_update =
+            TestSectionTree::get_section_tree_update(&sap1, tree.get_sections_dag(), &sk0);
         assert!(tree.update(tree_update)?);
 
         // node receives an outdated AE update for sap0
@@ -859,5 +870,13 @@ mod tests {
             // Finally, verify that we got the main_dag back
             prop_assert_eq!(main_dag, section_tree.sections_dag);
         }
+    }
+
+    /// Test helper
+    fn random_signed_sap(
+        prefix: Prefix,
+    ) -> (SectionSigned<SectionAuthorityProvider>, bls::SecretKey) {
+        let (sap, _, sk) = TestSAP::random_signed_sap(prefix, 0, 5, None);
+        (sap, sk)
     }
 }

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -461,11 +461,8 @@ impl SectionTreeUpdate {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils {
-    use super::{SectionTree, SectionTreeUpdate};
-    use crate::{
-        messaging::system::SectionSigned, network_knowledge::SectionsDAG,
-        test_utils::section_signed, SectionAuthorityProvider,
-    };
+    use super::{SectionTree, SectionTreeUpdate, SectionsDAG};
+    use crate::{messaging::system::SectionSigned, test_utils::TestKeys, SectionAuthorityProvider};
 
     pub struct TestSectionTree {}
 
@@ -476,41 +473,41 @@ pub mod test_utils {
 
             (tree, genesis_sk)
         }
-    }
 
-    /// Generate a `SectionTreeUpdate` where the SAP's section key is appended to the proof chain
-    pub fn get_section_tree_update(
-        sap: &SectionSigned<SectionAuthorityProvider>,
-        proof_chain: &SectionsDAG,
-        parent_sk: &bls::SecretKey,
-    ) -> SectionTreeUpdate {
-        let signed_key = section_signed(parent_sk, sap.section_key());
-        let mut proof_chain = proof_chain.clone();
-        proof_chain
-            .insert(
-                &parent_sk.public_key(),
-                signed_key.value,
-                signed_key.sig.signature,
-            )
-            .expect("Failed to insert into proof_chain");
-        SectionTreeUpdate::new(sap.clone(), proof_chain)
-    }
-
-    /// Generate a proof chain from the provided `genesis_key` followed by all keys provided in `other_keys`
-    pub fn gen_proof_chain(
-        genesis_key: &bls::SecretKey,
-        other_keys: &Vec<bls::SecretKey>,
-    ) -> SectionsDAG {
-        let mut proof_chain = SectionsDAG::new(genesis_key.public_key());
-        let mut parent = genesis_key.clone();
-        for key in other_keys {
-            let sig = parent.sign(key.public_key().to_bytes());
+        /// Generate a `SectionTreeUpdate` where the SAP's section key is appended to the proof chain
+        pub fn get_section_tree_update(
+            sap: &SectionSigned<SectionAuthorityProvider>,
+            proof_chain: &SectionsDAG,
+            parent_sk: &bls::SecretKey,
+        ) -> SectionTreeUpdate {
+            let signed_key = TestKeys::get_section_signed(parent_sk, sap.section_key());
+            let mut proof_chain = proof_chain.clone();
             proof_chain
-                .insert(&parent.public_key(), key.public_key(), sig)
+                .insert(
+                    &parent_sk.public_key(),
+                    signed_key.value,
+                    signed_key.sig.signature,
+                )
                 .expect("Failed to insert into proof_chain");
-            parent = key.clone();
+            SectionTreeUpdate::new(sap.clone(), proof_chain)
         }
-        proof_chain
+
+        /// Generate a proof chain from the provided `genesis_key` followed by all keys provided in `other_keys`
+        pub fn gen_proof_chain(
+            genesis_key: &bls::SecretKey,
+            other_keys: &Vec<bls::SecretKey>,
+        ) -> SectionsDAG {
+            let mut proof_chain = SectionsDAG::new(genesis_key.public_key());
+            let mut parent = genesis_key.clone();
+            for key in other_keys {
+                let sig = parent.sign(key.public_key().to_bytes());
+                proof_chain
+                    .insert(&parent.public_key(), key.public_key(), sig)
+                    .expect("Failed to insert into proof_chain");
+                parent = key.clone();
+            }
+            proof_chain
+        }
     }
 }
 

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -459,22 +459,77 @@ impl SectionTreeUpdate {
     }
 }
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils {
+    use super::{SectionTree, SectionTreeUpdate};
+    use crate::{
+        messaging::system::SectionSigned, network_knowledge::SectionsDAG,
+        test_utils::section_signed, SectionAuthorityProvider,
+    };
+
+    pub struct TestSectionTree {}
+
+    impl TestSectionTree {
+        pub fn random() -> (SectionTree, bls::SecretKey) {
+            let genesis_sk = bls::SecretKey::random();
+            let tree = SectionTree::new(genesis_sk.public_key());
+
+            (tree, genesis_sk)
+        }
+    }
+
+    /// Generate a `SectionTreeUpdate` where the SAP's section key is appended to the proof chain
+    pub fn get_section_tree_update(
+        sap: &SectionSigned<SectionAuthorityProvider>,
+        proof_chain: &SectionsDAG,
+        parent_sk: &bls::SecretKey,
+    ) -> SectionTreeUpdate {
+        let signed_key = section_signed(parent_sk, sap.section_key());
+        let mut proof_chain = proof_chain.clone();
+        proof_chain
+            .insert(
+                &parent_sk.public_key(),
+                signed_key.value,
+                signed_key.sig.signature,
+            )
+            .expect("Failed to insert into proof_chain");
+        SectionTreeUpdate::new(sap.clone(), proof_chain)
+    }
+
+    /// Generate a proof chain from the provided `genesis_key` followed by all keys provided in `other_keys`
+    pub fn gen_proof_chain(
+        genesis_key: &bls::SecretKey,
+        other_keys: &Vec<bls::SecretKey>,
+    ) -> SectionsDAG {
+        let mut proof_chain = SectionsDAG::new(genesis_key.public_key());
+        let mut parent = genesis_key.clone();
+        for key in other_keys {
+            let sig = parent.sign(key.public_key().to_bytes());
+            proof_chain
+                .insert(&parent.public_key(), key.public_key(), sig)
+                .expect("Failed to insert into proof_chain");
+            parent = key.clone();
+        }
+        proof_chain
+    }
+}
+
 #[cfg(test)]
-pub(crate) mod tests {
+mod tests {
     use super::*;
-    use crate::network_knowledge::{
-        sections_dag::tests::arb_sections_dag_and_proof_chains,
-        test_utils::{assert_lists, gen_section_tree_update, prefix, random_sap, section_signed},
+    use crate::{
+        network_knowledge::sections_dag::tests::arb_sections_dag_and_proof_chains,
+        test_utils::{assert_lists, gen_section_tree_update, prefix, TestSAP, TestSectionTree},
     };
     use eyre::Result;
     use proptest::{prelude::ProptestConfig, prop_assert_eq, proptest};
 
     #[test]
     fn insert_existing_prefix() {
-        let (mut tree, _, _) = new_network_section_tree();
+        let (mut tree, _) = TestSectionTree::random();
         let p0 = prefix("0");
-        let (sap0, _) = gen_section_auth(p0);
-        let (new_sap0, _) = gen_section_auth(p0);
+        let (sap0, _) = TestSAP::gen_section_auth(p0);
+        let (new_sap0, _) = TestSAP::gen_section_auth(p0);
         assert_ne!(sap0, new_sap0);
 
         assert!(tree.insert(sap0));
@@ -484,16 +539,16 @@ pub(crate) mod tests {
 
     #[test]
     fn insert_direct_descendants_of_existing_prefix() {
-        let (mut tree, _, _) = new_network_section_tree();
+        let (mut tree, _) = TestSectionTree::random();
         let p0 = prefix("0");
         let p00 = prefix("00");
         let p01 = prefix("01");
 
-        let (sap0, _) = gen_section_auth(p0);
+        let (sap0, _) = TestSAP::gen_section_auth(p0);
         assert!(tree.insert(sap0));
 
         // Insert the first sibling. Parent get pruned in the map.
-        let (sap00, _) = gen_section_auth(p00);
+        let (sap00, _) = TestSAP::gen_section_auth(p00);
         assert!(tree.insert(sap00.clone()));
 
         assert_eq!(tree.get(&p00), Some(sap00.value.clone()));
@@ -501,7 +556,7 @@ pub(crate) mod tests {
         assert_eq!(tree.get(&p0), None);
 
         // Insert the other sibling.
-        let (sap3, _) = gen_section_auth(p01);
+        let (sap3, _) = TestSAP::gen_section_auth(p01);
         assert!(tree.insert(sap3.clone()));
 
         assert_eq!(tree.get(&p00), Some(sap00.value));
@@ -511,11 +566,11 @@ pub(crate) mod tests {
 
     #[test]
     fn return_opposite_prefix_if_none_matching() -> Result<()> {
-        let (mut tree, _, _) = new_network_section_tree();
+        let (mut tree, _) = TestSectionTree::random();
         let p0 = prefix("0");
         let p1 = prefix("1");
 
-        let (sap0, _) = gen_section_auth(p0);
+        let (sap0, _) = TestSAP::gen_section_auth(p0);
 
         let _changed = tree.insert(sap0.clone());
 
@@ -543,17 +598,17 @@ pub(crate) mod tests {
 
     #[test]
     fn insert_indirect_descendants_of_existing_prefix() {
-        let (mut tree, _, _) = new_network_section_tree();
+        let (mut tree, _) = TestSectionTree::random();
         let p0 = prefix("0");
         let p000 = prefix("000");
         let p001 = prefix("001");
         let p00 = prefix("00");
         let p01 = prefix("01");
 
-        let (sap0, _) = gen_section_auth(p0);
-        let (sap01, _) = gen_section_auth(p01);
-        let (sap000, _) = gen_section_auth(p000);
-        let (sap001, _) = gen_section_auth(p001);
+        let (sap0, _) = TestSAP::gen_section_auth(p0);
+        let (sap01, _) = TestSAP::gen_section_auth(p01);
+        let (sap000, _) = TestSAP::gen_section_auth(p000);
+        let (sap001, _) = TestSAP::gen_section_auth(p001);
 
         assert!(tree.insert(sap0));
 
@@ -581,12 +636,12 @@ pub(crate) mod tests {
 
     #[test]
     fn insert_ancestor_of_existing_prefix() {
-        let (mut tree, _, _) = new_network_section_tree();
+        let (mut tree, _) = TestSectionTree::random();
         let p0 = prefix("0");
         let p00 = prefix("00");
 
-        let (sap0, _) = gen_section_auth(p0);
-        let (sap00, _) = gen_section_auth(p00);
+        let (sap0, _) = TestSAP::gen_section_auth(p0);
+        let (sap00, _) = TestSAP::gen_section_auth(p00);
         let _changed = tree.insert(sap00.clone());
 
         assert!(!tree.insert(sap0));
@@ -596,16 +651,16 @@ pub(crate) mod tests {
 
     #[test]
     fn get_matching() -> Result<()> {
-        let (mut tree, _, _) = new_network_section_tree();
+        let (mut tree, _) = TestSectionTree::random();
         let p = prefix("");
         let p0 = prefix("0");
         let p1 = prefix("1");
         let p10 = prefix("10");
 
-        let (sap, _) = gen_section_auth(p);
-        let (sap0, _) = gen_section_auth(p0);
-        let (sap1, _) = gen_section_auth(p1);
-        let (sap10, _) = gen_section_auth(p10);
+        let (sap, _) = TestSAP::gen_section_auth(p);
+        let (sap0, _) = TestSAP::gen_section_auth(p0);
+        let (sap1, _) = TestSAP::gen_section_auth(p1);
+        let (sap10, _) = TestSAP::gen_section_auth(p10);
 
         let _changed = tree.insert(sap.clone());
 
@@ -645,14 +700,14 @@ pub(crate) mod tests {
 
     #[test]
     fn get_matching_prefix() -> Result<()> {
-        let (mut tree, _, _) = new_network_section_tree();
+        let (mut tree, _) = TestSectionTree::random();
         let p0 = prefix("0");
         let p1 = prefix("1");
         let p10 = prefix("10");
 
-        let (sap0, _) = gen_section_auth(p0);
-        let (sap1, _) = gen_section_auth(p1);
-        let (sap10, _) = gen_section_auth(p10);
+        let (sap0, _) = TestSAP::gen_section_auth(p0);
+        let (sap1, _) = TestSAP::gen_section_auth(p1);
+        let (sap10, _) = TestSAP::gen_section_auth(p10);
 
         let _changed = tree.insert(sap0.clone());
         let _changed = tree.insert(sap1);
@@ -673,17 +728,17 @@ pub(crate) mod tests {
     #[test]
     fn closest() -> Result<()> {
         // Create map containing sections (00), (01) and (10)
-        let (mut tree, genesis_sk, genesis_pk) = new_network_section_tree();
-        let dag = SectionsDAG::new(genesis_pk);
+        let (mut tree, genesis_sk) = TestSectionTree::random();
+        let dag = SectionsDAG::new(genesis_sk.public_key());
         let p01 = prefix("01");
         let p10 = prefix("10");
         let p11 = prefix("11");
 
-        let (sap01, _) = gen_section_auth(p01);
+        let (sap01, _) = TestSAP::gen_section_auth(p01);
         let section_tree_update = gen_section_tree_update(&sap01, &dag, &genesis_sk);
         assert!(tree.update(section_tree_update)?);
 
-        let (sap10, _) = gen_section_auth(p10);
+        let (sap10, _) = TestSAP::gen_section_auth(p10);
         let section_tree_update = gen_section_tree_update(&sap10, &dag, &genesis_sk);
         assert!(tree.update(section_tree_update)?);
 
@@ -700,13 +755,13 @@ pub(crate) mod tests {
 
     #[test]
     fn proof_chain_should_contain_a_single_branch_during_update() -> Result<()> {
-        let (mut tree, genesis_sk, _) = new_network_section_tree();
+        let (mut tree, genesis_sk) = TestSectionTree::random();
 
-        let (sap0, _) = gen_section_auth(prefix("0"));
+        let (sap0, _) = TestSAP::gen_section_auth(prefix("0"));
         let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
         assert!(tree.update(tree_update)?);
 
-        let (sap1, _) = gen_section_auth(prefix("1"));
+        let (sap1, _) = TestSAP::gen_section_auth(prefix("1"));
         // instead of constructing a proof_chain from gen -> 1; we also include the branch '0'
         // which will result in an error while updating the SectionTree
         let tree_update = gen_section_tree_update(&sap1, tree.get_sections_dag(), &genesis_sk);
@@ -720,10 +775,10 @@ pub(crate) mod tests {
 
     #[test]
     fn updating_with_same_sap_should_return_false() -> Result<()> {
-        let (mut tree, genesis_sk, _) = new_network_section_tree();
+        let (mut tree, genesis_sk) = TestSectionTree::random();
 
         // node updated with sap0
-        let (sap0, _) = gen_section_auth(prefix("0"));
+        let (sap0, _) = TestSAP::gen_section_auth(prefix("0"));
         let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
         let tree_update_same = tree_update.clone();
         assert!(tree.update(tree_update)?);
@@ -736,16 +791,16 @@ pub(crate) mod tests {
 
     #[test]
     fn sap_with_same_parent_and_prefix_should_result_in_error_during_update() -> Result<()> {
-        let (mut tree, genesis_sk, _) = new_network_section_tree();
+        let (mut tree, genesis_sk) = TestSectionTree::random();
 
         // node updated with sap0
-        let (sap0, _) = gen_section_auth(prefix("0"));
+        let (sap0, _) = TestSAP::gen_section_auth(prefix("0"));
         let proof_chain = tree.get_sections_dag().clone();
         let tree_update = gen_section_tree_update(&sap0, &proof_chain, &genesis_sk);
         assert!(tree.update(tree_update)?);
 
         // node tries to update with sap signed by same parent for the same prefix
-        let (sap0_same, _) = gen_section_auth(prefix("0"));
+        let (sap0_same, _) = TestSAP::gen_section_auth(prefix("0"));
         let tree_update = gen_section_tree_update(&sap0_same, &proof_chain, &genesis_sk);
         assert!(matches!(
             tree.update(tree_update),
@@ -757,16 +812,16 @@ pub(crate) mod tests {
 
     #[test]
     fn outdated_sap_for_the_same_prefix_should_result_in_error_during_update() -> Result<()> {
-        let (mut tree, genesis_sk, _) = new_network_section_tree();
+        let (mut tree, genesis_sk) = TestSectionTree::random();
 
         // node updated with sap0
-        let (sap0, sk0) = gen_section_auth(prefix("0"));
+        let (sap0, sk0) = TestSAP::gen_section_auth(prefix("0"));
         let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
         let tree_update_outdated = tree_update.clone();
         assert!(tree.update(tree_update)?);
 
         // node updated with sap1 with same prefix
-        let (sap1, _) = gen_section_auth(prefix("0"));
+        let (sap1, _) = TestSAP::gen_section_auth(prefix("0"));
         let tree_update = gen_section_tree_update(&sap1, tree.get_sections_dag(), &sk0);
         assert!(tree.update(tree_update)?);
 
@@ -807,23 +862,5 @@ pub(crate) mod tests {
             // Finally, verify that we got the main_dag back
             prop_assert_eq!(main_dag, section_tree.sections_dag);
         }
-    }
-
-    // Test helpers
-    fn gen_section_auth(
-        prefix: Prefix,
-    ) -> (SectionSigned<SectionAuthorityProvider>, bls::SecretKey) {
-        let (section_auth, _, secret_key_set) = random_sap(prefix, 5, 0, None);
-        let sap = section_signed(&secret_key_set.secret_key(), section_auth);
-        (sap, secret_key_set.secret_key())
-    }
-
-    fn new_network_section_tree() -> (SectionTree, bls::SecretKey, BlsPublicKey) {
-        let genesis_sk = bls::SecretKey::random();
-        let genesis_pk = genesis_sk.public_key();
-
-        let map = SectionTree::new(genesis_pk);
-
-        (map, genesis_sk, genesis_pk)
     }
 }

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -488,7 +488,7 @@ impl SectionsDAG {
 }
 
 #[cfg(test)]
-pub(super) mod tests {
+pub(crate) mod tests {
     use super::{Error, SectionInfo, SectionsDAG};
     use crate::{
         messaging::system::SectionSigned,
@@ -1162,7 +1162,7 @@ pub(super) mod tests {
     }
 
     // Generate a random `SectionsDAG` and the SAP for each of the section key
-    pub(super) fn gen_random_sections_dag(
+    fn gen_random_sections_dag(
         seed: Option<u64>,
         n_sections: usize,
     ) -> Result<(

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -495,13 +495,12 @@ pub(super) mod tests {
         network_knowledge::test_utils::{
             assert_lists, prefix, random_sap_with_rng, section_signed,
         },
-        types::SecretKeySet,
         SectionAuthorityProvider,
     };
     use crdts::CmRDT;
     use eyre::{eyre, Result};
     use proptest::prelude::{any, proptest, ProptestConfig, Strategy};
-    use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
+    use rand::{rngs::StdRng, thread_rng, Rng, RngCore, SeedableRng};
     use std::collections::{BTreeMap, BTreeSet};
     use xor_name::Prefix;
 
@@ -1073,7 +1072,7 @@ pub(super) mod tests {
 
     // Test helpers
     fn gen_keypair() -> (bls::SecretKey, bls::PublicKey) {
-        let sk_set = SecretKeySet::random(None);
+        let sk_set = bls::SecretKeySet::random(0, &mut thread_rng());
         let sk = sk_set.secret_key();
         (sk.clone(), sk.public_key())
     }

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -492,9 +492,7 @@ pub(super) mod tests {
     use super::{Error, SectionInfo, SectionsDAG};
     use crate::{
         messaging::system::SectionSigned,
-        network_knowledge::test_utils::{
-            assert_lists, prefix, random_sap_with_rng, section_signed,
-        },
+        test_utils::{assert_lists, prefix, section_signed, TestSAP},
         SectionAuthorityProvider,
     };
     use crdts::CmRDT;
@@ -1182,7 +1180,8 @@ pub(super) mod tests {
             None => StdRng::from_entropy(),
         };
 
-        let (sap_gen, _, sk_gen) = random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None);
+        let (sap_gen, _, sk_gen) =
+            TestSAP::random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None);
         let sk_gen = sk_gen.secret_key();
         let sap_gen = section_signed(&sk_gen, sap_gen);
         let pk_gen = sap_gen.public_key_set().public_key();
@@ -1210,7 +1209,7 @@ pub(super) mod tests {
             >,
             dag: &mut SectionsDAG,
         ) -> Result<()> {
-            let (sap, _, sk_set) = random_sap_with_rng(rng, prefix, 0, 0, None);
+            let (sap, _, sk_set) = TestSAP::random_sap_with_rng(rng, prefix, 0, 0, None);
             let sap = section_signed(&sk_set.secret_key(), sap);
             let key = sap.public_key_set().public_key();
             let sig = sign(parent_sk, &key);

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -1175,7 +1175,7 @@ pub(crate) mod tests {
         };
 
         let (sap_gen, _, sk_gen) =
-            TestSAP::random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None);
+            TestSAP::random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None, None);
         let sk_gen = sk_gen.secret_key();
         let sap_gen = TestKeys::get_section_signed(&sk_gen, sap_gen);
         let pk_gen = sap_gen.public_key_set().public_key();
@@ -1203,7 +1203,7 @@ pub(crate) mod tests {
             >,
             dag: &mut SectionsDAG,
         ) -> Result<()> {
-            let (sap, _, sk_set) = TestSAP::random_sap_with_rng(rng, prefix, 0, 0, None);
+            let (sap, _, sk_set) = TestSAP::random_sap_with_rng(rng, prefix, 0, 0, None, None);
             let sap = TestKeys::get_section_signed(&sk_set.secret_key(), sap);
             let key = sap.public_key_set().public_key();
             let sig = TestKeys::sign(parent_sk, &key);

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -492,7 +492,7 @@ pub(super) mod tests {
     use super::{Error, SectionInfo, SectionsDAG};
     use crate::{
         messaging::system::SectionSigned,
-        test_utils::{assert_lists, prefix, section_signed, TestSAP},
+        test_utils::{assert_lists, prefix, TestKeys, TestSAP},
         SectionAuthorityProvider,
     };
     use crdts::CmRDT;
@@ -1077,15 +1077,9 @@ pub(super) mod tests {
 
     fn gen_signed_keypair(parent_sk: &bls::SecretKey) -> (bls::SecretKey, SectionInfo) {
         let (sk, pk) = gen_keypair();
-        let sig = sign(parent_sk, &pk);
+        let sig = TestKeys::sign(parent_sk, &pk);
         let info = SectionInfo { key: pk, sig };
         (sk, info)
-    }
-
-    fn sign(signing_sk: &bls::SecretKey, pk_to_sign: &bls::PublicKey) -> bls::Signature {
-        bincode::serialize(pk_to_sign)
-            .map(|bytes| signing_sk.sign(&bytes))
-            .expect("failed to serialize public key")
     }
 
     // Generate an arbitrary sized `SectionsDAG` and a list of partial_dags which inserted in
@@ -1183,7 +1177,7 @@ pub(super) mod tests {
         let (sap_gen, _, sk_gen) =
             TestSAP::random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None);
         let sk_gen = sk_gen.secret_key();
-        let sap_gen = section_signed(&sk_gen, sap_gen);
+        let sap_gen = TestKeys::get_section_signed(&sk_gen, sap_gen);
         let pk_gen = sap_gen.public_key_set().public_key();
 
         let mut dag = SectionsDAG::new(pk_gen);
@@ -1210,9 +1204,9 @@ pub(super) mod tests {
             dag: &mut SectionsDAG,
         ) -> Result<()> {
             let (sap, _, sk_set) = TestSAP::random_sap_with_rng(rng, prefix, 0, 0, None);
-            let sap = section_signed(&sk_set.secret_key(), sap);
+            let sap = TestKeys::get_section_signed(&sk_set.secret_key(), sap);
             let key = sap.public_key_set().public_key();
-            let sig = sign(parent_sk, &key);
+            let sig = TestKeys::sign(parent_sk, &key);
             dag.insert(&parent_sk.public_key(), sap.section_key(), sig)?;
             sections_map.insert(sap.section_key(), (sk_set.secret_key(), sap));
             Ok(())

--- a/sn_interface/src/network_knowledge/test_utils.rs
+++ b/sn_interface/src/network_knowledge/test_utils.rs
@@ -1,10 +1,6 @@
-use super::{
-    NetworkKnowledge, NodeState, SectionKeysProvider, SectionTree, SectionTreeUpdate, SectionsDAG,
-};
+use super::SectionKeysProvider;
 use crate::{
-    messaging::system::SectionSigned,
     network_knowledge::{section_keys::build_spent_proof_share, Error, MyNodeInfo, MIN_ADULT_AGE},
-    test_utils::{TestKeys, TestSAP},
     SectionAuthorityProvider,
 };
 use eyre::{eyre, Result};
@@ -32,7 +28,6 @@ pub fn gen_addr() -> SocketAddr {
     thread_local! {
         static NEXT_PORT: Cell<u16> = Cell::new(1000);
     }
-
     let port = NEXT_PORT.with(|cell| cell.replace(cell.get().wrapping_add(1)));
 
     ([192, 0, 2, 0], port).into()
@@ -57,51 +52,6 @@ pub fn gen_sorted_nodes(prefix: &Prefix, count: usize, age_diff: bool) -> Vec<My
         })
         .sorted_by_key(|node| node.name())
         .collect()
-}
-
-/// Generate a random `NetworkKnowledge` for testing.
-///
-/// Uses `random_sap_with_key` to generate SAP; section_peer list is updated with the `NodeState` as well
-pub fn gen_network_knowledge_with_key(
-    prefix: Prefix,
-    elder_count: usize,
-    adult_count: usize,
-    sk_set: &bls::SecretKeySet,
-) -> (NetworkKnowledge, Vec<MyNodeInfo>) {
-    let pk_set = sk_set.public_keys();
-    let (sap, node_infos) = TestSAP::random_sap_with_key(prefix, elder_count, adult_count, sk_set);
-    let signed_sap = TestKeys::get_section_signed(&sk_set.secret_key(), sap);
-    let section_tree_update =
-        SectionTreeUpdate::new(signed_sap, SectionsDAG::new(pk_set.public_key()));
-    let mut network_knowledge =
-        NetworkKnowledge::new(SectionTree::new(pk_set.public_key()), section_tree_update)
-            .expect("Failed to create NetworkKnowledge");
-
-    // update the sap members
-    for peer in network_knowledge.signed_sap.elders() {
-        let node_state = NodeState::joined(*peer, None);
-        let signed_state = TestKeys::get_section_signed(&sk_set.secret_key(), node_state);
-        let _changed = network_knowledge.section_peers.update(signed_state);
-    }
-    (network_knowledge, node_infos)
-}
-
-/// Generate a `SectionTreeUpdate` where the SAP's section key is appended to the proof chain
-pub fn gen_section_tree_update(
-    sap: &SectionSigned<SectionAuthorityProvider>,
-    proof_chain: &SectionsDAG,
-    parent_sk: &bls::SecretKey,
-) -> SectionTreeUpdate {
-    let signed_key = TestKeys::get_section_signed(parent_sk, sap.section_key());
-    let mut proof_chain = proof_chain.clone();
-    proof_chain
-        .insert(
-            &parent_sk.public_key(),
-            signed_key.value,
-            signed_key.sig.signature,
-        )
-        .expect("Failed to insert into proof chain");
-    SectionTreeUpdate::new(sap.clone(), proof_chain)
 }
 
 pub fn section_decision<P: Proposition>(

--- a/sn_interface/src/network_knowledge/test_utils.rs
+++ b/sn_interface/src/network_knowledge/test_utils.rs
@@ -78,7 +78,8 @@ pub fn gen_sorted_nodes(
                 gen_addr(),
             )
         }))
-        .sorted_by_key(|node| node.name())
+        .sorted_by_key(|node| node.age())
+        .rev()
         .collect()
 }
 

--- a/sn_interface/src/network_knowledge/test_utils.rs
+++ b/sn_interface/src/network_knowledge/test_utils.rs
@@ -33,15 +33,37 @@ pub fn gen_addr() -> SocketAddr {
     ([192, 0, 2, 0], port).into()
 }
 
-// Create `count` Nodes sorted by their names.
-// The `age_diff` flag is used to trigger nodes being generated with different age pattern.
-// The test of `handle_agreement_on_online_of_elder_candidate` requires most nodes to be with
-// age of MIN_AGE + 2 and one node with age of MIN_ADULT_AGE.
-pub fn gen_sorted_nodes(prefix: &Prefix, count: usize, age_diff: bool) -> Vec<MyNodeInfo> {
-    (0..count)
-        .map(|index| {
-            let age = if age_diff && index < count - 1 {
-                MIN_ADULT_AGE + 1
+/// Create `elder+adult` Nodes sorted by their names.
+///
+/// Optionally provide `age_pattern` to create elders with specific ages.
+/// If None = elder's age is set to `MIN_ADULT_AGE`
+/// If age_pattern.len() == elder, then apply the respective ages to each node
+/// If age_pattern.len() < elder, then the last element's value is taken as the age for the remaining nodes.
+/// If age_pattern.len() > elder, then the extra elements after `count` are ignored.
+pub fn gen_sorted_nodes(
+    prefix: &Prefix,
+    elder: usize,
+    adult: usize,
+    elder_age_pattern: Option<&[u8]>,
+) -> Vec<MyNodeInfo> {
+    let pattern = if let Some(user_pattern) = elder_age_pattern {
+        if user_pattern.is_empty() {
+            None
+        } else if user_pattern.len() < elder {
+            let last_element = user_pattern[user_pattern.len() - 1];
+            let mut pattern = vec![last_element; elder - user_pattern.len()];
+            pattern.extend_from_slice(user_pattern);
+            Some(pattern)
+        } else {
+            Some(Vec::from(user_pattern))
+        }
+    } else {
+        None
+    };
+    (0..elder)
+        .map(|idx| {
+            let age = if let Some(pattern) = &pattern {
+                pattern[idx]
             } else {
                 MIN_ADULT_AGE
             };
@@ -50,6 +72,12 @@ pub fn gen_sorted_nodes(prefix: &Prefix, count: usize, age_diff: bool) -> Vec<My
                 gen_addr(),
             )
         })
+        .chain((0..adult).map(|_| {
+            MyNodeInfo::new(
+                crate::types::keys::ed25519::gen_keypair(&prefix.range_inclusive(), MIN_ADULT_AGE),
+                gen_addr(),
+            )
+        }))
         .sorted_by_key(|node| node.name())
         .collect()
 }

--- a/sn_interface/src/network_knowledge/test_utils.rs
+++ b/sn_interface/src/network_knowledge/test_utils.rs
@@ -1,17 +1,27 @@
-use super::*;
-use crate::messaging::system::{SectionSig, SectionSigned};
-use crate::network_knowledge::section_keys::build_spent_proof_share;
-use crate::network_knowledge::{Error, MyNodeInfo, MIN_ADULT_AGE};
+use super::{
+    NetworkKnowledge, NodeState, SectionAuthUtils, SectionKeysProvider, SectionTree,
+    SectionTreeUpdate, SectionsDAG,
+};
+use crate::{
+    messaging::system::{SectionSig, SectionSigned},
+    network_knowledge::{section_keys::build_spent_proof_share, Error, MyNodeInfo, MIN_ADULT_AGE},
+    test_utils::TestSAP,
+    SectionAuthorityProvider,
+};
 use eyre::{eyre, Result};
 use itertools::Itertools;
-use rand::RngCore;
 use serde::Serialize;
 use sn_consensus::{Ballot, Consensus, Decision, Proposition, Vote, VoteResponse};
 use sn_dbc::{
     get_public_commitments_from_transaction, Commitment, Dbc, Owner, OwnerOnce, RingCtTransaction,
     Token, TransactionBuilder,
 };
-use std::{cell::Cell, collections::BTreeMap, fmt, net::SocketAddr};
+use std::{
+    cell::Cell,
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    net::SocketAddr,
+};
 use xor_name::Prefix;
 
 // Parse `Prefix` from string
@@ -51,61 +61,31 @@ pub fn gen_sorted_nodes(prefix: &Prefix, count: usize, age_diff: bool) -> Vec<My
         .collect()
 }
 
-/// Generate a random `SectionAuthorityProvider` for testing.
+/// Generate a random `NetworkKnowledge` for testing.
 ///
-/// The total number of members in the section will be `elder_count` + `adult_count`. A lot of
-/// tests don't require adults in the section, so zero is an acceptable value for
-/// `adult_count`.
-///
-/// An optional `sk_threshold_size` can be passed to specify the threshold when the secret key
-/// set is generated for the section key. Some tests require a low threshold.
-pub fn random_sap_with_rng<R: RngCore>(
-    rng: &mut R,
-    prefix: Prefix,
-    elder_count: usize,
-    adult_count: usize,
-    sk_threshold_size: Option<usize>,
-) -> (SectionAuthorityProvider, Vec<MyNodeInfo>, bls::SecretKeySet) {
-    let nodes = gen_sorted_nodes(&prefix, elder_count + adult_count, false);
-    let elders = nodes.iter().map(MyNodeInfo::peer).take(elder_count);
-    let members = nodes.iter().map(|i| NodeState::joined(i.peer(), None));
-    let poly = bls::poly::Poly::random(sk_threshold_size.unwrap_or(0), rng);
-    let sks = bls::SecretKeySet::from(poly);
-    let section_auth = SectionAuthorityProvider::new(elders, prefix, members, sks.public_keys(), 0);
-    (section_auth, nodes, sks)
-}
-
-pub fn random_sap(
-    prefix: Prefix,
-    elder_count: usize,
-    adult_count: usize,
-    sk_threshold_size: Option<usize>,
-) -> (SectionAuthorityProvider, Vec<MyNodeInfo>, bls::SecretKeySet) {
-    random_sap_with_rng(
-        &mut rand::thread_rng(),
-        prefix,
-        elder_count,
-        adult_count,
-        sk_threshold_size,
-    )
-}
-
-/// Generate a random `SectionAuthorityProvider` for testing.
-///
-/// The same as `random_sap`, but instead the secret key is provided. This can be useful for
-/// creating a section to share the same genesis key as another one.
-pub fn random_sap_with_key(
+/// Uses `random_sap_with_key` to generate SAP; section_peer list is updated with the `NodeState` as well
+pub fn gen_network_knowledge_with_key(
     prefix: Prefix,
     elder_count: usize,
     adult_count: usize,
     sk_set: &bls::SecretKeySet,
-) -> (SectionAuthorityProvider, Vec<MyNodeInfo>) {
-    let nodes = gen_sorted_nodes(&prefix, elder_count + adult_count, false);
-    let elders = nodes.iter().map(MyNodeInfo::peer).take(elder_count);
-    let members = nodes.iter().map(|i| NodeState::joined(i.peer(), None));
-    let section_auth =
-        SectionAuthorityProvider::new(elders, prefix, members, sk_set.public_keys(), 0);
-    (section_auth, nodes)
+) -> (NetworkKnowledge, Vec<MyNodeInfo>) {
+    let pk_set = sk_set.public_keys();
+    let (sap, node_infos) = TestSAP::random_sap_with_key(prefix, elder_count, adult_count, sk_set);
+    let signed_sap = section_signed(&sk_set.secret_key(), sap);
+    let section_tree_update =
+        SectionTreeUpdate::new(signed_sap, SectionsDAG::new(pk_set.public_key()));
+    let mut network_knowledge =
+        NetworkKnowledge::new(SectionTree::new(pk_set.public_key()), section_tree_update)
+            .expect("Failed to create NetworkKnowledge");
+
+    // update the sap members
+    for peer in network_knowledge.signed_sap.elders() {
+        let node_state = NodeState::joined(*peer, None);
+        let signed_state = section_signed(&sk_set.secret_key(), node_state);
+        let _changed = network_knowledge.section_peers.update(signed_state);
+    }
+    (network_knowledge, node_infos)
 }
 
 /// Generate a `SectionTreeUpdate` where the SAP's section key is appended to the proof chain

--- a/sn_interface/src/types/keys/mod.rs
+++ b/sn_interface/src/types/keys/mod.rs
@@ -18,3 +18,63 @@ pub(super) mod node_keypairs;
 pub(crate) mod public_key;
 pub(super) mod secret_key;
 pub(super) mod signature;
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils {
+    use crate::{
+        messaging::system::{SectionSig, SectionSigned},
+        network_knowledge::{SectionAuthUtils, SectionKeyShare},
+    };
+    use serde::Serialize;
+
+    /// bls key related test utilities
+    pub struct TestKeys {}
+
+    impl TestKeys {
+        /// Create `bls::Signature` for the given payload using the provided `bls::SecretKey`
+        pub fn sign<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> bls::Signature {
+            let bytes = bincode::serialize(payload).expect("Failed to serialize payload");
+            Self::sign_bytes(secret_key, &bytes)
+        }
+        /// Create `bls::Signature` for the given bytes using the provided `bls::SecretKey`
+        pub fn sign_bytes(secret_key: &bls::SecretKey, bytes: &[u8]) -> bls::Signature {
+            secret_key.sign(bytes)
+        }
+
+        /// Create `SectionSig` for the given bytes using the provided `bls::SecretKey`
+        pub fn get_section_sig_bytes(secret_key: &bls::SecretKey, bytes: &[u8]) -> SectionSig {
+            SectionSig {
+                public_key: secret_key.public_key(),
+                signature: Self::sign_bytes(secret_key, bytes),
+            }
+        }
+
+        /// Create `SectionSig` for the given payload using the provided `bls::SecretKey`
+        pub fn get_section_sig<T: Serialize>(
+            secret_key: &bls::SecretKey,
+            payload: &T,
+        ) -> SectionSig {
+            let bytes = bincode::serialize(payload).expect("Failed to serialize payload");
+            Self::get_section_sig_bytes(secret_key, &bytes)
+        }
+
+        /// Create signature for the given payload using the provided `bls::SecretKey` and
+        /// wrap them using `SectionSigned`
+        pub fn get_section_signed<T: Serialize>(
+            secret_key: &bls::SecretKey,
+            payload: T,
+        ) -> SectionSigned<T> {
+            let sig = Self::get_section_sig(secret_key, &payload);
+            SectionSigned::new(payload, sig)
+        }
+
+        /// Generate a `SectionKeyShare` from the `bls::SecretKeySet` and given index
+        pub fn get_section_key_share(sk_set: &bls::SecretKeySet, index: usize) -> SectionKeyShare {
+            SectionKeyShare {
+                public_key_set: sk_set.public_keys(),
+                index,
+                secret_key_share: sk_set.secret_key_share(index),
+            }
+        }
+    }
+}

--- a/sn_interface/src/types/keys/mod.rs
+++ b/sn_interface/src/types/keys/mod.rs
@@ -25,24 +25,28 @@ pub mod test_utils {
         messaging::system::{SectionSig, SectionSigned},
         network_knowledge::{SectionAuthUtils, SectionKeyShare},
     };
+    use bls::{blstrs::Scalar, poly::Poly, SecretKey, SecretKeySet, Signature};
+    use eyre::eyre;
     use serde::Serialize;
+    use std::collections::{BTreeMap, BTreeSet};
 
     /// bls key related test utilities
     pub struct TestKeys {}
 
     impl TestKeys {
         /// Create `bls::Signature` for the given payload using the provided `bls::SecretKey`
-        pub fn sign<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> bls::Signature {
+        pub fn sign<T: Serialize>(secret_key: &SecretKey, payload: &T) -> Signature {
             let bytes = bincode::serialize(payload).expect("Failed to serialize payload");
             Self::sign_bytes(secret_key, &bytes)
         }
+
         /// Create `bls::Signature` for the given bytes using the provided `bls::SecretKey`
-        pub fn sign_bytes(secret_key: &bls::SecretKey, bytes: &[u8]) -> bls::Signature {
+        pub fn sign_bytes(secret_key: &SecretKey, bytes: &[u8]) -> Signature {
             secret_key.sign(bytes)
         }
 
         /// Create `SectionSig` for the given bytes using the provided `bls::SecretKey`
-        pub fn get_section_sig_bytes(secret_key: &bls::SecretKey, bytes: &[u8]) -> SectionSig {
+        pub fn get_section_sig_bytes(secret_key: &SecretKey, bytes: &[u8]) -> SectionSig {
             SectionSig {
                 public_key: secret_key.public_key(),
                 signature: Self::sign_bytes(secret_key, bytes),
@@ -50,10 +54,7 @@ pub mod test_utils {
         }
 
         /// Create `SectionSig` for the given payload using the provided `bls::SecretKey`
-        pub fn get_section_sig<T: Serialize>(
-            secret_key: &bls::SecretKey,
-            payload: &T,
-        ) -> SectionSig {
+        pub fn get_section_sig<T: Serialize>(secret_key: &SecretKey, payload: &T) -> SectionSig {
             let bytes = bincode::serialize(payload).expect("Failed to serialize payload");
             Self::get_section_sig_bytes(secret_key, &bytes)
         }
@@ -61,7 +62,7 @@ pub mod test_utils {
         /// Create signature for the given payload using the provided `bls::SecretKey` and
         /// wrap them using `SectionSigned`
         pub fn get_section_signed<T: Serialize>(
-            secret_key: &bls::SecretKey,
+            secret_key: &SecretKey,
             payload: T,
         ) -> SectionSigned<T> {
             let sig = Self::get_section_sig(secret_key, &payload);
@@ -69,12 +70,125 @@ pub mod test_utils {
         }
 
         /// Generate a `SectionKeyShare` from the `bls::SecretKeySet` and given index
-        pub fn get_section_key_share(sk_set: &bls::SecretKeySet, index: usize) -> SectionKeyShare {
+        pub fn get_section_key_share(sk_set: &SecretKeySet, index: usize) -> SectionKeyShare {
             SectionKeyShare {
                 public_key_set: sk_set.public_keys(),
                 index,
                 secret_key_share: sk_set.secret_key_share(index),
             }
         }
+
+        /// Create `bls::SecretKeySet` from the provided set of `SecretKeyShare` if
+        /// we provide n shares, where n > threshold + 1.
+        pub fn get_sk_set_from_shares(
+            section_key_shares: &[SectionKeyShare],
+        ) -> eyre::Result<SecretKeySet> {
+            // need to first get the pub_key_set to calulcate the threshold
+            let pub_key_set = section_key_shares
+                .iter()
+                .map(|share| share.public_key_set.clone())
+                .collect::<BTreeSet<_>>();
+
+            if pub_key_set.len() != 1 {
+                return Err(eyre!("Found multiple pub_key_sets for given set of shares"));
+            }
+            let pub_key_set = pub_key_set
+                .into_iter()
+                .next()
+                .ok_or_else(|| eyre!("1 element is present"))?;
+
+            let secrets: BTreeMap<_, _> = section_key_shares
+                .iter()
+                .map(|share| {
+                    let bytes = share.secret_key_share.to_bytes();
+                    // cannot be mapped to Err
+                    let fr = Scalar::from_bytes_be(&bytes).unwrap();
+                    // share index + 1 gives us the polynomial coefficient index
+                    (share.index + 1, fr)
+                })
+                .collect();
+
+            // we need threshold + 1 unique shares
+            if secrets.len() <= pub_key_set.threshold() {
+                return Err(eyre!(
+                    "We need {} unique SectionKeyShare, we got {}",
+                    pub_key_set.threshold() + 1,
+                    secrets.len()
+                ));
+            }
+
+            // we need exactly threshold+1 shares to get the Poly, else error
+            let secrets: BTreeMap<_, _> = secrets
+                .into_iter()
+                .take(pub_key_set.threshold() + 1)
+                .collect();
+
+            // throws duplicated index if we have more shares than threshold + 1
+            let sk_set = SecretKeySet::from(Poly::interpolate(secrets)?);
+
+            Ok(sk_set)
+        }
+    }
+
+    #[test]
+    fn obtain_sk_set_from_shares() -> eyre::Result<()> {
+        let sks = SecretKeySet::random(3, &mut bls::rand::thread_rng());
+
+        // > threshold shares are needed to get the sk_set
+        // index can be any number
+        let sk_share_set = Vec::from([
+            TestKeys::get_section_key_share(&sks, 3),
+            TestKeys::get_section_key_share(&sks, 4),
+            TestKeys::get_section_key_share(&sks, 5),
+            TestKeys::get_section_key_share(&sks, 6),
+        ]);
+        assert_eq!(
+            TestKeys::get_sk_set_from_shares(&sk_share_set)?.to_bytes(),
+            sks.to_bytes()
+        );
+
+        // <= threshold will not produce an sk_set
+        let sk_share_set = Vec::from([
+            TestKeys::get_section_key_share(&sks, 3),
+            TestKeys::get_section_key_share(&sks, 4),
+            TestKeys::get_section_key_share(&sks, 5),
+        ]);
+        assert!(TestKeys::get_sk_set_from_shares(&sk_share_set).is_err());
+
+        // <= threshold will not produce an sk_set; even if #of shares > threshold
+        let sk_share_set = Vec::from([
+            TestKeys::get_section_key_share(&sks, 3),
+            TestKeys::get_section_key_share(&sks, 4),
+            TestKeys::get_section_key_share(&sks, 4),
+            TestKeys::get_section_key_share(&sks, 5),
+        ]);
+        assert!(TestKeys::get_sk_set_from_shares(&sk_share_set).is_err());
+
+        // >> threshold shares is still valid
+        let sk_share_set = Vec::from([
+            TestKeys::get_section_key_share(&sks, 3),
+            TestKeys::get_section_key_share(&sks, 4),
+            TestKeys::get_section_key_share(&sks, 5),
+            TestKeys::get_section_key_share(&sks, 6),
+            TestKeys::get_section_key_share(&sks, 7),
+        ]);
+        assert_eq!(
+            TestKeys::get_sk_set_from_shares(&sk_share_set)?.to_bytes(),
+            sks.to_bytes()
+        );
+
+        // >> threshold with reapeated shares is also valid
+        let sk_share_set = Vec::from([
+            TestKeys::get_section_key_share(&sks, 3),
+            TestKeys::get_section_key_share(&sks, 3),
+            TestKeys::get_section_key_share(&sks, 4),
+            TestKeys::get_section_key_share(&sks, 5),
+            TestKeys::get_section_key_share(&sks, 6),
+        ]);
+        assert_eq!(
+            TestKeys::get_sk_set_from_shares(&sk_share_set)?.to_bytes(),
+            sks.to_bytes()
+        );
+        Ok(())
     }
 }

--- a/sn_interface/src/types/keys/secret_key.rs
+++ b/sn_interface/src/types/keys/secret_key.rs
@@ -84,16 +84,3 @@ impl Display for SecretKey {
         Debug::fmt(self, formatter)
     }
 }
-
-#[cfg(any(test, feature = "test-utils"))]
-pub(crate) mod test_utils {
-    use crate::messaging::system::SectionSig;
-
-    /// Create signature for the given bytes using the given secret key.
-    pub fn keyed_signed(secret_key: &bls::SecretKey, bytes: &[u8]) -> SectionSig {
-        SectionSig {
-            public_key: secret_key.public_key(),
-            signature: secret_key.sign(bytes),
-        }
-    }
-}

--- a/sn_interface/src/types/keys/secret_key.rs
+++ b/sn_interface/src/types/keys/secret_key.rs
@@ -88,49 +88,6 @@ impl Display for SecretKey {
 #[cfg(any(test, feature = "test-utils"))]
 pub(crate) mod test_utils {
     use crate::messaging::system::SectionSig;
-    use crate::network_knowledge::{elder_count, supermajority};
-    use rand::RngCore;
-    use std::ops::Deref;
-
-    fn threshold() -> usize {
-        supermajority(elder_count()) - 1
-    }
-
-    // Wrapper for `bls::SecretKeySet` that also allows to retrieve the corresponding `bls::SecretKey`.
-    // Note: `bls::SecretKeySet` does have a `secret_key` method, but it's test-only and not available
-    // for the consumers of the crate.
-    #[derive(Clone)]
-    pub struct SecretKeySet {
-        set: bls::SecretKeySet,
-        key: bls::SecretKey,
-    }
-
-    impl SecretKeySet {
-        pub fn random(threshold_size: Option<usize>) -> Self {
-            Self::random_with_rng(&mut rand::thread_rng(), threshold_size)
-        }
-
-        pub fn random_with_rng<R: RngCore>(rng: &mut R, threshold_size: Option<usize>) -> Self {
-            let threshold_size = threshold_size.unwrap_or_else(threshold);
-            let poly = bls::poly::Poly::random(threshold_size, rng);
-            let key = bls::SecretKey::from_mut(&mut poly.evaluate(0));
-            let set = bls::SecretKeySet::from(poly);
-
-            Self { set, key }
-        }
-
-        pub fn secret_key(&self) -> &bls::SecretKey {
-            &self.key
-        }
-    }
-
-    impl Deref for SecretKeySet {
-        type Target = bls::SecretKeySet;
-
-        fn deref(&self) -> &Self::Target {
-            &self.set
-        }
-    }
 
     /// Create signature for the given bytes using the given secret key.
     pub fn keyed_signed(secret_key: &bls::SecretKey, bytes: &[u8]) -> SectionSig {

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -44,9 +44,6 @@ pub use peer::Peer;
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
-#[cfg(any(test, feature = "test-utils"))]
-pub use keys::secret_key::test_utils::keyed_signed;
-
 // TODO: temporary type tag for spentbook since its underlying data type is
 // still not implemented, it uses a Public Register for now.
 pub const SPENTBOOK_TYPE_TAG: u64 = 0;

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
 #[cfg(any(test, feature = "test-utils"))]
-pub use keys::secret_key::test_utils::{keyed_signed, SecretKeySet};
+pub use keys::secret_key::test_utils::keyed_signed;
 
 // TODO: temporary type tag for spentbook since its underlying data type is
 // still not implemented, it uses a Public Register for now.

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -60,7 +60,6 @@ qp2p = "~0.30.0"
 rand = "~0.8"
 rand-07 = { package = "rand", version = "~0.7.3" }
 rayon = "1.5.1"
-resource_proof = "1.0.39"
 rmp-serde = "1.0.0"
 self_encryption = "~0.27.5"
 sn_consensus = "3.1.2"

--- a/sn_node/benches/data_storage.rs
+++ b/sn_node/benches/data_storage.rs
@@ -8,9 +8,10 @@
 
 use sn_interface::{
     messaging::data::{CreateRegister, SignedRegisterCreate},
+    test_utils::TestKeys,
     types::{
         register::{Policy, User},
-        Chunk, Keypair, PublicKey, RegisterCmd, ReplicatedData,
+        Chunk, Keypair, PublicKey, RegisterCmd, ReplicatedData, SectionSig,
     },
 };
 use sn_node::{
@@ -212,17 +213,9 @@ fn bench_data_storage_reads(c: &mut Criterion) -> Result<()> {
     Ok(())
 }
 
-fn section_sig() -> sn_interface::messaging::SectionSig {
-    use sn_interface::messaging::system::SectionSig;
-
+fn section_sig() -> SectionSig {
     let sk = bls::SecretKey::random();
-    let public_key = sk.public_key();
-    let data = "hello".to_string();
-    let signature = sk.sign(&data);
-    SectionSig {
-        public_key,
-        signature,
-    }
+    TestKeys::get_section_sig_bytes(&sk, "hello".as_bytes())
 }
 
 fn custom_criterion() -> Criterion {

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -428,17 +428,7 @@ async fn send_messages(
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::node::{messages::WireMsgUtils, Error as RoutingError, MIN_ADULT_AGE};
-
-    use sn_interface::{
-        elder_count, init_logger,
-        network_knowledge::{
-            test_utils::*, NodeState, SectionAuthorityProvider, SectionTreeUpdate, SectionsDAG,
-        },
-        types::PublicKey,
-    };
-
     use assert_matches::assert_matches;
     use eyre::{eyre, Error, Result};
     use futures::{
@@ -446,6 +436,12 @@ mod tests {
         pin_mut,
     };
     use itertools::Itertools;
+    use sn_interface::{
+        elder_count, init_logger,
+        network_knowledge::{NodeState, SectionAuthorityProvider, SectionTreeUpdate, SectionsDAG},
+        test_utils::*,
+        types::PublicKey,
+    };
     use tokio::task;
     use xor_name::XorName;
 
@@ -460,7 +456,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(10);
 
         let (genesis_sap, _genesis_nodes, genesis_sk_set) =
-            random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -479,7 +475,7 @@ mod tests {
         let bootstrap = async move { state.try_join(join_timeout).await.map_err(Error::from) };
 
         let (next_sap, next_elders, next_sk_set) =
-            random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
 
         let next_section_key = next_sk_set.public_keys().public_key();
         let section_tree_update = gen_section_tree_update(
@@ -567,7 +563,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -596,7 +592,7 @@ mod tests {
                     assert_matches!(msg, NodeMsg::JoinRequest{..}));
 
             // Send JoinResponse::Redirect
-            let (new_sap, _, _) = random_sap(Prefix::default(), elder_count(), 0, None);
+            let (new_sap, _, _) = TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
 
             send_response(
                 &recv_tx,
@@ -645,7 +641,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -670,7 +666,8 @@ mod tests {
             assert_matches!(wire_msg.into_msg(), Ok(MsgType::Node { msg, .. }) =>
             assert_matches!(msg, NodeMsg::JoinRequest{..}));
 
-            let (new_sap, _, new_sk_set) = random_sap(Prefix::default(), elder_count(), 0, None);
+            let (new_sap, _, new_sk_set) =
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
             let new_pk_set = new_sk_set.public_keys();
 
             send_response(
@@ -722,7 +719,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -785,7 +782,7 @@ mod tests {
         let bad_prefix = Prefix::default().pushed(!first_bit);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            random_sap(Prefix::default(), 1, 0, None);
+            TestSAP::random_sap(Prefix::default(), 1, 0, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -808,7 +805,7 @@ mod tests {
 
             // Send `Retry` with bad prefix
             let bad_section_tree_update = {
-                let (bad_sap, _, _) = random_sap(bad_prefix, 1, 0, None);
+                let (bad_sap, _, _) = TestSAP::random_sap(bad_prefix, 1, 0, None);
                 let mut bad_signed_sap = signed_genesis_sap.clone();
                 bad_signed_sap.value = bad_sap;
                 SectionTreeUpdate::new(bad_signed_sap, proof_chain.clone())
@@ -824,7 +821,8 @@ mod tests {
             task::yield_now().await;
 
             // Send `Retry` with valid update
-            let (next_sap, next_elders, next_sk_set) = random_sap(Prefix::default(), 1, 0, None);
+            let (next_sap, next_elders, next_sk_set) =
+                TestSAP::random_sap(Prefix::default(), 1, 0, None);
             let next_section_key = next_sk_set.public_keys().public_key();
             let section_tree_update = gen_section_tree_update(
                 &section_signed(&next_sk_set.secret_key(), next_sap),

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -456,7 +456,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(10);
 
         let (genesis_sap, _genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -475,7 +475,7 @@ mod tests {
         let bootstrap = async move { state.try_join(join_timeout).await.map_err(Error::from) };
 
         let (next_sap, next_elders, next_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
 
         let next_section_key = next_sk_set.public_keys().public_key();
         let section_tree_update = TestSectionTree::get_section_tree_update(
@@ -563,7 +563,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -592,7 +592,8 @@ mod tests {
                     assert_matches!(msg, NodeMsg::JoinRequest{..}));
 
             // Send JoinResponse::Redirect
-            let (new_sap, _, _) = TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            let (new_sap, _, _) =
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
 
             send_response(
                 &recv_tx,
@@ -641,7 +642,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -667,7 +668,7 @@ mod tests {
             assert_matches!(msg, NodeMsg::JoinRequest{..}));
 
             let (new_sap, _, new_sk_set) =
-                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
             let new_pk_set = new_sk_set.public_keys();
 
             send_response(
@@ -719,7 +720,7 @@ mod tests {
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -782,7 +783,7 @@ mod tests {
         let bad_prefix = Prefix::default().pushed(!first_bit);
 
         let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), 1, 0, None);
+            TestSAP::random_sap(Prefix::default(), 1, 0, None, None);
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -805,7 +806,7 @@ mod tests {
 
             // Send `Retry` with bad prefix
             let bad_section_tree_update = {
-                let (bad_sap, _, _) = TestSAP::random_sap(bad_prefix, 1, 0, None);
+                let (bad_sap, _, _) = TestSAP::random_sap(bad_prefix, 1, 0, None, None);
                 let mut bad_signed_sap = signed_genesis_sap.clone();
                 bad_signed_sap.value = bad_sap;
                 SectionTreeUpdate::new(bad_signed_sap, proof_chain.clone())
@@ -822,7 +823,7 @@ mod tests {
 
             // Send `Retry` with valid update
             let (next_sap, next_elders, next_sk_set) =
-                TestSAP::random_sap(Prefix::default(), 1, 0, None);
+                TestSAP::random_sap(Prefix::default(), 1, 0, None, None);
             let next_section_key = next_sk_set.public_keys().public_key();
             let section_tree_update = TestSectionTree::get_section_tree_update(
                 &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap),

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -478,7 +478,7 @@ mod tests {
             TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
 
         let next_section_key = next_sk_set.public_keys().public_key();
-        let section_tree_update = gen_section_tree_update(
+        let section_tree_update = TestSectionTree::get_section_tree_update(
             &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap.clone()),
             &SectionsDAG::new(genesis_pk),
             &genesis_sk,
@@ -824,7 +824,7 @@ mod tests {
             let (next_sap, next_elders, next_sk_set) =
                 TestSAP::random_sap(Prefix::default(), 1, 0, None);
             let next_section_key = next_sk_set.public_keys().public_key();
-            let section_tree_update = gen_section_tree_update(
+            let section_tree_update = TestSectionTree::get_section_tree_update(
                 &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap),
                 &SectionsDAG::new(genesis_pk),
                 &genesis_sk,

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -465,7 +465,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone());
+        let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone());
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -479,7 +479,7 @@ mod tests {
 
         let next_section_key = next_sk_set.public_keys().public_key();
         let section_tree_update = gen_section_tree_update(
-            &section_signed(&next_sk_set.secret_key(), next_sap.clone()),
+            &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap.clone()),
             &SectionsDAG::new(genesis_pk),
             &genesis_sk,
         );
@@ -572,7 +572,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone());
+        let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone());
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -650,7 +650,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone());
+        let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone());
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -728,7 +728,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone());
+        let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone());
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -786,7 +786,7 @@ mod tests {
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone());
+        let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone());
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap.clone()));
 
@@ -825,7 +825,7 @@ mod tests {
                 TestSAP::random_sap(Prefix::default(), 1, 0, None);
             let next_section_key = next_sk_set.public_keys().public_key();
             let section_tree_update = gen_section_tree_update(
-                &section_signed(&next_sk_set.secret_key(), next_sap),
+                &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap),
                 &SectionsDAG::new(genesis_pk),
                 &genesis_sk,
             );

--- a/sn_node/src/node/bootstrap/relocate.rs
+++ b/sn_node/src/node/bootstrap/relocate.rs
@@ -249,10 +249,8 @@ mod tests {
     use sn_interface::{
         elder_count,
         messaging::system::{JoinAsRelocatedResponse, NodeMsg},
-        network_knowledge::{
-            test_utils::{gen_addr, section_signed},
-            MyNodeInfo, NodeState, SectionAuthorityProvider, MIN_ADULT_AGE,
-        },
+        network_knowledge::{MyNodeInfo, NodeState, SectionAuthorityProvider, MIN_ADULT_AGE},
+        test_utils::{gen_addr, TestKeys},
         types::{keys::ed25519, Peer},
     };
     use std::{collections::BTreeSet, net::SocketAddr};
@@ -268,7 +266,7 @@ mod tests {
             gen_addr(),
         );
         let node_state = NodeState::joined(node.peer(), None);
-        let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state);
+        let signed_node_state = TestKeys::get_section_signed(&from_sk_set.secret_key(), node_state);
         // to_sap
         let (to_sap, _) = generate_sap();
 
@@ -315,7 +313,8 @@ mod tests {
                 gen_addr(),
             );
             let node_state = NodeState::joined(node.peer(), None);
-            let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state);
+            let signed_node_state =
+                TestKeys::get_section_signed(&from_sk_set.secret_key(), node_state);
             // to_sap
             let (to_sap, to_sk_set) = generate_sap();
 
@@ -380,7 +379,8 @@ mod tests {
                 gen_addr(),
             );
             let node_state = NodeState::joined(node.peer(), None);
-            let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state);
+            let signed_node_state =
+                TestKeys::get_section_signed(&from_sk_set.secret_key(), node_state);
             // to_sap
             let (to_sap, to_sk_set) = generate_sap();
 

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -12,7 +12,7 @@ use sn_interface::{
         data::{ClientMsg, Error as MessagingDataError},
         serialisation::WireMsg,
         system::{JoinResponse, NodeCmd, NodeMsg, OperationId},
-        AuthorityProof, ClientAuth, MsgId, MsgType,
+        AuthorityProof, ClientAuth, MsgId,
     },
     network_knowledge::{
         test_utils::*, MembershipState, NodeState, RelocateDetails, SectionAuthorityProvider,

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -17,7 +17,7 @@ use sn_interface::{
     network_knowledge::{
         test_utils::*, MembershipState, NodeState, RelocateDetails, SectionAuthorityProvider,
     },
-    types::{Keypair, Peer, ReplicatedData, SecretKeySet},
+    types::{Keypair, Peer, ReplicatedData},
 };
 use std::collections::BTreeSet;
 use std::sync::Arc;

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -6,12 +6,11 @@ use crate::node::{
 use assert_matches::assert_matches;
 use eyre::eyre;
 use eyre::Result;
-use qp2p::SendStream;
 use sn_interface::{
     messaging::{
-        data::{ClientMsg, Error as MessagingDataError},
+        data::ClientMsg,
         serialisation::WireMsg,
-        system::{JoinResponse, NodeCmd, NodeMsg, OperationId},
+        system::{JoinResponse, NodeCmd, NodeMsg},
         AuthorityProof, ClientAuth, MsgId,
     },
     network_knowledge::{
@@ -20,8 +19,6 @@ use sn_interface::{
     types::{Keypair, Peer, ReplicatedData},
 };
 use std::collections::BTreeSet;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 
 pub(crate) struct HandleOnlineStatus {
     pub(crate) node_approval_sent: bool,

--- a/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
@@ -1,18 +1,11 @@
-use crate::node::{api::gen_genesis_dbc, flow_ctrl::dispatcher::Dispatcher};
+use crate::node::api::gen_genesis_dbc;
 use eyre::{eyre, Result};
 use sn_dbc::{
-    get_public_commitments_from_transaction, Commitment, Dbc, Hash, IndexedSignatureShare,
-    KeyImage, Owner, OwnerOnce, PublicKey, RingCtTransaction, Signature, SpentProof,
-    SpentProofContent, SpentProofShare, Token, TransactionBuilder,
+    Dbc, KeyImage, Owner, OwnerOnce, RingCtTransaction, SpentProof, SpentProofShare, Token,
+    TransactionBuilder,
 };
-use sn_interface::network_knowledge::section_keys::build_spent_proof_share;
-use sn_interface::{
-    messaging::data::{ClientMsg, DataCmd, RegisterCmd, SpentbookCmd},
-    network_knowledge::{SectionAuthorityProvider, SectionKeysProvider},
-    types::{Peer, ReplicatedData},
-};
+use sn_interface::{messaging::data::RegisterCmd, types::ReplicatedData};
 use std::collections::BTreeSet;
-use std::str::FromStr;
 
 /// Get the spent proof share that's packaged inside the data that's to be replicated to the adults
 /// in the section.

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -44,11 +44,12 @@ use sn_interface::{
         Dst, MsgId, MsgType, WireMsg,
     },
     network_knowledge::{
-        recommended_section_size, supermajority, test_utils::*, Error as NetworkKnowledgeError,
-        MembershipState, MyNodeInfo, NetworkKnowledge, NodeState, RelocateDetails,
-        SectionAuthorityProvider, SectionKeyShare, SectionKeysProvider, SectionTree,
-        SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
+        recommended_section_size, supermajority, Error as NetworkKnowledgeError, MembershipState,
+        MyNodeInfo, NetworkKnowledge, NodeState, RelocateDetails, SectionAuthorityProvider,
+        SectionKeyShare, SectionKeysProvider, SectionTree, SectionTreeUpdate, SectionsDAG,
+        MIN_ADULT_AGE,
     },
+    test_utils::*,
     types::{keyed_signed, keys::ed25519, Peer, PublicKey, ReplicatedData},
 };
 
@@ -656,7 +657,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
                 RelocatedPeerRole::Elder => elder_count(),
                 RelocatedPeerRole::NonElder => recommended_section_size(),
             };
-            let (section_auth, mut nodes, sk_set) = random_sap(prefix, elder_count(), 0, None);
+            let (section_auth, mut nodes, sk_set) = TestSAP::random_sap(prefix, elder_count(), 0, None);
             let (mut section, section_key_share) =
                 network_utils::create_section(&sk_set, &section_auth, None, None)?;
 

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code)]
 pub(crate) mod cmd_utils;
 pub(crate) mod dbc_utils;
 pub(crate) mod network_utils;
@@ -20,59 +20,40 @@ use crate::{
         flow_ctrl::{dispatcher::Dispatcher, event_channel},
         messages::WireMsgUtils,
         messaging::{OutgoingMsg, Peers},
-        Cmd, Error, Event, MembershipEvent, Proposal, Result as RoutingResult,
+        Cmd, Error, Event, MembershipEvent, Proposal,
     },
     storage::UsedSpace,
 };
-
 use cmd_utils::{
-    get_client_msg_parts_for_handling, handle_online_cmd, run_and_collect_cmds,
-    run_node_handle_client_msg_and_collect_cmds,
+    handle_online_cmd, run_and_collect_cmds, run_node_handle_client_msg_and_collect_cmds,
 };
-use sn_consensus::Decision;
-use sn_dbc::{Hash, OwnerOnce, SpentProofShare, TransactionBuilder};
+use sn_dbc::Hash;
 use sn_interface::{
     elder_count, init_logger,
     messaging::{
-        data::{
-            ClientMsg, CmdResponse, DataCmd, Error as MessagingDataError, RegisterCmd, SpentbookCmd,
-        },
-        system::{
-            AntiEntropyKind, JoinAsRelocatedRequest, JoinRequest, JoinResponse, NodeCmd, NodeMsg,
-            SectionSig, SectionSigned,
-        },
-        Dst, MsgId, MsgType, WireMsg,
+        data::{ClientMsg, DataCmd, SpentbookCmd},
+        system::{AntiEntropyKind, JoinAsRelocatedRequest, NodeCmd, NodeMsg, SectionSigned},
+        Dst, MsgType, WireMsg,
     },
     network_knowledge::{
         recommended_section_size, supermajority, Error as NetworkKnowledgeError, MembershipState,
         MyNodeInfo, NetworkKnowledge, NodeState, RelocateDetails, SectionAuthorityProvider,
-        SectionKeyShare, SectionKeysProvider, SectionTree, SectionTreeUpdate, SectionsDAG,
-        MIN_ADULT_AGE,
+        SectionKeysProvider, SectionTree, SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
     },
     test_utils::*,
-    types::{keys::ed25519, Peer, PublicKey, ReplicatedData},
+    types::{keys::ed25519, PublicKey, ReplicatedData},
 };
 
 use assert_matches::assert_matches;
-use bls::Signature;
-use ed25519_dalek::Signer;
-use eyre::{bail, eyre, Context, Result};
-use itertools::Itertools;
-use rand::{distributions::Alphanumeric, rngs::OsRng, thread_rng, Rng};
-use resource_proof::ResourceProof as ChallengeSolver;
+use eyre::{bail, eyre, Result};
+use rand::thread_rng;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     iter,
     net::Ipv4Addr,
-    ops::Deref,
-    path::Path,
     sync::Arc,
 };
-use tempfile::tempdir;
-use tokio::{
-    sync::{mpsc, RwLock},
-    time::{timeout, Duration},
-};
+use tokio::sync::{mpsc, RwLock};
 use xor_name::{Prefix, XorName};
 
 #[tokio::test]
@@ -192,7 +173,8 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
             let section_chain = SectionsDAG::new(pk);
 
             // Creates nodes where everybody has age 6 except one has 5.
-            let mut nodes: Vec<_> = gen_sorted_nodes(&Prefix::default(), elder_count(), true);
+            let mut nodes: Vec<_> =
+                gen_sorted_nodes(&Prefix::default(), elder_count(), 0, Some(&[6, 5]));
 
             let elders = nodes.iter().map(MyNodeInfo::peer);
             let members = nodes.iter().map(|n| NodeState::joined(n.peer(), None));
@@ -387,7 +369,7 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
     local
         .run_until(async move {
             let (section_auth, mut nodes, sk_set) =
-                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
 
             let (mut section, _) =
                 network_utils::create_section(&sk_set, &section_auth, None, None)?;
@@ -436,12 +418,6 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
         .await
 }
 
-#[derive(PartialEq)]
-enum UntrustedMessageSource {
-    Peer,
-    Accumulation,
-}
-
 #[tokio::test]
 async fn ae_msg_from_the_future_is_handled() -> Result<()> {
     // The setup here is too complex for the TestNodeBuilder.
@@ -456,7 +432,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
             let pk0 = sk0.public_key();
 
             let (old_sap, mut nodes, sk_set1) =
-                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
             let members =
                 BTreeSet::from_iter(nodes.iter().map(|n| NodeState::joined(n.peer(), None)));
             let pk1 = sk_set1.secret_key().public_key();
@@ -666,7 +642,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
                 RelocatedPeerRole::Elder => elder_count(),
                 RelocatedPeerRole::NonElder => recommended_section_size(),
             };
-            let (section_auth, mut nodes, sk_set) = TestSAP::random_sap(prefix, elder_count(), 0, None);
+            let (section_auth, mut nodes, sk_set) = TestSAP::random_sap(prefix, elder_count(), 0, None, None);
             let (mut section, section_key_share) =
                 network_utils::create_section(&sk_set, &section_auth, None, None)?;
 

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -49,7 +49,7 @@ use sn_interface::{
         SectionAuthorityProvider, SectionKeyShare, SectionKeysProvider, SectionTree,
         SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
     },
-    types::{keyed_signed, keys::ed25519, Peer, PublicKey, ReplicatedData, SecretKeySet},
+    types::{keyed_signed, keys::ed25519, Peer, PublicKey, ReplicatedData},
 };
 
 use assert_matches::assert_matches;
@@ -57,7 +57,7 @@ use bls::Signature;
 use ed25519_dalek::Signer;
 use eyre::{bail, eyre, Context, Result};
 use itertools::Itertools;
-use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
+use rand::{distributions::Alphanumeric, rngs::OsRng, thread_rng, Rng};
 use resource_proof::ResourceProof as ChallengeSolver;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
@@ -186,7 +186,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async move {
-            let sk_set = bls::SecretKeySet::random(0, &mut rand::thread_rng());
+            let sk_set = bls::SecretKeySet::random(0, &mut thread_rng());
             let pk = sk_set.secret_key().public_key();
             let section_chain = SectionsDAG::new(pk);
 
@@ -478,7 +478,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
             .await?;
 
             // Create new `Section` as a successor to the previous one.
-            let sk_set2 = SecretKeySet::random(None);
+            let sk_set2 = bls::SecretKeySet::random(0, &mut thread_rng());
             let sk2 = sk_set2.secret_key();
             let pk2 = sk2.public_key();
 
@@ -501,7 +501,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
             );
             let new_section_elders: BTreeSet<_> = new_sap.names();
             let section_tree_update = gen_section_tree_update(
-                &section_signed(sk2, new_sap.clone()),
+                &section_signed(&sk2, new_sap.clone()),
                 &node.section_chain(),
                 &sk_set1.secret_key(),
             );
@@ -746,7 +746,7 @@ async fn msg_to_self() -> Result<()> {
         .await?;
         let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
 
-        let genesis_sk_set = bls::SecretKeySet::random(0, &mut rand::thread_rng());
+        let genesis_sk_set = bls::SecretKeySet::random(0, &mut thread_rng());
         let (node, _) = MyNode::first_node(
             comm,
             info.keypair.clone(),
@@ -807,7 +807,7 @@ async fn handle_elders_update() -> Result<()> {
                 .map(|p| NodeState::joined(p, None)),
         );
 
-        let sk_set0 = SecretKeySet::random(None);
+        let sk_set0 = bls::SecretKeySet::random(0, &mut thread_rng());
         let pk0 = sk_set0.secret_key().public_key();
 
         let sap0 = SectionAuthorityProvider::new(
@@ -822,13 +822,13 @@ async fn handle_elders_update() -> Result<()> {
 
         for peer in [&adult_peer, &promoted_peer] {
             let node_state = NodeState::joined(*peer, None);
-            let node_state = section_signed(sk_set0.secret_key(), node_state);
+            let node_state = section_signed(&sk_set0.secret_key(), node_state);
             assert!(section0.update_member(node_state));
         }
 
         let demoted_peer = other_elder_peers.remove(0);
 
-        let sk_set1 = SecretKeySet::random(None);
+        let sk_set1 = bls::SecretKeySet::random(0, &mut thread_rng());
 
         let pk1 = sk_set1.secret_key().public_key();
         // Create `HandleAgreement` cmd for an `NewElders` proposal. This will demote one of the
@@ -844,7 +844,7 @@ async fn handle_elders_update() -> Result<()> {
         );
         let elder_names1: BTreeSet<_> = sap1.names();
 
-        let signed_sap1 = section_signed(sk_set1.secret_key(), sap1);
+        let signed_sap1 = section_signed(&sk_set1.secret_key(), sap1);
         let proposal = Proposal::NewElders(signed_sap1.clone());
         let signature = sk_set0.secret_key().sign(&proposal.as_signable_bytes()?);
         let sig = SectionSig {
@@ -963,7 +963,7 @@ async fn handle_demote_during_split() -> Result<()> {
             );
 
             // Create the pre-split section
-            let sk_set_v0 = SecretKeySet::random(None);
+            let sk_set_v0 = bls::SecretKeySet::random(0, &mut thread_rng());
             let section_auth_v0 = SectionAuthorityProvider::new(
                 iter::once(info.peer()).chain(peers_a.iter().cloned()),
                 Prefix::default(),
@@ -977,7 +977,7 @@ async fn handle_demote_during_split() -> Result<()> {
             // all peers b are added
             for peer in peers_b.iter().chain(iter::once(&peer_c)).cloned() {
                 let node_state = NodeState::joined(peer, None);
-                let node_state = section_signed(sk_set_v0.secret_key(), node_state);
+                let node_state = section_signed(&sk_set_v0.secret_key(), node_state);
                 assert!(section.update_member(node_state));
             }
 
@@ -996,8 +996,8 @@ async fn handle_demote_during_split() -> Result<()> {
             )
             .await?;
 
-            let sk_set_v1_p0 = SecretKeySet::random(None);
-            let sk_set_v1_p1 = SecretKeySet::random(None);
+            let sk_set_v1_p0 = bls::SecretKeySet::random(0, &mut thread_rng());
+            let sk_set_v1_p1 = bls::SecretKeySet::random(0, &mut thread_rng());
 
             // Simulate DKG round finished succesfully by adding the new section
             // key share to our cache (according to which split section we'll belong to).
@@ -1036,7 +1036,7 @@ async fn handle_demote_during_split() -> Result<()> {
                 0,
             );
 
-            let signed_sap = section_signed(sk_set_v1_p0.secret_key(), section_auth);
+            let signed_sap = section_signed(&sk_set_v1_p0.secret_key(), section_auth);
             let cmd = create_our_elders_cmd(signed_sap)?;
             let mut cmds = run_and_collect_cmds(cmd, &dispatcher).await?;
 
@@ -1049,7 +1049,7 @@ async fn handle_demote_during_split() -> Result<()> {
                 0,
             );
 
-            let signed_sap = section_signed(sk_set_v1_p1.secret_key(), section_auth);
+            let signed_sap = section_signed(&sk_set_v1_p1.secret_key(), section_auth);
             let cmd = create_our_elders_cmd(signed_sap)?;
 
             let new_cmds = run_and_collect_cmds(cmd, &dispatcher).await?;
@@ -1238,7 +1238,7 @@ async fn spentbook_spend_spent_proof_with_key_not_in_section_chain_should_return
                     .build()
                     .await?;
 
-            let sk_set = bls::SecretKeySet::random(0, &mut rand::thread_rng());
+            let sk_set = bls::SecretKeySet::random(0, &mut thread_rng());
             let (key_image, tx, spent_proofs, spent_transactions) =
                 dbc_utils::get_genesis_dbc_spend_info(&sk_set)?;
 

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -174,7 +174,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
 
             // Creates nodes where everybody has age 6 except one has 5.
             let mut nodes: Vec<_> =
-                gen_sorted_nodes(&Prefix::default(), elder_count(), 0, Some(&[6, 5]));
+                gen_sorted_nodes(&Prefix::default(), elder_count(), 0, Some(&[5, 6]));
 
             let elders = nodes.iter().map(MyNodeInfo::peer);
             let members = nodes.iter().map(|n| NodeState::joined(n.peer(), None));

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -50,7 +50,7 @@ use sn_interface::{
         MIN_ADULT_AGE,
     },
     test_utils::*,
-    types::{keyed_signed, keys::ed25519, Peer, PublicKey, ReplicatedData},
+    types::{keys::ed25519, Peer, PublicKey, ReplicatedData},
 };
 
 use assert_matches::assert_matches;
@@ -110,7 +110,7 @@ async fn membership_churn_starts_on_join_request_from_relocated_node() -> Result
                 Some(relocated_node_old_name),
                 relocate_details,
             );
-            let relocate_proof = section_signed(&sk_set.secret_key(), node_state);
+            let relocate_proof = TestKeys::get_section_signed(&sk_set.secret_key(), node_state);
 
             let signature_over_new_name =
                 ed25519::sign(&relocated_node.name().0, &relocated_node_old_keypair);
@@ -204,7 +204,8 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
                 0,
             );
             let section_tree_update = {
-                let signed_sap = section_signed(&sk_set.secret_key(), section_auth.clone());
+                let signed_sap =
+                    TestKeys::get_section_signed(&sk_set.secret_key(), section_auth.clone());
                 SectionTreeUpdate::new(signed_sap, section_chain)
             };
 
@@ -213,7 +214,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
 
             for peer in section_auth.elders() {
                 let node_state = NodeState::joined(*peer, None);
-                let sig = prove(&sk_set.secret_key(), &node_state);
+                let sig = TestKeys::get_section_sig(&sk_set.secret_key(), &node_state);
                 let _updated = section.update_member(SectionSigned {
                     value: node_state,
                     sig,
@@ -360,7 +361,10 @@ async fn handle_agreement_on_offline_of_non_elder() -> Result<()> {
 
             let node_state = NodeState::left(existing_peer, None);
             let proposal = Proposal::VoteNodeOffline(node_state.clone());
-            let sig = keyed_signed(&sk_set.secret_key(), &proposal.as_signable_bytes()?);
+            let sig = TestKeys::get_section_sig_bytes(
+                &sk_set.secret_key(),
+                &proposal.as_signable_bytes()?,
+            );
 
             let _cmds =
                 run_and_collect_cmds(Cmd::HandleAgreement { proposal, sig }, &dispatcher).await?;
@@ -389,7 +393,7 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
 
             let existing_peer = network_utils::create_peer(MIN_ADULT_AGE);
             let node_state = NodeState::joined(existing_peer, None);
-            let node_state = section_signed(&sk_set.secret_key(), node_state);
+            let node_state = TestKeys::get_section_signed(&sk_set.secret_key(), node_state);
             let _updated = section.update_member(node_state);
 
             // Pick the elder to remove.
@@ -409,7 +413,10 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
                     .await?;
             // Handle agreement on the Offline proposal
             let proposal = Proposal::VoteNodeOffline(remove_node_state.clone());
-            let sig = keyed_signed(&sk_set.secret_key(), &proposal.as_signable_bytes()?);
+            let sig = TestKeys::get_section_sig_bytes(
+                &sk_set.secret_key(),
+                &proposal.as_signable_bytes()?,
+            );
 
             let _cmds =
                 run_and_collect_cmds(Cmd::HandleAgreement { proposal, sig }, &dispatcher).await?;
@@ -452,8 +459,8 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
                 BTreeSet::from_iter(nodes.iter().map(|n| NodeState::joined(n.peer(), None)));
             let pk1 = sk_set1.secret_key().public_key();
 
-            let section_tree_update = gen_section_tree_update(
-                &section_signed(&sk_set1.secret_key(), old_sap.clone()),
+            let section_tree_update = TestSectionTree::get_section_tree_update(
+                &TestKeys::get_section_signed(&sk_set1.secret_key(), old_sap.clone()),
                 &SectionsDAG::new(pk0),
                 &sk0,
             );
@@ -463,7 +470,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
             // Create our node
             let (event_sender, mut event_receiver) =
                 event_channel::new(network_utils::TEST_EVENT_CHANNEL_SIZE);
-            let section_key_share = network_utils::create_section_key_share(&sk_set1, 0);
+            let section_key_share = TestKeys::get_section_key_share(&sk_set1, 0);
             let node = nodes.remove(0);
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
             let comm = network_utils::create_comm().await?;
@@ -501,8 +508,8 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
                 0,
             );
             let new_section_elders: BTreeSet<_> = new_sap.names();
-            let section_tree_update = gen_section_tree_update(
-                &section_signed(&sk2, new_sap.clone()),
+            let section_tree_update = TestSectionTree::get_section_tree_update(
+                &TestKeys::get_section_signed(&sk2, new_sap.clone()),
                 &node.section_chain(),
                 &sk_set1.secret_key(),
             );
@@ -525,7 +532,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
             // Simulate DKG round finished succesfully by adding
             // the new section key share to our cache
             node.section_keys_provider
-                .insert(network_utils::create_section_key_share(&sk_set2, 0));
+                .insert(TestKeys::get_section_key_share(&sk_set2, 0));
 
             let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)));
 
@@ -666,13 +673,13 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
                 adults -= 1;
                 let non_elder_peer = network_utils::create_peer(MIN_ADULT_AGE);
                 let node_state = NodeState::joined(non_elder_peer, None);
-                let node_state = section_signed(&sk_set.secret_key(), node_state);
+                let node_state =  TestKeys::get_section_signed(&sk_set.secret_key(), node_state);
                 assert!(section.update_member(node_state));
             }
 
             let non_elder_peer = network_utils::create_peer(MIN_ADULT_AGE - 1);
             let node_state = NodeState::joined(non_elder_peer, None);
-            let node_state = section_signed(&sk_set.secret_key(), node_state);
+            let node_state =  TestKeys::get_section_signed(&sk_set.secret_key(), node_state);
             assert!(section.update_member(node_state));
             let node = nodes.remove(0);
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
@@ -809,7 +816,6 @@ async fn handle_elders_update() -> Result<()> {
         );
 
         let sk_set0 = bls::SecretKeySet::random(0, &mut thread_rng());
-        let pk0 = sk_set0.secret_key().public_key();
 
         let sap0 = SectionAuthorityProvider::new(
             iter::once(info.peer()).chain(other_elder_peers.clone()),
@@ -823,7 +829,7 @@ async fn handle_elders_update() -> Result<()> {
 
         for peer in [&adult_peer, &promoted_peer] {
             let node_state = NodeState::joined(*peer, None);
-            let node_state = section_signed(&sk_set0.secret_key(), node_state);
+            let node_state =  TestKeys::get_section_signed(&sk_set0.secret_key(), node_state);
             assert!(section0.update_member(node_state));
         }
 
@@ -845,13 +851,9 @@ async fn handle_elders_update() -> Result<()> {
         );
         let elder_names1: BTreeSet<_> = sap1.names();
 
-        let signed_sap1 = section_signed(&sk_set1.secret_key(), sap1);
+        let signed_sap1 =  TestKeys::get_section_signed(&sk_set1.secret_key(), sap1);
         let proposal = Proposal::NewElders(signed_sap1.clone());
-        let signature = sk_set0.secret_key().sign(&proposal.as_signable_bytes()?);
-        let sig = SectionSig {
-            signature,
-            public_key: pk0,
-        };
+        let sig = TestKeys::get_section_sig_bytes(&sk_set0.secret_key(), &proposal.as_signable_bytes()?);
 
         let (event_sender, mut event_receiver) = event_channel::new(network_utils::TEST_EVENT_CHANNEL_SIZE);
         let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
@@ -870,7 +872,7 @@ async fn handle_elders_update() -> Result<()> {
         // Simulate DKG round finished successfully by adding
         // the new section key share to our cache
         node.section_keys_provider
-            .insert(network_utils::create_section_key_share(&sk_set1, 0));
+            .insert(TestKeys::get_section_key_share(&sk_set1, 0));
 
         let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)));
 
@@ -978,7 +980,7 @@ async fn handle_demote_during_split() -> Result<()> {
             // all peers b are added
             for peer in peers_b.iter().chain(iter::once(&peer_c)).cloned() {
                 let node_state = NodeState::joined(peer, None);
-                let node_state = section_signed(&sk_set_v0.secret_key(), node_state);
+                let node_state = TestKeys::get_section_signed(&sk_set_v0.secret_key(), node_state);
                 assert!(section.update_member(node_state));
             }
 
@@ -1004,10 +1006,10 @@ async fn handle_demote_during_split() -> Result<()> {
             // key share to our cache (according to which split section we'll belong to).
             if prefix0.matches(&node_name) {
                 node.section_keys_provider
-                    .insert(network_utils::create_section_key_share(&sk_set_v1_p0, 0));
+                    .insert(TestKeys::get_section_key_share(&sk_set_v1_p0, 0));
             } else {
                 node.section_keys_provider
-                    .insert(network_utils::create_section_key_share(&sk_set_v1_p1, 0));
+                    .insert(TestKeys::get_section_key_share(&sk_set_v1_p1, 0));
             }
 
             let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)));
@@ -1016,11 +1018,10 @@ async fn handle_demote_during_split() -> Result<()> {
             let create_our_elders_cmd =
                 |signed_sap: SectionSigned<SectionAuthorityProvider>| -> Result<_> {
                     let proposal = Proposal::NewElders(signed_sap.clone());
-                    let signature = sk_set_v0.secret_key().sign(&proposal.as_signable_bytes()?);
-                    let sig = SectionSig {
-                        signature,
-                        public_key: sk_set_v0.public_keys().public_key(),
-                    };
+                    let sig = TestKeys::get_section_sig_bytes(
+                        &sk_set_v0.secret_key(),
+                        &proposal.as_signable_bytes()?,
+                    );
 
                     Ok(Cmd::HandleNewEldersAgreement {
                         new_elders: signed_sap,
@@ -1037,7 +1038,7 @@ async fn handle_demote_during_split() -> Result<()> {
                 0,
             );
 
-            let signed_sap = section_signed(&sk_set_v1_p0.secret_key(), section_auth);
+            let signed_sap = TestKeys::get_section_signed(&sk_set_v1_p0.secret_key(), section_auth);
             let cmd = create_our_elders_cmd(signed_sap)?;
             let mut cmds = run_and_collect_cmds(cmd, &dispatcher).await?;
 
@@ -1050,7 +1051,7 @@ async fn handle_demote_during_split() -> Result<()> {
                 0,
             );
 
-            let signed_sap = section_signed(&sk_set_v1_p1.secret_key(), section_auth);
+            let signed_sap = TestKeys::get_section_signed(&sk_set_v1_p1.secret_key(), section_auth);
             let cmd = create_our_elders_cmd(signed_sap)?;
 
             let new_cmds = run_and_collect_cmds(cmd, &dispatcher).await?;

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -386,7 +386,8 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async move {
-            let (section_auth, mut nodes, sk_set) = network_utils::create_section_auth();
+            let (section_auth, mut nodes, sk_set) =
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
 
             let (mut section, _) =
                 network_utils::create_section(&sk_set, &section_auth, None, None)?;
@@ -454,7 +455,8 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
             let sk0 = bls::SecretKey::random();
             let pk0 = sk0.public_key();
 
-            let (old_sap, mut nodes, sk_set1) = network_utils::create_section_auth();
+            let (old_sap, mut nodes, sk_set1) =
+                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
             let members =
                 BTreeSet::from_iter(nodes.iter().map(|n| NodeState::joined(n.peer(), None)));
             let pk1 = sk_set1.secret_key().public_key();

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -238,7 +238,7 @@ impl TestNodeBuilder {
                 let sk_set = self.genesis_sk_set.ok_or_else(|| {
                     eyre!("The secret key set must be supplied when providing a custom section")
                 })?;
-                let section_key_share = create_section_key_share(&sk_set, 0);
+                let section_key_share = TestKeys::get_section_key_share(&sk_set, 0);
                 (
                     custom_section,
                     section_key_share,
@@ -276,7 +276,7 @@ impl TestNodeBuilder {
 
         if let Some(custom_peer) = self.custom_peer {
             let node_state = NodeState::joined(custom_peer, None);
-            let node_state = section_signed(&sk_set.secret_key(), node_state);
+            let node_state = TestKeys::get_section_signed(&sk_set.secret_key(), node_state);
             let _updated = section.update_member(node_state);
         }
 
@@ -320,7 +320,7 @@ pub(crate) fn create_section(
     let (mut section, section_key_share) =
         do_create_section(sap, genesis_sk_set, other_keys, parent_section_tree)?;
     for ns in sap.members() {
-        let auth_ns = section_signed(&genesis_sk_set.secret_key(), ns.clone());
+        let auth_ns = TestKeys::get_section_signed(&genesis_sk_set.secret_key(), ns.clone());
         let _updated = section.update_member(auth_ns);
     }
     Ok((section, section_key_share))
@@ -336,21 +336,10 @@ pub(crate) fn create_section_with_elders(
     let (mut section, section_key_share) = do_create_section(sap, sk_set, None, None)?;
     for peer in sap.elders() {
         let node_state = NodeState::joined(*peer, None);
-        let node_state = section_signed(&sk_set.secret_key(), node_state);
+        let node_state = TestKeys::get_section_signed(&sk_set.secret_key(), node_state);
         let _updated = section.update_member(node_state);
     }
     Ok((section, section_key_share))
-}
-
-pub(crate) fn create_section_key_share(
-    sk_set: &bls::SecretKeySet,
-    index: usize,
-) -> SectionKeyShare {
-    SectionKeyShare {
-        public_key_set: sk_set.public_keys(),
-        index,
-        secret_key_share: sk_set.secret_key_share(index),
-    }
 }
 
 pub(crate) fn create_section_auth() -> (SectionAuthorityProvider, Vec<MyNodeInfo>, bls::SecretKeySet)
@@ -429,7 +418,7 @@ fn do_create_section(
         (section_chain, genesis_ks.secret_key(), 0)
     };
 
-    let signed_sap = section_signed(&last_sk, section_auth.clone());
+    let signed_sap = TestKeys::get_section_signed(&last_sk, section_auth.clone());
     let section_tree_update = SectionTreeUpdate::new(signed_sap, section_chain);
     let section_tree = if let Some(parent_section_tree) = parent_section_tree {
         parent_section_tree
@@ -439,7 +428,7 @@ fn do_create_section(
     let section = NetworkKnowledge::new(section_tree, section_tree_update)?;
 
     let sks = bls::SecretKeySet::from_bytes(last_sk.to_bytes().to_vec())?;
-    let section_key_share = create_section_key_share(&sks, share_index);
+    let section_key_share = TestKeys::get_section_key_share(&sks, share_index);
     Ok((section, section_key_share))
 }
 

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -333,20 +333,14 @@ pub(crate) fn create_section_with_elders(
     sk_set: &bls::SecretKeySet,
     sap: &SectionAuthorityProvider,
 ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
-    let (mut section, section_key_share) = do_create_section(sap, sk_set, None, None)?;
+    let (mut section, section_key_share) =
+        TestNetworkKnowledge::do_create_section(sap, sk_set, None, None)?;
     for peer in sap.elders() {
         let node_state = NodeState::joined(*peer, None);
         let node_state = TestKeys::get_section_signed(&sk_set.secret_key(), node_state);
         let _updated = section.update_member(node_state);
     }
     Ok((section, section_key_share))
-}
-
-pub(crate) fn create_section_auth() -> (SectionAuthorityProvider, Vec<MyNodeInfo>, bls::SecretKeySet)
-{
-    let (section_auth, elders, secret_key_set) =
-        TestSAP::random_sap(Prefix::default(), elder_count(), 0, None);
-    (section_auth, elders, secret_key_set)
 }
 
 pub(crate) fn create_peer(age: u8) -> Peer {
@@ -407,7 +401,8 @@ fn do_create_section(
 ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
     let (section_chain, last_sk, share_index) = if let Some(other_section_keys) = other_section_keys
     {
-        let section_chain = make_section_chain(&genesis_ks.secret_key(), &other_section_keys)?;
+        let section_chain =
+            TestSectionTree::gen_proof_chain(&genesis_ks.secret_key(), &other_section_keys);
         let last_key = other_section_keys
             .last()
             .ok_or_else(|| eyre!("The section keys list must be populated"))?;
@@ -430,18 +425,4 @@ fn do_create_section(
     let sks = bls::SecretKeySet::from_bytes(last_sk.to_bytes().to_vec())?;
     let section_key_share = TestKeys::get_section_key_share(&sks, share_index);
     Ok((section, section_key_share))
-}
-
-fn make_section_chain(
-    genesis_key: &bls::SecretKey,
-    other_keys: &Vec<bls::SecretKey>,
-) -> Result<SectionsDAG> {
-    let mut section_chain = SectionsDAG::new(genesis_key.public_key());
-    let mut parent = genesis_key.clone();
-    for key in other_keys {
-        let sig = parent.sign(key.public_key().to_bytes());
-        section_chain.insert(&parent.public_key(), key.public_key(), sig)?;
-        parent = key.clone();
-    }
-    Ok(section_chain)
 }

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -28,7 +28,7 @@ pub(crate) static TEST_EVENT_CHANNEL_SIZE: usize = 20;
 /// Utility for constructing a Node with a mock network section.
 ///
 /// The purpose is to reduce test setup verbosity when unit testing things like message handlers.
-pub(crate) struct TestNodeBuilder<'a> {
+pub(crate) struct TestNodeBuilder {
     pub(crate) prefix: Prefix,
     pub(crate) elder_count: usize,
     pub(crate) adult_count: usize,
@@ -42,10 +42,10 @@ pub(crate) struct TestNodeBuilder<'a> {
     pub(crate) custom_peer: Option<Peer>,
     pub(crate) other_section_keys: Option<Vec<bls::SecretKey>>,
     pub(crate) parent_section_tree: Option<SectionTree>,
-    pub(crate) elder_age_pattern: Option<&'a [u8]>,
+    pub(crate) elder_age_pattern: Option<Vec<u8>>,
 }
 
-impl<'a> TestNodeBuilder<'a> {
+impl TestNodeBuilder {
     /// Create an instance of the builder.
     ///
     /// At the minimum a prefix for the section and an elder count value are required.
@@ -55,7 +55,7 @@ impl<'a> TestNodeBuilder<'a> {
     ///
     /// To supply different values for these, use the `adult_count` and `section_sk_threshold`
     /// functions to set them.
-    pub(crate) fn new(prefix: Prefix, elder_count: usize) -> TestNodeBuilder<'a> {
+    pub(crate) fn new(prefix: Prefix, elder_count: usize) -> TestNodeBuilder {
         let supermajority = 1 + elder_count * 2 / 3;
         let (event_sender, _) = event_channel::new(TEST_EVENT_CHANNEL_SIZE);
         Self {
@@ -77,7 +77,7 @@ impl<'a> TestNodeBuilder<'a> {
     }
 
     /// Provide a the genesis key set for the section to be created with.
-    pub(crate) fn genesis_sk_set(mut self, sk_set: bls::SecretKeySet) -> TestNodeBuilder<'a> {
+    pub(crate) fn genesis_sk_set(mut self, sk_set: bls::SecretKeySet) -> TestNodeBuilder {
         self.genesis_sk_set = Some(sk_set);
         self
     }
@@ -85,10 +85,7 @@ impl<'a> TestNodeBuilder<'a> {
     /// Provide other keys for the section chain.
     ///
     /// This list should *not* include the genesis key.
-    pub(crate) fn other_section_keys(
-        mut self,
-        other_keys: Vec<bls::SecretKey>,
-    ) -> TestNodeBuilder<'a> {
+    pub(crate) fn other_section_keys(mut self, other_keys: Vec<bls::SecretKey>) -> TestNodeBuilder {
         self.other_section_keys = Some(other_keys);
         self
     }
@@ -99,7 +96,7 @@ impl<'a> TestNodeBuilder<'a> {
     pub(crate) fn parent_section_tree(
         mut self,
         parent_section_tree: SectionTree,
-    ) -> TestNodeBuilder<'a> {
+    ) -> TestNodeBuilder {
         self.parent_section_tree = Some(parent_section_tree);
         self
     }
@@ -109,7 +106,7 @@ impl<'a> TestNodeBuilder<'a> {
     /// The default is 0.
     ///
     /// The total members for the section will be `elder_count` + `adult_count`.
-    pub(crate) fn adult_count(mut self, count: usize) -> TestNodeBuilder<'a> {
+    pub(crate) fn adult_count(mut self, count: usize) -> TestNodeBuilder {
         self.adult_count = count;
         self
     }
@@ -119,7 +116,7 @@ impl<'a> TestNodeBuilder<'a> {
     /// The default is the supermajority of the elder count, minus one.
     ///
     /// It will sometimes be necessary to set this value to 0.
-    pub(crate) fn section_sk_threshold(mut self, threshold: usize) -> TestNodeBuilder<'a> {
+    pub(crate) fn section_sk_threshold(mut self, threshold: usize) -> TestNodeBuilder {
         self.section_sk_threshold = threshold;
         self
     }
@@ -134,7 +131,7 @@ impl<'a> TestNodeBuilder<'a> {
     ///
     /// In your test, it may be desirable to control the amount of commands that would be
     /// generated.
-    pub(crate) fn data_copy_count(mut self, count: usize) -> TestNodeBuilder<'a> {
+    pub(crate) fn data_copy_count(mut self, count: usize) -> TestNodeBuilder {
         self.data_copy_count = count;
         self
     }
@@ -144,7 +141,7 @@ impl<'a> TestNodeBuilder<'a> {
     /// The event sender and receiver is a pair. If you need to access the receiver in the test,
     /// create the pair in the test setup and then pass the sender in here and then access the
     /// receiver as needed.
-    pub(crate) fn event_sender(mut self, event_sender: EventSender) -> TestNodeBuilder<'a> {
+    pub(crate) fn event_sender(mut self, event_sender: EventSender) -> TestNodeBuilder {
         self.node_event_sender = event_sender;
         self
     }
@@ -161,7 +158,7 @@ impl<'a> TestNodeBuilder<'a> {
         section: NetworkKnowledge,
         sk_set: bls::SecretKeySet,
         first_node: MyNodeInfo,
-    ) -> TestNodeBuilder<'a> {
+    ) -> TestNodeBuilder {
         self.section = Some(section);
         self.genesis_sk_set = Some(sk_set);
         self.first_node = Some(first_node);
@@ -171,7 +168,7 @@ impl<'a> TestNodeBuilder<'a> {
     /// Specify a single custom peer in the section.
     ///
     /// This may have a different age than other members in the section.
-    pub(crate) fn custom_peer(mut self, peer: Peer) -> TestNodeBuilder<'a> {
+    pub(crate) fn custom_peer(mut self, peer: Peer) -> TestNodeBuilder {
         self.custom_peer = Some(peer);
         self
     }
@@ -182,8 +179,8 @@ impl<'a> TestNodeBuilder<'a> {
     /// If age_pattern.len() == elder, then apply the respective ages to each node
     /// If age_pattern.len() < elder, then the last element's value is taken as the age for the remaining nodes.
     /// If age_pattern.len() > elder, then the extra elements after `count` are ignored.
-    pub(crate) fn elder_age_pattern(mut self, elder_age_pattern: &'a [u8]) -> TestNodeBuilder<'a> {
-        self.elder_age_pattern = Some(elder_age_pattern);
+    pub(crate) fn elder_age_pattern(mut self, elder_age_pattern: &[u8]) -> TestNodeBuilder {
+        self.elder_age_pattern = Some(Vec::from(elder_age_pattern));
         self
     }
 
@@ -206,13 +203,12 @@ impl<'a> TestNodeBuilder<'a> {
         } else {
             bls::SecretKeySet::random(self.section_sk_threshold, &mut rand::thread_rng())
         };
-
         let (sap, _) = TestSAP::random_sap_with_key(
             self.prefix,
             self.elder_count,
             self.adult_count,
             &section_key_set,
-            self.elder_age_pattern,
+            self.elder_age_pattern.as_ref().map(Vec::as_ref),
         );
         let genesis_key_set = if let Some(ref genesis_sk_set) = self.genesis_sk_set {
             genesis_sk_set.clone()
@@ -266,7 +262,7 @@ impl<'a> TestNodeBuilder<'a> {
                         self.elder_count,
                         self.adult_count,
                         &sk_set,
-                        self.elder_age_pattern,
+                        self.elder_age_pattern.as_ref().map(Vec::as_ref),
                     );
                     (sap, nodes, sk_set)
                 } else {
@@ -274,7 +270,7 @@ impl<'a> TestNodeBuilder<'a> {
                         self.prefix,
                         self.elder_count,
                         self.adult_count,
-                        self.elder_age_pattern,
+                        self.elder_age_pattern.as_ref().map(Vec::as_ref),
                         Some(self.section_sk_threshold),
                     )
                 };
@@ -348,8 +344,7 @@ pub(crate) fn create_section_with_elders(
     sk_set: &bls::SecretKeySet,
     sap: &SectionAuthorityProvider,
 ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
-    let (mut section, section_key_share) =
-        TestNetworkKnowledge::do_create_section(sap, sk_set, None, None)?;
+    let (mut section, section_key_share) = do_create_section(sap, sk_set, None, None)?;
     for peer in sap.elders() {
         let node_state = NodeState::joined(*peer, None);
         let node_state = TestKeys::get_section_signed(&sk_set.secret_key(), node_state);

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -19,7 +19,7 @@ use sn_interface::{
         test_utils::*, MyNodeInfo, NetworkKnowledge, NodeState, SectionAuthorityProvider,
         SectionKeyShare, SectionTree, SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
     },
-    types::{keys::ed25519, Peer, SecretKeySet},
+    types::{keys::ed25519, Peer},
 };
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
@@ -296,7 +296,7 @@ impl TestNodeBuilder {
 
 pub(crate) fn create_section_with_key(
     prefix: Prefix,
-    sk_set: &SecretKeySet,
+    sk_set: &bls::SecretKeySet,
 ) -> Result<(NetworkKnowledge, SectionAuthorityProvider)> {
     let (sap, _) = random_sap_with_key(prefix, elder_count(), 0, sk_set);
     let (section, _) = create_section(sk_set, &sap, None, None)?;
@@ -326,13 +326,13 @@ pub(crate) fn create_section(
 ///
 /// Some tests require the condition where only the elders were marked as joined members.
 pub(crate) fn create_section_with_elders(
-    sk_set: &SecretKeySet,
+    sk_set: &bls::SecretKeySet,
     sap: &SectionAuthorityProvider,
 ) -> Result<(NetworkKnowledge, SectionKeyShare)> {
     let (mut section, section_key_share) = do_create_section(sap, sk_set, None, None)?;
     for peer in sap.elders() {
         let node_state = NodeState::joined(*peer, None);
-        let node_state = section_signed(sk_set.secret_key(), node_state);
+        let node_state = section_signed(&sk_set.secret_key(), node_state);
         let _updated = section.update_member(node_state);
     }
     Ok((section, section_key_share))

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -436,14 +436,15 @@ mod tests {
     };
     use crate::UsedSpace;
     use sn_interface::{
-        messaging::system::SectionSigned, network_knowledge::SectionAuthorityProvider,
+        messaging::{system::SectionSigned, MsgKind},
+        network_knowledge::SectionAuthorityProvider,
     };
 
     use sn_interface::{
         elder_count,
-        messaging::{Dst, MsgId, MsgKind},
+        messaging::{Dst, MsgId},
         network_knowledge::{MyNodeInfo, SectionKeyShare, SectionKeysProvider, SectionsDAG},
-        test_utils::{gen_addr, section_signed, TestSAP},
+        test_utils::{gen_addr, TestKeys, TestSAP},
         types::keys::ed25519,
     };
 
@@ -649,7 +650,7 @@ mod tests {
                 TestSAP::random_sap(prefix0, elder_count(), 0, None);
             let info = nodes.remove(0);
             let sap_sk = secret_key_set.secret_key();
-            let signed_sap = section_signed(&sap_sk, sap);
+            let signed_sap = TestKeys::get_section_signed(&sap_sk, sap);
 
             let (proof_chain, genesis_sk_set) = create_proof_chain(signed_sap.section_key())
                 .context("failed to create section chain")?;
@@ -683,12 +684,11 @@ mod tests {
             let (other_sap, _, secret_key_set) =
                 TestSAP::random_sap(prefix1, elder_count(), 0, None);
             let other_sap_sk = secret_key_set.secret_key();
-            let other_sap = section_signed(&other_sap_sk, other_sap);
+            let other_sap = TestKeys::get_section_signed(&other_sap_sk, other_sap);
             // generate a proof chain for this other SAP
             let mut proof_chain = SectionsDAG::new(genesis_pk);
-            let signature = bincode::serialize(&other_sap_sk.public_key())
-                .map(|bytes| genesis_sk_set.secret_key().sign(&bytes))?;
-            proof_chain.insert(&genesis_pk, other_sap_sk.public_key(), signature)?;
+            let sig = TestKeys::sign(&genesis_sk_set.secret_key(), &other_sap_sk.public_key());
+            proof_chain.insert(&genesis_pk, other_sap_sk.public_key(), sig)?;
 
             Ok(Self {
                 node,
@@ -738,15 +738,11 @@ mod tests {
         // insert random second section key
         let second_sk_set = bls::SecretKeySet::random(0, &mut rand::thread_rng());
         let second_pk = second_sk_set.public_keys().public_key();
-        let sig = genesis_sk_set
-            .secret_key()
-            .sign(&bincode::serialize(&second_pk)?);
+        let sig = TestKeys::sign(&genesis_sk_set.secret_key(), &second_pk);
         proof_chain.insert(&genesis_pk, second_pk, sig)?;
 
         // insert third key which is provided `last_key`
-        let last_sig = second_sk_set
-            .secret_key()
-            .sign(&bincode::serialize(&last_key)?);
+        let last_sig = TestKeys::sign(&second_sk_set.secret_key(), &last_key);
         proof_chain.insert(&second_pk, last_key, last_sig)?;
 
         Ok((proof_chain, genesis_sk_set))

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -647,7 +647,7 @@ mod tests {
 
             // generate a SAP for prefix0
             let (sap, mut nodes, secret_key_set) =
-                TestSAP::random_sap(prefix0, elder_count(), 0, None);
+                TestSAP::random_sap(prefix0, elder_count(), 0, None, None);
             let info = nodes.remove(0);
             let sap_sk = secret_key_set.secret_key();
             let signed_sap = TestKeys::get_section_signed(&sap_sk, sap);
@@ -682,7 +682,7 @@ mod tests {
 
             // generate other SAP for prefix1
             let (other_sap, _, secret_key_set) =
-                TestSAP::random_sap(prefix1, elder_count(), 0, None);
+                TestSAP::random_sap(prefix1, elder_count(), 0, None, None);
             let other_sap_sk = secret_key_set.secret_key();
             let other_sap = TestKeys::get_section_signed(&other_sap_sk, other_sap);
             // generate a proof chain for this other SAP

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -442,10 +442,8 @@ mod tests {
     use sn_interface::{
         elder_count,
         messaging::{Dst, MsgId, MsgKind},
-        network_knowledge::{
-            test_utils::{gen_addr, random_sap, section_signed},
-            MyNodeInfo, SectionKeyShare, SectionKeysProvider, SectionsDAG,
-        },
+        network_knowledge::{MyNodeInfo, SectionKeyShare, SectionKeysProvider, SectionsDAG},
+        test_utils::{gen_addr, section_signed, TestSAP},
         types::keys::ed25519,
     };
 
@@ -647,7 +645,8 @@ mod tests {
             let prefix1 = Prefix::default().pushed(true);
 
             // generate a SAP for prefix0
-            let (sap, mut nodes, secret_key_set) = random_sap(prefix0, elder_count(), 0, None);
+            let (sap, mut nodes, secret_key_set) =
+                TestSAP::random_sap(prefix0, elder_count(), 0, None);
             let info = nodes.remove(0);
             let sap_sk = secret_key_set.secret_key();
             let signed_sap = section_signed(&sap_sk, sap);
@@ -681,7 +680,8 @@ mod tests {
             let _ = node.update_network_knowledge(section_tree_update, None)?;
 
             // generate other SAP for prefix1
-            let (other_sap, _, secret_key_set) = random_sap(prefix1, elder_count(), 0, None);
+            let (other_sap, _, secret_key_set) =
+                TestSAP::random_sap(prefix1, elder_count(), 0, None);
             let other_sap_sk = secret_key_set.secret_key();
             let other_sap = section_signed(&other_sap_sk, other_sap);
             // generate a proof chain for this other SAP

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn serialize_for_signing() -> Result<()> {
         // Proposal::SectionInfo
-        let (section_auth, _, _) = TestSAP::random_sap(Prefix::default(), 4, 0, None);
+        let (section_auth, _, _) = TestSAP::random_sap(Prefix::default(), 4, 0, None, None);
         let proposal = Proposal::SectionInfo(section_auth.clone());
         verify_serialize_for_signing(&proposal, &section_auth)?;
 

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -62,7 +62,7 @@ impl Proposal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sn_interface::network_knowledge::test_utils::random_sap;
+    use sn_interface::test_utils::TestSAP;
 
     use eyre::Result;
     use serde::Serialize;
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn serialize_for_signing() -> Result<()> {
         // Proposal::SectionInfo
-        let (section_auth, _, _) = random_sap(Prefix::default(), 4, 0, None);
+        let (section_auth, _, _) = TestSAP::random_sap(Prefix::default(), 4, 0, None);
         let proposal = Proposal::SectionInfo(section_auth.clone());
         verify_serialize_for_signing(&proposal, &section_auth)?;
 

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -62,7 +62,7 @@ impl Proposal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sn_interface::test_utils::TestSAP;
+    use sn_interface::test_utils::{TestKeys, TestSAP};
 
     use eyre::Result;
     use serde::Serialize;
@@ -79,8 +79,7 @@ mod tests {
         // Proposal::NewElders
         let new_sk = bls::SecretKey::random();
         let new_pk = new_sk.public_key();
-        let section_signed_auth =
-            sn_interface::network_knowledge::test_utils::section_signed(&new_sk, section_auth);
+        let section_signed_auth = TestKeys::get_section_signed(&new_sk, section_auth);
         let proposal = Proposal::NewElders(section_signed_auth);
         verify_serialize_for_signing(&proposal, &new_pk)?;
 

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -127,13 +127,13 @@ mod tests {
             test_utils::section_signed, SectionAuthorityProvider, SectionTreeUpdate, SectionsDAG,
             MIN_ADULT_AGE,
         },
-        types::{Peer, SecretKeySet},
+        types::Peer,
     };
 
     use eyre::Result;
     use itertools::Itertools;
     use proptest::{collection::SizeRange, prelude::*};
-    use rand::{rngs::SmallRng, Rng, SeedableRng};
+    use rand::{rngs::SmallRng, thread_rng, Rng, SeedableRng};
     use sn_interface::network_knowledge::SectionTree;
     use std::net::SocketAddr;
     use xor_name::{Prefix, XOR_NAME_LEN};
@@ -164,7 +164,7 @@ mod tests {
     }
 
     fn proptest_actions_impl(peers: Vec<Peer>, signature_trailing_zeros: u8) -> Result<()> {
-        let sk_set = SecretKeySet::random(None);
+        let sk_set = bls::SecretKeySet::random(0, &mut thread_rng());
         let sk = sk_set.secret_key();
         let genesis_pk = sk.public_key();
 
@@ -183,7 +183,7 @@ mod tests {
             0,
         );
         let section_tree_update = {
-            let signed_sap = section_signed(sk, section_auth);
+            let signed_sap = section_signed(&sk, section_auth);
             SectionTreeUpdate::new(signed_sap, SectionsDAG::new(genesis_pk))
         };
 
@@ -192,7 +192,7 @@ mod tests {
 
         for peer in &peers {
             let info = NodeState::joined(*peer, None);
-            let info = section_signed(sk, info);
+            let info = section_signed(&sk, info);
 
             assert!(network_knowledge.update_member(info));
         }

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -124,9 +124,9 @@ mod tests {
     use sn_interface::{
         elder_count,
         network_knowledge::{
-            test_utils::section_signed, SectionAuthorityProvider, SectionTreeUpdate, SectionsDAG,
-            MIN_ADULT_AGE,
+            SectionAuthorityProvider, SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
         },
+        test_utils::TestKeys,
         types::Peer,
     };
 
@@ -183,7 +183,7 @@ mod tests {
             0,
         );
         let section_tree_update = {
-            let signed_sap = section_signed(&sk, section_auth);
+            let signed_sap = TestKeys::get_section_signed(&sk, section_auth);
             SectionTreeUpdate::new(signed_sap, SectionsDAG::new(genesis_pk))
         };
 
@@ -192,7 +192,7 @@ mod tests {
 
         for peer in &peers {
             let info = NodeState::joined(*peer, None);
-            let info = section_signed(&sk, info);
+            let info = TestKeys::get_section_signed(&sk, info);
 
             assert!(network_knowledge.update_member(info));
         }

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -246,17 +246,18 @@ fn list_files_in(path: &Path) -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{DataStorage, Error, UsedSpace};
-
     use sn_interface::{
         init_logger,
         messaging::{
             data::{CreateRegister, DataQueryVariant, SignedRegisterCreate},
             system::NodeQueryResponse,
         },
+        test_utils::TestKeys,
         types::{
             register::{Policy, User},
             utils::random_bytes,
             Chunk, ChunkAddress, DataAddress, Keypair, PublicKey, RegisterCmd, ReplicatedData,
+            SectionSig,
         },
     };
 
@@ -360,16 +361,9 @@ mod tests {
         Ok(())
     }
 
-    use sn_interface::messaging::system::SectionSig;
     fn section_sig() -> SectionSig {
         let sk = bls::SecretKey::random();
-        let public_key = sk.public_key();
-        let data = "hello".to_string();
-        let signature = sk.sign(&data);
-        SectionSig {
-            public_key,
-            signature,
-        }
+        TestKeys::get_section_sig_bytes(&sk, "hello".as_bytes())
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Removes a test utility wrapper for `bls::SecretKeySet` . It was previously wrapped because there was no way to get `SecretKey` from the set. The current version of `bls::SecretKeySet` provides a method to do so.
- Organizes test utility functions into their own structs, e.g., `TestKeys` for all the key related utils, etc,. 
- Adds an utility to get `SecretKeySet` from a list of `SecretKeyShares`
- Adds an utility to get `NodeInfo` with varying age
- Removes unused dependency from `flow_ctrl/tests/`