### PR TITLE
fix(sn_node): avoid mem size change across compiler version update

### DIFF
--- a/sn_node/src/node/cfg/config_handler.rs
+++ b/sn_node/src/node/cfg/config_handler.rs
@@ -461,11 +461,12 @@ fn project_dirs() -> Result<PathBuf> {
 }
 
 #[test]
-fn smoke() {
+fn smoke() -> Result<()> {
     // NOTE: IF this value is being changed due to a change in the config,
     // the change in config also be handled in Config::merge()
     // and in examples/config_handling.rs
-    let expected_size = 424;
+    let expected_size = 109;
 
-    assert_eq!(std::mem::size_of::<Config>(), expected_size);
+    assert_eq!(bincode::serialize(&Config::default())?.len(), expected_size);
+    Ok(())
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
