### PR TITLE
refactor(tests): remove some `?` noise in tests

### DIFF
--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -657,22 +657,16 @@ impl Session {
 mod tests {
     use super::*;
     use sn_interface::network_knowledge::{
-        test_utils::{random_sap, section_signed},
+        test_utils::{prefix, random_sap, section_signed},
         SectionTree,
     };
 
-    use eyre::{eyre, Result};
+    use eyre::Result;
     use qp2p::Config;
     use std::{
         net::{Ipv4Addr, SocketAddr},
         time::Duration,
     };
-    use xor_name::Prefix;
-
-    fn prefix(s: &str) -> Result<Prefix> {
-        s.parse()
-            .map_err(|err| eyre!("failed to parse Prefix '{}': {}", s, err))
-    }
 
     fn new_network_network_contacts() -> (SectionTree, bls::SecretKey, bls::PublicKey) {
         let genesis_sk = bls::SecretKey::random();
@@ -687,9 +681,9 @@ mod tests {
     async fn cmd_sent_to_all_elders() -> Result<()> {
         let elders_len = 5;
 
-        let prefix = prefix("0")?;
+        let prefix = prefix("0");
         let (section_auth, _, secret_key_set) = random_sap(prefix, elders_len, 0, None);
-        let sap0 = section_signed(&secret_key_set.secret_key(), section_auth)?;
+        let sap0 = section_signed(&secret_key_set.secret_key(), section_auth);
         let (mut network_contacts, _genesis_sk, _) = new_network_network_contacts();
         assert!(network_contacts.insert_without_chain(sap0));
 

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -649,12 +649,12 @@ mod tests {
         let (mut knowledge, _) = NetworkKnowledge::first_node(peer, sk_gen.clone())?;
 
         // section 1
-        let (sap1, _, sk_1) = random_sap(prefix("1")?, 0, 0, None);
-        let sap1 = section_signed(&sk_1.secret_key(), sap1)?;
+        let (sap1, _, sk_1) = random_sap(prefix("1"), 0, 0, None);
+        let sap1 = section_signed(&sk_1.secret_key(), sap1);
         let our_node_name_prefix_1 = sap1.prefix().name();
         let proof_chain = knowledge.section_chain();
         let section_tree_update =
-            gen_section_tree_update(&sap1, &proof_chain, &sk_gen.secret_key())?;
+            gen_section_tree_update(&sap1, &proof_chain, &sk_gen.secret_key());
         assert!(knowledge.update_knowledge_if_valid(
             section_tree_update,
             None,
@@ -663,10 +663,10 @@ mod tests {
         assert_eq!(knowledge.signed_sap, sap1);
 
         // section with different prefix (0) and our node name doesn't match
-        let (sap0, _, sk_0) = random_sap(prefix("0")?, 0, 0, None);
-        let sap0 = section_signed(&sk_0.secret_key(), sap0)?;
+        let (sap0, _, sk_0) = random_sap(prefix("0"), 0, 0, None);
+        let sap0 = section_signed(&sk_0.secret_key(), sap0);
         let section_tree_update =
-            gen_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key())?;
+            gen_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key());
         // our node is still in prefix1
         assert!(knowledge.update_knowledge_if_valid(
             section_tree_update,

--- a/sn_interface/src/network_knowledge/section_peers.rs
+++ b/sn_interface/src/network_knowledge/section_peers.rs
@@ -137,7 +137,7 @@ mod tests {
 
         // adding node set 1
         let sk_1 = SecretKeySet::random(None).secret_key().clone();
-        let nodes_1 = gen_random_signed_node_states(1, MembershipState::Left, &sk_1)?;
+        let nodes_1 = gen_random_signed_node_states(1, MembershipState::Left, &sk_1);
         nodes_1.iter().for_each(|node| {
             section_peers.update(node.clone());
         });
@@ -154,11 +154,8 @@ mod tests {
             dst_section_key: bls::SecretKey::random().public_key(),
             age: 10,
         };
-        let nodes_2 = gen_random_signed_node_states(
-            1,
-            MembershipState::Relocated(Box::new(relocate)),
-            &sk_2,
-        )?;
+        let nodes_2 =
+            gen_random_signed_node_states(1, MembershipState::Relocated(Box::new(relocate)), &sk_2);
         nodes_2.iter().for_each(|node| {
             section_peers.update(node.clone());
         });
@@ -173,7 +170,7 @@ mod tests {
 
         // adding node set 3
         let sk_3 = SecretKeySet::random(None).secret_key().clone();
-        let nodes_3 = gen_random_signed_node_states(1, MembershipState::Left, &sk_3)?;
+        let nodes_3 = gen_random_signed_node_states(1, MembershipState::Left, &sk_3);
         nodes_3.iter().for_each(|node| {
             section_peers.update(node.clone());
         });
@@ -188,7 +185,7 @@ mod tests {
 
         // adding node set 4
         let sk_4 = SecretKeySet::random(None).secret_key().clone();
-        let nodes_4 = gen_random_signed_node_states(1, MembershipState::Left, &sk_4)?;
+        let nodes_4 = gen_random_signed_node_states(1, MembershipState::Left, &sk_4);
         nodes_4.iter().for_each(|node| {
             section_peers.update(node.clone());
         });
@@ -206,7 +203,7 @@ mod tests {
         //              |
         //              -> 5
         let sk_5 = SecretKeySet::random(None).secret_key().clone();
-        let nodes_5 = gen_random_signed_node_states(1, MembershipState::Left, &sk_5)?;
+        let nodes_5 = gen_random_signed_node_states(1, MembershipState::Left, &sk_5);
         nodes_5.iter().for_each(|node| {
             section_peers.update(node.clone());
         });
@@ -223,11 +220,11 @@ mod tests {
     }
 
     #[test]
-    fn archived_members_should_not_be_moved_to_members_list() -> Result<()> {
+    fn archived_members_should_not_be_moved_to_members_list() {
         let mut rng = thread_rng();
         let mut section_peers = SectionPeers::default();
         let sk = SecretKeySet::random(None).secret_key().clone();
-        let node_left = gen_random_signed_node_states(1, MembershipState::Left, &sk)?[0].clone();
+        let node_left = gen_random_signed_node_states(1, MembershipState::Left, &sk)[0].clone();
         let relocate = RelocateDetails {
             previous_name: XorName::random(&mut rng),
             dst: XorName::random(&mut rng),
@@ -235,31 +232,30 @@ mod tests {
             age: 10,
         };
         let node_relocated =
-            gen_random_signed_node_states(1, MembershipState::Relocated(Box::new(relocate)), &sk)?
+            gen_random_signed_node_states(1, MembershipState::Relocated(Box::new(relocate)), &sk)
                 [0]
             .clone();
 
         assert!(section_peers.update(node_left.clone()));
         assert!(section_peers.update(node_relocated.clone()));
 
-        let node_left_joins = section_signed(&sk, NodeState::joined(*node_left.peer(), None))?;
+        let node_left_joins = section_signed(&sk, NodeState::joined(*node_left.peer(), None));
         let node_relocated_joins =
-            section_signed(&sk, NodeState::joined(*node_relocated.peer(), None))?;
+            section_signed(&sk, NodeState::joined(*node_relocated.peer(), None));
         assert!(!section_peers.update(node_left_joins));
         assert!(!section_peers.update(node_relocated_joins));
 
         assert_lists(section_peers.archive.values(), &[node_left, node_relocated]);
         assert!(section_peers.members().is_empty());
-        Ok(())
     }
 
     #[test]
-    fn members_should_be_archived_if_they_leave_or_relocate() -> Result<()> {
+    fn members_should_be_archived_if_they_leave_or_relocate() {
         let mut rng = thread_rng();
         let mut section_peers = SectionPeers::default();
         let sk = SecretKeySet::random(None).secret_key().clone();
 
-        let node_1 = gen_random_signed_node_states(1, MembershipState::Joined, &sk)?[0].clone();
+        let node_1 = gen_random_signed_node_states(1, MembershipState::Joined, &sk)[0].clone();
         let relocate = RelocateDetails {
             previous_name: XorName::random(&mut rng),
             dst: XorName::random(&mut rng),
@@ -267,22 +263,21 @@ mod tests {
             age: 10,
         };
         let node_2 =
-            gen_random_signed_node_states(1, MembershipState::Relocated(Box::new(relocate)), &sk)?
+            gen_random_signed_node_states(1, MembershipState::Relocated(Box::new(relocate)), &sk)
                 [0]
             .clone();
         assert!(section_peers.update(node_1.clone()));
         assert!(section_peers.update(node_2.clone()));
 
         let node_1 = NodeState::left(*node_1.peer(), Some(node_1.name()));
-        let node_1 = section_signed(&sk, node_1)?;
+        let node_1 = section_signed(&sk, node_1);
         let node_2 = NodeState::left(*node_2.peer(), Some(node_2.name()));
-        let node_2 = section_signed(&sk, node_2)?;
+        let node_2 = section_signed(&sk, node_2);
         assert!(section_peers.update(node_1.clone()));
         assert!(section_peers.update(node_2.clone()));
 
         assert!(section_peers.members().is_empty());
         assert_lists(section_peers.archive.values(), &[node_1, node_2]);
-        Ok(())
     }
 
     // Test helpers
@@ -291,7 +286,7 @@ mod tests {
         num_nodes: usize,
         membership_state: MembershipState,
         secret_key: &bls::SecretKey,
-    ) -> Result<Vec<SectionSigned<NodeState>>> {
+    ) -> Vec<SectionSigned<NodeState>> {
         let mut rng = thread_rng();
         let mut signed_node_states = Vec::new();
         for _ in 0..num_nodes {
@@ -305,9 +300,9 @@ mod tests {
                     NodeState::relocated(peer, None, (**details).clone())
                 }
             };
-            let sig = section_signed(secret_key, node_state)?;
+            let sig = section_signed(secret_key, node_state);
             signed_node_states.push(sig);
         }
-        Ok(signed_node_states)
+        signed_node_states
     }
 }

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -466,36 +466,34 @@ pub(crate) mod tests {
         sections_dag::tests::arb_sections_dag_and_proof_chains,
         test_utils::{assert_lists, gen_section_tree_update, prefix, random_sap, section_signed},
     };
-    use eyre::{Context, Result};
+    use eyre::Result;
     use proptest::{prelude::ProptestConfig, prop_assert_eq, proptest};
 
     #[test]
-    fn insert_existing_prefix() -> Result<()> {
+    fn insert_existing_prefix() {
         let (mut tree, _, _) = new_network_section_tree();
-        let p0 = prefix("0")?;
-        let (sap0, _) = gen_section_auth(p0)?;
-        let (new_sap0, _) = gen_section_auth(p0)?;
+        let p0 = prefix("0");
+        let (sap0, _) = gen_section_auth(p0);
+        let (new_sap0, _) = gen_section_auth(p0);
         assert_ne!(sap0, new_sap0);
 
         assert!(tree.insert(sap0));
         assert!(tree.insert(new_sap0.clone()));
         assert_eq!(tree.get(&p0), Some(new_sap0.value));
-
-        Ok(())
     }
 
     #[test]
-    fn insert_direct_descendants_of_existing_prefix() -> Result<()> {
+    fn insert_direct_descendants_of_existing_prefix() {
         let (mut tree, _, _) = new_network_section_tree();
-        let p0 = prefix("0")?;
-        let p00 = prefix("00")?;
-        let p01 = prefix("01")?;
+        let p0 = prefix("0");
+        let p00 = prefix("00");
+        let p01 = prefix("01");
 
-        let (sap0, _) = gen_section_auth(p0)?;
+        let (sap0, _) = gen_section_auth(p0);
         assert!(tree.insert(sap0));
 
         // Insert the first sibling. Parent get pruned in the map.
-        let (sap00, _) = gen_section_auth(p00)?;
+        let (sap00, _) = gen_section_auth(p00);
         assert!(tree.insert(sap00.clone()));
 
         assert_eq!(tree.get(&p00), Some(sap00.value.clone()));
@@ -503,23 +501,21 @@ pub(crate) mod tests {
         assert_eq!(tree.get(&p0), None);
 
         // Insert the other sibling.
-        let (sap3, _) = gen_section_auth(p01)?;
+        let (sap3, _) = gen_section_auth(p01);
         assert!(tree.insert(sap3.clone()));
 
         assert_eq!(tree.get(&p00), Some(sap00.value));
         assert_eq!(tree.get(&p01), Some(sap3.value));
         assert_eq!(tree.get(&p0), None);
-
-        Ok(())
     }
 
     #[test]
     fn return_opposite_prefix_if_none_matching() -> Result<()> {
         let (mut tree, _, _) = new_network_section_tree();
-        let p0 = prefix("0")?;
-        let p1 = prefix("1")?;
+        let p0 = prefix("0");
+        let p1 = prefix("1");
 
-        let (sap0, _) = gen_section_auth(p0)?;
+        let (sap0, _) = gen_section_auth(p0);
 
         let _changed = tree.insert(sap0.clone());
 
@@ -546,18 +542,18 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn insert_indirect_descendants_of_existing_prefix() -> Result<()> {
+    fn insert_indirect_descendants_of_existing_prefix() {
         let (mut tree, _, _) = new_network_section_tree();
-        let p0 = prefix("0")?;
-        let p000 = prefix("000")?;
-        let p001 = prefix("001")?;
-        let p00 = prefix("00")?;
-        let p01 = prefix("01")?;
+        let p0 = prefix("0");
+        let p000 = prefix("000");
+        let p001 = prefix("001");
+        let p00 = prefix("00");
+        let p01 = prefix("01");
 
-        let (sap0, _) = gen_section_auth(p0)?;
-        let (sap01, _) = gen_section_auth(p01)?;
-        let (sap000, _) = gen_section_auth(p000)?;
-        let (sap001, _) = gen_section_auth(p001)?;
+        let (sap0, _) = gen_section_auth(p0);
+        let (sap01, _) = gen_section_auth(p01);
+        let (sap000, _) = gen_section_auth(p000);
+        let (sap001, _) = gen_section_auth(p001);
 
         assert!(tree.insert(sap0));
 
@@ -581,39 +577,35 @@ pub(crate) mod tests {
         assert_eq!(tree.get(&p00), None);
         assert_eq!(tree.get(&p01), Some(sap01.value));
         assert_eq!(tree.get(&p0), None);
-
-        Ok(())
     }
 
     #[test]
-    fn insert_ancestor_of_existing_prefix() -> Result<()> {
+    fn insert_ancestor_of_existing_prefix() {
         let (mut tree, _, _) = new_network_section_tree();
-        let p0 = prefix("0")?;
-        let p00 = prefix("00")?;
+        let p0 = prefix("0");
+        let p00 = prefix("00");
 
-        let (sap0, _) = gen_section_auth(p0)?;
-        let (sap00, _) = gen_section_auth(p00)?;
+        let (sap0, _) = gen_section_auth(p0);
+        let (sap00, _) = gen_section_auth(p00);
         let _changed = tree.insert(sap00.clone());
 
         assert!(!tree.insert(sap0));
         assert_eq!(tree.get(&p0), None);
         assert_eq!(tree.get(&p00), Some(sap00.value));
-
-        Ok(())
     }
 
     #[test]
     fn get_matching() -> Result<()> {
         let (mut tree, _, _) = new_network_section_tree();
-        let p = prefix("")?;
-        let p0 = prefix("0")?;
-        let p1 = prefix("1")?;
-        let p10 = prefix("10")?;
+        let p = prefix("");
+        let p0 = prefix("0");
+        let p1 = prefix("1");
+        let p10 = prefix("10");
 
-        let (sap, _) = gen_section_auth(p)?;
-        let (sap0, _) = gen_section_auth(p0)?;
-        let (sap1, _) = gen_section_auth(p1)?;
-        let (sap10, _) = gen_section_auth(p10)?;
+        let (sap, _) = gen_section_auth(p);
+        let (sap0, _) = gen_section_auth(p0);
+        let (sap1, _) = gen_section_auth(p1);
+        let (sap10, _) = gen_section_auth(p10);
 
         let _changed = tree.insert(sap.clone());
 
@@ -639,7 +631,7 @@ pub(crate) mod tests {
 
         // sap1 get pruned once sap10 inserted.
         assert_eq!(
-            tree.section_by_name(&prefix("11")?.substituted_in(xor_name::rand::random()))?,
+            tree.section_by_name(&prefix("11").substituted_in(xor_name::rand::random()))?,
             sap10.value
         );
 
@@ -654,13 +646,13 @@ pub(crate) mod tests {
     #[test]
     fn get_matching_prefix() -> Result<()> {
         let (mut tree, _, _) = new_network_section_tree();
-        let p0 = prefix("0")?;
-        let p1 = prefix("1")?;
-        let p10 = prefix("10")?;
+        let p0 = prefix("0");
+        let p1 = prefix("1");
+        let p10 = prefix("10");
 
-        let (sap0, _) = gen_section_auth(p0)?;
-        let (sap1, _) = gen_section_auth(p1)?;
-        let (sap10, _) = gen_section_auth(p10)?;
+        let (sap0, _) = gen_section_auth(p0);
+        let (sap1, _) = gen_section_auth(p1);
+        let (sap10, _) = gen_section_auth(p10);
 
         let _changed = tree.insert(sap0.clone());
         let _changed = tree.insert(sap1);
@@ -669,11 +661,11 @@ pub(crate) mod tests {
         assert_eq!(tree.section_by_prefix(&p0)?, sap0.value);
 
         // sap1 get pruned once sap10 inserted.
-        assert_eq!(tree.section_by_prefix(&prefix("11")?)?, sap10.value);
+        assert_eq!(tree.section_by_prefix(&prefix("11"))?, sap10.value);
 
         assert_eq!(tree.section_by_prefix(&p10)?, sap10.value);
 
-        assert_eq!(tree.section_by_prefix(&prefix("101")?)?, sap10.value);
+        assert_eq!(tree.section_by_prefix(&prefix("101"))?, sap10.value);
 
         Ok(())
     }
@@ -683,16 +675,16 @@ pub(crate) mod tests {
         // Create map containing sections (00), (01) and (10)
         let (mut tree, genesis_sk, genesis_pk) = new_network_section_tree();
         let dag = SectionsDAG::new(genesis_pk);
-        let p01 = prefix("01")?;
-        let p10 = prefix("10")?;
-        let p11 = prefix("11")?;
+        let p01 = prefix("01");
+        let p10 = prefix("10");
+        let p11 = prefix("11");
 
-        let (sap01, _) = gen_section_auth(p01)?;
-        let section_tree_update = gen_section_tree_update(&sap01, &dag, &genesis_sk)?;
+        let (sap01, _) = gen_section_auth(p01);
+        let section_tree_update = gen_section_tree_update(&sap01, &dag, &genesis_sk);
         assert!(tree.update(section_tree_update)?);
 
-        let (sap10, _) = gen_section_auth(p10)?;
-        let section_tree_update = gen_section_tree_update(&sap10, &dag, &genesis_sk)?;
+        let (sap10, _) = gen_section_auth(p10);
+        let section_tree_update = gen_section_tree_update(&sap10, &dag, &genesis_sk);
         assert!(tree.update(section_tree_update)?);
 
         let n01 = p01.substituted_in(xor_name::rand::random());
@@ -710,14 +702,14 @@ pub(crate) mod tests {
     fn proof_chain_should_contain_a_single_branch_during_update() -> Result<()> {
         let (mut tree, genesis_sk, _) = new_network_section_tree();
 
-        let (sap0, _) = gen_section_auth(prefix("0")?)?;
-        let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk)?;
+        let (sap0, _) = gen_section_auth(prefix("0"));
+        let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
         assert!(tree.update(tree_update)?);
 
-        let (sap1, _) = gen_section_auth(prefix("1")?)?;
+        let (sap1, _) = gen_section_auth(prefix("1"));
         // instead of constructing a proof_chain from gen -> 1; we also include the branch '0'
         // which will result in an error while updating the SectionTree
-        let tree_update = gen_section_tree_update(&sap1, tree.get_sections_dag(), &genesis_sk)?;
+        let tree_update = gen_section_tree_update(&sap1, tree.get_sections_dag(), &genesis_sk);
         assert!(matches!(
             tree.update(tree_update),
             Err(Error::MultipleBranchError)
@@ -731,8 +723,8 @@ pub(crate) mod tests {
         let (mut tree, genesis_sk, _) = new_network_section_tree();
 
         // node updated with sap0
-        let (sap0, _) = gen_section_auth(prefix("0")?)?;
-        let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk)?;
+        let (sap0, _) = gen_section_auth(prefix("0"));
+        let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
         let tree_update_same = tree_update.clone();
         assert!(tree.update(tree_update)?);
 
@@ -747,14 +739,14 @@ pub(crate) mod tests {
         let (mut tree, genesis_sk, _) = new_network_section_tree();
 
         // node updated with sap0
-        let (sap0, _) = gen_section_auth(prefix("0")?)?;
+        let (sap0, _) = gen_section_auth(prefix("0"));
         let proof_chain = tree.get_sections_dag().clone();
-        let tree_update = gen_section_tree_update(&sap0, &proof_chain, &genesis_sk)?;
+        let tree_update = gen_section_tree_update(&sap0, &proof_chain, &genesis_sk);
         assert!(tree.update(tree_update)?);
 
         // node tries to update with sap signed by same parent for the same prefix
-        let (sap0_same, _) = gen_section_auth(prefix("0")?)?;
-        let tree_update = gen_section_tree_update(&sap0_same, &proof_chain, &genesis_sk)?;
+        let (sap0_same, _) = gen_section_auth(prefix("0"));
+        let tree_update = gen_section_tree_update(&sap0_same, &proof_chain, &genesis_sk);
         assert!(matches!(
             tree.update(tree_update),
             Err(Error::UntrustedProofChain(_))
@@ -768,14 +760,14 @@ pub(crate) mod tests {
         let (mut tree, genesis_sk, _) = new_network_section_tree();
 
         // node updated with sap0
-        let (sap0, sk0) = gen_section_auth(prefix("0")?)?;
-        let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk)?;
+        let (sap0, sk0) = gen_section_auth(prefix("0"));
+        let tree_update = gen_section_tree_update(&sap0, tree.get_sections_dag(), &genesis_sk);
         let tree_update_outdated = tree_update.clone();
         assert!(tree.update(tree_update)?);
 
         // node updated with sap1 with same prefix
-        let (sap1, _) = gen_section_auth(prefix("0")?)?;
-        let tree_update = gen_section_tree_update(&sap1, tree.get_sections_dag(), &sk0)?;
+        let (sap1, _) = gen_section_auth(prefix("0"));
+        let tree_update = gen_section_tree_update(&sap1, tree.get_sections_dag(), &sk0);
         assert!(tree.update(tree_update)?);
 
         // node receives an outdated AE update for sap0
@@ -820,11 +812,10 @@ pub(crate) mod tests {
     // Test helpers
     fn gen_section_auth(
         prefix: Prefix,
-    ) -> Result<(SectionSigned<SectionAuthorityProvider>, bls::SecretKey)> {
+    ) -> (SectionSigned<SectionAuthorityProvider>, bls::SecretKey) {
         let (section_auth, _, secret_key_set) = random_sap(prefix, 5, 0, None);
-        let sap = section_signed(&secret_key_set.secret_key(), section_auth)
-            .context(format!("Failed to generate SAP for prefix {:?}", prefix))?;
-        Ok((sap, secret_key_set.secret_key()))
+        let sap = section_signed(&secret_key_set.secret_key(), section_auth);
+        (sap, secret_key_set.secret_key())
     }
 
     fn new_network_section_tree() -> (SectionTree, bls::SecretKey, BlsPublicKey) {

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -1185,7 +1185,7 @@ pub(super) mod tests {
 
         let (sap_gen, _, sk_gen) = random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None);
         let sk_gen = sk_gen.secret_key();
-        let sap_gen = section_signed(&sk_gen, sap_gen)?;
+        let sap_gen = section_signed(&sk_gen, sap_gen);
         let pk_gen = sap_gen.public_key_set().public_key();
 
         let mut dag = SectionsDAG::new(pk_gen);
@@ -1212,7 +1212,7 @@ pub(super) mod tests {
             dag: &mut SectionsDAG,
         ) -> Result<()> {
             let (sap, _, sk_set) = random_sap_with_rng(rng, prefix, 0, 0, None);
-            let sap = section_signed(&sk_set.secret_key(), sap)?;
+            let sap = section_signed(&sk_set.secret_key(), sap);
             let key = sap.public_key_set().public_key();
             let sig = sign(parent_sk, &key);
             dag.insert(&parent_sk.public_key(), sap.section_key(), sig)?;
@@ -1221,8 +1221,8 @@ pub(super) mod tests {
         }
 
         // insert prefix 0,1
-        insert(prefix("0")?, &sk_gen, &mut rng, &mut sections_map, &mut dag)?;
-        insert(prefix("1")?, &sk_gen, &mut rng, &mut sections_map, &mut dag)?;
+        insert(prefix("0"), &sk_gen, &mut rng, &mut sections_map, &mut dag)?;
+        insert(prefix("1"), &sk_gen, &mut rng, &mut sections_map, &mut dag)?;
 
         while count < n_sections {
             let leaves: Vec<_> = dag.leaf_keys().into_iter().collect();
@@ -1236,9 +1236,9 @@ pub(super) mod tests {
 
             if rng.gen_range(0..2) % 2 == 0 {
                 // Split, insert two sections; increment the prefix
-                let pref = prefix(format!("{:b}0", sap_leaf.prefix()).as_str())?;
+                let pref = prefix(format!("{:b}0", sap_leaf.prefix()).as_str());
                 insert(pref, &sk_leaf, &mut rng, &mut sections_map, &mut dag)?;
-                let pref = prefix(format!("{:b}1", sap_leaf.prefix()).as_str())?;
+                let pref = prefix(format!("{:b}1", sap_leaf.prefix()).as_str());
                 insert(pref, &sk_leaf, &mut rng, &mut sections_map, &mut dag)?;
                 count += 2;
             } else {
@@ -1254,8 +1254,8 @@ pub(super) mod tests {
             }
         }
         let map = sections_map
-            .iter()
-            .map(|(key, (_, sap))| (*key, sap.clone()))
+            .into_iter()
+            .map(|(key, (_, sap))| (key, sap))
             .collect();
         Ok((dag, map))
     }

--- a/sn_interface/src/network_knowledge/test_utils.rs
+++ b/sn_interface/src/network_knowledge/test_utils.rs
@@ -180,12 +180,10 @@ pub fn section_decision<P: Proposition>(
         1
     );
 
-    let decision = nodes[0]
+    nodes[0]
         .decision
         .clone()
-        .expect("We should have seen a decision, this is a bug");
-
-    decision
+        .expect("We should have seen a decision, this is a bug")
 }
 
 // Wrap the given payload in `SectionSigned`

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -456,7 +456,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone())?;
+        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone());
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -470,10 +470,10 @@ mod tests {
 
         let next_section_key = next_sk_set.public_keys().public_key();
         let section_tree_update = gen_section_tree_update(
-            &section_signed(&next_sk_set.secret_key(), next_sap.clone())?,
+            &section_signed(&next_sk_set.secret_key(), next_sap.clone()),
             &SectionsDAG::new(genesis_pk),
             &genesis_sk,
-        )?;
+        );
 
         // Create the task that executes the body of the test, but don't run it either.
         let others = async {
@@ -521,7 +521,7 @@ mod tests {
             // Name changed
             let new_peer = Peer::new(dst.name, node.peer().addr());
             // Send JoinResponse::Approved
-            let decision = section_decision(&next_sk_set, NodeState::joined(new_peer, None))?;
+            let decision = section_decision(&next_sk_set, NodeState::joined(new_peer, None));
             send_response(
                 &recv_tx,
                 JoinResponse::Approved {
@@ -563,7 +563,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone())?;
+        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone());
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -641,7 +641,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone())?;
+        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone());
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -718,7 +718,7 @@ mod tests {
             gen_addr(),
         );
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone())?;
+        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone());
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap));
 
@@ -776,7 +776,7 @@ mod tests {
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
-        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone())?;
+        let signed_genesis_sap = section_signed(&genesis_sk, genesis_sap.clone());
         let mut tree = SectionTree::new(genesis_pk);
         assert!(tree.insert_without_chain(signed_genesis_sap.clone()));
 
@@ -814,10 +814,10 @@ mod tests {
             let (next_sap, next_elders, next_sk_set) = random_sap(Prefix::default(), 1, 0, None);
             let next_section_key = next_sk_set.public_keys().public_key();
             let section_tree_update = gen_section_tree_update(
-                &section_signed(&next_sk_set.secret_key(), next_sap)?,
+                &section_signed(&next_sk_set.secret_key(), next_sap),
                 &SectionsDAG::new(genesis_pk),
                 &genesis_sk,
-            )?;
+            );
             let good_elders: Vec<&MyNodeInfo> =
                 next_elders.iter().take(2 * elder_count() / 3).collect_vec();
             for elder in good_elders.iter() {

--- a/sn_node/src/node/bootstrap/relocate.rs
+++ b/sn_node/src/node/bootstrap/relocate.rs
@@ -268,7 +268,7 @@ mod tests {
             gen_addr(),
         );
         let node_state = NodeState::joined(node.peer(), None);
-        let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state)?;
+        let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state);
         // to_sap
         let (to_sap, _) = generate_sap();
 
@@ -315,7 +315,7 @@ mod tests {
                 gen_addr(),
             );
             let node_state = NodeState::joined(node.peer(), None);
-            let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state)?;
+            let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state);
             // to_sap
             let (to_sap, to_sk_set) = generate_sap();
 
@@ -380,7 +380,7 @@ mod tests {
                 gen_addr(),
             );
             let node_state = NodeState::joined(node.peer(), None);
-            let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state)?;
+            let signed_node_state = section_signed(&from_sk_set.secret_key(), node_state);
             // to_sap
             let (to_sap, to_sk_set) = generate_sap();
 

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -35,7 +35,7 @@ pub(crate) async fn handle_online_cmd(
     section_auth: &SectionAuthorityProvider,
 ) -> Result<HandleOnlineStatus> {
     let node_state = NodeState::joined(*peer, None);
-    let membership_decision = section_decision(sk_set, node_state)?;
+    let membership_decision = section_decision(sk_set, node_state);
 
     let all_cmds = run_and_collect_cmds(
         Cmd::HandleMembershipDecision(membership_decision),

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -106,7 +106,7 @@ async fn membership_churn_starts_on_join_request_from_relocated_node() -> Result
                 Some(relocated_node_old_name),
                 relocate_details,
             );
-            let relocate_proof = section_signed(&sk_set.secret_key(), node_state)?;
+            let relocate_proof = section_signed(&sk_set.secret_key(), node_state);
 
             let signature_over_new_name =
                 ed25519::sign(&relocated_node.name().0, &relocated_node_old_keypair);
@@ -199,7 +199,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
                 0,
             );
             let section_tree_update = {
-                let signed_sap = section_signed(&sk_set.secret_key(), section_auth.clone())?;
+                let signed_sap = section_signed(&sk_set.secret_key(), section_auth.clone());
                 SectionTreeUpdate::new(signed_sap, section_chain)
             };
 
@@ -208,7 +208,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
 
             for peer in section_auth.elders() {
                 let node_state = NodeState::joined(*peer, None);
-                let sig = prove(&sk_set.secret_key(), &node_state)?;
+                let sig = prove(&sk_set.secret_key(), &node_state);
                 let _updated = section.update_member(SectionSigned {
                     value: node_state,
                     sig,
@@ -231,7 +231,7 @@ async fn handle_agreement_on_online_of_elder_candidate() -> Result<()> {
             let new_peer = network_utils::create_peer(MIN_ADULT_AGE + 1);
             let node_state = NodeState::joined(new_peer, Some(xor_name::rand::random()));
 
-            let membership_decision = section_decision(&sk_set, node_state.clone())?;
+            let membership_decision = section_decision(&sk_set, node_state.clone());
 
             // Force this node to join
             dispatcher
@@ -384,7 +384,7 @@ async fn handle_agreement_on_offline_of_elder() -> Result<()> {
 
             let existing_peer = network_utils::create_peer(MIN_ADULT_AGE);
             let node_state = NodeState::joined(existing_peer, None);
-            let node_state = section_signed(&sk_set.secret_key(), node_state)?;
+            let node_state = section_signed(&sk_set.secret_key(), node_state);
             let _updated = section.update_member(node_state);
 
             // Pick the elder to remove.
@@ -448,10 +448,10 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
             let pk1 = sk_set1.secret_key().public_key();
 
             let section_tree_update = gen_section_tree_update(
-                &section_signed(&sk_set1.secret_key(), old_sap.clone())?,
+                &section_signed(&sk_set1.secret_key(), old_sap.clone()),
                 &SectionsDAG::new(pk0),
                 &sk0,
-            )?;
+            );
             let network_knowledge =
                 NetworkKnowledge::new(SectionTree::new(pk0), section_tree_update)?;
 
@@ -497,10 +497,10 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
             );
             let new_section_elders: BTreeSet<_> = new_sap.names();
             let section_tree_update = gen_section_tree_update(
-                &section_signed(sk2, new_sap.clone())?,
+                &section_signed(sk2, new_sap.clone()),
                 &node.section_chain(),
                 &sk_set1.secret_key(),
-            )?;
+            );
 
             // Create the `Sync` message containing the new `Section`.
             let wire_msg = WireMsg::single_src(
@@ -659,13 +659,13 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
                 adults -= 1;
                 let non_elder_peer = network_utils::create_peer(MIN_ADULT_AGE);
                 let node_state = NodeState::joined(non_elder_peer, None);
-                let node_state = section_signed(&sk_set.secret_key(), node_state)?;
+                let node_state = section_signed(&sk_set.secret_key(), node_state);
                 assert!(section.update_member(node_state));
             }
 
             let non_elder_peer = network_utils::create_peer(MIN_ADULT_AGE - 1);
             let node_state = NodeState::joined(non_elder_peer, None);
-            let node_state = section_signed(&sk_set.secret_key(), node_state)?;
+            let node_state = section_signed(&sk_set.secret_key(), node_state);
             assert!(section.update_member(node_state));
             let node = nodes.remove(0);
             let (max_capacity, root_storage_dir) = create_test_max_capacity_and_root_storage()?;
@@ -688,7 +688,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
             };
 
             let membership_decision =
-                network_utils::create_relocation_trigger(&sk_set, relocated_peer.age())?;
+                network_utils::create_relocation_trigger(&sk_set, relocated_peer.age());
             let cmds = run_and_collect_cmds(
                 Cmd::HandleMembershipDecision(membership_decision),
                 &dispatcher,
@@ -816,7 +816,7 @@ async fn handle_elders_update() -> Result<()> {
 
         for peer in [&adult_peer, &promoted_peer] {
             let node_state = NodeState::joined(*peer, None);
-            let node_state = section_signed(sk_set0.secret_key(), node_state)?;
+            let node_state = section_signed(sk_set0.secret_key(), node_state);
             assert!(section0.update_member(node_state));
         }
 
@@ -838,7 +838,7 @@ async fn handle_elders_update() -> Result<()> {
         );
         let elder_names1: BTreeSet<_> = sap1.names();
 
-        let signed_sap1 = section_signed(sk_set1.secret_key(), sap1)?;
+        let signed_sap1 = section_signed(sk_set1.secret_key(), sap1);
         let proposal = Proposal::NewElders(signed_sap1.clone());
         let signature = sk_set0.secret_key().sign(&proposal.as_signable_bytes()?);
         let sig = SectionSig {
@@ -971,7 +971,7 @@ async fn handle_demote_during_split() -> Result<()> {
             // all peers b are added
             for peer in peers_b.iter().chain(iter::once(&peer_c)).cloned() {
                 let node_state = NodeState::joined(peer, None);
-                let node_state = section_signed(sk_set_v0.secret_key(), node_state)?;
+                let node_state = section_signed(sk_set_v0.secret_key(), node_state);
                 assert!(section.update_member(node_state));
             }
 
@@ -1030,7 +1030,7 @@ async fn handle_demote_during_split() -> Result<()> {
                 0,
             );
 
-            let signed_sap = section_signed(sk_set_v1_p0.secret_key(), section_auth)?;
+            let signed_sap = section_signed(sk_set_v1_p0.secret_key(), section_auth);
             let cmd = create_our_elders_cmd(signed_sap)?;
             let mut cmds = run_and_collect_cmds(cmd, &dispatcher).await?;
 
@@ -1043,7 +1043,7 @@ async fn handle_demote_during_split() -> Result<()> {
                 0,
             );
 
-            let signed_sap = section_signed(sk_set_v1_p1.secret_key(), section_auth)?;
+            let signed_sap = section_signed(sk_set_v1_p1.secret_key(), section_auth);
             let cmd = create_our_elders_cmd(signed_sap)?;
 
             let new_cmds = run_and_collect_cmds(cmd, &dispatcher).await?;

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -648,7 +648,7 @@ mod tests {
             let (sap, mut nodes, secret_key_set) = random_sap(prefix0, elder_count(), 0, None);
             let info = nodes.remove(0);
             let sap_sk = secret_key_set.secret_key();
-            let signed_sap = section_signed(&sap_sk, sap)?;
+            let signed_sap = section_signed(&sap_sk, sap);
 
             let (proof_chain, genesis_sk_set) = create_proof_chain(signed_sap.section_key())
                 .context("failed to create section chain")?;
@@ -681,7 +681,7 @@ mod tests {
             // generate other SAP for prefix1
             let (other_sap, _, secret_key_set) = random_sap(prefix1, elder_count(), 0, None);
             let other_sap_sk = secret_key_set.secret_key();
-            let other_sap = section_signed(&other_sap_sk, other_sap)?;
+            let other_sap = section_signed(&other_sap_sk, other_sap);
             // generate a proof chain for this other SAP
             let mut proof_chain = SectionsDAG::new(genesis_pk);
             let signature = bincode::serialize(&other_sap_sk.public_key())

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -80,7 +80,7 @@ mod tests {
         let new_sk = bls::SecretKey::random();
         let new_pk = new_sk.public_key();
         let section_signed_auth =
-            sn_interface::network_knowledge::test_utils::section_signed(&new_sk, section_auth)?;
+            sn_interface::network_knowledge::test_utils::section_signed(&new_sk, section_auth);
         let proposal = Proposal::NewElders(section_signed_auth);
         verify_serialize_for_signing(&proposal, &new_pk)?;
 

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -183,7 +183,7 @@ mod tests {
             0,
         );
         let section_tree_update = {
-            let signed_sap = section_signed(sk, section_auth)?;
+            let signed_sap = section_signed(sk, section_auth);
             SectionTreeUpdate::new(signed_sap, SectionsDAG::new(genesis_pk))
         };
 
@@ -192,7 +192,7 @@ mod tests {
 
         for peer in &peers {
             let info = NodeState::joined(*peer, None);
-            let info = section_signed(sk, info)?;
+            let info = section_signed(sk, info);
 
             assert!(network_knowledge.update_member(info));
         }


### PR DESCRIPTION
This PR makes a few test helpers panic instead of returning Result.

All the helpers changed would never return Err if the tests are written correctly, so a panic here is justified I think.

i.e. `prefix(&str)` takes a string of 0's and 1's, and returns a `Prefix`. passing anything other than 0's and 1's, i.e. `prefix("abc")` is a bad test ==> panic early.

This reduces some symbol noise in the tests, some tests are more affected than others but I think it generally reduces load when reading through.


