### PR TITLE
refactor(client): remove client internal channels from within Session mod

### DIFF
--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -6,13 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{messaging::NUM_OF_ELDERS_SUBSET_FOR_QUERIES, MsgResponse, Session};
+use super::{MsgResponse, Session};
 
 use crate::{Error, Result};
 
 use qp2p::{RecvStream, UsrMsgBytes};
 use sn_interface::{
-    at_least_one_correct_elder,
     messaging::{
         data::ClientMsg,
         system::{AntiEntropyKind, NodeMsg},
@@ -24,16 +23,19 @@ use sn_interface::{
 
 use itertools::Itertools;
 use rand::{rngs::OsRng, seq::SliceRandom};
-use std::net::SocketAddr;
-use tokio::sync::mpsc;
-use tracing::Instrument;
 use xor_name::XorName;
+
+// Maximum number of times we'll re-send a msg upon receiving an AE response for it
+const MAX_AE_RETRIES_TO_ATTEMPT: u8 = 5;
+
+struct MsgResent {
+    new_peer: Peer,
+    new_recv_stream: RecvStream,
+}
 
 impl Session {
     #[instrument(skip_all, level = "debug")]
-    pub(crate) async fn read_msg_from_recvstream(
-        recv_stream: &mut RecvStream,
-    ) -> Result<MsgType, Error> {
+    async fn read_msg_from_recvstream(recv_stream: &mut RecvStream) -> Result<MsgType, Error> {
         let bytes = recv_stream.next().await?;
         let wire_msg = WireMsg::from(bytes)?;
         let msg_type = wire_msg.into_msg()?;
@@ -41,123 +43,102 @@ impl Session {
         Ok(msg_type)
     }
 
-    // Spawn a task to wait for a single msg incoming on the provided RecvStream
+    // Wait for a msg response incoming on the provided RecvStream
     #[instrument(skip_all, level = "debug")]
-    pub(crate) fn spawn_recv_stream_listener(
-        mut session: Self,
-        msg_id: MsgId,
-        peer: Peer,
+    pub(crate) async fn recv_stream_listener(
+        &self,
+        correlation_id: MsgId,
+        mut peer: Peer,
         peer_index: usize,
         mut recv_stream: RecvStream,
-        resp_tx: mpsc::Sender<MsgResponse>,
-    ) {
-        let addr = peer.addr();
-        let stream_id = recv_stream.id();
-        debug!("Waiting for response msg on {stream_id} from {peer:?} for {msg_id:?}");
-
-        let _handle = tokio::spawn(async move {
-            match Self::read_msg_from_recvstream(&mut recv_stream).await {
-                Ok(MsgType::Client { msg_id, msg, .. }) => {
-                    Self::handle_client_msg(msg_id, msg, peer.addr(), resp_tx).await;
-                }
-                Ok(MsgType::Node { msg, .. }) => {
-                    debug!("AE msg received for {msg_id:?}");
-                    if let Err(err) = session
-                        .handle_system_msg(msg, peer, peer_index, resp_tx)
-                        .await
-                    {
-                        error!(
-                            "Error while handling incoming system msg on {stream_id} \
-                            from {addr:?} for {msg_id:?}: {err:?}"
-                        );
-                    }
-                }
-                Err(error) => {
-                    error!(
-                        "Error while processing incoming msg on {stream_id} \
-                        from {addr:?} in response to {msg_id:?}: {error:?}"
-                    );
-                }
+    ) -> MsgResponse {
+        // Unless we receive AntiEntropy responses, which require re-sending the
+        // message, the first msg received is the response we expect and return
+        let mut attempt = 0;
+        let result = loop {
+            let addr = peer.addr();
+            if attempt > MAX_AE_RETRIES_TO_ATTEMPT {
+                break MsgResponse::Failure(
+                    addr,
+                    Error::AntiEntropyMaxRetries {
+                        msg_id: correlation_id,
+                        retries: attempt - 1,
+                    },
+                );
             }
 
-            // TODO: ???? once we drop the stream, do we know the connection is closed ???
-            trace!("{} to {}", LogMarker::StreamClosed, addr);
-        })
-        .in_current_span();
+            let stream_id = recv_stream.id();
+            debug!("Waiting for response msg on {stream_id} from {peer:?} for {correlation_id:?}, attempt #{attempt}");
+
+            match Self::read_msg_from_recvstream(&mut recv_stream).await {
+                Ok(MsgType::Client { msg_id, msg, .. }) => {
+                    break Self::handle_client_msg(msg_id, msg, peer, correlation_id).await;
+                }
+                Ok(MsgType::Node { msg_id, msg, .. }) => match self
+                    .handle_system_msg(msg_id, msg, peer, peer_index, correlation_id)
+                    .await
+                {
+                    Ok(MsgResent {
+                        new_peer,
+                        new_recv_stream,
+                    }) => {
+                        recv_stream = new_recv_stream;
+                        trace!("{} to {}", LogMarker::StreamClosed, addr);
+                        peer = new_peer;
+                        attempt += 1;
+                        continue;
+                    }
+                    Err(err) => break MsgResponse::Failure(addr, err),
+                },
+                Err(err) => break MsgResponse::Failure(addr, err),
+            }
+        };
+
+        trace!("{} to {}", LogMarker::StreamClosed, peer.addr());
+        result
     }
 
     async fn handle_system_msg(
-        &mut self,
+        &self,
+        msg_id: MsgId,
         msg: NodeMsg,
         src_peer: Peer,
-        peer_index: usize,
-        resp_tx: mpsc::Sender<MsgResponse>,
-    ) -> Result<(), Error> {
+        src_peer_index: usize,
+        correlation_id: MsgId,
+    ) -> Result<MsgResent> {
         match msg {
             NodeMsg::AntiEntropy {
                 section_tree_update,
                 kind:
                     AntiEntropyKind::Redirect { bounced_msg } | AntiEntropyKind::Retry { bounced_msg },
             } => {
-                debug!("AE-Redirect/Retry msg received");
-                let result = self
-                    .handle_ae_msg(
-                        section_tree_update,
-                        bounced_msg,
-                        src_peer,
-                        peer_index,
-                        resp_tx,
-                    )
-                    .await;
-                if result.is_err() {
-                    error!("Failed to handle AE msg from {src_peer:?}, {result:?}");
-                }
-                result
+                debug!("AE Redirect/Retry msg with id {msg_id:?} received for {correlation_id:?}");
+                self.handle_ae_msg(section_tree_update, bounced_msg, src_peer, src_peer_index)
+                    .await
             }
-            msg_type => {
-                warn!("Unexpected msg type received in system handler: {msg_type:?}");
-                Ok(())
+            other_msg => {
+                warn!("Unexpected NodeMsg type with id {msg_id:?} received for {correlation_id:?}: {other_msg:?}");
+                Err(Error::UnexpectedNodeMsg {
+                    msg_id: correlation_id,
+                    peer: src_peer,
+                    msg: other_msg,
+                })
             }
-        }
-    }
-
-    #[instrument(skip(resp_tx), level = "debug")]
-    async fn write_msg_response(
-        resp_tx: mpsc::Sender<MsgResponse>,
-        correlation_id: MsgId,
-        src_addr: SocketAddr,
-        msg_resp: MsgResponse,
-    ) {
-        if let Err(err) = resp_tx.send(msg_resp).await {
-            // this is not necessarily a problem, the receiver could have closed
-            // the channel if enough responses were already received
-            warn!(
-                "Error reporting from response listener, response received from {src_addr:?} for \
-                correlation_id {correlation_id:?}: {err:?}"
-            );
-        } else {
-            debug!(
-                "Response received from {src_addr:?} for correlation_id {correlation_id:?} \
-                reported from listener"
-            );
         }
     }
 
     // Handle msgs intended for client consumption (re: queries + cmds)
-    #[instrument(skip(resp_tx), level = "debug")]
+    #[instrument(level = "debug")]
     async fn handle_client_msg(
         msg_id: MsgId,
         msg: ClientMsg,
-        src_addr: SocketAddr,
-        resp_tx: mpsc::Sender<MsgResponse>,
-    ) {
+        src_peer: Peer,
+        correlation_id: MsgId,
+    ) -> MsgResponse {
+        let src_addr = src_peer.addr();
         debug!("ClientMsg with id {msg_id:?} received from {src_addr:?}",);
 
-        if resp_tx.is_closed() {
-            debug!("Resp tx is closed. Client could have received all needed responses, so we can drop anything further.");
-            return;
-        }
-        let (msg_resp, correlation_id) = match msg {
+        match msg {
             ClientMsg::QueryResponse {
                 response,
                 correlation_id,
@@ -166,9 +147,7 @@ impl Session {
                     "ClientMsg with id {msg_id:?} is QueryResponse regarding correlation_id \
                     {correlation_id:?} with response {response:?}"
                 );
-
-                let resp = MsgResponse::QueryResponse(src_addr, Box::new(response));
-                (resp, correlation_id)
+                MsgResponse::QueryResponse(src_addr, Box::new(response))
             }
             ClientMsg::CmdResponse {
                 response,
@@ -178,28 +157,31 @@ impl Session {
                     "ClientMsg with id {msg_id:?} is CmdResponse regarding correlation_id \
                     {correlation_id:?} with response {response:?}"
                 );
-                let resp = MsgResponse::CmdResponse(src_addr, Box::new(response));
-                (resp, correlation_id)
+                MsgResponse::CmdResponse(src_addr, Box::new(response))
             }
-            _ => {
-                warn!("Ignoring unexpected msg type received: {msg:?}");
-                return;
+            other_msg => {
+                warn!("Unexpected ClientMsg type received with id {msg_id:?} for {correlation_id:?}: {other_msg:?}");
+                MsgResponse::Failure(
+                    src_addr,
+                    Error::UnexpectedClientMsg {
+                        msg_id: correlation_id,
+                        peer: src_peer,
+                        msg: other_msg,
+                    },
+                )
             }
-        };
-
-        Self::write_msg_response(resp_tx, correlation_id, src_addr, msg_resp).await;
+        }
     }
 
     // Handle Anti-Entropy Redirect or Retry msgs
     #[instrument(skip_all, level = "debug")]
     async fn handle_ae_msg(
-        &mut self,
+        &self,
         section_tree_update: SectionTreeUpdate,
         bounced_msg: UsrMsgBytes,
         src_peer: Peer,
         src_peer_index: usize,
-        resp_tx: mpsc::Sender<MsgResponse>,
-    ) -> Result<(), Error> {
+    ) -> Result<MsgResent> {
         let target_sap = section_tree_update.signed_sap.value.clone();
         debug!("Received Anti-Entropy from {src_peer}, with SAP: {target_sap:?}");
 
@@ -207,50 +189,56 @@ impl Session {
         self.update_network_knowledge(section_tree_update, src_peer)
             .await;
 
-        if let Some((msg_id, elders, service_msg, dst, auth)) =
-            Self::new_target_elders(bounced_msg.clone(), &target_sap).await?
-        {
-            debug!("{msg_id:?} AE bounced msg going out again. Resending original message (sent to {src_peer:?}) to new section eldere");
+        let (msg_id, elders, service_msg, dst, auth) =
+            Self::new_target_elders(src_peer, bounced_msg.clone(), &target_sap).await?;
 
-            // The actual order of elders doesn't really matter. All that matters is we pass each AE response
-            // we get through the same hoops, to then be able to ping a new elder on a 1-1 basis for the src_peer
-            // we initially targetted.
-            let deterministic_ordering = XorName::from_content(
-                b"Arbitrary string that we use to sort new SAP elders consistently",
-            );
+        debug!("{msg_id:?} AE bounced msg going out again. Resending original message (sent to {src_peer:?}) to new section eldere");
 
-            // here we send this to only one elder for each AE message we get in. We _should_ have one per elder we sent to.
-            // deterministically sent to closest elder based upon the initial sender index
-            let ordered_elders = elders
-                .iter()
-                .sorted_by(|lhs, rhs| deterministic_ordering.cmp_distance(&lhs.name(), &rhs.name()))
-                .cloned()
-                .collect_vec();
+        // The actual order of elders doesn't really matter. All that matters is we pass each AE response
+        // we get through the same hoops, to then be able to ping a new elder on a 1-1 basis for the src_peer
+        // we initially targetted.
+        let deterministic_ordering = XorName::from_content(
+            b"Arbitrary string that we use to sort new SAP elders consistently",
+        );
 
-            let target_elder = ordered_elders.get(src_peer_index);
+        // here we send this to only one elder for each AE message we get in. We _should_ have one per elder we sent to.
+        // deterministically sent to closest elder based upon the initial sender index
+        let ordered_elders = elders
+            .iter()
+            .sorted_by(|lhs, rhs| deterministic_ordering.cmp_distance(&lhs.name(), &rhs.name()))
+            .cloned()
+            .collect_vec();
 
-            // there should always be one
-            if let Some(elder) = target_elder {
-                let payload = WireMsg::serialize_msg_payload(&service_msg)?;
-                let wire_msg =
-                    WireMsg::new_msg(msg_id, payload, MsgKind::Client(auth.into_inner()), dst);
+        let target_elder = ordered_elders.get(src_peer_index);
 
-                debug!("Resending original message on AE-Redirect with updated details. Expecting an AE-Retry next");
+        // there should always be one
+        if let Some(elder) = target_elder {
+            let payload = WireMsg::serialize_msg_payload(&service_msg)?;
+            let wire_msg =
+                WireMsg::new_msg(msg_id, payload, MsgKind::Client(auth.into_inner()), dst);
+            let bytes = wire_msg.serialize()?;
 
-                self.send_msg(vec![*elder], wire_msg, msg_id, false, resp_tx)
-                    .await?;
-            } else {
-                return Err(Error::AntiEntropyNoSapElders);
-            }
+            debug!("Resending original message {msg_id:?} received on AE Redirect/Retry with updated details.");
+
+            let link = self.peer_links.get_or_create_link(elder, false).await;
+            let new_recv_stream = link
+                .send_bi(bytes, msg_id)
+                .await
+                .map_err(|_| Error::FailedToInitateBiDiStream(msg_id))?;
+
+            Ok(MsgResent {
+                new_peer: *elder,
+                new_recv_stream,
+            })
+        } else {
+            Err(Error::AntiEntropyNoSapElders)
         }
-
-        Ok(())
     }
 
     /// Update our network knowledge making sure proof chain validates the
     /// new SAP based on currently known remote section SAP or genesis key.
     async fn update_network_knowledge(
-        &mut self,
+        &self,
         section_tree_update: SectionTreeUpdate,
         src_peer: Peer,
     ) {
@@ -258,7 +246,7 @@ impl Session {
         let sap = section_tree_update.signed_sap.value.clone();
         let mut network = self.network.write().await;
         debug!("Attempting to update our knowledge... WRITE LOCK GOT");
-        // Update our network PrefixMap based upon passed in knowledge
+        // Update our network SectionTree based upon passed in knowledge
         match network.update(section_tree_update) {
             Ok(true) => {
                 debug!(
@@ -290,9 +278,10 @@ impl Session {
     #[instrument(skip_all, level = "debug")]
     #[allow(clippy::type_complexity)]
     async fn new_target_elders(
+        src_peer: Peer,
         bounced_msg: UsrMsgBytes,
         received_auth: &SectionAuthorityProvider,
-    ) -> Result<Option<(MsgId, Vec<Peer>, ClientMsg, Dst, AuthorityProof<ClientAuth>)>, Error> {
+    ) -> Result<(MsgId, Vec<Peer>, ClientMsg, Dst, AuthorityProof<ClientAuth>), Error> {
         let (msg_id, service_msg, dst, auth) = match WireMsg::deserialize(bounced_msg)? {
             MsgType::Client {
                 msg_id,
@@ -300,57 +289,57 @@ impl Session {
                 auth,
                 dst,
             } => (msg_id, msg, dst, auth),
-            other => {
-                warn!("Unexpected non-ClientMsg returned in AE-Redirect response: {other:?}");
-                return Ok(None);
+            MsgType::Node { msg_id, msg, .. } => {
+                warn!("Unexpected bounced msg received in AE response: {msg:?}");
+                return Err(Error::UnexpectedNodeMsg {
+                    msg_id,
+                    peer: src_peer,
+                    msg,
+                });
             }
         };
 
-        trace!("Bounced msg ({msg_id:?}) received in an AE response: {service_msg:?}");
-
-        let (_target_count, dst_address_of_bounced_msg) = match service_msg.clone() {
-            ClientMsg::Cmd(cmd) => (at_least_one_correct_elder(), cmd.dst_name()),
-            ClientMsg::Query(query) => (NUM_OF_ELDERS_SUBSET_FOR_QUERIES, query.variant.dst_name()),
-            _ => {
+        trace!("Bounced msg {msg_id:?} received in an AE response: {service_msg:?}");
+        let dst_address_of_bounced_msg = match service_msg.clone() {
+            ClientMsg::Cmd(cmd) => cmd.dst_name(),
+            ClientMsg::Query(query) => query.variant.dst_name(),
+            msg => {
                 warn!(
-                    "Invalid bounced msg {msg_id:?} received in AE response: {service_msg:?}. Msg is of invalid type"
+                    "Invalid type of bounced msg {msg_id:?} received in AE response: {service_msg:?}"
                 );
-                // Early return with random name as we will discard the msg at the caller func
-                return Ok(None);
+                return Err(Error::UnexpectedClientMsg {
+                    msg_id,
+                    peer: src_peer,
+                    msg,
+                });
             }
         };
 
-        let target_public_key;
+        let target_public_key = received_auth.section_key();
 
         // We normally have received auth when we're in AE-Redirect
-        let mut target_elders: Vec<_> = {
-            target_public_key = received_auth.section_key();
+        let mut target_elders: Vec<_> = received_auth
+            .elders_vec()
+            .into_iter()
+            .sorted_by(|lhs, rhs| dst_address_of_bounced_msg.cmp_distance(&lhs.name(), &rhs.name()))
+            .collect();
 
-            received_auth
-                .elders_vec()
-                .into_iter()
-                .sorted_by(|lhs, rhs| {
-                    dst_address_of_bounced_msg.cmp_distance(&lhs.name(), &rhs.name())
-                })
-                .collect()
-        };
+        if target_elders.is_empty() {
+            Err(Error::AntiEntropyNoSapElders)
+        } else {
+            // shuffle so elders sent to is random for better availability
+            target_elders.shuffle(&mut OsRng);
 
-        // shuffle so elders sent to is random for better availability
-        target_elders.shuffle(&mut OsRng);
-
-        // Let's rebuild the msg with the updated destination details
-        let dst = Dst {
-            name: dst.name,
-            section_key: target_public_key,
-        };
-
-        if !target_elders.is_empty() {
+            // Let's rebuild the msg with the updated destination details
+            let dst = Dst {
+                name: dst.name,
+                section_key: target_public_key,
+            };
             debug!(
                 "Final target elders for resending {msg_id:?}: {service_msg:?} msg \
                 are {target_elders:?}"
             );
+            Ok((msg_id, target_elders, service_msg, dst, auth))
         }
-
-        Ok(Some((msg_id, target_elders, service_msg, dst, auth)))
     }
 }

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -9,7 +9,7 @@
 mod listeners;
 mod messaging;
 
-use crate::Result;
+use crate::{Error, Result};
 use sn_interface::{
     messaging::data::{CmdResponse, QueryResponse},
     network_knowledge::SectionTree,
@@ -26,6 +26,7 @@ use tokio::sync::RwLock;
 pub(super) enum MsgResponse {
     CmdResponse(SocketAddr, Box<CmdResponse>),
     QueryResponse(SocketAddr, Box<QueryResponse>),
+    Failure(SocketAddr, Error),
 }
 
 #[derive(Debug)]

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -8,7 +8,8 @@
 
 use sn_interface::{
     messaging::{
-        data::{DataQueryVariant, Error as ErrorMsg, QueryResponse},
+        data::{ClientMsg, DataQueryVariant, Error as ErrorMsg, QueryResponse},
+        system::NodeMsg,
         Error as MessagingError, MsgId,
     },
     types::{Error as DtError, Peer},
@@ -31,6 +32,17 @@ pub enum Error {
     /// No elder was found to be closest from provided SAP. (The sap must therefore be empty)
     #[error("No elders found in AntiEntropy msg SAP")]
     AntiEntropyNoSapElders,
+    /// Maximum number of retries upon AntiEntropy responses was reached
+    #[error(
+        "Maximum number of retries upon AntiEntropy responses was reached. \
+        Message {msg_id:?} was re-sent {retries} times due to AE responses."
+    )]
+    AntiEntropyMaxRetries {
+        /// Id of the cmd message sent
+        msg_id: MsgId,
+        /// Number of times the msg was re-sent
+        retries: u8,
+    },
     /// Failed to obtain network contacts to bootstrap to
     #[error("Failed to obtain network contacts to bootstrap to: {0}")]
     NetworkContacts(String),
@@ -132,6 +144,26 @@ pub enum Error {
         query: DataQueryVariant,
         /// Unexpected response received
         response: QueryResponse,
+    },
+    /// Unexpected NodeMsg received
+    #[error("Unexpected type of NodeMsg received from {peer} in response to {msg_id:?}. Received: {msg:?}")]
+    UnexpectedNodeMsg {
+        /// MsgId of the msg sent
+        msg_id: MsgId,
+        /// Peer the unexpected msg was received from
+        peer: Peer,
+        /// Unexpected msg received
+        msg: NodeMsg,
+    },
+    /// Unexpected ClientMsg received
+    #[error("Unexpected type of ClientMsg received from {peer} in response to {msg_id:?}. Received: {msg:?}")]
+    UnexpectedClientMsg {
+        /// MsgId of the msg sent
+        msg_id: MsgId,
+        /// Peer the unexpected msg was received from
+        peer: Peer,
+        /// Unexpected msg received
+        msg: ClientMsg,
     },
     /// Other types errors
     #[error(transparent)]


### PR DESCRIPTION
- Also additional errors are defined now for the responses listener to report any type of failure so they are not considered as a lack of response.
- Setting a limit to the number of retries upon AntiEntropy responses received for a msg.