### PR TITLE
chore(test_utils): use `TestSapBuilder`

### DIFF
--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -615,7 +615,7 @@ mod tests {
     use super::*;
     use sn_interface::{
         network_knowledge::SectionTree,
-        test_utils::{prefix, TestKeys, TestSAP},
+        test_utils::{prefix, TestKeys, TestSapBuilder},
     };
 
     use eyre::Result;
@@ -636,9 +636,8 @@ mod tests {
         let elders_len = 5;
 
         let prefix = prefix("0");
-        let (section_auth, _, secret_key_set) =
-            TestSAP::random_sap(prefix, elders_len, 0, None, None);
-        let sap0 = TestKeys::get_section_signed(&secret_key_set.secret_key(), section_auth);
+        let (sap, secret_key_set, ..) = TestSapBuilder::new(prefix).elder_count(elders_len).build();
+        let sap0 = TestKeys::get_section_signed(&secret_key_set.secret_key(), sap);
         let (mut network_contacts, _genesis_sk, _) = new_network_network_contacts();
         assert!(network_contacts.insert_without_chain(sap0));
 

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -518,7 +518,7 @@ mod tests {
     use super::*;
     use crate::{
         network_knowledge::sections_dag::tests::arb_sections_dag_and_proof_chains,
-        test_utils::{assert_lists, prefix, TestSAP, TestSectionTree},
+        test_utils::{assert_lists, prefix, TestKeys, TestSapBuilder, TestSectionTree},
     };
     use eyre::Result;
     use proptest::{prelude::ProptestConfig, prop_assert_eq, proptest};
@@ -876,7 +876,11 @@ mod tests {
     fn random_signed_sap(
         prefix: Prefix,
     ) -> (SectionSigned<SectionAuthorityProvider>, bls::SecretKey) {
-        let (sap, _, sk) = TestSAP::random_signed_sap(prefix, 0, 5, None);
-        (sap, sk)
+        let (sap, sk, ..) = TestSapBuilder::new(prefix)
+            .elder_count(0)
+            .adult_count(5)
+            .build();
+        let sap = TestKeys::get_section_signed(&sk.secret_key(), sap);
+        (sap, sk.secret_key())
     }
 }

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -492,7 +492,7 @@ pub(crate) mod tests {
     use super::{Error, SectionInfo, SectionsDAG};
     use crate::{
         messaging::system::SectionSigned,
-        test_utils::{assert_lists, prefix, TestKeys, TestSAP},
+        test_utils::{assert_lists, prefix, TestKeys, TestSapBuilder},
         SectionAuthorityProvider,
     };
     use crdts::CmRDT;
@@ -1174,8 +1174,9 @@ pub(crate) mod tests {
             None => StdRng::from_entropy(),
         };
 
-        let (sap_gen, _, sk_gen) =
-            TestSAP::random_sap_with_rng(&mut rng, Prefix::default(), 0, 0, None, None);
+        let (sap_gen, sk_gen, ..) = TestSapBuilder::new(Prefix::default())
+            .elder_count(0)
+            .build_rng(&mut rng);
         let sk_gen = sk_gen.secret_key();
         let sap_gen = TestKeys::get_section_signed(&sk_gen, sap_gen);
         let pk_gen = sap_gen.public_key_set().public_key();
@@ -1203,7 +1204,7 @@ pub(crate) mod tests {
             >,
             dag: &mut SectionsDAG,
         ) -> Result<()> {
-            let (sap, _, sk_set) = TestSAP::random_sap_with_rng(rng, prefix, 0, 0, None, None);
+            let (sap, sk_set, ..) = TestSapBuilder::new(prefix).elder_count(0).build_rng(rng);
             let sap = TestKeys::get_section_signed(&sk_set.secret_key(), sap);
             let key = sap.public_key_set().public_key();
             let sig = TestKeys::sign(parent_sk, &key);

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -459,8 +459,7 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(10);
 
-        let (genesis_sap, _genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
+        let (genesis_sap, genesis_sk_set, ..) = TestSapBuilder::new(Prefix::default()).build();
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -478,8 +477,8 @@ mod tests {
         // Create the bootstrap task, but don't run it yet.
         let bootstrap = async move { state.try_join(join_timeout).await.map_err(Error::from) };
 
-        let (next_sap, next_elders, next_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
+        let (next_sap, next_sk_set, next_elders, _) =
+            TestSapBuilder::new(Prefix::default()).build();
 
         let next_section_key = next_sk_set.public_keys().public_key();
         let section_tree_update = TestSectionTree::get_section_tree_update(
@@ -566,8 +565,8 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
+        let (genesis_sap, genesis_sk_set, genesis_nodes, _) =
+            TestSapBuilder::new(Prefix::default()).build();
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -596,8 +595,7 @@ mod tests {
                     assert_matches!(msg, NodeMsg::JoinRequest{..}));
 
             // Send JoinResponse::Redirect
-            let (new_sap, _, _) =
-                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
+            let (new_sap, ..) = TestSapBuilder::new(Prefix::default()).build();
 
             send_response(
                 &recv_tx,
@@ -645,8 +643,8 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
+        let (genesis_sap, genesis_sk_set, genesis_nodes, _) =
+            TestSapBuilder::new(Prefix::default()).build();
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -671,8 +669,7 @@ mod tests {
             assert_matches!(wire_msg.into_msg(), Ok(MsgType::Node { msg, .. }) =>
             assert_matches!(msg, NodeMsg::JoinRequest{..}));
 
-            let (new_sap, _, new_sk_set) =
-                TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
+            let (new_sap, new_sk_set, ..) = TestSapBuilder::new(Prefix::default()).build();
             let new_pk_set = new_sk_set.public_keys();
 
             send_response(
@@ -723,8 +720,8 @@ mod tests {
         let (send_tx, mut send_rx) = mpsc::channel(1);
         let (recv_tx, mut recv_rx) = mpsc::channel(1);
 
-        let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), elder_count(), 0, None, None);
+        let (genesis_sap, genesis_sk_set, genesis_nodes, _) =
+            TestSapBuilder::new(Prefix::default()).build();
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -786,8 +783,10 @@ mod tests {
         let first_bit = node.name().bit(0);
         let bad_prefix = Prefix::default().pushed(!first_bit);
 
-        let (genesis_sap, genesis_nodes, genesis_sk_set) =
-            TestSAP::random_sap(Prefix::default(), 1, 0, None, None);
+        let (genesis_sap, genesis_sk_set, genesis_nodes, _) =
+            TestSapBuilder::new(Prefix::default())
+                .elder_count(1)
+                .build();
         let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
 
@@ -810,7 +809,7 @@ mod tests {
 
             // Send `Retry` with bad prefix
             let bad_section_tree_update = {
-                let (bad_sap, _, _) = TestSAP::random_sap(bad_prefix, 1, 0, None, None);
+                let (bad_sap, ..) = TestSapBuilder::new(bad_prefix).elder_count(1).build();
                 let mut bad_signed_sap = signed_genesis_sap.clone();
                 bad_signed_sap.value = bad_sap;
                 SectionTreeUpdate::new(bad_signed_sap, proof_chain.clone())
@@ -826,8 +825,9 @@ mod tests {
             task::yield_now().await;
 
             // Send `Retry` with valid update
-            let (next_sap, next_elders, next_sk_set) =
-                TestSAP::random_sap(Prefix::default(), 1, 0, None, None);
+            let (next_sap, next_sk_set, next_elders, _) = TestSapBuilder::new(Prefix::default())
+                .elder_count(1)
+                .build();
             let next_section_key = next_sk_set.public_keys().public_key();
             let section_tree_update = TestSectionTree::get_section_tree_update(
                 &TestKeys::get_section_signed(&next_sk_set.secret_key(), next_sap),

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -438,10 +438,9 @@ mod tests {
     };
 
     use sn_interface::{
-        elder_count,
         messaging::{Dst, MsgId},
         network_knowledge::{MyNodeInfo, SectionKeyShare, SectionKeysProvider, SectionsDAG},
-        test_utils::{gen_addr, TestKeys, TestSAP},
+        test_utils::{gen_addr, TestKeys, TestSapBuilder},
         types::keys::ed25519,
     };
 
@@ -580,8 +579,7 @@ mod tests {
             let prefix1 = Prefix::default().pushed(true);
 
             // generate a SAP for prefix0
-            let (sap, mut nodes, secret_key_set) =
-                TestSAP::random_sap(prefix0, elder_count(), 0, None, None);
+            let (sap, secret_key_set, mut nodes, _) = TestSapBuilder::new(prefix0).build();
             let info = nodes.remove(0);
             let sap_sk = secret_key_set.secret_key();
             let signed_sap = TestKeys::get_section_signed(&sap_sk, sap);
@@ -615,8 +613,7 @@ mod tests {
             let _ = node.update_network_knowledge(section_tree_update, None)?;
 
             // generate other SAP for prefix1
-            let (other_sap, _, secret_key_set) =
-                TestSAP::random_sap(prefix1, elder_count(), 0, None, None);
+            let (other_sap, secret_key_set, ..) = TestSapBuilder::new(prefix1).build();
             let other_sap_sk = secret_key_set.secret_key();
             let other_sap = TestKeys::get_section_signed(&other_sap_sk, other_sap);
             // generate a proof chain for this other SAP

--- a/sn_node/src/node/proposal.rs
+++ b/sn_node/src/node/proposal.rs
@@ -62,7 +62,7 @@ impl Proposal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sn_interface::test_utils::{TestKeys, TestSAP};
+    use sn_interface::test_utils::{TestKeys, TestSapBuilder};
 
     use eyre::Result;
     use serde::Serialize;
@@ -72,15 +72,17 @@ mod tests {
     #[test]
     fn serialize_for_signing() -> Result<()> {
         // Proposal::SectionInfo
-        let (section_auth, _, _) = TestSAP::random_sap(Prefix::default(), 4, 0, None, None);
-        let proposal = Proposal::SectionInfo(section_auth.clone());
-        verify_serialize_for_signing(&proposal, &section_auth)?;
+        let (sap, ..) = TestSapBuilder::new(Prefix::default())
+            .elder_count(4)
+            .build();
+        let proposal = Proposal::SectionInfo(sap.clone());
+        verify_serialize_for_signing(&proposal, &sap)?;
 
         // Proposal::NewElders
         let new_sk = bls::SecretKey::random();
         let new_pk = new_sk.public_key();
-        let section_signed_auth = TestKeys::get_section_signed(&new_sk, section_auth);
-        let proposal = Proposal::NewElders(section_signed_auth);
+        let signed_sap = TestKeys::get_section_signed(&new_sk, sap);
+        let proposal = Proposal::NewElders(signed_sap);
         verify_serialize_for_signing(&proposal, &new_pk)?;
 
         Ok(())


### PR DESCRIPTION
- https://github.com/maidsafe/safe_network/pull/1755/commits/cd0b27a3aed7bb10a7bb1ab933bea208fb17b432 feat(test_utils): introduce `TestSapBuilder` to generate custom SAPs
Replaces the standalone utils into a single one to generate random
SAPs for testing.
- https://github.com/maidsafe/safe_network/pull/1755/commits/08054dbdb4d34cb7fc045189316d322f02d1c629 chore(test_utils): replace `TestSAP` with `TestSapBuilder`
