### PR TITLE
chore(node): Pass around MyNodeState to avoid holding locks

### DIFF
--- a/.github/workflows/run_pr_checks.yml
+++ b/.github/workflows/run_pr_checks.yml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Run client tests
         env:
-          RUST_LOG: "sn_client=trace,qp2p=debug"
+          RUST_LOG: "sn_client,sn_interface"
         run: cd sn_client && cargo test --release --features check-replicas -- --test-threads=1
         timeout-minutes: 50
 
@@ -454,7 +454,7 @@ jobs:
         run: ./target/release/testnet --interval 30000
         id: section-startup
         env:
-          RUST_LOG: "sn_node,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
+          RUST_LOG: "sn_node,sn_consensus,sn_dysfunction,sn_interface"
 
       - name: Wait for all nodes to join
         shell: bash
@@ -467,7 +467,7 @@ jobs:
 
       - name: Run API tests
         env:
-          RUST_LOG: "sn_client=trace"
+          RUST_LOG: "sn_client,sn_interface"
         run: cd sn_api && cargo test --release --features check-replicas -- --test-threads=1
         timeout-minutes: 30
 
@@ -558,7 +558,7 @@ jobs:
         run: ./target/release/testnet --interval 30000
         id: section-startup
         env:
-          RUST_LOG: "sn_node,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
+          RUST_LOG: "sn_node,sn_consensus,sn_dysfunction,sn_interface"
 
       - name: Wait for all nodes to join
         shell: bash

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -645,7 +645,6 @@ mod tests {
         store_and_read(&client, 20 * 1024 * 1024).await;
     }
 
-    #[ignore = "too hectic for CI so far"]
     #[tokio::test(flavor = "multi_thread")]
     async fn store_and_read_40mb() {
         init_logger();

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -646,6 +646,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "too heavy for CI"]
     async fn store_and_read_40mb() {
         init_logger();
         let _outer_span = tracing::info_span!("store_and_read_40mb").entered();

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -70,7 +70,7 @@ impl Session {
             }
 
             let stream_id = recv_stream.id();
-            debug!("Waiting for response msg on {stream_id} from {peer:?} for {correlation_id:?}, attempt #{attempt}");
+            debug!("Waiting for response msg on {stream_id} from {peer:?} @ index: {peer_index} for {correlation_id:?}, attempt #{attempt}");
 
             match Self::read_msg_from_recvstream(&mut recv_stream).await {
                 Ok(MsgType::ClientMsgResponse { msg_id, msg, .. }) => {
@@ -125,7 +125,7 @@ impl Session {
                 kind:
                     AntiEntropyKind::Redirect { bounced_msg } | AntiEntropyKind::Retry { bounced_msg },
             } => {
-                debug!("AE Redirect/Retry msg with id {msg_id:?} received for {correlation_id:?}");
+                debug!("AE Redirect/Retry msg with id {msg_id:?} received for {correlation_id:?} from {src_peer:?}@{src_peer_index:?}");
                 self.handle_ae_msg(
                     section_tree_update,
                     bounced_msg,
@@ -192,7 +192,7 @@ impl Session {
         correlation_id: MsgId,
     ) -> Result<MsgResent> {
         let target_sap = section_tree_update.signed_sap.value.clone();
-        debug!("Received Anti-Entropy from {src_peer}, with SAP: {target_sap:?}");
+        debug!("Received Anti-Entropy from {src_peer} (index:{src_peer_index:?}), with SAP: {target_sap:?}");
 
         // Try to update our network knowledge first
         self.update_network_knowledge(section_tree_update, src_peer)
@@ -201,8 +201,6 @@ impl Session {
         let (msg_id, elders, service_msg, dst, auth) =
             Self::new_target_elders(src_peer, bounced_msg.clone(), &target_sap, correlation_id)
                 .await?;
-
-        debug!("{msg_id:?} AE bounced msg going out again. Resending original message (sent to {src_peer:?}) to new section eldere");
 
         // The actual order of elders doesn't really matter. All that matters is we pass each AE response
         // we get through the same hoops, to then be able to ping a new elder on a 1-1 basis for the src_peer
@@ -228,7 +226,7 @@ impl Session {
                 WireMsg::new_msg(msg_id, payload, MsgKind::Client(auth.into_inner()), dst);
             let bytes = wire_msg.serialize()?;
 
-            debug!("Resending original message {msg_id:?} received on AE Redirect/Retry with updated details.");
+            debug!("{msg_id:?} AE bounced msg going out again. Resending original message (sent to index {src_peer_index:?} peer: {src_peer:?}) to new section elder {elder:?}");
 
             let link = self.peer_links.get_or_create_link(elder, false).await;
             let new_recv_stream = link
@@ -310,7 +308,9 @@ impl Session {
             }
         };
 
-        trace!("Bounced msg {msg_id:?} received in an AE response: {service_msg:?}");
+        trace!(
+            "Bounced msg {msg_id:?} received in an AE response: {service_msg:?} from {src_peer:?}"
+        );
         let dst_address_of_bounced_msg = match service_msg.clone() {
             ClientMsg::Cmd(cmd) => cmd.dst_name(),
             ClientMsg::Query(query) => query.variant.dst_name(),

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -266,6 +266,7 @@ impl NetworkKnowledge {
         updated_members: Option<SectionPeersMsg>,
         our_name: &XorName,
     ) -> Result<bool> {
+        trace!("Attempting to update network knoweldge");
         let mut there_was_an_update = false;
         let signed_sap = section_tree_update.signed_sap.clone();
         let sap_prefix = signed_sap.prefix();

--- a/sn_node/benches/data_storage.rs
+++ b/sn_node/benches/data_storage.rs
@@ -189,7 +189,7 @@ fn bench_data_storage_reads(c: &mut Criterion) -> Result<()> {
 
     for size in &size_ranges {
         group.bench_with_input(BenchmarkId::new("chunk keys", size), size, |b, &size| {
-            let mut storage = get_new_data_store()
+            let storage = get_new_data_store()
                 .context("Could not create a temp data store")
                 .unwrap();
 

--- a/sn_node/src/comm/link.rs
+++ b/sn_node/src/comm/link.rs
@@ -183,7 +183,10 @@ impl Link {
         msg_id: MsgId,
     ) -> Result<Connection, SendToOneError> {
         if self.connections.is_empty() {
-            debug!("{msg_id:?} attempting to create a connection");
+            debug!(
+                "{msg_id:?} attempting to create a connection to {:?}",
+                self.peer
+            );
             self.create_connection(msg_id).await
         } else {
             trace!(

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -159,9 +159,8 @@ impl PeerSessionWorker {
                 SessionCmd::Send(job) => {
                     if let Some(send_stream) = job.send_stream {
                         // send response on the stream
-                        debug!("SEND STREAM EXISTSSSS");
+                        debug!("Sending on stream via PeerSessionWorker");
                         let _handle = tokio::spawn(async move {
-                            trace!("USING BIDI! OH DEAR, FASTEN SEATBELTS");
                             let stream_prio = 10;
                             let mut send_stream = send_stream.lock().await;
                             send_stream.set_priority(stream_prio);
@@ -190,7 +189,7 @@ impl PeerSessionWorker {
                         SessionStatus::Ok
                     } else {
                         //another
-                        debug!("sending fresh msg flow over a connection");
+                        debug!("Sending a fresh msg flow over a connection");
                         match self.send_over_peer_connection(job).await {
                             Ok(s) => s,
                             Err(error) => {

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -32,6 +32,8 @@ use sn_dbc::{
 use std::{path::PathBuf, sync::Arc};
 use xor_name::XorName;
 
+use super::core::MyNodeSnapshot;
+
 impl MyNode {
     pub(crate) async fn first_node(
         comm: Comm,
@@ -103,8 +105,12 @@ impl MyNode {
     }
 
     /// Returns the SAP of the section matching the name.
-    pub(crate) fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
-        self.network_knowledge
+    pub(crate) fn matching_section(
+        snapshot: &MyNodeSnapshot,
+        name: &XorName,
+    ) -> Result<SectionAuthorityProvider> {
+        snapshot
+            .network_knowledge
             .section_auth_by_name(name)
             .map_err(Error::from)
     }

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -17,8 +17,7 @@ use crate::{
 
 use sn_interface::{
     network_knowledge::{
-        MyNodeInfo, NetworkKnowledge, SectionAuthorityProvider, SectionKeyShare, SectionsDAG,
-        GENESIS_DBC_SK,
+        MyNodeInfo, NetworkKnowledge, SectionKeyShare, SectionsDAG, GENESIS_DBC_SK,
     },
     types::log_markers::LogMarker,
 };
@@ -30,9 +29,6 @@ use sn_dbc::{
     SpentProofContent, SpentProofShare, Token, TransactionBuilder, TrueInput,
 };
 use std::{path::PathBuf, sync::Arc};
-use xor_name::XorName;
-
-use super::core::MyNodeSnapshot;
 
 impl MyNode {
     pub(crate) async fn first_node(
@@ -102,17 +98,6 @@ impl MyNode {
     /// Returns the current BLS public key set
     pub(crate) fn public_key_set(&self) -> Result<bls::PublicKeySet> {
         Ok(self.key_share()?.public_key_set)
-    }
-
-    /// Returns the SAP of the section matching the name.
-    pub(crate) fn matching_section(
-        snapshot: &MyNodeSnapshot,
-        name: &XorName,
-    ) -> Result<SectionAuthorityProvider> {
-        snapshot
-            .network_knowledge
-            .section_auth_by_name(name)
-            .map_err(Error::from)
     }
 
     /// Returns our key share in the current BLS group if this node is a member of one, or

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -232,7 +232,7 @@ impl<'a> Joiner<'a> {
                     }
 
                     // make sure we received a valid and trusted new SAP
-                    let _is_new_sap = match self.section_tree.update(section_tree_update) {
+                    let is_new_sap = match self.section_tree.update(section_tree_update) {
                         Ok(updated) => updated,
                         Err(err) => {
                             debug!("Ignoring section tree updated in JoinResponse::Retry with an invalid or known SAP: {err:?}");
@@ -240,10 +240,9 @@ impl<'a> Joiner<'a> {
                         }
                     };
 
-                    let enough_responses_asking_to_retry =
-                        self.should_retry_after_response(sender, signed_sap.elders_set());
-
-                    if enough_responses_asking_to_retry {
+                    if is_new_sap
+                        || self.should_retry_after_response(sender, signed_sap.elders_set())
+                    {
                         let already_retried_for_this_sap =
                             self.retry_sap_cache.contains(&signed_sap);
 

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -6,9 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::node::core::MyNodeSnapshot;
 use crate::node::{Cmd, Error, MyNode, Prefix, Result};
 
 use bytes::Bytes;
+
 use futures::FutureExt;
 use itertools::Itertools;
 use qp2p::{SendStream, UsrMsgBytes};
@@ -35,7 +37,7 @@ const REPONSE_TIMEOUT: Duration = Duration::from_secs(7); // w/ 6s qp2p timeout,
 impl MyNode {
     // Locate ideal holders for this data, instruct them to store the data
     pub(crate) async fn replicate_data_to_adults(
-        &self,
+        snapshot: &MyNodeSnapshot,
         data: ReplicatedData,
         msg_id: MsgId,
         targets: BTreeSet<Peer>,
@@ -50,32 +52,37 @@ impl MyNode {
         // Right now we've a new msg for just one datum.
         // Atm that's perhaps more bother than its worth..
         let msg = NodeMsg::NodeCmd(NodeCmd::ReplicateOneData(data));
-
-        let (kind, payload) = self.serialize_node_msg(msg)?;
-
         let mut send_tasks = vec![];
 
+        let (kind, payload) = MyNode::serialize_node_msg(snapshot.name, msg)?;
+        let section_key = snapshot.network_knowledge.section_key();
+        let comm = snapshot.comm.clone();
+
+        debug!("replication read locks got");
+        // drop the read lock before we do anything async
+
         for target in targets {
-            let bytes_to_adult = self.form_usr_msg_bytes_to_node(
+            let bytes_to_adult = MyNode::form_usr_msg_bytes_to_node(
+                section_key,
                 payload.clone(),
                 kind.clone(),
                 Some(target),
                 msg_id,
             )?;
 
+            let comm = comm.clone();
             info!("About to send {msg_id:?} to holder: {:?}", &target,);
 
             send_tasks.push(
                 async move {
                     (
                         target,
-                        self.comm
-                            .send_out_bytes_to_peer_and_return_response(
-                                target,
-                                msg_id,
-                                bytes_to_adult.clone(),
-                            )
-                            .await,
+                        comm.send_out_bytes_to_peer_and_return_response(
+                            target,
+                            msg_id,
+                            bytes_to_adult.clone(),
+                        )
+                        .await,
                     )
                 }
                 .boxed(),
@@ -87,22 +94,16 @@ impl MyNode {
 
     // Locate ideal holders for this data, instruct them to store the data
     pub(crate) async fn replicate_data_to_adults_and_ack_to_client(
-        &self,
+        snapshot: &MyNodeSnapshot,
         cmd: DataCmd,
         data: ReplicatedData,
         msg_id: MsgId,
         targets: BTreeSet<Peer>,
         client_response_stream: Arc<Mutex<SendStream>>,
     ) -> Result<()> {
-        info!(
-            "Replicating data from client {msg_id:?} {:?} to holders {:?}",
-            data.name(),
-            &targets,
-        );
-
         let targets_len = targets.len();
 
-        let responses = self.replicate_data_to_adults(data, msg_id, targets).await?;
+        let responses = MyNode::replicate_data_to_adults(snapshot, data, msg_id, targets).await?;
         let mut success_count = 0;
         let mut ack_response = None;
         let mut last_error = None;
@@ -123,8 +124,13 @@ impl MyNode {
         // everything went fine, tell the client that
         if success_count == targets_len {
             if let Some(response) = ack_response {
-                self.send_ack_to_client_on_stream(response, msg_id, client_response_stream.clone())
-                    .await?;
+                MyNode::send_ack_to_client_on_stream(
+                    snapshot,
+                    response,
+                    msg_id,
+                    client_response_stream.clone(),
+                )
+                .await?;
             } else {
                 // This should not be possible with above checks
                 error!("No valid ack response to send from all responses for {msg_id:?}")
@@ -133,7 +139,8 @@ impl MyNode {
             error!("Storage was not completely successful for {msg_id:?}");
 
             if let Some(error) = last_error {
-                self.send_cmd_error_response_over_stream(
+                MyNode::send_cmd_error_response_over_stream(
+                    snapshot,
                     cmd,
                     error,
                     msg_id,
@@ -148,7 +155,7 @@ impl MyNode {
 
     /// Parses WireMsg and if DataStored Ack, we send a response to the client
     async fn send_ack_to_client_on_stream(
-        &self,
+        snapshot: &MyNodeSnapshot,
         response: WireMsg,
         msg_id: MsgId,
         send_stream: Arc<Mutex<SendStream>>,
@@ -163,10 +170,11 @@ impl MyNode {
                 correlation_id: msg_id,
             };
 
-            let (kind, payload) = self.serialize_client_msg_response(client_msg)?;
+            let (kind, payload) = MyNode::serialize_client_msg_response(snapshot.name, client_msg)?;
 
             debug!("{msg_id:?} sending cmd response ack back to client");
-            self.send_msg_on_stream(
+            MyNode::send_msg_on_stream(
+                snapshot.network_knowledge.section_key(),
                 payload,
                 kind,
                 send_stream,
@@ -185,7 +193,7 @@ impl MyNode {
 
     /// Find target adult, sends a bidi msg, awaiting response, and then sends this on to the client
     pub(crate) async fn read_data_from_adult_and_respond_to_client(
-        &self,
+        snapshot: MyNodeSnapshot,
         query: DataQuery,
         msg_id: MsgId,
         auth: AuthorityProof<ClientAuth>,
@@ -203,7 +211,7 @@ impl MyNode {
             operation_id
         );
 
-        let targets = self.target_data_holders_including_full(address.name());
+        let targets = MyNode::target_data_holders_including_full(&snapshot, address.name());
 
         // Query only the nth adult
         let target = if let Some(peer) = targets.iter().nth(query.adult_index) {
@@ -211,12 +219,13 @@ impl MyNode {
         } else {
             debug!("No targets found for {msg_id:?}");
             let error = Error::InsufficientAdults {
-                prefix: self.network_knowledge().prefix(),
+                prefix: snapshot.network_knowledge.prefix(),
                 expected: query.adult_index as u8 + 1,
                 found: targets.len() as u8,
             };
 
-            self.query_error_response(
+            MyNode::send_query_error_response_on_stream(
+                snapshot,
                 error,
                 &query.variant,
                 source_client,
@@ -235,24 +244,30 @@ impl MyNode {
             operation_id,
         });
 
-        let (kind, payload) = self.serialize_node_msg(msg)?;
+        let (kind, payload) = MyNode::serialize_node_msg(snapshot.name, msg)?;
 
-        let bytes_to_adult =
-            self.form_usr_msg_bytes_to_node(payload, kind, Some(target), msg_id)?;
+        let comm = snapshot.comm.clone();
+
+        let bytes_to_adult = MyNode::form_usr_msg_bytes_to_node(
+            snapshot.network_knowledge.section_key(),
+            payload,
+            kind,
+            Some(target),
+            msg_id,
+        )?;
 
         debug!("sending out {msg_id:?}");
         // TODO: how to determine this time?
         // TODO: don't use arbitrary time here. (But 3s is very realistic here under normal load)
         let response = match tokio::time::timeout(REPONSE_TIMEOUT, async {
-            self.comm
-                .send_out_bytes_to_peer_and_return_response(target, msg_id, bytes_to_adult)
+            comm.send_out_bytes_to_peer_and_return_response(target, msg_id, bytes_to_adult)
                 .await
         })
         .await
         {
             Ok(resp) => resp,
             Err(_elapsed) => {
-                error!("No response before arbitrary timeout. Marking adult as dysfunctional");
+                error!("{msg_id:?}: No response from {target:?} before arbitrary timeout. Marking adult as dysfunctional");
                 return Ok(vec![Cmd::TrackNodeIssueInDysfunction {
                     name: target.name(),
                     // TODO: no need for op id tracking here, this can be a simple counter
@@ -273,10 +288,17 @@ impl MyNode {
                 correlation_id: msg_id,
             };
 
-            let (kind, payload) = self.serialize_client_msg_response(client_msg)?;
+            let (kind, payload) = MyNode::serialize_client_msg_response(snapshot.name, client_msg)?;
 
-            self.send_msg_on_stream(payload, kind, client_response_stream, Some(target), msg_id)
-                .await?;
+            MyNode::send_msg_on_stream(
+                snapshot.network_knowledge.section_key(),
+                payload,
+                kind,
+                client_response_stream,
+                Some(target),
+                msg_id,
+            )
+            .await?;
         } else {
             error!(
                 "Unexpected reponse to query from node. To : {msg_id:?}; response: {response:?}"
@@ -289,7 +311,7 @@ impl MyNode {
 
     /// Send an OutgoingMsg on a given stream
     pub(crate) async fn send_msg_on_stream(
-        &self,
+        section_key: bls::PublicKey,
         payload: Bytes,
         kind: MsgKind,
         send_stream: Arc<Mutex<SendStream>>,
@@ -297,14 +319,20 @@ impl MyNode {
         original_msg_id: MsgId,
     ) -> Result<()> {
         // TODO why do we need dst here?
-        let bytes = self.form_usr_msg_bytes_to_node(payload, kind, target_peer, original_msg_id)?;
-        trace!("USING BIDI to send to msg {original_msg_id:?}! OH DEAR, FASTEN SEATBELTS");
+        let bytes = MyNode::form_usr_msg_bytes_to_node(
+            section_key,
+            payload,
+            kind,
+            target_peer,
+            original_msg_id,
+        )?;
+        trace!("Sending {original_msg_id:?} to recipient over stream");
         let stream_prio = 10;
         let mut send_stream = send_stream.lock().await;
 
-        debug!("stream locked for {original_msg_id:?} to {target_peer:?}");
+        trace!("Stream locked for {original_msg_id:?} to {target_peer:?}");
         send_stream.set_priority(stream_prio);
-        debug!("prio set for {original_msg_id:?} to {target_peer:?}");
+        trace!("Prio set for {original_msg_id:?} to {target_peer:?}");
         if let Err(error) = send_stream.send_user_msg(bytes).await {
             error!(
                 "Could not send query response {original_msg_id:?} to peer {target_peer:?} over response stream: {error:?}",
@@ -313,20 +341,20 @@ impl MyNode {
             return Err(Error::from(error));
         }
 
-        debug!("msg away for {original_msg_id:?} to {target_peer:?}");
+        trace!("Msg away for {original_msg_id:?} to {target_peer:?}");
         if let Err(error) = send_stream.finish().await {
             error!(
                         "Could not close response stream for {original_msg_id:?} to peer {target_peer:?}: {error:?}",
                     );
         }
 
-        debug!("sent the msg over stream {original_msg_id:?} to {target_peer:?}");
+        debug!("Sent the msg over stream {original_msg_id:?} to {target_peer:?}");
 
         Ok(())
     }
 
     pub(crate) fn form_usr_msg_bytes_to_node(
-        &self,
+        section_key: bls::PublicKey,
         payload: Bytes,
         kind: MsgKind,
         target: Option<Peer>,
@@ -336,7 +364,7 @@ impl MyNode {
         // we first generate the XorName
         let dst = Dst {
             name: dst_name,
-            section_key: self.network_knowledge().section_key(),
+            section_key,
         };
 
         #[allow(unused_mut)]
@@ -394,15 +422,14 @@ impl MyNode {
         changed
     }
 
-    pub(crate) fn full_adults(&self) -> BTreeSet<XorName> {
-        self.capacity.full_adults()
-    }
-
     /// Construct list of adults that hold target data, including full nodes.
     /// List is sorted by distance from `target`.
-    fn target_data_holders_including_full(&self, target: &XorName) -> BTreeSet<Peer> {
-        let full_adults = self.full_adults();
-        let adults = self.network_knowledge().adults();
+    fn target_data_holders_including_full(
+        snapshot: &MyNodeSnapshot,
+        target: &XorName,
+    ) -> BTreeSet<Peer> {
+        let full_adults = &snapshot.full_adults;
+        let adults = snapshot.network_knowledge.adults();
 
         let mut candidates = adults
             .clone()
@@ -453,11 +480,14 @@ impl MyNode {
     }
 
     /// Used to fetch the list of holders for given name of data. Excludes full nodes
-    pub(crate) fn target_data_holders(&self, target: XorName) -> BTreeSet<Peer> {
-        let full_adults = self.full_adults();
+    pub(crate) fn target_data_holders(
+        snapshot: &MyNodeSnapshot,
+        target: XorName,
+    ) -> BTreeSet<Peer> {
+        let full_adults = &snapshot.full_adults;
         trace!("full_adults = {}", full_adults.len());
         // TODO: reuse our_adults_sorted_by_distance_to API when core is merged into upper layer
-        let adults = self.network_knowledge().adults();
+        let adults = snapshot.network_knowledge.adults();
 
         trace!("Total adults known about: {:?}", adults.len());
 

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -47,10 +47,10 @@ impl CmdCtrl {
         node_identifier: XorName,
         cmd_process_api: tokio::sync::mpsc::Sender<(Cmd, Vec<usize>)>,
     ) {
-        trace!("about to spawn task for processing cmd: {cmd:?}, id: {id:?}");
         if id.is_empty() {
             id.push(self.id_counter.fetch_add(1, Ordering::SeqCst));
         }
+
         let dispatcher = self.dispatcher.clone();
         let _ = tokio::task::spawn(async move {
             debug!("> spawned process for cmd {cmd:?}, id: {id:?}");

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -13,7 +13,7 @@ use sn_consensus::Decision;
 use sn_dysfunction::IssueType;
 use sn_interface::{
     messaging::{
-        data::ClientMsg,
+        data::{ClientMsg, StorageLevel},
         system::{NodeMsg, SectionSig, SectionSigned},
         AuthorityProof, ClientAuth, MsgId, WireMsg,
     },
@@ -58,6 +58,8 @@ pub(crate) enum Cmd {
         wire_msg: WireMsg,
         send_stream: Option<Arc<Mutex<SendStream>>>,
     },
+    /// Update our own storage level
+    SetStorageLevel(StorageLevel),
     /// Log a Node's Punishment, this pulls dysfunction and write locks out of some functions
     TrackNodeIssueInDysfunction { name: XorName, issue: IssueType },
     HandleValidNodeMsg {
@@ -142,6 +144,7 @@ impl Cmd {
         use sn_interface::statemap::State;
         match self {
             Cmd::SendMsg { .. } => State::Comms,
+            Cmd::SetStorageLevel { .. } => State::Node,
             Cmd::HandleFailedSendToNode { .. } => State::Comms,
             Cmd::ValidateMsg { .. } => State::Validation,
             Cmd::HandleValidNodeMsg { msg, .. } => msg.statemap_states(),
@@ -160,6 +163,10 @@ impl Cmd {
 impl fmt::Display for Cmd {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(not(feature = "test-utils"))]
+            Cmd::SetStorageLevel(level) => {
+                write!(f, "SetStorageLevel {:?}", level)
+            }
             #[cfg(not(feature = "test-utils"))]
             Cmd::ValidateMsg { wire_msg, .. } => {
                 write!(f, "ValidateMsg {:?}", wire_msg.msg_id())

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -186,9 +186,8 @@ impl Dispatcher {
                 // we should queue this
                 for data in data_batch {
                     trace!("data being enqueued for replication {:?}", data);
-                    debug!("[NODE WRITE]: data for repl write...");
                     let mut node = self.node.write().await;
-                    debug!("[NODE WRITE]: data for repl write gottt...");
+                    debug!("[NODE WRITE]: data for repl write got");
                     if let Some(peers_set) = node.pending_data_to_replicate_to_peers.get_mut(&data)
                     {
                         debug!("data already queued, adding peer");
@@ -204,11 +203,17 @@ impl Dispatcher {
                 Ok(vec![])
             }
             Cmd::ProposeVoteNodesOffline(names) => {
-                debug!("[NODE WRITE]: propose offline write gottt...");
-
                 let mut node = self.node.write().await;
-                debug!("[NODE WRITE]: propose offline write gottt...");
+                debug!("[NODE WRITE]: propose offline write got");
                 node.cast_offline_proposals(&names)
+            }
+            Cmd::SetStorageLevel(new_level) => {
+                let mut node = self.node.write().await;
+                debug!("[NODE WRITE]: Setting storage level");
+
+                node.data_storage.set_storage_level(new_level);
+
+                Ok(vec![])
             }
         }
     }

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -102,29 +102,25 @@ impl Dispatcher {
             } => {
                 debug!("Updating network knowledge before handling message");
                 let mut snapshot = self.node.read().await.snapshot();
-                // block off the write lock to ensure it's dropped
-                {
-                    debug!("[NODE READ]: update client knowledge got");
+                debug!("[NODE READ]: update client knowledge got");
 
-                    let name = snapshot.name;
-                    let there_was_an_update =
-                        snapshot.network_knowledge.update_knowledge_if_valid(
-                            SectionTreeUpdate::new(signed_sap.clone(), proof_chain.clone()),
-                            None,
-                            &name,
-                        )?;
+                let name = snapshot.name;
+                let there_was_an_update = snapshot.network_knowledge.update_knowledge_if_valid(
+                    SectionTreeUpdate::new(signed_sap.clone(), proof_chain.clone()),
+                    None,
+                    &name,
+                )?;
 
-                    if there_was_an_update {
-                        // okay lets do it for real
-                        let mut node = self.node.write().await;
-                        debug!("[NODE WRITE]: update client write got");
-                        let updated = node.network_knowledge.update_knowledge_if_valid(
-                            SectionTreeUpdate::new(signed_sap, proof_chain),
-                            None,
-                            &name,
-                        )?;
-                        debug!("Network knowledge was updated: {updated}");
-                    }
+                if there_was_an_update {
+                    // okay lets do it for real
+                    let mut node = self.node.write().await;
+                    debug!("[NODE WRITE]: update client write got");
+                    let updated = node.network_knowledge.update_knowledge_if_valid(
+                        SectionTreeUpdate::new(signed_sap, proof_chain),
+                        None,
+                        &name,
+                    )?;
+                    debug!("Network knowledge was updated: {updated}");
                 }
 
                 debug!("[NODE READ]: update & validate msg lock got");

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -46,7 +46,7 @@ impl Dispatcher {
                 send_stream,
             } => {
                 trace!("Sending msg: {msg_id:?}");
-                let snapshot = self.node.read().await.get_snapshot();
+                let snapshot = self.node.read().await.snapshot();
                 debug!("[NODE READ]: send msg lock got");
 
                 let peer_msgs = {
@@ -101,7 +101,7 @@ impl Dispatcher {
                 send_stream,
             } => {
                 debug!("Updating network knowledge before handling message");
-                let mut snapshot = self.node.read().await.get_snapshot();
+                let mut snapshot = self.node.read().await.snapshot();
                 // block off the write lock to ensure it's dropped
                 {
                     debug!("[NODE READ]: update client knowledge got");

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -63,6 +63,7 @@ impl FlowCtrl {
             // this is NOT the node's current name. It's the initial name... but will not change
             // for the entire statemap
             let node_identifier = node.read().await.info().name();
+            debug!("[NODE READ]: flowctrl start msg lock got");
 
             while let Some((cmd, cmd_id)) = incoming_cmds_from_apis.recv().await {
                 cmd_ctrl

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -68,7 +68,7 @@ impl FlowCtrl {
         self.enqueue_cmds_for_standard_periodic_checks(context)
             .await;
 
-        if context.is_not_elder {
+        if !context.is_elder {
             self.enqueue_cmds_for_adult_periodic_checks(context).await;
 
             // we've pushed what we have as an adult and processed incoming msgs

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -62,7 +62,7 @@ impl FlowCtrl {
     /// Generate and fire commands for all types of periodic checks
     pub(super) async fn perform_periodic_checks(&mut self) {
         debug!("[NODE READ]: periodic msg lock attempt...");
-        let snapshot = &self.node.read().await.get_snapshot();
+        let snapshot = &self.node.read().await.snapshot();
         debug!("[NODE READ]: periodic msg lock got");
 
         self.enqueue_cmds_for_standard_periodic_checks(snapshot)

--- a/sn_node/src/node/logging/log_ctx.rs
+++ b/sn_node/src/node/logging/log_ctx.rs
@@ -22,6 +22,9 @@ impl LogCtx {
     }
 
     pub(crate) async fn prefix(&self) -> Prefix {
-        self.node.read().await.network_knowledge().prefix()
+        debug!("[NODE READ]: logging lock attempt");
+        let p = self.node.read().await.network_knowledge().prefix();
+        debug!("[NODE READ]: logging lock got");
+        p
     }
 }

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -132,7 +132,7 @@ impl MyNode {
         section_sig: SectionSig,
     ) -> Result<Vec<Cmd>> {
         trace!("{}", LogMarker::HandlingNewEldersAgreement);
-        let snapshot = self.snapshot();
+        let context = self.context();
         let mut section_chain = self.section_chain();
         let last_key = section_chain.last_key()?;
 
@@ -151,7 +151,7 @@ impl MyNode {
                     Ok(true) => {
                         info!("Updated our network knowledge for {:?}", prefix);
                         info!("Writing updated knowledge to disk");
-                        MyNode::write_section_tree(&snapshot);
+                        MyNode::write_section_tree(&context);
                     }
                     Err(err) => {
                         error!("Error updating our network knowledge for {prefix:?}: {err:?}")
@@ -168,6 +168,6 @@ impl MyNode {
             self.network_knowledge.section_tree()
         );
 
-        self.update_on_elder_change(&snapshot)
+        self.update_on_elder_change(&context)
     }
 }

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -132,7 +132,7 @@ impl MyNode {
         section_sig: SectionSig,
     ) -> Result<Vec<Cmd>> {
         trace!("{}", LogMarker::HandlingNewEldersAgreement);
-        let snapshot = self.get_snapshot();
+        let snapshot = self.snapshot();
         let mut section_chain = self.section_chain();
         let last_key = section_chain.last_key()?;
 

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -132,7 +132,7 @@ impl MyNode {
         section_sig: SectionSig,
     ) -> Result<Vec<Cmd>> {
         trace!("{}", LogMarker::HandlingNewEldersAgreement);
-        let snapshot = self.state_snapshot();
+        let snapshot = self.get_snapshot();
         let mut section_chain = self.section_chain();
         let last_key = section_chain.last_key()?;
 
@@ -151,7 +151,7 @@ impl MyNode {
                     Ok(true) => {
                         info!("Updated our network knowledge for {:?}", prefix);
                         info!("Writing updated knowledge to disk");
-                        self.write_section_tree()
+                        MyNode::write_section_tree(&snapshot);
                     }
                     Err(err) => {
                         error!("Error updating our network knowledge for {prefix:?}: {err:?}")

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -229,7 +229,7 @@ impl MyNode {
 
         let latest_context = node.read().await.context();
         // Only trigger reorganize data when there is a membership change happens.
-        if updated && latest_context.is_not_elder {
+        if updated && !latest_context.is_elder {
             // only done if adult, since as an elder we dont want to get any more
             // data for our name (elders will eventually be caching data in general)
             cmds.push(MyNode::ask_for_any_new_data(&latest_context).await);

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -6,12 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::node::core::MyNodeSnapshot;
 use crate::node::{
     flow_ctrl::cmds::Cmd, messaging::Peers, Error, Event, MembershipEvent, MyNode, Result,
-    StateSnapshot,
 };
-
 use bls::PublicKey as BlsPublicKey;
+use itertools::Itertools;
 use qp2p::{SendStream, UsrMsgBytes};
 use sn_interface::{
     messaging::{
@@ -22,13 +22,14 @@ use sn_interface::{
     types::{log_markers::LogMarker, Peer, PublicKey},
 };
 use std::{collections::BTreeSet, sync::Arc};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use xor_name::{Prefix, XorName};
 
 impl MyNode {
     /// Send `AntiEntropy` update message to all nodes in our own section.
     pub(crate) fn send_ae_update_to_our_section(&self) -> Result<Option<Cmd>> {
         let our_name = self.info().name();
+        let snapshot = &self.get_snapshot();
         let recipients: BTreeSet<_> = self
             .network_knowledge
             .section_members()
@@ -47,7 +48,9 @@ impl MyNode {
         match self.section_chain().get_parent_key(&leaf) {
             Ok(prev_pk) => {
                 let prev_pk = prev_pk.unwrap_or(*self.section_chain().genesis_key());
-                Ok(Some(self.send_ae_update_to_nodes(recipients, prev_pk)))
+                Ok(Some(MyNode::send_ae_update_to_nodes(
+                    snapshot, recipients, prev_pk,
+                )))
             }
             Err(_) => {
                 error!("SectionsDAG fields went out of sync");
@@ -58,21 +61,25 @@ impl MyNode {
 
     /// Send `AntiEntropy` update message to the specified nodes.
     pub(crate) fn send_ae_update_to_nodes(
-        &self,
+        snapshot: &MyNodeSnapshot,
         recipients: BTreeSet<Peer>,
         section_pk: BlsPublicKey,
     ) -> Cmd {
-        let members = self.network_knowledge.section_signed_members();
+        let members = snapshot.network_knowledge.section_signed_members();
 
-        let ae_msg = self.generate_ae_msg(Some(section_pk), AntiEntropyKind::Update { members });
+        let ae_msg = MyNode::generate_ae_msg(
+            snapshot,
+            Some(section_pk),
+            AntiEntropyKind::Update { members },
+        );
 
-        self.send_system_msg(ae_msg, Peers::Multiple(recipients))
+        MyNode::send_system_msg(ae_msg, Peers::Multiple(recipients))
     }
 
     /// Send `MetadataExchange` packet to the specified nodes
     pub(crate) fn send_metadata_updates(&self, recipients: BTreeSet<Peer>, prefix: &Prefix) -> Cmd {
         let metadata = self.get_metadata_of(prefix);
-        self.send_system_msg(
+        MyNode::send_system_msg(
             NodeMsg::NodeCmd(NodeCmd::ReceiveMetadata { metadata }),
             Peers::Multiple(recipients),
         )
@@ -82,18 +89,18 @@ impl MyNode {
     /// Send AntiEntropy update message to the nodes in our sibling section.
     pub(crate) fn send_updates_to_sibling_section(
         &self,
-        our_prev_state: &StateSnapshot,
+        prev_snapshot: &MyNodeSnapshot,
     ) -> Result<Vec<Cmd>> {
         debug!("{}", LogMarker::AeSendUpdateToSiblings);
-        let sibling_prefix = self.network_knowledge.prefix().sibling();
-        if let Some(sibling_sap) = self
+        let sibling_prefix = prev_snapshot.network_knowledge.prefix().sibling();
+        if let Some(sibling_sap) = prev_snapshot
             .network_knowledge
             .section_tree()
             .get_signed(&sibling_prefix)
         {
             let promoted_sibling_elders: BTreeSet<_> = sibling_sap
                 .elders()
-                .filter(|peer| !our_prev_state.elders.contains(&peer.name()))
+                .filter(|peer| !prev_snapshot.network_knowledge.elders().contains(peer))
                 .cloned()
                 .collect();
 
@@ -104,14 +111,18 @@ impl MyNode {
 
             // Using previous_key as dst_section_key as newly promoted
             // sibling Elders shall still in the state of pre-split.
-            let previous_section_key = our_prev_state.section_key;
+            let previous_section_key = prev_snapshot.network_knowledge.section_key();
             let sibling_prefix = sibling_sap.prefix();
 
             let mut cmds =
                 vec![self.send_metadata_updates(promoted_sibling_elders.clone(), &sibling_prefix)];
 
             // Also send AE update to sibling section's new Elders
-            cmds.push(self.send_ae_update_to_nodes(promoted_sibling_elders, previous_section_key));
+            cmds.push(MyNode::send_ae_update_to_nodes(
+                prev_snapshot,
+                promoted_sibling_elders,
+                previous_section_key,
+            ));
 
             Ok(cmds)
         } else {
@@ -122,20 +133,21 @@ impl MyNode {
 
     // Private helper to generate AntiEntropy message to update
     // a peer abot our SAP, with proof_chain and members list.
-    fn generate_ae_msg(
-        &self,
+    pub(crate) fn generate_ae_msg(
+        snapshot: &MyNodeSnapshot,
         dst_section_key: Option<BlsPublicKey>,
         kind: AntiEntropyKind,
     ) -> NodeMsg {
-        let signed_sap = self.network_knowledge.signed_sap();
+        let signed_sap = snapshot.network_knowledge.signed_sap();
 
         let proof_chain = dst_section_key
             .and_then(|key| {
-                self.network_knowledge
+                snapshot
+                    .network_knowledge
                     .get_proof_chain_to_current_section(&key)
                     .ok()
             })
-            .unwrap_or_else(|| self.network_knowledge.section_chain());
+            .unwrap_or_else(|| snapshot.network_knowledge.section_chain());
 
         let section_tree_update = SectionTreeUpdate::new(signed_sap, proof_chain);
 
@@ -185,12 +197,13 @@ impl MyNode {
 
     #[instrument(skip_all)]
     pub(crate) async fn handle_anti_entropy_msg(
-        &mut self,
+        node: Arc<RwLock<MyNode>>,
         section_tree_update: SectionTreeUpdate,
         kind: AntiEntropyKind,
         sender: Peer,
     ) -> Result<Vec<Cmd>> {
-        let snapshot = self.state_snapshot();
+        debug!("[NODE READ]: handling AE read gottt...");
+        let starting_snapshot = node.read().await.get_snapshot();
         let sap = section_tree_update.signed_sap.value.clone();
 
         let members = if let AntiEntropyKind::Update { members } = kind.clone() {
@@ -199,30 +212,51 @@ impl MyNode {
             None
         };
 
-        let updated = self.update_network_knowledge(section_tree_update, members)?;
+        // block off the write lock
+        let (updated, mut cmds) = {
+            let mut write_locked_node = node.write().await;
+            debug!("[NODE WRITE]: handling AE write gottt...");
+            let updated =
+                write_locked_node.update_network_knowledge(section_tree_update, members)?;
 
-        // always run this, only changes will trigger events
-        let mut cmds = self.update_on_elder_change(&snapshot)?;
+            debug!("net knowledge udpated");
+            // always run this, only changes will trigger events
+            let cmds = write_locked_node.update_on_elder_change(&starting_snapshot)?;
+            debug!("updated for elder change");
 
+            (updated, cmds)
+        };
+
+        let latest_snapshot = node.read().await.get_snapshot();
         // Only trigger reorganize data when there is a membership change happens.
-        if updated && self.is_not_elder() {
+        if updated && latest_snapshot.is_not_elder {
             // only done if adult, since as an elder we dont want to get any more
             // data for our name (elders will eventually be caching data in general)
-            cmds.push(self.ask_for_any_new_data().await);
+            cmds.push(MyNode::ask_for_any_new_data(&latest_snapshot).await);
         }
 
         if updated {
-            self.write_section_tree();
+            MyNode::write_section_tree(&latest_snapshot);
             let prefix = sap.prefix();
             info!("SectionTree written to disk with update for prefix {prefix:?}");
 
             // check if we've been kicked out of the section
-            if snapshot.members.contains(&self.name())
-                && !self.state_snapshot().members.contains(&self.name())
+            if starting_snapshot
+                .network_knowledge
+                .members()
+                .iter()
+                .map(|m| m.name())
+                .contains(&latest_snapshot.name)
+                && !latest_snapshot
+                    .network_knowledge
+                    .members()
+                    .iter()
+                    .map(|m| m.name())
+                    .contains(&latest_snapshot.name)
             {
                 error!("Detected that we've been removed from the section");
                 // move off thread to keep fn sync
-                let event_sender = self.event_sender.clone();
+                let event_sender = starting_snapshot.event_sender.clone();
                 let _handle = tokio::spawn(async move {
                     event_sender
                         .send(Event::Membership(MembershipEvent::RemovedFromSection))
@@ -231,13 +265,17 @@ impl MyNode {
 
                 return Err(Error::RemovedFromSection);
             }
+        } else {
+            debug!("No update to network knowledge");
         }
 
         // Check if we need to resend any messsages and who should we send it to.
         let (bounced_msg, response_peer) = match kind {
             AntiEntropyKind::Update { .. } => {
                 // log the msg as received. Elders track this for other elders in dysfunction
-                self.dysfunction_tracking
+                node.write()
+                    .await
+                    .dysfunction_tracking
                     .ae_update_msg_received(&sender.name());
                 return Ok(cmds);
             } // Nope, bail early
@@ -282,16 +320,22 @@ impl MyNode {
             error!("Dropping bounced msg ({sender:?}) received in AE-Retry from {msg_id:?} as suggested new dst section key is the same as previously sent: {:?}", sap.section_key());
             return Ok(cmds);
         }
+
         trace!("Resend Original {msg_id:?} to {response_peer:?} with {msg_to_resend:?}");
-        cmds.push(self.send_system_msg(msg_to_resend, Peers::Single(response_peer)));
+        trace!("{}", LogMarker::AeResendAfterRedirect);
+
+        cmds.push(MyNode::send_system_msg(
+            msg_to_resend,
+            Peers::Single(response_peer),
+        ));
         Ok(cmds)
     }
 
     // If entropy is found, determine the msg to send in order to
     // bring the sender's knowledge about us up to date.
     pub(crate) fn check_for_entropy(
-        &self,
         wire_msg: &WireMsg,
+        snapshot: &MyNodeSnapshot,
         dst_section_key: &BlsPublicKey,
         dst_name: XorName,
         sender: &Peer,
@@ -299,15 +343,18 @@ impl MyNode {
     ) -> Result<Option<Cmd>> {
         // Check if the message has reached the correct section,
         // if not, we'll need to respond with AE
-        let our_prefix = self.network_knowledge.prefix();
+
+        let our_prefix = snapshot.network_knowledge.prefix();
+        let our_section_key = snapshot.network_knowledge.section_key();
         let msg_id = wire_msg.msg_id();
         // Let's try to find a section closer to the destination, if it's not for us.
-        if !self.network_knowledge.prefix().matches(&dst_name) {
+        if !snapshot.network_knowledge.prefix().matches(&dst_name) {
+            let closest_sap = snapshot.network_knowledge.closest_signed_sap(&dst_name);
             debug!(
                 "AE: {msg_id:?} prefix not matching. We are: {:?}, they sent to: {:?}",
                 our_prefix, dst_name
             );
-            return match self.network_knowledge.closest_signed_sap(&dst_name) {
+            return match closest_sap {
                 Some((signed_sap, proof_chain)) => {
                     info!(
                         "{msg_id:?} Found a better matching prefix {:?}",
@@ -356,21 +403,21 @@ impl MyNode {
             };
         }
 
-        let section_key = self.network_knowledge.section_key();
         trace!(
             "Performing AE checks on {msg_id:?}, provided pk was: {:?} ours is: {:?}",
             dst_section_key,
-            section_key
+            our_section_key
         );
 
-        if dst_section_key == &section_key {
+        if dst_section_key == &our_section_key {
             // Destination section key matches our current section key
             return Ok(None);
         }
 
         let bounced_msg = wire_msg.serialize()?;
 
-        let ae_msg = self.generate_ae_msg(
+        let ae_msg = MyNode::generate_ae_msg(
+            snapshot,
             Some(*dst_section_key),
             AntiEntropyKind::Retry { bounced_msg },
         );
@@ -393,25 +440,33 @@ impl MyNode {
         }
     }
 
-    // Generate an AE redirect cmd for the given message
+    /// Generate an AE redirect response and send to the client on the provided stream.
+    /// This moves the rest of the operation onto a new thread to not block the dispatcher
     pub(crate) async fn ae_redirect_client_to_our_elders(
-        &self,
+        ae_msg: NodeMsg,
+        snapshot: MyNodeSnapshot,
         sender: Peer,
         client_response_stream: Arc<Mutex<SendStream>>,
-        bounced_msg: UsrMsgBytes,
+        _bounced_msg: UsrMsgBytes,
     ) -> Result<()> {
         trace!(
             "{} in ae_redirect to elders for {sender:?} ",
             LogMarker::AeSendRedirect
         );
 
-        let ae_msg = self.generate_ae_msg(None, AntiEntropyKind::Redirect { bounced_msg });
-        let (kind, payload) = self.serialize_node_msg(ae_msg)?;
+        let (kind, payload) = MyNode::serialize_node_msg(snapshot.name, ae_msg)?;
 
         let msg_id = MsgId::new();
 
-        self.send_msg_on_stream(payload, kind, client_response_stream, Some(sender), msg_id)
-            .await
+        MyNode::send_msg_on_stream(
+            snapshot.network_knowledge.section_key(),
+            payload,
+            kind,
+            client_response_stream,
+            Some(sender),
+            msg_id,
+        )
+        .await
     }
 }
 
@@ -451,9 +506,10 @@ mod tests {
         let dst_name = our_prefix.substituted_in(xor_name::rand::random());
         let dst_section_key = env.node.network_knowledge().section_key();
 
-        let cmd = env
-            .node
-            .check_for_entropy(&msg, &dst_section_key, dst_name, &sender, None)?;
+        let snapshot = env.node.get_snapshot();
+
+        let cmd =
+            MyNode::check_for_entropy(&msg, &snapshot, &dst_section_key, dst_name, &sender, None)?;
 
         assert!(cmd.is_none());
         Ok(())
@@ -472,10 +528,20 @@ mod tests {
         // since it's not aware of the other prefix, it will redirect to self
         let dst_section_key = other_pk;
         let dst_name = env.other_signed_sap.prefix().name();
+        let snapshot = env.node.get_snapshot();
 
-        let cmd = env
-            .node
-            .check_for_entropy(&wire_msg, &dst_section_key, dst_name, &sender, None);
+        // let cmd = env
+        //     .node
+        //     .check_for_entropy(&wire_msg, &dst_section_key, dst_name, &sender, None);
+
+        let cmd = MyNode::check_for_entropy(
+            &wire_msg,
+            &snapshot,
+            &dst_section_key,
+            dst_name,
+            &sender,
+            None,
+        );
 
         let msg = assert_matches!(cmd, Ok(Some(Cmd::SendMsg { msg, .. })) => {
             msg
@@ -492,11 +558,18 @@ mod tests {
             .node
             .update_network_knowledge(section_tree_update, None,)?);
 
+        let snapshot = env.node.get_snapshot();
+
         // and it now shall give us an AE redirect msg
         // with the SAP we inserted for other prefix
-        let cmd = env
-            .node
-            .check_for_entropy(&wire_msg, &dst_section_key, dst_name, &sender, None);
+        let cmd = MyNode::check_for_entropy(
+            &wire_msg,
+            &snapshot,
+            &dst_section_key,
+            dst_name,
+            &sender,
+            None,
+        );
 
         let msg = assert_matches!(cmd, Ok(Some(Cmd::SendMsg { msg, .. })) => {
             msg
@@ -512,15 +585,14 @@ mod tests {
     async fn ae_outdated_dst_key_of_our_section() -> Result<()> {
         let env = Env::new().await?;
         let our_prefix = env.node.network_knowledge().prefix();
-
+        let snapshot = env.node.get_snapshot();
         let msg = env.create_msg(&our_prefix, env.node.network_knowledge().section_key())?;
         let sender = env.node.info().peer();
         let dst_name = our_prefix.substituted_in(xor_name::rand::random());
         let dst_section_key = env.node.network_knowledge().genesis_key();
 
-        let cmd = env
-            .node
-            .check_for_entropy(&msg, dst_section_key, dst_name, &sender, None)?;
+        let cmd =
+            MyNode::check_for_entropy(&msg, &snapshot, dst_section_key, dst_name, &sender, None)?;
 
         let msg = assert_matches!(cmd, Some(Cmd::SendMsg { msg, .. }) => {
             msg
@@ -544,10 +616,10 @@ mod tests {
 
         let bogus_env = Env::new().await?;
         let dst_section_key = bogus_env.node.network_knowledge().genesis_key();
+        let snapshot = env.node.get_snapshot();
 
-        let cmd = env
-            .node
-            .check_for_entropy(&msg, dst_section_key, dst_name, &sender, None)?;
+        let cmd =
+            MyNode::check_for_entropy(&msg, &snapshot, dst_section_key, dst_name, &sender, None)?;
 
         let msg = assert_matches!(cmd, Some(Cmd::SendMsg { msg, .. }) => {
             msg

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -530,10 +530,6 @@ mod tests {
         let dst_name = env.other_signed_sap.prefix().name();
         let snapshot = env.node.get_snapshot();
 
-        // let cmd = env
-        //     .node
-        //     .check_for_entropy(&wire_msg, &dst_section_key, dst_name, &sender, None);
-
         let cmd = MyNode::check_for_entropy(
             &wire_msg,
             &snapshot,
@@ -558,13 +554,12 @@ mod tests {
             .node
             .update_network_knowledge(section_tree_update, None,)?);
 
-        let snapshot = env.node.get_snapshot();
-
+        let new_snapshot = env.node.get_snapshot();
         // and it now shall give us an AE redirect msg
         // with the SAP we inserted for other prefix
         let cmd = MyNode::check_for_entropy(
             &wire_msg,
-            &snapshot,
+            &new_snapshot,
             &dst_section_key,
             dst_name,
             &sender,

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -6,7 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::{flow_ctrl::cmds::Cmd, Error, MyNode, Result};
+use crate::node::{core::MyNodeSnapshot, flow_ctrl::cmds::Cmd, Error, MyNode, Result};
+
 use bytes::Bytes;
 
 use qp2p::SendStream;
@@ -39,8 +40,8 @@ use xor_name::XorName;
 
 impl MyNode {
     /// Forms a `QueryError` msg to send back to the client on a stream
-    pub(crate) async fn query_error_response(
-        &self,
+    pub(crate) async fn send_query_error_response_on_stream(
+        snapshot: MyNodeSnapshot,
         error: Error,
         query: &DataQueryVariant,
         source_peer: Peer,
@@ -52,9 +53,10 @@ impl MyNode {
             correlation_id,
         };
 
-        let (kind, payload) = self.serialize_client_msg_response(the_error_msg)?;
+        let (kind, payload) = MyNode::serialize_client_msg_response(snapshot.name, the_error_msg)?;
 
-        self.send_msg_on_stream(
+        MyNode::send_msg_on_stream(
+            snapshot.network_knowledge.section_key(),
             payload,
             kind,
             send_stream,
@@ -66,7 +68,7 @@ impl MyNode {
 
     /// Forms a `CmdError` msg to send back to the client over the response stream
     pub(crate) async fn send_cmd_error_response_over_stream(
-        &self,
+        snapshot: &MyNodeSnapshot,
         cmd: DataCmd,
         error: Error,
         correlation_id: MsgId,
@@ -77,10 +79,11 @@ impl MyNode {
             correlation_id,
         };
 
-        let (kind, payload) = self.serialize_client_msg_response(client_msg)?;
+        let (kind, payload) = MyNode::serialize_client_msg_response(snapshot.name, client_msg)?;
 
         debug!("{correlation_id:?} sending cmd response error back to client");
-        self.send_msg_on_stream(
+        MyNode::send_msg_on_stream(
+            snapshot.network_knowledge.section_key(),
             payload,
             kind,
             send_stream,
@@ -93,7 +96,7 @@ impl MyNode {
     /// Handle data query
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn handle_data_query_at_adult(
-        &self,
+        snapshot: &MyNodeSnapshot,
         operation_id: OperationId,
         query: &DataQueryVariant,
         auth: ClientAuth,
@@ -101,7 +104,7 @@ impl MyNode {
         msg_id: MsgId,
         send_stream: Option<Arc<Mutex<SendStream>>>,
     ) -> Result<()> {
-        let response = self
+        let response = snapshot
             .data_storage
             .query(query, User::Key(auth.public_key))
             .await;
@@ -112,10 +115,15 @@ impl MyNode {
             operation_id,
         };
 
-        let (kind, payload) = self.serialize_node_msg(msg)?;
+        let (kind, payload) = MyNode::serialize_node_msg(snapshot.name, msg)?;
 
-        let bytes =
-            self.form_usr_msg_bytes_to_node(payload, kind, Some(requesting_elder), msg_id)?;
+        let bytes = MyNode::form_usr_msg_bytes_to_node(
+            snapshot.network_knowledge.section_key(),
+            payload,
+            kind,
+            Some(requesting_elder),
+            msg_id,
+        )?;
 
         if let Some(send_stream) = send_stream {
             // send response on the stream
@@ -141,34 +149,31 @@ impl MyNode {
         Ok(())
     }
 
-    /// Handle incoming client msgs. Though NOT queries, as this requires
-    /// mutable access to the Node
+    /// Handle incoming client msgs.
     pub(crate) async fn handle_valid_client_msg(
-        &self,
+        snapshot: MyNodeSnapshot,
         msg_id: MsgId,
         msg: ClientMsg,
         auth: AuthorityProof<ClientAuth>,
         origin: Peer,
         send_stream: Arc<Mutex<SendStream>>,
     ) -> Result<Vec<Cmd>> {
-        if !self.is_elder() {
-            warn!("could not handle valid as not elder");
-            return Ok(vec![]);
-        }
+        debug!("Handling client {msg_id:?}");
+
         trace!("{:?}: {:?} ", LogMarker::ClientMsgToBeHandled, msg);
 
         let cmd = match msg {
             ClientMsg::Cmd(cmd) => cmd,
             ClientMsg::Query(query) => {
-                return self
-                    .read_data_from_adult_and_respond_to_client(
-                        query,
-                        msg_id,
-                        auth,
-                        origin,
-                        send_stream,
-                    )
-                    .await
+                return MyNode::read_data_from_adult_and_respond_to_client(
+                    snapshot,
+                    query,
+                    msg_id,
+                    auth,
+                    origin,
+                    send_stream,
+                )
+                .await
             }
         };
 
@@ -210,7 +215,7 @@ impl MyNode {
                     };
                     return Ok(vec![update_command]);
                 }
-                self.extract_contents_as_replicated_data(cmd)
+                MyNode::extract_contents_as_replicated_data(&snapshot, cmd)
             }
         };
 
@@ -218,8 +223,14 @@ impl MyNode {
             Ok(data) => data,
             Err(error) => {
                 debug!("Will send error response back to client");
-                self.send_cmd_error_response_over_stream(cmd, error, msg_id, send_stream)
-                    .await?;
+                MyNode::send_cmd_error_response_over_stream(
+                    &snapshot,
+                    cmd,
+                    error,
+                    msg_id,
+                    send_stream,
+                )
+                .await?;
 
                 return Ok(vec![]);
             }
@@ -228,13 +239,13 @@ impl MyNode {
         trace!("{:?}: {:?}", LogMarker::DataStoreReceivedAtElder, data);
 
         let cmds = vec![];
-        let targets = self.target_data_holders(data.name());
+        let targets = MyNode::target_data_holders(&snapshot, data.name());
 
         // make sure the expected replication factor is achieved
         if data_copy_count() > targets.len() {
             error!("InsufficientAdults for storing data reliably");
             let error = Error::InsufficientAdults {
-                prefix: self.network_knowledge().prefix(),
+                prefix: snapshot.network_knowledge.prefix(),
                 expected: data_copy_count() as u8,
                 found: targets.len() as u8,
             };
@@ -242,7 +253,7 @@ impl MyNode {
             debug!("Will send error response back to client");
 
             // TODO: Use response stream here. This wont work anymore!
-            self.send_cmd_error_response_over_stream(cmd, error, msg_id, send_stream)
+            MyNode::send_cmd_error_response_over_stream(&snapshot, cmd, error, msg_id, send_stream)
                 .await?;
             return Ok(vec![]);
         }
@@ -250,8 +261,15 @@ impl MyNode {
         // the replication msg sent to adults
         // cmds here may be dysfunction tracking.
         // CmdAcks are sent over the send stream herein
-        self.replicate_data_to_adults_and_ack_to_client(cmd, data, msg_id, targets, send_stream)
-            .await?;
+        MyNode::replicate_data_to_adults_and_ack_to_client(
+            &snapshot,
+            cmd,
+            data,
+            msg_id,
+            targets,
+            send_stream,
+        )
+        .await?;
 
         // TODO: handle failed responses
         // cmds.extend();
@@ -260,7 +278,10 @@ impl MyNode {
     }
 
     // helper to extract the contents of the cmd as ReplicatedData
-    fn extract_contents_as_replicated_data(&self, cmd: SpentbookCmd) -> Result<ReplicatedData> {
+    fn extract_contents_as_replicated_data(
+        snapshot: &MyNodeSnapshot,
+        cmd: SpentbookCmd,
+    ) -> Result<ReplicatedData> {
         let SpentbookCmd::Spend {
             key_image,
             tx,
@@ -271,15 +292,20 @@ impl MyNode {
 
         info!("Processing spend request for key image: {:?}", key_image);
 
-        let spent_proof_share =
-            self.gen_spent_proof_share(&key_image, &tx, &spent_proofs, &spent_transactions)?;
-        let reg_cmd = self.gen_register_cmd(&key_image, &spent_proof_share)?;
+        let spent_proof_share = MyNode::gen_spent_proof_share(
+            snapshot,
+            &key_image,
+            &tx,
+            &spent_proofs,
+            &spent_transactions,
+        )?;
+        let reg_cmd = MyNode::gen_register_cmd(snapshot, &key_image, &spent_proof_share)?;
         Ok(ReplicatedData::SpentbookWrite(reg_cmd))
     }
 
     /// Generate a spent proof share from the information provided by the client.
     fn gen_spent_proof_share(
-        &self,
+        snapshot: &MyNodeSnapshot,
         key_image: &KeyImage,
         tx: &RingCtTransaction,
         spent_proofs: &BTreeSet<SpentProof>,
@@ -304,7 +330,7 @@ impl MyNode {
 
         // Verify each spent proof is signed by a known section key (or the genesis key).
         for pk in &spent_proofs_keys {
-            if !self.network_knowledge.verify_section_key_is_known(pk) {
+            if !snapshot.network_knowledge.verify_section_key_is_known(pk) {
                 warn!(
                     "Dropping spend request: spent proof is signed by unknown section with public \
                     key {:?}",
@@ -348,8 +374,8 @@ impl MyNode {
         let spent_proof_share = build_spent_proof_share(
             key_image,
             tx,
-            &self.network_knowledge.section_auth(),
-            &self.section_keys_provider,
+            &snapshot.network_knowledge.section_auth(),
+            &snapshot.section_keys_provider,
             public_commitments,
         )?;
         Ok(spent_proof_share)
@@ -358,7 +384,7 @@ impl MyNode {
     /// Generate the RegisterCmd to write the SpentProofShare as an entry in the Spentbook
     /// (Register).
     fn gen_register_cmd(
-        &self,
+        snapshot: &MyNodeSnapshot,
         key_image: &KeyImage,
         spent_proof_share: &SpentProofShare,
     ) -> Result<RegisterCmd> {
@@ -366,7 +392,7 @@ impl MyNode {
         let _ = permissions.insert(User::Anyone, Permissions::new(true));
 
         // use our own keypair for generating the register command
-        let own_keypair = Keypair::Ed25519(self.info().keypair);
+        let own_keypair = Keypair::Ed25519(snapshot.keypair.clone());
         let owner = User::Key(own_keypair.public_key());
         let policy = Policy { owner, permissions };
 

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -102,7 +102,7 @@ impl MyNode {
 
         // send it to the other participants
         if !others.is_empty() {
-            cmds.push(self.send_system_msg(node_msg, Peers::Multiple(others)))
+            cmds.push(MyNode::send_system_msg(node_msg, Peers::Multiple(others)))
         }
 
         // handle our own
@@ -156,12 +156,12 @@ impl MyNode {
             pub_keys,
             votes,
         };
-        self.send_system_msg(node_msg, Peers::Multiple(recipients))
+        MyNode::send_system_msg(node_msg, Peers::Multiple(recipients))
     }
 
     fn request_dkg_ae(&self, session_id: &DkgSessionId, sender: Peer) -> Cmd {
         let node_msg = NodeMsg::DkgAE(session_id.clone());
-        self.send_system_msg(node_msg, Peers::Single(sender))
+        MyNode::send_system_msg(node_msg, Peers::Single(sender))
     }
 
     fn aggregate_dkg_start(
@@ -287,7 +287,7 @@ impl MyNode {
             sig,
         };
 
-        let cmd = self.send_system_msg(node_msg, Peers::Multiple(peers));
+        let cmd = MyNode::send_system_msg(node_msg, Peers::Multiple(peers));
         Ok(vec![cmd])
     }
 
@@ -554,7 +554,7 @@ impl MyNode {
                 pub_keys,
                 votes: our_votes,
             };
-            let cmd = self.send_system_msg(node_msg, Peers::Single(sender));
+            let cmd = MyNode::send_system_msg(node_msg, Peers::Single(sender));
             Ok(vec![cmd])
         } else {
             Ok(vec![])
@@ -578,7 +578,7 @@ impl MyNode {
             pub_keys,
             votes,
         };
-        let cmd = self.send_system_msg(node_msg, Peers::Single(sender));
+        let cmd = MyNode::send_system_msg(node_msg, Peers::Single(sender));
         Ok(vec![cmd])
     }
 
@@ -664,7 +664,7 @@ impl MyNode {
             pub_key: *pub_key,
             sig: *sig,
         };
-        let cmd = self.send_system_msg(node_msg, Peers::Multiple(peers));
+        let cmd = MyNode::send_system_msg(node_msg, Peers::Multiple(peers));
         vec![cmd]
     }
 
@@ -767,7 +767,7 @@ impl MyNode {
         // it to sign any msg that needs section agreement.
         self.section_keys_provider.insert(key_share.clone());
 
-        let snapshot = self.state_snapshot();
+        let snapshot = self.get_snapshot();
 
         // If we are lagging, we may have been already approved as new Elder, and
         // an AE update provided us with this same SAP but already signed by previous Elders,

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -767,7 +767,7 @@ impl MyNode {
         // it to sign any msg that needs section agreement.
         self.section_keys_provider.insert(key_share.clone());
 
-        let snapshot = self.get_snapshot();
+        let snapshot = self.snapshot();
 
         // If we are lagging, we may have been already approved as new Elder, and
         // an AE update provided us with this same SAP but already signed by previous Elders,

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -767,7 +767,7 @@ impl MyNode {
         // it to sign any msg that needs section agreement.
         self.section_keys_provider.insert(key_share.clone());
 
-        let snapshot = self.snapshot();
+        let context = self.context();
 
         // If we are lagging, we may have been already approved as new Elder, and
         // an AE update provided us with this same SAP but already signed by previous Elders,
@@ -776,7 +776,7 @@ impl MyNode {
             .network_knowledge
             .try_update_current_sap(key_share_pk, &sap.prefix())
         {
-            self.update_on_elder_change(&snapshot)
+            self.update_on_elder_change(&context)
         } else {
             // This proposal is sent to the current set of elders to be aggregated
             // and section signed.

--- a/sn_node/src/node/messaging/handover.rs
+++ b/sn_node/src/node/messaging/handover.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{
+    core::MyNodeSnapshot,
     flow_ctrl::cmds::Cmd,
     handover::{Error as HandoverError, Handover},
     membership::{elder_candidates, try_split_dkg},
@@ -29,7 +30,8 @@ impl MyNode {
         &mut self,
         sap_candidates: SapCandidate,
     ) -> Result<Vec<Cmd>> {
-        let mut cmds = Vec::new();
+        let snapshot = &self.get_snapshot();
+        let mut cmds = vec![];
         match &self.handover_voting {
             Some(handover_voting_state) => {
                 let mut vs = handover_voting_state.clone();
@@ -37,7 +39,7 @@ impl MyNode {
                 self.handover_voting = Some(vs.clone());
 
                 debug!("{}: {:?}", LogMarker::HandoverConsensusTrigger, &vote);
-                cmds.push(self.broadcast_handover_vote_msg(vote));
+                cmds.push(MyNode::broadcast_handover_vote_msg(snapshot, vote));
 
                 // For handover 2 elders sap, only the handover vote from genesis is required.
                 // Which make the vote state reached consensus when initialized.
@@ -58,10 +60,14 @@ impl MyNode {
     }
 
     /// Broadcast handover Vote message to Elders
-    pub(crate) fn broadcast_handover_vote_msg(&self, signed_vote: SignedVote<SapCandidate>) -> Cmd {
+    pub(crate) fn broadcast_handover_vote_msg(
+        snapshot: &MyNodeSnapshot,
+        signed_vote: SignedVote<SapCandidate>,
+    ) -> Cmd {
         // Deliver each SignedVote to all current Elders
         trace!("Broadcasting Vote msg: {:?}", signed_vote);
-        self.send_msg_to_our_elders(NodeMsg::HandoverVotes(vec![signed_vote]))
+
+        MyNode::send_msg_to_our_elders(snapshot, NodeMsg::HandoverVotes(vec![signed_vote]))
     }
 
     /// Broadcast the decision of the terminated handover consensus by proposing the NewElders SAP
@@ -100,9 +106,9 @@ impl MyNode {
     }
 
     /// helper to handle a handover vote
-    #[instrument(skip(self), level = "trace")]
+    #[instrument(skip(snapshot), level = "trace")]
     fn handle_vote(
-        &self,
+        snapshot: &MyNodeSnapshot,
         handover_state: &mut Handover,
         signed_vote: SignedVote<SapCandidate>,
         peer: Peer,
@@ -113,7 +119,10 @@ impl MyNode {
                     ">>> Handover Vote msg successfully handled, broadcasting our vote: {:?}",
                     signed_vote
                 );
-                Ok(vec![self.broadcast_handover_vote_msg(signed_vote)])
+                Ok(vec![MyNode::broadcast_handover_vote_msg(
+                    snapshot,
+                    signed_vote,
+                )])
             }
             Ok(VoteResponse::WaitingForMoreVotes) => {
                 trace!(
@@ -292,12 +301,12 @@ impl MyNode {
         signed_vote: SignedVote<SapCandidate>,
     ) -> Result<Vec<Cmd>> {
         self.check_signed_vote_saps(&signed_vote)?;
-
+        let snapshot = &self.get_snapshot();
         match &self.handover_voting {
             Some(handover_state) => {
                 let had_consensus_value = handover_state.consensus_value().is_some();
                 let mut state = handover_state.clone();
-                let mut cmds = self.handle_vote(&mut state, signed_vote, peer)?;
+                let mut cmds = MyNode::handle_vote(snapshot, &mut state, signed_vote, peer)?;
 
                 // check for unsuccessful termination
                 state.handle_empty_set_decision();
@@ -345,7 +354,10 @@ impl MyNode {
                     // We hit an error while processing this vote, perhaps we are missing information.
                     // We'll send a handover AE request to see if they can help us catch up.
                     debug!("{:?}", LogMarker::HandoverSendingAeUpdateRequest);
-                    cmds.push(self.send_system_msg(NodeMsg::HandoverAE(gen), Peers::Single(peer)));
+                    cmds.push(MyNode::send_system_msg(
+                        NodeMsg::HandoverAE(gen),
+                        Peers::Single(peer),
+                    ));
                     // return the vec w/ the AE cmd there so as not to loop and generate AE for
                     // any subsequent commands
                     return Ok(cmds);
@@ -369,12 +381,10 @@ impl MyNode {
 
         if let Some(handover) = self.handover_voting.as_ref() {
             match handover.anti_entropy(gen) {
-                Ok(catchup_votes) => {
-                    Some(self.send_system_msg(
-                        NodeMsg::HandoverVotes(catchup_votes),
-                        Peers::Single(peer),
-                    ))
-                }
+                Ok(catchup_votes) => Some(MyNode::send_system_msg(
+                    NodeMsg::HandoverVotes(catchup_votes),
+                    Peers::Single(peer),
+                )),
                 Err(e) => {
                     error!("Handover - Error while processing anti-entropy {:?}", e);
                     None

--- a/sn_node/src/node/messaging/handover.rs
+++ b/sn_node/src/node/messaging/handover.rs
@@ -30,7 +30,7 @@ impl MyNode {
         &mut self,
         sap_candidates: SapCandidate,
     ) -> Result<Vec<Cmd>> {
-        let snapshot = &self.get_snapshot();
+        let snapshot = &self.snapshot();
         let mut cmds = vec![];
         match &self.handover_voting {
             Some(handover_voting_state) => {
@@ -301,7 +301,7 @@ impl MyNode {
         signed_vote: SignedVote<SapCandidate>,
     ) -> Result<Vec<Cmd>> {
         self.check_signed_vote_saps(&signed_vote)?;
-        let snapshot = &self.get_snapshot();
+        let snapshot = &self.snapshot();
         match &self.handover_voting {
             Some(handover_state) => {
                 let had_consensus_value = handover_state.consensus_value().is_some();

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::{flow_ctrl::cmds::Cmd, messaging::Peers, MyNode, Result};
+use crate::node::{core::MyNodeSnapshot, flow_ctrl::cmds::Cmd, messaging::Peers, MyNode, Result};
 
 use sn_interface::{
     messaging::system::{
@@ -26,24 +26,22 @@ use tokio::sync::RwLock;
 impl MyNode {
     pub(crate) async fn handle_join_request(
         node: Arc<RwLock<MyNode>>,
+        snapshot: &MyNodeSnapshot,
         peer: Peer,
         join_request: JoinRequest,
     ) -> Result<Option<Cmd>> {
-        debug!("Handling join. Received {:?} from {}", join_request, peer);
-
-        let node_read_lock = node.read().await;
-
-        debug!("Handling join. node read for {join_request:?}");
+        debug!("Handling join. Received {join_request:?} from {peer:?}");
 
         let provided_section_key = join_request.section_key();
 
-        let our_section_key = node_read_lock.network_knowledge.section_key();
+        let our_section_key = snapshot.network_knowledge.section_key();
         let section_key_matches = provided_section_key == our_section_key;
 
         // Ignore `JoinRequest` if we are not elder, unless the join request
         // is outdated in which case we'll reply with `JoinResponse::Retry`
         // with the up-to-date info.
-        if node_read_lock.is_not_elder() && section_key_matches {
+        if snapshot.is_not_elder && section_key_matches {
+            warn!("Join req received to our section key, but I am not an elder...");
             // Note: We don't bounce this message because the current bounce-resend
             // mechanism wouldn't preserve the original SocketAddr which is needed for
             // properly handling this message.
@@ -52,33 +50,29 @@ impl MyNode {
             return Ok(None);
         }
 
-        let our_prefix = node_read_lock.network_knowledge.prefix();
+        let our_prefix = snapshot.network_knowledge.prefix();
         if !our_prefix.matches(&peer.name()) {
             debug!("Redirecting JoinRequest from {peer} - name doesn't match our prefix {our_prefix:?}.");
-            let retry_sap = node_read_lock.matching_section(&peer.name())?;
+            let retry_sap = MyNode::matching_section(snapshot, &peer.name())?;
             let msg = NodeMsg::JoinResponse(Box::new(JoinResponse::Redirect(retry_sap)));
             trace!("Sending {:?} to {}", msg, peer);
             trace!("{}", LogMarker::SendJoinRedirected);
-            return Ok(Some(
-                node_read_lock.send_system_msg(msg, Peers::Single(peer)),
-            ));
+            return Ok(Some(MyNode::send_system_msg(msg, Peers::Single(peer))));
         }
 
-        if !node_read_lock.joins_allowed {
+        if !snapshot.joins_allowed {
             debug!("Rejecting JoinRequest from {peer} - joins currently not allowed.");
             let msg = NodeMsg::JoinResponse(Box::new(JoinResponse::Rejected(
                 JoinRejectionReason::JoinsDisallowed,
             )));
             trace!("{}", LogMarker::SendJoinsDisallowed);
             trace!("Sending {:?} to {}", msg, peer);
-            return Ok(Some(
-                node_read_lock.send_system_msg(msg, Peers::Single(peer)),
-            ));
+            return Ok(Some(MyNode::send_system_msg(msg, Peers::Single(peer))));
         }
 
-        let is_age_valid = node_read_lock.verify_joining_node_age(&peer);
+        let is_age_valid = MyNode::verify_joining_node_age(&peer);
 
-        trace!("our_prefix={our_prefix:?}, is_age_valid={is_age_valid:?}");
+        trace!("Join proceeding: our_prefix={our_prefix:?}, is_age_valid={is_age_valid:?}");
 
         if !section_key_matches {
             trace!("{}", LogMarker::SendJoinRetryNotCorrectKey);
@@ -94,54 +88,52 @@ impl MyNode {
         }
 
         if !section_key_matches || !is_age_valid {
-            let signed_sap = node_read_lock.network_knowledge.signed_sap();
-            let proof_chain = node_read_lock.network_knowledge.section_chain();
+            let signed_sap = snapshot.network_knowledge.signed_sap();
+            let proof_chain = snapshot.network_knowledge.section_chain();
             let msg = NodeMsg::JoinResponse(Box::new(JoinResponse::Retry {
                 section_tree_update: SectionTreeUpdate::new(signed_sap, proof_chain),
             }));
             trace!("Sending {:?} to {}", msg, peer);
-            return Ok(Some(
-                node_read_lock.send_system_msg(msg, Peers::Single(peer)),
-            ));
+            return Ok(Some(MyNode::send_system_msg(msg, Peers::Single(peer))));
         }
 
         // It's reachable, let's then propose membership
         let node_state = NodeState::joined(peer, None);
 
-        // drop readlock and get write lock
-        drop(node_read_lock);
+        debug!("[NODE WRITE]: join propose membership write...");
         let mut node = node.write().await;
-
+        debug!("[NODE WRITE]: join propose membership write gottt...");
         Ok(node.propose_membership_change(node_state))
     }
 
-    pub(crate) fn verify_joining_node_age(&self, peer: &Peer) -> bool {
+    pub(crate) fn verify_joining_node_age(peer: &Peer) -> bool {
         // Age should be MIN_ADULT_AGE for joining nodes.
         peer.age() == MIN_ADULT_AGE
     }
 
     pub(crate) async fn handle_join_as_relocated_request(
         node: Arc<RwLock<MyNode>>,
+        snapshot: &MyNodeSnapshot,
         peer: Peer,
         join_request: JoinAsRelocatedRequest,
     ) -> Option<Cmd> {
         debug!("Received JoinAsRelocatedRequest {join_request:?} from {peer}",);
-        let read_locked_node = node.read().await;
-        let comm = read_locked_node.comm.clone();
-        let our_prefix = read_locked_node.network_knowledge.prefix();
+
+        let comm = snapshot.comm.clone();
+        let our_prefix = snapshot.network_knowledge.prefix();
         if !our_prefix.matches(&peer.name())
-            || join_request.section_key != read_locked_node.network_knowledge.section_key()
+            || join_request.section_key != snapshot.network_knowledge.section_key()
         {
             debug!("JoinAsRelocatedRequest from {peer} - name doesn't match our prefix {our_prefix:?}.");
 
             let msg = NodeMsg::JoinAsRelocatedResponse(Box::new(JoinAsRelocatedResponse::Retry(
-                read_locked_node.network_knowledge.section_auth(),
+                snapshot.network_knowledge.section_auth(),
             )));
 
             trace!("{} b", LogMarker::SendJoinAsRelocatedResponse);
 
             trace!("Sending {msg:?} to {peer}");
-            return Some(read_locked_node.send_system_msg(msg, Peers::Single(peer)));
+            return Some(MyNode::send_system_msg(msg, Peers::Single(peer)));
         }
 
         let state = join_request.relocate_proof.value.state();
@@ -151,7 +143,7 @@ impl MyNode {
                 debug!("Ignoring JoinAsRelocatedRequest from {peer} - invalid sig.");
                 return None;
             }
-            let known_keys = read_locked_node.network_knowledge.known_keys();
+            let known_keys = snapshot.network_knowledge.known_keys();
             if !known_keys.contains(&join_request.relocate_proof.sig.public_key) {
                 debug!("Ignoring JoinAsRelocatedRequest from {peer} - untrusted src.");
                 return None;
@@ -166,10 +158,7 @@ impl MyNode {
         if !relocate_details.verify_identity(&peer.name(), &join_request.signature_over_new_name) {
             debug!("Ignoring JoinAsRelocatedRequest from {peer} - invalid node name signature.");
             return None;
-        }
-
-        // drop read lock before we do reachability check
-        drop(read_locked_node);
+        };
 
         // Finally do reachability check
         if comm.is_reachable(&peer.addr()).await.is_err() {
@@ -177,14 +166,16 @@ impl MyNode {
                 JoinAsRelocatedResponse::NodeNotReachable(peer.addr()),
             ));
             trace!("{}", LogMarker::SendJoinAsRelocatedResponse);
-            let read_locked_node = node.read().await;
 
             trace!("Sending {:?} to {}", msg, peer);
-            return Some(read_locked_node.send_system_msg(msg, Peers::Single(peer)));
+            return Some(MyNode::send_system_msg(msg, Peers::Single(peer)));
         };
 
-        node.write()
-            .await
-            .propose_membership_change(join_request.relocate_proof.value)
+        debug!("[NODE WRITE]: join as relocated write...");
+
+        let mut x = node.write().await;
+        debug!("[NODE WRITE]: join as relocated write gottt...");
+
+        x.propose_membership_change(join_request.relocate_proof.value)
     }
 }

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -53,7 +53,7 @@ impl MyNode {
         let our_prefix = snapshot.network_knowledge.prefix();
         if !our_prefix.matches(&peer.name()) {
             debug!("Redirecting JoinRequest from {peer} - name doesn't match our prefix {our_prefix:?}.");
-            let retry_sap = MyNode::matching_section(snapshot, &peer.name())?;
+            let retry_sap = snapshot.section_sap_matching_name(&peer.name())?;
             let msg = NodeMsg::JoinResponse(Box::new(JoinResponse::Redirect(retry_sap)));
             trace!("Sending {:?} to {}", msg, peer);
             trace!("{}", LogMarker::SendJoinRedirected);

--- a/sn_node/src/node/messaging/join.rs
+++ b/sn_node/src/node/messaging/join.rs
@@ -40,7 +40,7 @@ impl MyNode {
         // Ignore `JoinRequest` if we are not elder, unless the join request
         // is outdated in which case we'll reply with `JoinResponse::Retry`
         // with the up-to-date info.
-        if context.is_not_elder && section_key_matches {
+        if !context.is_elder && section_key_matches {
             warn!("Join req received to our section key, but I am not an elder...");
             // Note: We don't bounce this message because the current bounce-resend
             // mechanism wouldn't preserve the original SocketAddr which is needed for

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -30,7 +30,7 @@ impl MyNode {
             node_state.state()
         );
 
-        let snapshot = &self.get_snapshot();
+        let snapshot = &self.snapshot();
         let prefix = self.network_knowledge.prefix();
         if let Some(membership) = self.membership.as_mut() {
             let membership_vote = match membership.propose(node_state, &prefix) {
@@ -77,7 +77,7 @@ impl MyNode {
             LogMarker::MembershipVotesBeingHandled
         );
 
-        let snapshot = &self.get_snapshot();
+        let snapshot = &self.snapshot();
         let prefix = snapshot.network_knowledge.prefix();
 
         let mut cmds = vec![];

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{
-    core::MyNodeSnapshot, flow_ctrl::cmds::Cmd, membership, messaging::Peers, relocation::ChurnId,
+    core::NodeContext, flow_ctrl::cmds::Cmd, membership, messaging::Peers, relocation::ChurnId,
     Event, MembershipEvent, MyNode, Result,
 };
 
@@ -30,7 +30,7 @@ impl MyNode {
             node_state.state()
         );
 
-        let snapshot = &self.snapshot();
+        let context = &self.context();
         let prefix = self.network_knowledge.prefix();
         if let Some(membership) = self.membership.as_mut() {
             let membership_vote = match membership.propose(node_state, &prefix) {
@@ -41,7 +41,7 @@ impl MyNode {
                 }
             };
             Some(MyNode::send_msg_to_our_elders(
-                snapshot,
+                context,
                 NodeMsg::MembershipVotes(vec![membership_vote]),
             ))
         } else {
@@ -53,13 +53,13 @@ impl MyNode {
     /// Get our latest vote if any at this generation, and get cmds to resend to all elders
     /// (which should in turn trigger them to resend their votes)
     #[instrument(skip_all)]
-    pub(crate) async fn membership_gossip_votes(snapshot: &MyNodeSnapshot) -> Option<Cmd> {
-        let membership = snapshot.membership.clone();
+    pub(crate) async fn membership_gossip_votes(context: &NodeContext) -> Option<Cmd> {
+        let membership = context.membership.clone();
         if let Some(membership) = membership {
             trace!("{}", LogMarker::GossippingMembershipVotes);
             if let Ok(ae_votes) = membership.anti_entropy(membership.generation()) {
                 let cmd =
-                    MyNode::send_msg_to_our_elders(snapshot, NodeMsg::MembershipVotes(ae_votes));
+                    MyNode::send_msg_to_our_elders(context, NodeMsg::MembershipVotes(ae_votes));
                 return Some(cmd);
             }
         }
@@ -77,8 +77,8 @@ impl MyNode {
             LogMarker::MembershipVotesBeingHandled
         );
 
-        let snapshot = &self.snapshot();
-        let prefix = snapshot.network_knowledge.prefix();
+        let context = &self.context();
+        let prefix = context.network_knowledge.prefix();
 
         let mut cmds = vec![];
 
@@ -125,7 +125,7 @@ impl MyNode {
             };
 
             if let Some(vote_msg) = vote_broadcast {
-                cmds.push(MyNode::send_msg_to_our_elders(snapshot, vote_msg));
+                cmds.push(MyNode::send_msg_to_our_elders(context, vote_msg));
             }
         }
 
@@ -133,7 +133,7 @@ impl MyNode {
     }
 
     pub(crate) fn handle_membership_anti_entropy(
-        snapshot: &MyNodeSnapshot,
+        context: &NodeContext,
         peer: Peer,
         gen: Generation,
     ) -> Option<Cmd> {
@@ -144,7 +144,7 @@ impl MyNode {
             peer
         );
 
-        if let Some(membership) = snapshot.membership.as_ref() {
+        if let Some(membership) = context.membership.as_ref() {
             match membership.anti_entropy(gen) {
                 Ok(catchup_votes) => {
                     debug!("Sending catchup votes to {peer:?}");

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -120,7 +120,7 @@ impl MyNode {
                 debug!("Attempting read lock get to get node context");
 
                 // first some AntiEntropy checks...
-                if context.is_not_elder {
+                if !context.is_elder {
                     let bounced_msg = wire_msg.serialize()?;
                     let ae_msg = MyNode::generate_ae_msg(
                         &context,
@@ -200,7 +200,7 @@ impl MyNode {
     ) -> Result<Vec<Cmd>> {
         // Adult nodes don't need to carry out entropy checking,
         // however the message shall always be handled.
-        if context.is_not_elder {
+        if !context.is_elder {
             return Ok(vec![]);
         }
         // For the case of receiving a join request not matching our prefix,

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -74,7 +74,7 @@ impl MyNode {
             }
         };
 
-        let snapshot = node.read().await.get_snapshot();
+        let snapshot = node.read().await.snapshot();
         debug!("[NODE READ]: validate msg lock got");
         match msg_type {
             MsgType::Node { msg_id, dst, msg } => {

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     node::{
-        flow_ctrl::cmds::Cmd, messaging::Peers, Event, MembershipEvent, MyNode,
-        Proposal as CoreProposal, Result, MIN_LEVEL_WHEN_FULL,
+        core::MyNodeSnapshot, flow_ctrl::cmds::Cmd, messaging::Peers, Event, MembershipEvent,
+        MyNode, Proposal as CoreProposal, Result, MIN_LEVEL_WHEN_FULL,
     },
     storage::Error as StorageError,
 };
@@ -32,56 +32,57 @@ use xor_name::XorName;
 
 impl MyNode {
     /// Send a (`NodeMsg`) message to all Elders in our section
-    pub(crate) fn send_msg_to_our_elders(&self, msg: NodeMsg) -> Cmd {
-        let sap = self.network_knowledge.section_auth();
+    pub(crate) fn send_msg_to_our_elders(snapshot: &MyNodeSnapshot, msg: NodeMsg) -> Cmd {
+        let sap = snapshot.network_knowledge.section_auth();
         let recipients = sap.elders_set();
-        self.send_system_msg(msg, Peers::Multiple(recipients))
+        MyNode::send_system_msg(msg, Peers::Multiple(recipients))
     }
 
     /// Send a (`NodeMsg`) message to a node
-    pub(crate) fn send_system_msg(&self, msg: NodeMsg, recipients: Peers) -> Cmd {
+    pub(crate) fn send_system_msg(msg: NodeMsg, recipients: Peers) -> Cmd {
         trace!("{}: {:?}", LogMarker::SendToNodes, msg);
         Cmd::send_msg(msg, recipients)
     }
 
     pub(crate) async fn store_data_as_adult_and_respond(
-        &mut self,
+        snapshot: &mut MyNodeSnapshot,
         data: ReplicatedData,
         response_stream: Option<Arc<Mutex<SendStream>>>,
         target: Peer,
         original_msg_id: MsgId,
     ) -> Result<Vec<Cmd>> {
         let mut cmds = vec![];
-
-        let section_pk = PublicKey::Bls(self.network_knowledge.section_key());
-        let node_keypair = Keypair::Ed25519(self.keypair.clone());
+        let section_pk = PublicKey::Bls(snapshot.network_knowledge.section_key());
+        let node_keypair = Keypair::Ed25519(snapshot.keypair.clone());
         let data_addr = data.address();
+        let our_node_name = snapshot.name;
+
         trace!("About to store data from {original_msg_id:?}: {data_addr:?}");
         // TODO: Respond with errors etc over the bidi stream
 
         // We are an adult here, so just store away!
         // This may return a DatabaseFull error... but we should have reported storage increase
         // well before this
-        match self
+        match snapshot
             .data_storage
             .store(&data, section_pk, node_keypair.clone())
             .await
         {
             Ok(level_report) => {
                 info!("Storage level report: {:?}", level_report);
-                cmds.extend(self.record_storage_level_if_any(level_report)?);
+                cmds.extend(MyNode::record_storage_level_if_any(snapshot, level_report)?);
             }
             Err(StorageError::NotEnoughSpace) => {
                 // storage full
                 error!("Not enough space to store more data");
-                let node_id = PublicKey::from(self.keypair.public);
+                let node_id = PublicKey::from(snapshot.keypair.public);
                 let msg = NodeMsg::NodeEvent(NodeEvent::CouldNotStoreData {
                     node_id,
                     data,
                     full: true,
                 });
 
-                cmds.push(self.send_msg_to_our_elders(msg))
+                cmds.push(MyNode::send_msg_to_our_elders(snapshot, msg))
             }
             Err(error) => {
                 // the rest seem to be non-problematic errors.. (?)
@@ -93,11 +94,18 @@ impl MyNode {
 
         trace!("Data has been stored: {data_addr:?}");
         let msg = NodeMsg::NodeEvent(NodeEvent::DataStored(data_addr));
-        let (kind, payload) = self.serialize_node_msg(msg)?;
+        let (kind, payload) = MyNode::serialize_node_msg(our_node_name, msg)?;
 
         if let Some(stream) = response_stream {
-            self.send_msg_on_stream(payload, kind, stream, Some(target), original_msg_id)
-                .await?;
+            MyNode::send_msg_on_stream(
+                snapshot.network_knowledge.section_key(),
+                payload,
+                kind,
+                stream,
+                Some(target),
+                original_msg_id,
+            )
+            .await?;
         } else {
             error!("Cannot respond over stream, none exists after storing! {data_addr:?}");
         }
@@ -119,12 +127,14 @@ impl MyNode {
         match msg {
             NodeMsg::Relocate(node_state) => {
                 let mut node = node.write().await;
+                debug!("[NODE WRITE]: Relocated write gottt...");
 
                 trace!("Handling msg: Relocate from {}: {:?}", sender, msg_id);
                 Ok(node.handle_relocate(node_state)?.into_iter().collect())
             }
             NodeMsg::JoinAsRelocatedResponse(join_response) => {
                 let mut node = node.write().await;
+                debug!("[NODE WRITE]: joinasreloac write gottt...");
                 trace!("Handling msg: JoinAsRelocatedResponse from {}", sender);
                 if let Some(ref mut joining_as_relocated) = node.relocate_state {
                     if let Some(cmd) =
@@ -146,19 +156,20 @@ impl MyNode {
                 kind,
             } => {
                 trace!("Handling msg: AE from {sender}: {msg_id:?}");
-                let mut node = node.write().await;
                 // as we've data storage reqs inside here for reorganisation, we have async calls to
                 // the fs
-                node.handle_anti_entropy_msg(section_tree_update, kind, sender)
-                    .await
+                MyNode::handle_anti_entropy_msg(node, section_tree_update, kind, sender).await
             }
             // Respond to a probe msg
             // We always respond to probe msgs if we're an elder as health checks use this to see if a node is alive
             // and repsonsive, as well as being a method of keeping nodes up to date.
             NodeMsg::AntiEntropyProbe(section_key) => {
-                let node = node.read().await;
+                debug!("[NODE READ]: aeprobe attempts");
+                let snapshot = node.read().await.get_snapshot();
+                debug!("[NODE READ]: aeprobe lock got");
+
                 let mut cmds = vec![];
-                if !node.is_elder() {
+                if !snapshot.is_elder {
                     // early return here as we do not get health checks as adults,
                     // normal AE rules should have applied
                     return Ok(cmds);
@@ -167,12 +178,19 @@ impl MyNode {
                 trace!("Received Probe message from {}: {:?}", sender, msg_id);
                 let mut recipients = BTreeSet::new();
                 let _existed = recipients.insert(sender);
-                cmds.push(node.send_ae_update_to_nodes(recipients, section_key));
+                cmds.push(MyNode::send_ae_update_to_nodes(
+                    &snapshot,
+                    recipients,
+                    section_key,
+                ));
                 Ok(cmds)
             }
             // The AcceptedOnlineShare for relocation will be received here.
             NodeMsg::JoinResponse(join_response) => {
                 let mut node = node.write().await;
+                debug!("[NODE WRITE]: join response write gottt...");
+                let snapshot = node.get_snapshot();
+
                 match *join_response {
                     JoinResponse::Approved {
                         section_tree_update,
@@ -183,11 +201,10 @@ impl MyNode {
                             sender
                         );
                         info!("Relocation: Successfully aggregated ApprovalShares for joining the network");
-
                         if let Some(ref mut joining_as_relocated) = node.relocate_state {
                             let new_node = joining_as_relocated.node.clone();
                             let new_name = new_node.name();
-                            let previous_name = node.info().name();
+                            let previous_name = snapshot.name;
                             let new_keypair = new_node.keypair;
 
                             info!(
@@ -198,7 +215,7 @@ impl MyNode {
                             let recipients: Vec<_> =
                                 section_tree_update.signed_sap.elders().cloned().collect();
 
-                            let section_tree = node.network_knowledge.section_tree().clone();
+                            let section_tree = snapshot.network_knowledge.section_tree().clone();
                             let new_network_knowledge =
                                 NetworkKnowledge::new(section_tree, section_tree_update)?;
 
@@ -206,7 +223,6 @@ impl MyNode {
                             //       or still using the cmd pattern.
                             //       As the sending of the JoinRequest as notification
                             //       may require the `node` to be switched to new already.
-
                             node.relocate(new_keypair.clone(), new_network_knowledge)?;
 
                             trace!(
@@ -215,7 +231,7 @@ impl MyNode {
                             );
 
                             // move off thread to keep fn sync
-                            let event_sender = node.event_sender.clone();
+                            let event_sender = snapshot.event_sender;
                             let _handle = tokio::spawn(async move {
                                 event_sender
                                     .send(Event::Membership(MembershipEvent::Relocated {
@@ -240,11 +256,14 @@ impl MyNode {
             }
             NodeMsg::HandoverVotes(votes) => {
                 let mut node = node.write().await;
-
+                debug!("[NODE WRITE]: handover votes write gottt...");
                 node.handle_handover_msg(sender, votes)
             }
             NodeMsg::HandoverAE(gen) => {
+                debug!("[NODE READ]: handover ae attempts");
                 let node = node.read().await;
+                debug!("[NODE READ]: handover ae got");
+
                 Ok(node
                     .handle_handover_anti_entropy(sender, gen)
                     .into_iter()
@@ -252,20 +271,26 @@ impl MyNode {
             }
             NodeMsg::JoinRequest(join_request) => {
                 trace!("Handling msg {:?}: JoinRequest from {}", msg_id, sender);
-                MyNode::handle_join_request(node, sender, join_request)
+                let snapshot = &node.read().await.get_snapshot();
+                debug!("[NODE READ]: joinReq read got");
+
+                MyNode::handle_join_request(node, snapshot, sender, join_request)
                     .await
                     .map(|c| c.into_iter().collect())
             }
             NodeMsg::JoinAsRelocatedRequest(join_request) => {
                 trace!("Handling msg: JoinAsRelocatedRequest from {}", sender);
-                if node.read().await.is_not_elder()
-                    && join_request.section_key == node.read().await.network_knowledge.section_key()
+                let snapshot = &node.read().await.get_snapshot();
+                debug!("[NODE READ]: joinReqas relocated read got");
+
+                if snapshot.is_not_elder
+                    && join_request.section_key == snapshot.network_knowledge.section_key()
                 {
                     return Ok(vec![]);
                 }
 
                 Ok(
-                    MyNode::handle_join_as_relocated_request(node, sender, *join_request)
+                    MyNode::handle_join_as_relocated_request(node, snapshot, sender, *join_request)
                         .await
                         .into_iter()
                         .collect(),
@@ -273,22 +298,28 @@ impl MyNode {
             }
             NodeMsg::MembershipVotes(votes) => {
                 let mut node = node.write().await;
+                debug!("[NODE WRITE]: MembershipVotes write gottt...");
                 let mut cmds = vec![];
                 cmds.extend(node.handle_membership_votes(sender, votes)?);
                 Ok(cmds)
             }
             NodeMsg::MembershipAE(gen) => {
-                let node = node.read().await;
-                Ok(node
-                    .handle_membership_anti_entropy(sender, gen)
-                    .into_iter()
-                    .collect())
+                debug!("[NODE READ]: membership ae read ");
+                let snapshopt = node.read().await.get_snapshot();
+                debug!("[NODE READ]: membership ae read got");
+
+                Ok(
+                    MyNode::handle_membership_anti_entropy(&snapshopt, sender, gen)
+                        .into_iter()
+                        .collect(),
+                )
             }
             NodeMsg::Propose {
                 proposal,
                 sig_share,
             } => {
                 let mut node = node.write().await;
+                debug!("[NODE WRITE]: PROPOSE write gottt...");
                 if node.is_not_elder() {
                     trace!("Adult handling a Propose msg from {}: {:?}", sender, msg_id);
                 }
@@ -321,6 +352,7 @@ impl MyNode {
                 );
 
                 let mut node = node.write().await;
+                debug!("[NODE WRITE]: DKGstart write gottt...");
                 node.log_dkg_session(&sender.name());
                 node.handle_dkg_start(session_id, elder_sig)
             }
@@ -337,6 +369,7 @@ impl MyNode {
                     sender
                 );
                 let mut node = node.write().await;
+                debug!("[NODE WRITE]: DKG Ephemeral write gottt...");
                 node.handle_dkg_ephemeral_pubkey(&session_id, section_auth, pub_key, sig, sender)
             }
             NodeMsg::DkgVotes {
@@ -352,16 +385,21 @@ impl MyNode {
                     votes
                 );
                 let mut node = node.write().await;
+                debug!("[NODE WRITE]: DKG Votes write gottt...");
                 node.log_dkg_session(&sender.name());
                 node.handle_dkg_votes(&session_id, pub_keys, votes, sender)
             }
             NodeMsg::DkgAE(session_id) => {
+                debug!("[NODE READ]: dkg ae read ");
+
                 let node = node.read().await;
+                debug!("[NODE READ]: dkg ae read got");
                 trace!("Handling msg: DkgAE s{} from {}", session_id.sh(), sender);
                 node.handle_dkg_anti_entropy(session_id, sender)
             }
             NodeMsg::NodeCmd(NodeCmd::RecordStorageLevel { node_id, level, .. }) => {
                 let mut node = node.write().await;
+                debug!("[NODE WRITE]: RecordStorage write gottt...");
                 let changed = node.set_storage_level(&node_id, level);
                 if changed && level.value() == MIN_LEVEL_WHEN_FULL {
                     // ..then we accept a new node in place of the full node
@@ -371,6 +409,7 @@ impl MyNode {
             }
             NodeMsg::NodeCmd(NodeCmd::ReceiveMetadata { metadata }) => {
                 let mut node = node.write().await;
+                debug!("[NODE WRITE]: ReceveMeta write gottt...");
                 info!("Processing received MetadataExchange packet: {:?}", msg_id);
                 node.set_adult_levels(metadata);
                 Ok(vec![])
@@ -385,35 +424,44 @@ impl MyNode {
                 data,
                 full,
             }) => {
-                let mut node = node.write().await;
                 info!(
                     "Processing CouldNotStoreData event with MsgId: {:?}",
                     msg_id
                 );
-                if node.is_not_elder() {
+
+                let snapshot = node.read().await.get_snapshot();
+                debug!("[NODE READ]: could ont store data read got");
+
+                if snapshot.is_not_elder {
                     error!("Received unexpected message while Adult");
                     return Ok(vec![]);
                 }
 
                 if full {
-                    let changed =
-                        node.set_storage_level(&node_id, StorageLevel::from(StorageLevel::MAX)?);
+                    let mut write_locked_node = node.write().await;
+                    debug!("[NODE WRITE]: CouldNotStore write gottt...");
+                    let changed = write_locked_node
+                        .set_storage_level(&node_id, StorageLevel::from(StorageLevel::MAX)?);
                     if changed {
                         // ..then we accept a new node in place of the full node
-                        node.joins_allowed = true;
+                        write_locked_node.joins_allowed = true;
                     }
                 }
 
-                let targets = node.target_data_holders(data.name());
+                let targets = MyNode::target_data_holders(&snapshot, data.name());
 
                 // TODO: handle responses where replication failed...
-                let _results = node.replicate_data_to_adults(data, msg_id, targets).await?;
+                let _results =
+                    MyNode::replicate_data_to_adults(&snapshot, data, msg_id, targets).await?;
 
                 Ok(vec![])
             }
             NodeMsg::NodeCmd(NodeCmd::ReplicateOneData(data)) => {
-                let node_read_lock = node.read().await;
-                if node_read_lock.is_elder() {
+                debug!("[NODE READ]: replicate one data");
+                let mut snapshot = node.read().await.get_snapshot();
+                debug!("[NODE READ]: replicate one data read got");
+
+                if snapshot.is_elder {
                     error!("Received unexpected message while Elder");
                     return Ok(vec![]);
                 }
@@ -422,64 +470,63 @@ impl MyNode {
                     data.address()
                 );
 
-                // ensure we drop the read lock as it's not needed
-                drop(node_read_lock);
-
-                // grab the write lock each time in the loop to not hold it over large data sets
-                let mut node = node.write().await;
-
-                debug!(
-                    "Attempting to store data locally as adult:: write lock gotten: {:?}",
-                    data.address()
-                );
                 // store data and respond w/ack on the response stream
-                node.store_data_as_adult_and_respond(data, send_stream, sender, msg_id)
-                    .await
+                MyNode::store_data_as_adult_and_respond(
+                    &mut snapshot,
+                    data,
+                    send_stream,
+                    sender,
+                    msg_id,
+                )
+                .await
             }
             NodeMsg::NodeCmd(NodeCmd::ReplicateData(data_collection)) => {
-                let node_read_lock = node.read().await;
-
                 info!("ReplicateData MsgId: {:?}", msg_id);
+                let mut snapshot = node.read().await.get_snapshot();
+                debug!("[NODE READ]: replicate data read got");
 
-                if node_read_lock.is_elder() {
+                if snapshot.is_elder {
                     error!("Received unexpected message while Elder");
                     return Ok(vec![]);
                 }
 
                 let mut cmds = vec![];
 
-                let section_pk = PublicKey::Bls(node_read_lock.network_knowledge.section_key());
-                let node_keypair = Keypair::Ed25519(node_read_lock.keypair.clone());
-                // ensure we drop the read lock as it's not needed
-                drop(node_read_lock);
+                let section_pk = PublicKey::Bls(snapshot.network_knowledge.section_key());
+                let node_keypair = Keypair::Ed25519(snapshot.keypair.clone());
 
                 for data in data_collection {
                     // grab the write lock each time in the loop to not hold it over large data sets
-                    let mut node = node.write().await;
+                    let store_result = snapshot
+                        .data_storage
+                        .store(&data, section_pk, node_keypair.clone())
+                        .await;
 
                     // We are an adult here, so just store away!
                     // This may return a DatabaseFull error... but we should have reported storage increase
                     // well before this
-                    match node
-                        .data_storage
-                        .store(&data, section_pk, node_keypair.clone())
-                        .await
-                    {
+                    match store_result {
                         Ok(level_report) => {
                             info!("Storage level report: {:?}", level_report);
-                            cmds.extend(node.record_storage_level_if_any(level_report)?);
+                            cmds.extend(MyNode::record_storage_level_if_any(
+                                &snapshot,
+                                level_report,
+                            )?);
+
+                            info!("End of message flow.");
                         }
                         Err(StorageError::NotEnoughSpace) => {
                             // storage full
                             error!("Not enough space to store more data");
-                            let node_id = PublicKey::from(node.keypair.public);
+
+                            let node_id = PublicKey::from(snapshot.keypair.public);
                             let msg = NodeMsg::NodeEvent(NodeEvent::CouldNotStoreData {
                                 node_id,
                                 data,
                                 full: true,
                             });
 
-                            cmds.push(node.send_msg_to_our_elders(msg))
+                            cmds.push(MyNode::send_msg_to_our_elders(&snapshot, msg))
                         }
                         Err(error) => {
                             // the rest seem to be non-problematic errors.. (?)
@@ -491,33 +538,37 @@ impl MyNode {
                 Ok(cmds)
             }
             NodeMsg::NodeCmd(NodeCmd::SendAnyMissingRelevantData(known_data_addresses)) => {
-                let node = node.read().await;
-
                 info!(
                     "{:?} MsgId: {:?}",
                     LogMarker::RequestForAnyMissingData,
                     msg_id
                 );
-                Ok(node
-                    .get_missing_data_for_node(sender, known_data_addresses)
-                    .await
-                    .into_iter()
-                    .collect())
+                let snapshot = &node.read().await.get_snapshot();
+                debug!("[NODE READ]: send missing data read got");
+
+                Ok(
+                    MyNode::get_missing_data_for_node(snapshot, sender, known_data_addresses)
+                        .await
+                        .into_iter()
+                        .collect(),
+                )
             }
             NodeMsg::NodeQuery(NodeQuery::Data {
                 query,
                 auth,
                 operation_id,
             }) => {
-                let node = node.read().await;
-
                 // A request from EndUser - via elders - for locally stored data
                 debug!(
                     "Handle NodeQuery with msg_id {:?}, operation_id {}",
                     msg_id, operation_id
                 );
+                let snapshot = node.read().await.get_snapshot();
 
-                node.handle_data_query_at_adult(
+                debug!("[NODE READ]: node query read got");
+
+                MyNode::handle_data_query_at_adult(
+                    &snapshot,
                     operation_id,
                     &query,
                     auth,
@@ -542,11 +593,14 @@ impl MyNode {
         }
     }
 
-    fn record_storage_level_if_any(&self, level: Option<StorageLevel>) -> Result<Vec<Cmd>> {
+    fn record_storage_level_if_any(
+        snapshot: &MyNodeSnapshot,
+        level: Option<StorageLevel>,
+    ) -> Result<Vec<Cmd>> {
         let mut cmds = vec![];
         if let Some(level) = level {
             info!("Storage has now passed {} % used.", 10 * level.value());
-            let node_id = PublicKey::from(self.keypair.public);
+            let node_id = PublicKey::from(snapshot.keypair.public);
             let node_xorname = XorName::from(node_id);
 
             // we ask the section to record the new level reached
@@ -556,7 +610,9 @@ impl MyNode {
                 level,
             });
 
-            let dst = Peers::Multiple(self.network_knowledge.elders());
+            // TODO: Force a lock on node to record new storage level only if one has been breached...
+
+            let dst = Peers::Multiple(snapshot.network_knowledge.elders());
 
             cmds.push(Cmd::send_msg(msg, dst));
         }

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -165,7 +165,7 @@ impl MyNode {
             // and repsonsive, as well as being a method of keeping nodes up to date.
             NodeMsg::AntiEntropyProbe(section_key) => {
                 debug!("[NODE READ]: aeprobe attempts");
-                let snapshot = node.read().await.get_snapshot();
+                let snapshot = node.read().await.snapshot();
                 debug!("[NODE READ]: aeprobe lock got");
 
                 let mut cmds = vec![];
@@ -189,7 +189,7 @@ impl MyNode {
             NodeMsg::JoinResponse(join_response) => {
                 let mut node = node.write().await;
                 debug!("[NODE WRITE]: join response write gottt...");
-                let snapshot = node.get_snapshot();
+                let snapshot = node.snapshot();
 
                 match *join_response {
                     JoinResponse::Approved {
@@ -271,7 +271,7 @@ impl MyNode {
             }
             NodeMsg::JoinRequest(join_request) => {
                 trace!("Handling msg {:?}: JoinRequest from {}", msg_id, sender);
-                let snapshot = &node.read().await.get_snapshot();
+                let snapshot = &node.read().await.snapshot();
                 debug!("[NODE READ]: joinReq read got");
 
                 MyNode::handle_join_request(node, snapshot, sender, join_request)
@@ -280,7 +280,7 @@ impl MyNode {
             }
             NodeMsg::JoinAsRelocatedRequest(join_request) => {
                 trace!("Handling msg: JoinAsRelocatedRequest from {}", sender);
-                let snapshot = &node.read().await.get_snapshot();
+                let snapshot = &node.read().await.snapshot();
                 debug!("[NODE READ]: joinReqas relocated read got");
 
                 if snapshot.is_not_elder
@@ -305,7 +305,7 @@ impl MyNode {
             }
             NodeMsg::MembershipAE(gen) => {
                 debug!("[NODE READ]: membership ae read ");
-                let snapshopt = node.read().await.get_snapshot();
+                let snapshopt = node.read().await.snapshot();
                 debug!("[NODE READ]: membership ae read got");
 
                 Ok(
@@ -429,7 +429,7 @@ impl MyNode {
                     msg_id
                 );
 
-                let snapshot = node.read().await.get_snapshot();
+                let snapshot = node.read().await.snapshot();
                 debug!("[NODE READ]: could ont store data read got");
 
                 if snapshot.is_not_elder {
@@ -458,7 +458,7 @@ impl MyNode {
             }
             NodeMsg::NodeCmd(NodeCmd::ReplicateOneData(data)) => {
                 debug!("[NODE READ]: replicate one data");
-                let mut snapshot = node.read().await.get_snapshot();
+                let mut snapshot = node.read().await.snapshot();
                 debug!("[NODE READ]: replicate one data read got");
 
                 if snapshot.is_elder {
@@ -482,7 +482,7 @@ impl MyNode {
             }
             NodeMsg::NodeCmd(NodeCmd::ReplicateData(data_collection)) => {
                 info!("ReplicateData MsgId: {:?}", msg_id);
-                let snapshot = node.read().await.get_snapshot();
+                let snapshot = node.read().await.snapshot();
                 debug!("[NODE READ]: replicate data read got");
 
                 if snapshot.is_elder {
@@ -543,7 +543,7 @@ impl MyNode {
                     LogMarker::RequestForAnyMissingData,
                     msg_id
                 );
-                let snapshot = &node.read().await.get_snapshot();
+                let snapshot = &node.read().await.snapshot();
                 debug!("[NODE READ]: send missing data read got");
 
                 Ok(
@@ -563,7 +563,7 @@ impl MyNode {
                     "Handle NodeQuery with msg_id {:?}, operation_id {}",
                     msg_id, operation_id
                 );
-                let snapshot = node.read().await.get_snapshot();
+                let snapshot = node.read().await.snapshot();
 
                 debug!("[NODE READ]: node query read got");
 

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -283,7 +283,7 @@ impl MyNode {
                 let context = &node.read().await.context();
                 debug!("[NODE READ]: joinReqas relocated read got");
 
-                if context.is_not_elder
+                if !context.is_elder
                     && join_request.section_key == context.network_knowledge.section_key()
                 {
                     return Ok(vec![]);
@@ -432,7 +432,7 @@ impl MyNode {
                 let context = node.read().await.context();
                 debug!("[NODE READ]: could ont store data read got");
 
-                if context.is_not_elder {
+                if !context.is_elder {
                     error!("Received unexpected message while Adult");
                     return Ok(vec![]);
                 }

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -482,7 +482,7 @@ impl MyNode {
             }
             NodeMsg::NodeCmd(NodeCmd::ReplicateData(data_collection)) => {
                 info!("ReplicateData MsgId: {:?}", msg_id);
-                let mut snapshot = node.read().await.get_snapshot();
+                let snapshot = node.read().await.get_snapshot();
                 debug!("[NODE READ]: replicate data read got");
 
                 if snapshot.is_elder {
@@ -593,6 +593,8 @@ impl MyNode {
         }
     }
 
+    /// Sets Cmd to locally record the storage level and send msgs to Elders
+    /// Advising the same
     fn record_storage_level_if_any(
         snapshot: &MyNodeSnapshot,
         level: Option<StorageLevel>,
@@ -600,6 +602,9 @@ impl MyNode {
         let mut cmds = vec![];
         if let Some(level) = level {
             info!("Storage has now passed {} % used.", 10 * level.value());
+
+            // Run a SetStorageLevel Cmd to actually update the DataStorage instance
+            cmds.push(Cmd::SetStorageLevel(level));
             let node_id = PublicKey::from(snapshot.keypair.public);
             let node_xorname = XorName::from(node_id);
 
@@ -609,8 +614,6 @@ impl MyNode {
                 node_id,
                 level,
             });
-
-            // TODO: Force a lock on node to record new storage level only if one has been breached...
 
             let dst = Peers::Multiple(snapshot.network_knowledge.elders());
 

--- a/sn_node/src/node/messaging/proposal.rs
+++ b/sn_node/src/node/messaging/proposal.rs
@@ -84,7 +84,7 @@ impl MyNode {
             .filter(|peer| peer.name() != our_name)
             .collect();
 
-        cmds.push(self.send_system_msg(msg, Peers::Multiple(recipients)));
+        cmds.push(MyNode::send_system_msg(msg, Peers::Multiple(recipients)));
 
         Ok(cmds)
     }

--- a/sn_node/src/node/messaging/serialize.rs
+++ b/sn_node/src/node/messaging/serialize.rs
@@ -11,23 +11,27 @@ use crate::node::{MyNode, Result};
 use sn_interface::messaging::{data::ClientMsgResponse, system::NodeMsg, MsgKind, WireMsg};
 
 use bytes::Bytes;
+use xor_name::XorName;
 
 impl MyNode {
     /// Serialize a message for a Client
     pub(crate) fn serialize_client_msg_response(
-        &self,
+        our_node_name: XorName,
         msg: ClientMsgResponse,
     ) -> Result<(MsgKind, Bytes)> {
         let payload = WireMsg::serialize_msg_payload(&msg)?;
-        let kind = MsgKind::ClientMsgResponse(self.name());
+        let kind = MsgKind::ClientMsgResponse(our_node_name);
 
         Ok((kind, payload))
     }
 
     /// Serialize a message for a Node
-    pub(crate) fn serialize_node_msg(&self, msg: NodeMsg) -> Result<(MsgKind, Bytes)> {
+    pub(crate) fn serialize_node_msg(
+        our_node_name: XorName,
+        msg: NodeMsg,
+    ) -> Result<(MsgKind, Bytes)> {
         let payload = WireMsg::serialize_msg_payload(&msg)?;
-        let kind = MsgKind::Node(self.name());
+        let kind = MsgKind::Node(our_node_name);
 
         Ok((kind, payload))
     }

--- a/sn_node/src/node/messaging/update_section.rs
+++ b/sn_node/src/node/messaging/update_section.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::{flow_ctrl::cmds::Cmd, messaging::Peers, MyNode};
+use crate::node::{core::MyNodeSnapshot, flow_ctrl::cmds::Cmd, messaging::Peers, MyNode};
 
 use sn_interface::{
     data_copy_count,
@@ -20,9 +20,9 @@ use std::collections::BTreeSet;
 impl MyNode {
     /// Given what data the peer has, we shall calculate what data the peer is missing that
     /// we have, and send such data to the peer.
-    #[instrument(skip(self, data_sender_has))]
+    #[instrument(skip(snapshot, data_sender_has))]
     pub(crate) async fn get_missing_data_for_node(
-        &self,
+        snapshot: &MyNodeSnapshot,
         sender: Peer,
         data_sender_has: Vec<DataAddress>,
     ) -> Option<Cmd> {
@@ -30,7 +30,7 @@ impl MyNode {
         // Collection of data addresses that we do not have
 
         // TODO: can we cache this data stored per churn event?
-        let data_i_have = self.data_storage.data_addrs().await;
+        let data_i_have = snapshot.data_storage.data_addrs().await;
         trace!("Our data got");
 
         if data_i_have.is_empty() {
@@ -38,7 +38,7 @@ impl MyNode {
             return None;
         }
 
-        let adults = self.network_knowledge.adults();
+        let adults = snapshot.network_knowledge.adults();
         let adults_names = adults.iter().map(|p2p_node| p2p_node.name());
 
         let mut data_for_sender = vec![];
@@ -78,15 +78,15 @@ impl MyNode {
     /// Will send a list of currently known/owned data to relevant nodes.
     /// These nodes should send back anything missing (in batches).
     /// Relevant nodes should be all _prior_ neighbours + _new_ elders.
-    #[instrument(skip(self))]
-    pub(crate) async fn ask_for_any_new_data(&self) -> Cmd {
+    #[instrument(skip(snapshot))]
+    pub(crate) async fn ask_for_any_new_data(snapshot: &MyNodeSnapshot) -> Cmd {
         trace!("{:?}", LogMarker::DataReorganisationUnderway);
         debug!("Querying section for any new data");
-        let data_i_have = self.data_storage.data_addrs().await;
+        let data_i_have = snapshot.data_storage.data_addrs().await;
 
-        let my_name = self.info().name();
-        let adults = self.network_knowledge.adults();
-        let elders = self.network_knowledge.elders();
+        let my_name = snapshot.name;
+        let adults = snapshot.network_knowledge.adults();
+        let elders = snapshot.network_knowledge.elders();
 
         // find data targets that are not us.
         let mut target_members = adults
@@ -114,6 +114,6 @@ impl MyNode {
         }
 
         let msg = NodeMsg::NodeCmd(NodeCmd::SendAnyMissingRelevantData(data_i_have));
-        self.send_system_msg(msg, Peers::Multiple(target_members))
+        MyNode::send_system_msg(msg, Peers::Multiple(target_members))
     }
 }

--- a/sn_node/src/node/messaging/update_section.rs
+++ b/sn_node/src/node/messaging/update_section.rs
@@ -29,7 +29,7 @@ impl MyNode {
         trace!("Getting missing data for node");
         // Collection of data addresses that we do not have
 
-        // TODO: can we cache this data stored per churn event?
+        // TODO: can cache this data stored per churn event?
         let data_i_have = snapshot.data_storage.data_addrs().await;
         trace!("Our data got");
 

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -152,7 +152,6 @@ mod core {
     pub(crate) struct NodeContext {
         pub(crate) root_storage_dir: PathBuf,
         pub(crate) is_elder: bool,
-        pub(crate) is_not_elder: bool,
         pub(crate) data_storage: DataStorage,
         pub(crate) name: XorName,
         pub(crate) info: MyNodeInfo,
@@ -186,7 +185,6 @@ mod core {
             NodeContext {
                 root_storage_dir: self.root_storage_dir.clone(),
                 is_elder: self.is_elder(),
-                is_not_elder: self.is_not_elder(),
                 name: self.name(),
                 info: self.info(),
                 full_adults: self.capacity.full_adults(),

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -171,7 +171,7 @@ mod core {
         /// Generate a read only snapshot of a subset of the node's state
         /// Useful for longer running processes to avoid having to acquire
         /// read locks eg
-        pub(crate) fn get_snapshot(&self) -> MyNodeSnapshot {
+        pub(crate) fn snapshot(&self) -> MyNodeSnapshot {
             MyNodeSnapshot {
                 root_storage_dir: self.root_storage_dir.clone(),
                 is_elder: self.is_elder(),
@@ -274,7 +274,7 @@ mod core {
                 membership,
             };
 
-            let snapshot = &node.get_snapshot();
+            let snapshot = &node.snapshot();
 
             // Write the section tree to this node's root storage directory
             MyNode::write_section_tree(snapshot);
@@ -518,7 +518,7 @@ mod core {
 
         /// Updates various state if elders changed.
         pub(crate) fn update_on_elder_change(&mut self, old: &MyNodeSnapshot) -> Result<Vec<Cmd>> {
-            let new = self.get_snapshot();
+            let new = self.snapshot();
             let new_section_key = new.network_knowledge.section_key();
             let new_prefix = new.network_knowledge.prefix();
             let old_prefix = old.network_knowledge.prefix();

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -167,6 +167,18 @@ mod core {
         pub(crate) membership: Option<Membership>,
     }
 
+    impl MyNodeSnapshot {
+        /// Returns the SAP of the section matching the name.
+        pub(crate) fn section_sap_matching_name(
+            &self,
+            name: &XorName,
+        ) -> Result<SectionAuthorityProvider> {
+            self.network_knowledge
+                .section_auth_by_name(name)
+                .map_err(Error::from)
+        }
+    }
+
     impl MyNode {
         /// Generate a read only snapshot of a subset of the node's state
         /// Useful for longer running processes to avoid having to acquire

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -48,7 +48,6 @@ pub use self::{
 };
 pub use crate::storage::DataStorage;
 
-// pub(crate) use self::monitoring::RateLimits;
 #[cfg(test)]
 pub(crate) use relocation::{check as relocation_check, ChurnId};
 
@@ -776,13 +775,4 @@ mod core {
             });
         }
     }
-
-    // #[derive(Clone)]
-    // pub(crate) struct StateSnapshot {
-    //     pub(crate) is_elder: bool,
-    //     pub(crate) section_key: bls::PublicKey,
-    //     pub(crate) prefix: Prefix,
-    //     pub(crate) elders: BTreeSet<XorName>,
-    //     pub(crate) members: BTreeSet<XorName>,
-    // }
 }

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -106,17 +106,19 @@ async fn new_node(
         bootstrap_node(config, used_space, root_dir, join_timeout).await?;
 
     {
-        let read_only_node = node.read().await;
+        debug!("[NODE WRITE]: new node...");
+        let snapshot = node.read().await.get_snapshot();
+        debug!("[NODE WRITE]: new node write got");
 
         // Network keypair may have to be changed due to naming criteria or network requirements.
-        let keypair_as_bytes = read_only_node.keypair.to_bytes();
+        let keypair_as_bytes = snapshot.keypair.to_bytes();
         store_network_keypair(root_dir, keypair_as_bytes).await?;
 
         let our_pid = std::process::id();
-        let node_prefix = read_only_node.network_knowledge().prefix();
-        let node_name = read_only_node.info().name();
-        let node_age = read_only_node.info().age();
-        let our_conn_info = read_only_node.info().addr;
+        let node_prefix = snapshot.network_knowledge.prefix();
+        let node_name = snapshot.name;
+        let node_age = snapshot.info.age();
+        let our_conn_info = snapshot.info.addr;
         let our_conn_info_json = serde_json::to_string(&our_conn_info)
             .unwrap_or_else(|_| "Failed to serialize connection info".into());
         println!(

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -107,7 +107,7 @@ async fn new_node(
 
     {
         debug!("[NODE WRITE]: new node...");
-        let snapshot = node.read().await.get_snapshot();
+        let snapshot = node.read().await.snapshot();
         debug!("[NODE WRITE]: new node write got");
 
         // Network keypair may have to be changed due to naming criteria or network requirements.

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -107,18 +107,18 @@ async fn new_node(
 
     {
         debug!("[NODE WRITE]: new node...");
-        let snapshot = node.read().await.snapshot();
+        let context = node.read().await.context();
         debug!("[NODE WRITE]: new node write got");
 
         // Network keypair may have to be changed due to naming criteria or network requirements.
-        let keypair_as_bytes = snapshot.keypair.to_bytes();
+        let keypair_as_bytes = context.keypair.to_bytes();
         store_network_keypair(root_dir, keypair_as_bytes).await?;
 
         let our_pid = std::process::id();
-        let node_prefix = snapshot.network_knowledge.prefix();
-        let node_name = snapshot.name;
-        let node_age = snapshot.info.age();
-        let our_conn_info = snapshot.info.addr;
+        let node_prefix = context.network_knowledge.prefix();
+        let node_name = context.name;
+        let node_age = context.info.age();
+        let our_conn_info = context.info.addr;
         let our_conn_info_json = serde_json::to_string(&our_conn_info)
             .unwrap_or_else(|_| "Failed to serialize connection info".into());
         println!(

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -88,8 +88,8 @@ impl NodeTestApi {
 
     /// Returns the info about the section matching the name.
     pub async fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
-        let snapshot = &self.node.read().await.snapshot();
-        snapshot.section_sap_matching_name(name)
+        let context = &self.node.read().await.context();
+        context.section_sap_matching_name(name)
     }
 
     /// Send a system msg.

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -88,7 +88,7 @@ impl NodeTestApi {
 
     /// Returns the info about the section matching the name.
     pub async fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
-        let snapshot = &self.node.read().await.get_snapshot();
+        let snapshot = &self.node.read().await.snapshot();
         MyNode::matching_section(snapshot, name)
     }
 

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -89,7 +89,7 @@ impl NodeTestApi {
     /// Returns the info about the section matching the name.
     pub async fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
         let snapshot = &self.node.read().await.snapshot();
-        MyNode::matching_section(snapshot, name)
+        snapshot.section_sap_matching_name(name)
     }
 
     /// Send a system msg.

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -88,7 +88,8 @@ impl NodeTestApi {
 
     /// Returns the info about the section matching the name.
     pub async fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
-        self.node.read().await.matching_section(name)
+        let snapshot = &self.node.read().await.get_snapshot();
+        MyNode::matching_section(snapshot, name)
     }
 
     /// Send a system msg.

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -344,7 +344,7 @@ mod tests {
         let used_space = UsedSpace::new(usize::MAX);
 
         // Create instance
-        let mut storage = DataStorage::new(path, used_space)?;
+        let storage = DataStorage::new(path, used_space)?;
 
         // 5mb random data chunk
         let bytes = random_bytes(5 * 1024 * 1024);
@@ -383,7 +383,7 @@ mod tests {
         let used_space = UsedSpace::new(usize::MAX);
 
         // Create instance
-        let mut storage = DataStorage::new(path, used_space)?;
+        let storage = DataStorage::new(path, used_space)?;
 
         // create reg cmd
 

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -60,10 +60,16 @@ impl DataStorage {
         })
     }
 
+    /// Update the storage level on data storage
+    /// (To avoid needing a write lock for general storage ops, we separate out this state operation)
+    pub fn set_storage_level(&mut self, new_level: StorageLevel) {
+        self.last_recorded_level = new_level;
+    }
+
     /// Store data in the local store
     #[instrument(skip(self))]
     pub async fn store(
-        &mut self,
+        &self,
         data: &ReplicatedData,
         section_pk: PublicKey,
         node_keypair: Keypair,
@@ -96,7 +102,6 @@ impl DataStorage {
             // every level represents 10 percentage points
             if used_space_level as u8 >= next_level.value() {
                 debug!("Next level for storage has been reached");
-                self.last_recorded_level = next_level;
                 return Ok(Some(next_level));
             }
         }

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -37,7 +37,9 @@ use xor_name::XorName;
 
 const BIT_TREE_DEPTH: usize = 20;
 
-/// Operations on data.
+/// Operations on data stored to disk.
+/// As data the storage struct may be cloned throughoout the node
+/// Operations here must be persisted to disk.
 #[derive(Debug, Clone)]
 // exposed as pub due to benches
 pub struct DataStorage {


### PR DESCRIPTION
For longer running message handling, we now pass around the inital MyNodeState. This avoids a tonnnn of read locks and therefore hopefully prevents holding up write and reads needlessly.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
