### PR TITLE
Reduce duplicate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,7 +3897,6 @@ dependencies = [
  "bincode",
  "blsttc",
  "bytes",
- "chrono",
  "clap",
  "clap_complete",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4224,7 +4224,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak",
  "tokio",
- "tokio-util 0.6.10",
+ "tokio-util 0.7.4",
  "tracing",
  "tracing-appender",
  "tracing-core",
@@ -4666,7 +4666,6 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "slab",
  "tokio",
 ]
 
@@ -4680,6 +4679,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,21 +910,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size",
- "unicode-width",
- "winapi",
-]
-
-[[package]]
-name = "console"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
@@ -933,6 +918,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "terminal_size",
+ "unicode-width",
  "winapi",
 ]
 
@@ -2172,7 +2158,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
- "console 0.15.2",
+ "console",
  "lazy_static",
  "number_prefix",
  "regex",
@@ -3942,7 +3928,7 @@ dependencies = [
  "clap_complete",
  "color-eyre",
  "comfy-table",
- "console 0.14.1",
+ "console",
  "criterion",
  "ctor",
  "dirs-next 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,13 +889,13 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "5.0.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b103d85ca6e209388771bfb7aa6b68a7aeec4afbf6f0a0264bfbf50360e5212e"
+checksum = "1090f39f45786ec6dc6286f8ea9c75d0a7ef0a0d3cda674cef0c3af7b307fbc2"
 dependencies = [
  "crossterm",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "unicode-width",
 ]
 
@@ -1075,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.23.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -1301,16 +1301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "dirs-next"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf36e65a80337bea855cd4ef9b8401ffce06a7baedf2e85ec467b1ac3f6e82b6"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
 ]
 
 [[package]]
@@ -2370,8 +2360,8 @@ dependencies = [
  "eyre",
  "grep",
  "sn_interface",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "walkdir",
 ]
 
@@ -3874,7 +3864,7 @@ dependencies = [
  "blsttc",
  "bytes",
  "color-eyre",
- "dirs-next 2.0.0",
+ "dirs-next",
  "ed25519-dalek",
  "env_logger",
  "futures",
@@ -3931,7 +3921,7 @@ dependencies = [
  "console",
  "criterion",
  "ctor",
- "dirs-next 2.0.0",
+ "dirs-next",
  "duct",
  "ed25519-dalek",
  "futures",
@@ -3979,7 +3969,7 @@ dependencies = [
  "crdts",
  "criterion",
  "custom_debug",
- "dirs-next 2.0.0",
+ "dirs-next",
  "ed25519",
  "ed25519-dalek",
  "eyre",
@@ -4004,8 +3994,8 @@ dependencies = [
  "sn_dbc",
  "sn_interface",
  "sn_launch_tool",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "tempfile",
  "termcolor",
  "thiserror",
@@ -4028,7 +4018,7 @@ dependencies = [
  "assert_fs",
  "color-eyre",
  "ctor",
- "dirs-next 2.0.0",
+ "dirs-next",
  "multibase",
  "rand 0.8.5",
  "reqwest",
@@ -4121,8 +4111,8 @@ dependencies = [
  "sn_consensus",
  "sn_dbc",
  "sn_sdkg",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -4137,13 +4127,13 @@ dependencies = [
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913e030d6cb0a1e34ab1961c1564d0e9f782aaacf7661ac8102dd570d3607cd3"
+checksum = "75b26a1d1e66d075d93e1be3d042366eb97dde9b308ad8c3263b359715487794"
 dependencies = [
  "clap",
  "color-eyre",
- "dirs-next 1.0.2",
+ "dirs-next",
  "eyre",
  "tracing",
  "tracing-subscriber",
@@ -4170,7 +4160,7 @@ dependencies = [
  "ctor",
  "custom_debug",
  "dashmap",
- "dirs-next 2.0.0",
+ "dirs-next",
  "ed25519",
  "ed25519-dalek",
  "eyre",
@@ -4203,8 +4193,8 @@ dependencies = [
  "sn_dysfunction",
  "sn_interface",
  "sn_sdkg",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "sysinfo",
  "tempfile",
  "thiserror",
@@ -4282,12 +4272,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
 name = "strum_macros"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck 0.3.3",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "rustversion",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.0",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "rustversion",
@@ -4404,7 +4413,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
- "dirs-next 2.0.0",
+ "dirs-next",
  "rustversion",
  "winapi",
 ]
@@ -4452,7 +4461,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "color-eyre",
- "dirs-next 2.0.0",
+ "dirs-next",
  "eyre",
  "sn_launch_tool",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,7 +358,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.4",
+ "itoa",
  "matchit",
  "memchr",
  "mime",
@@ -643,7 +649,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde",
 ]
 
 [[package]]
@@ -752,6 +757,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,17 +791,6 @@ checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags",
- "textwrap 0.11.0",
- "unicode-width",
 ]
 
 [[package]]
@@ -786,7 +807,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -795,7 +816,7 @@ version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
 dependencies = [
- "clap 3.2.23",
+ "clap",
 ]
 
 [[package]]
@@ -948,7 +969,7 @@ dependencies = [
  "tonic 0.8.2",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -987,15 +1008,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap",
  "criterion-plot",
- "csv",
  "futures",
  "itertools",
  "lazy_static",
@@ -1005,7 +1027,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -1015,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -1115,28 +1136,6 @@ checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr 0.2.17",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1951,7 +1950,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.4",
+ "itoa",
 ]
 
 [[package]]
@@ -2047,7 +2046,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.4",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2242,12 +2241,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
@@ -2387,22 +2380,13 @@ dependencies = [
 name = "log_cmds_inspector"
 version = "0.1.0"
 dependencies = [
- "clap 3.2.23",
+ "clap",
  "eyre",
  "grep",
  "sn_interface",
  "strum",
  "strum_macros",
  "walkdir",
-]
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -3486,7 +3470,7 @@ version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e67c3c4a88195d906d92d90fcf35902f5820d44cbaffb7535c2cf9348cf36fd"
 dependencies = [
- "clap 3.2.23",
+ "clap",
  "termion",
  "tiny-keccak",
 ]
@@ -3710,16 +3694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,7 +3710,7 @@ version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
- "itoa 1.0.4",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3767,7 +3741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.4",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3944,7 +3918,7 @@ dependencies = [
  "tiny-keccak",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
  "uhttp_uri",
  "url",
  "urlencoding",
@@ -3964,7 +3938,7 @@ dependencies = [
  "blsttc",
  "bytes",
  "chrono",
- "clap 3.2.23",
+ "clap",
  "clap_complete",
  "color-eyre",
  "comfy-table",
@@ -3999,7 +3973,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
  "url",
  "walkdir",
  "xor_name",
@@ -4015,7 +3989,7 @@ dependencies = [
  "blsttc",
  "bytes",
  "cargo-husky",
- "clap 3.2.23",
+ "clap",
  "crdts",
  "criterion",
  "custom_debug",
@@ -4053,7 +4027,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
  "uluru",
  "url",
  "walkdir",
@@ -4121,7 +4095,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
  "xor_name",
 ]
 
@@ -4169,7 +4143,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
  "uluru",
  "url",
  "xor_name",
@@ -4181,12 +4155,12 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913e030d6cb0a1e34ab1961c1564d0e9f782aaacf7661ac8102dd570d3607cd3"
 dependencies = [
- "clap 3.2.23",
+ "clap",
  "color-eyre",
  "dirs-next 1.0.2",
  "eyre",
  "tracing",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4201,7 +4175,7 @@ dependencies = [
  "bytes",
  "cargo-husky",
  "chrono",
- "clap 3.2.23",
+ "clap",
  "clap_complete",
  "color-eyre",
  "console-subscriber",
@@ -4255,7 +4229,7 @@ dependencies = [
  "tracing-appender",
  "tracing-core",
  "tracing-opentelemetry",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
  "uluru",
  "url",
  "walkdir",
@@ -4490,7 +4464,7 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 name = "testnet"
 version = "0.1.0"
 dependencies = [
- "clap 3.2.23",
+ "clap",
  "color-eyre",
  "dirs-next 2.0.0",
  "eyre",
@@ -4498,16 +4472,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.16",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4571,7 +4536,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa 1.0.4",
+ "itoa",
  "serde",
  "time-core",
  "time-macros",
@@ -4875,7 +4840,7 @@ checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
  "time 0.3.17",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4906,7 +4871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4941,7 +4906,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4956,33 +4921,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
-]
-
-[[package]]
-name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "matchers 0.1.0",
+ "matchers",
  "nu-ansi-term",
  "once_cell",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,14 +2144,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.16.2"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+checksum = "4295cbb7573c16d310e99e713cf9e75101eb190ab31fccd35f2d2691b4352b19"
 dependencies = [
  "console",
- "lazy_static",
  "number_prefix",
- "regex",
+ "portable-atomic",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2758,16 +2758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "pest"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
-dependencies = [
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +2861,12 @@ dependencies = [
  "wepoll-ffi",
  "winapi",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
 
 [[package]]
 name = "ppv-lite86"
@@ -3123,9 +3119,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
 dependencies = [
  "memchr",
 ]
@@ -3614,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "self_update"
-version = "0.28.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc3e89793fe56c82104ddc103c998e4e94713cb975202207829e61031eb4be6"
+checksum = "7e08f3ce73aed26096783c26570ba416ff8f4524c89a14bcdf068967dc80daef"
 dependencies = [
  "either",
  "flate2",
@@ -3635,21 +3631,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -4929,12 +4913,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
-
-[[package]]
 name = "uhttp_uri"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5494,13 +5472,13 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.13"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
 dependencies = [
  "byteorder",
  "crc32fast",
+ "crossbeam-utils",
  "flate2",
- "thiserror",
- "time 0.1.44",
+ "time 0.3.17",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,8 +894,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1090f39f45786ec6dc6286f8ea9c75d0a7ef0a0d3cda674cef0c3af7b307fbc2"
 dependencies = [
  "crossterm",
- "strum 0.24.1",
- "strum_macros 0.24.3",
+ "strum",
+ "strum_macros",
  "unicode-width",
 ]
 
@@ -2360,8 +2360,8 @@ dependencies = [
  "eyre",
  "grep",
  "sn_interface",
- "strum 0.23.0",
- "strum_macros 0.23.1",
+ "strum",
+ "strum_macros",
  "walkdir",
 ]
 
@@ -3994,8 +3994,8 @@ dependencies = [
  "sn_dbc",
  "sn_interface",
  "sn_launch_tool",
- "strum 0.23.0",
- "strum_macros 0.23.1",
+ "strum",
+ "strum_macros",
  "tempfile",
  "termcolor",
  "thiserror",
@@ -4111,8 +4111,8 @@ dependencies = [
  "sn_consensus",
  "sn_dbc",
  "sn_sdkg",
- "strum 0.23.0",
- "strum_macros 0.23.1",
+ "strum",
+ "strum_macros",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -4193,8 +4193,8 @@ dependencies = [
  "sn_dysfunction",
  "sn_interface",
  "sn_sdkg",
- "strum 0.23.0",
- "strum_macros 0.23.1",
+ "strum",
+ "strum_macros",
  "sysinfo",
  "tempfile",
  "thiserror",
@@ -4267,28 +4267,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
-
-[[package]]
-name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum_macros"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
- "rustversion",
- "syn 1.0.103",
-]
 
 [[package]]
 name = "strum_macros"

--- a/log_cmds_inspector/Cargo.toml
+++ b/log_cmds_inspector/Cargo.toml
@@ -24,7 +24,7 @@ name="log_cmds_inspector"
 eyre = "~0.6.5"
 grep="~0.2.8"
 clap = { version = "3.0.0", features = ["derive", "env"] }
-strum = "~0.23.0"
-strum_macros = "~0.23.1"
+strum = "0.24"
+strum_macros = "0.24"
 walkdir = "2"
 sn_interface = { path = "../sn_interface", version = "^0.15.0" }

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -20,7 +20,6 @@ ansi_term = "~0.12"
 bincode = "1.3.3"
 bls = { package = "blsttc", version = "8.0" }
 bytes = { version = "1.0.1", features = ["serde"] }
-chrono = "~0.4"
 color-eyre = "~0.6"
 comfy-table = "6.0"
 console = "0.15"

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -53,7 +53,7 @@ url = "2.2.2"
 xor_name = "~5.0.0"
 
 [dependencies.self_update]
-version = "~0.28.0"
+version = "0.32"
 default-features = false
 features = [
     "rustls",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -22,7 +22,7 @@ bls = { package = "blsttc", version = "8.0" }
 bytes = { version = "1.0.1", features = ["serde"] }
 chrono = "~0.4"
 color-eyre = "~0.6"
-comfy-table = "5.0.1"
+comfy-table = "6.0"
 console = "0.15"
 dirs-next = "2.0.0"
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
@@ -39,7 +39,7 @@ reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls
 rmp-serde = "1.0.0"
 sn_api = { path = "../sn_api", version = "^0.74.0", default-features = false, features = ["app"] }
 sn_dbc = { version = "8.1.0", features = ["serdes"] }
-sn_launch_tool = "~0.12.0"
+sn_launch_tool = "0.12"
 serde = "1.0.123"
 serde_json = "1.0.62"
 serde_yaml = "~0.8"

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -48,7 +48,7 @@ clap_complete = { version = "3.0.0" }
 tokio = { version = "1.6.0", features = ["macros"] }
 tempfile = "3.2.0"
 tracing = "~0.1.26"
-tracing-subscriber = "~0.2.15"
+tracing-subscriber = "0.3"
 url = "2.2.2"
 xor_name = "~5.0.0"
 
@@ -73,7 +73,7 @@ assert_fs = "1.0"
 ctor = "~0.1"
 duct = "~0.13"
 predicates = "2.0"
-criterion = "~0.3"
+criterion = "0.4"
 walkdir = "2.3.1"
 multibase = "~0.9.1"
 xor_name = "~5.0.0"

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -23,7 +23,7 @@ bytes = { version = "1.0.1", features = ["serde"] }
 chrono = "~0.4"
 color-eyre = "~0.6"
 comfy-table = "5.0.1"
-console = "~0.14"
+console = "0.15"
 dirs-next = "2.0.0"
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 hex = "~0.4"

--- a/sn_cli/src/main.rs
+++ b/sn_cli/src/main.rs
@@ -48,8 +48,8 @@ async fn main() -> Result<(), Report> {
         tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_thread_names(true)
-            .with_ansi(false);
-        tracing_subscriber::fmt::init();
+            .with_ansi(false)
+            .init();
     };
 
     debug!("Starting Safe CLI...");

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -90,7 +90,7 @@ features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 
 [dev-dependencies]
 clap = { version = "3.0.0", features = ["derive", "env"] }
-criterion = { version = "~0.3", features = ["async_tokio"] }
+criterion = { version = "0.4", features = ["async_tokio"] }
 eyre = "~0.6.5"
 grep="~0.2.8"
 proptest = "1.0.0"

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -72,8 +72,8 @@ serde_json = "1.0.53"
 signature = "1.1.10"
 sn_dbc = { version = "8.1.0", features = ["serdes"] }
 sn_interface = { path = "../sn_interface", version = "^0.15.0" }
-strum = "~0.23.0"
-strum_macros = "~0.23.1"
+strum = "0.24"
+strum_macros = "0.24"
 tempfile = "3.2.0"
 thiserror = "1.0.23"
 tracing = "~0.1.26"

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -49,8 +49,8 @@ signature = "1.1.10"
 sn_consensus = "3.1"
 sn_dbc = { version = "8.1.0", features = ["serdes"] }
 sn_sdkg = "3.0.0"
-strum = "~0.23.0"
-strum_macros = "~0.23.1"
+strum = "0.24"
+strum_macros = "0.24"
 tempfile = "3.2.0"
 thiserror = "1.0.23"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -106,7 +106,7 @@ assert_matches = "1.3"
 ctor = "~0.1.20"
 proptest = "1.0.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
-tokio-util = { version = "~0.6.7", features = ["time"] }
+tokio-util = { version = "~0.7", features = ["time"] }
 walkdir = "2"
 yansi = "~0.5.0"
 sn_interface = { path = "../sn_interface", version = "^0.15.0", features= ["test-utils", "proptest"] }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -75,8 +75,8 @@ serde_json = "1.0.53"
 signature = "1.1.10"
 clap = { version = "3.0.0", features = ["derive"] }
 clap_complete = { version = "3.0.0" }
-strum = "~0.23.0"
-strum_macros = "~0.23.1"
+strum = "0.24"
+strum_macros = "0.24"
 sysinfo = "~0.23.2"
 tempfile = "3.2.0"
 thiserror = "1.0.23"

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -101,7 +101,7 @@ version = "1.17.0"
 features = ["fs", "io-util", "macros", "rt-multi-thread", "sync"]
 
 [dev-dependencies]
-criterion = { version = "~0.3", features = ["async_tokio"] }
+criterion = { version = "0.4", features = ["async_tokio"] }
 assert_matches = "1.3"
 ctor = "~0.1.20"
 proptest = "1.0.0"

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -92,7 +92,7 @@ walkdir = "2"
 xor_name = "~5.0.0"
 
 [dependencies.self_update]
-version = "~0.28.0"
+version = "0.32"
 default-features = false
 features = ["archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate", "rustls"]
 

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -21,7 +21,6 @@ use bls::PublicKey;
 use clap::Parser;
 use eyre::{eyre, Context, Error, Result};
 use futures::{
-    future,
     stream::{self, StreamExt},
     Stream,
 };
@@ -696,7 +695,6 @@ impl ChurnSchedule {
 
         // never yield again once the schedule is exhausted
         queue
-            .filter_map(|result| future::ready(result.ok()))
             .map(|expired| expired.into_inner())
             .chain(stream::pending())
     }


### PR DESCRIPTION
I noticed quite a few duplicated dependencies being pulled in i.e. `dirs-next = 0.1` and `dirs-next = 0.2`. You can see the full list with `cargo tree -d`.

With this PR, we consolidate quite a few dependencies which should net us a small improvement in compilation time.

A weak measure of how much duplication there is in our dependencies can be gotten by counting number of lines produced by  `cargo tree -d`
```bash
# On main
$ cargo tree -d | wc -l
800
```
```bash
# On this branch
$ cargo tree -d | wc -l
720
```