### PR TITLE
refactor(responses): return correct cmd response

### DIFF
--- a/sn_cli/src/operations/node.rs
+++ b/sn_cli/src/operations/node.rs
@@ -241,7 +241,7 @@ fn kill_nodes(exec_name: &str) -> Result<()> {
 #[cfg(target_os = "windows")]
 fn kill_nodes(exec_name: &str) -> Result<()> {
     let output = Command::new("taskkill")
-        .args(&["/F", "/IM", exec_name])
+        .args(["/F", "/IM", exec_name])
         .output()
         .wrap_err_with(|| {
             format!(

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -62,10 +62,10 @@ impl Session {
             if attempt > MAX_AE_RETRIES_TO_ATTEMPT {
                 break MsgResponse::Failure(
                     addr,
-                    Box::new(Error::AntiEntropyMaxRetries {
+                    Error::AntiEntropyMaxRetries {
                         msg_id: correlation_id,
                         retries: attempt - 1,
-                    }),
+                    },
                 );
             }
 
@@ -90,17 +90,17 @@ impl Session {
                         attempt += 1;
                         continue;
                     }
-                    Err(err) => break MsgResponse::Failure(addr, Box::new(err)),
+                    Err(err) => break MsgResponse::Failure(addr, err),
                 },
                 Ok(msg @ MsgType::Client { .. }) => {
                     warn!("Unexpected ClientMsg type received for {correlation_id:?}: {msg:?}");
                     break MsgResponse::Failure(
                         addr,
-                        Box::new(Error::UnexpectedMsgType {
+                        Error::UnexpectedMsgType {
                             correlation_id,
                             peer,
                             msg,
-                        }),
+                        },
                     );
                 }
                 Ok(msg @ MsgType::NodeDataResponse { .. }) => {
@@ -109,14 +109,14 @@ impl Session {
                     );
                     break MsgResponse::Failure(
                         addr,
-                        Box::new(Error::UnexpectedMsgType {
+                        Error::UnexpectedMsgType {
                             correlation_id,
                             peer,
                             msg,
-                        }),
+                        },
                     );
                 }
-                Err(err) => break MsgResponse::Failure(addr, Box::new(err)),
+                Err(err) => break MsgResponse::Failure(addr, err),
             }
         };
 

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -104,10 +104,10 @@ impl Session {
             };
 
             match result {
-                Ok(()) => {
+                Ok(address) => {
                     let preexisting = !received_acks.insert(src) || received_errors.contains(&src);
                     debug!(
-                        "ACK from {src:?} read from set for msg_id {msg_id:?} - preexisting??: {preexisting:?}",
+                        "ACK of {address:?} from {src:?} read from set for msg_id {msg_id:?} - preexisting??: {preexisting:?}",
                     );
 
                     if received_acks.len() >= expected_acks {
@@ -600,7 +600,10 @@ impl Session {
                     Err(error) => {
                         error!("Error sending {msg_id:?} bidi to {peer:?}: {error:?}");
                         session.peer_links.remove_link_from_peer_links(&peer).await;
-                        MsgResponse::Failure(peer.addr(), Error::FailedToInitateBiDiStream(msg_id))
+                        MsgResponse::Failure(
+                            peer.addr(),
+                            Box::new(Error::FailedToInitateBiDiStream(msg_id)),
+                        )
                     }
                 }
             });

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -600,10 +600,7 @@ impl Session {
                     Err(error) => {
                         error!("Error sending {msg_id:?} bidi to {peer:?}: {error:?}");
                         session.peer_links.remove_link_from_peer_links(&peer).await;
-                        MsgResponse::Failure(
-                            peer.addr(),
-                            Box::new(Error::FailedToInitateBiDiStream(msg_id)),
-                        )
+                        MsgResponse::Failure(peer.addr(), Error::FailedToInitateBiDiStream(msg_id))
                     }
                 }
             });

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -26,7 +26,7 @@ use tokio::sync::RwLock;
 pub(super) enum MsgResponse {
     CmdResponse(SocketAddr, Box<CmdResponse>),
     QueryResponse(SocketAddr, Box<QueryResponse>),
-    Failure(SocketAddr, Box<Error>),
+    Failure(SocketAddr, Error),
 }
 
 #[derive(Debug)]

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -26,7 +26,7 @@ use tokio::sync::RwLock;
 pub(super) enum MsgResponse {
     CmdResponse(SocketAddr, Box<CmdResponse>),
     QueryResponse(SocketAddr, Box<QueryResponse>),
-    Failure(SocketAddr, Error),
+    Failure(SocketAddr, Box<Error>),
 }
 
 #[derive(Debug)]

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -19,7 +19,7 @@ use xor_name::Prefix;
 pub type Result<T, E = Error> = result::Result<T, E>;
 
 /// Errors that can occur when interactive with client messaging APIs.
-#[derive(Error, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Error, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Error {
     /// Access denied for user

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -50,11 +50,13 @@ pub enum Error {
     /// User entry could not be found on the data
     #[error("Requested user not found {0:?}")]
     NoSuchUser(User),
-    /// Invalid Operation such as a POST on ImmutableData
+    /// Invalid Operation
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
     /// A DBC spend request could not be processed because the processing section was unaware of
     /// the section that signed one of the input spent proofs.
     #[error("Spent proof is signed by section key {0:?} that is unknown to the current section")]
     SpentProofUnknownSectionKey(bls::PublicKey),
+    #[error("Trying to produce a CmdResponse error for a data type not resulting from a cmd")]
+    NoCorrespondingCmdError,
 }

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -241,16 +241,8 @@ impl CmdResponse {
                 CmdResponse::EditRegister(Ok(data.address()))
             }
             ReplicatedData::SpentbookWrite(_) => CmdResponse::SpendKey(Ok(data.address())),
-            ReplicatedData::RegisterLog(_) => {
-                return Err(Error::InvalidOperation(
-                    "RegisterLog is not resulting from a cmd.".to_string(),
-                ))
-            }
-            ReplicatedData::SpentbookLog(_) => {
-                return Err(Error::InvalidOperation(
-                    "SpentbookLog is not resulting from a cmd.".to_string(),
-                ))
-            }
+            ReplicatedData::RegisterLog(_) => return Err(Error::NoCorrespondingCmdError), // this should be unreachable, since `RegisterLog` is not resulting from a cmd.
+            ReplicatedData::SpentbookLog(_) => return Err(Error::NoCorrespondingCmdError), // this should be unreachable, since `SpentbookLog` is not resulting from a cmd.
         };
         Ok(res)
     }

--- a/sn_interface/src/messaging/msg_kind.rs
+++ b/sn_interface/src/messaging/msg_kind.rs
@@ -22,7 +22,9 @@ pub enum MsgKind {
     /// Authority is needed to access private data, such as reading or writing a private file.
     Client(ClientAuth),
     /// A data response sent from a Node (along with its name) to the client
-    ClientMsgResponse(XorName),
+    ClientDataResponse(XorName),
     /// A message from a Node along with its name
     Node(XorName),
+    /// A data response sent from an Adult (along with its name) to Elders
+    NodeDataResponse(XorName),
 }

--- a/sn_interface/src/messaging/system/node_msgs.rs
+++ b/sn_interface/src/messaging/system/node_msgs.rs
@@ -19,7 +19,7 @@ use xor_name::XorName;
 /// cmd message sent among nodes
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub enum NodeCmd {
+pub enum NodeDataCmd {
     /// Notify Elders on nearing max capacity
     RecordStorageLevel {
         /// Node Id
@@ -29,7 +29,7 @@ pub enum NodeCmd {
         /// The storage level reported by the node.
         level: StorageLevel,
     },
-    /// Tells an Adult to store a  data
+    /// Tells an Adult to store a data
     ReplicateOneData(ReplicatedData),
     /// Tells an Adult to store a replica of some data set
     ReplicateData(Vec<ReplicatedData>),
@@ -57,22 +57,19 @@ pub enum NodeEvent {
         /// Whether store failed due to full
         full: bool,
     },
-    DataStored(DataAddress),
 }
 
 /// Query originating at a node
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
-pub enum NodeQuery {
+pub struct NodeDataQuery {
     /// Data is handled by Adults
-    Data {
-        /// The query
-        query: DataQueryVariant,
-        /// Client signature
-        auth: ClientAuth,
-        /// The operation id that recorded in Elders for this query
-        operation_id: OperationId,
-    },
+    /// The query
+    pub query: DataQueryVariant,
+    /// Client signature
+    pub auth: ClientAuth,
+    /// The operation id that recorded in Elders for this query
+    pub operation_id: OperationId,
 }
 
 /// Responses to queries sent from Elders to Adults.

--- a/sn_interface/src/types/errors.rs
+++ b/sn_interface/src/types/errors.rs
@@ -66,8 +66,10 @@ pub enum Error {
     /// BLS key error
     #[error(transparent)]
     BlsError(#[from] BlsError),
-    #[error("The operation is invalid in its context: {0}.")]
-    InvalidOperation(String),
+    #[error(
+        "There is no CmdResponse for the variant of ReplicatedData as it is not used in a cmd."
+    )]
+    NoCmdResponseForTheVariant,
 }
 
 impl From<bincode::Error> for Error {

--- a/sn_interface/src/types/errors.rs
+++ b/sn_interface/src/types/errors.rs
@@ -66,6 +66,8 @@ pub enum Error {
     /// BLS key error
     #[error(transparent)]
     BlsError(#[from] BlsError),
+    #[error("The operation is invalid in its context: {0}.")]
+    InvalidOperation(String),
 }
 
 impl From<bincode::Error> for Error {

--- a/sn_interface/src/types/log_markers.rs
+++ b/sn_interface/src/types/log_markers.rs
@@ -50,7 +50,7 @@ pub enum LogMarker {
     // Chunks
     StoringChunk,
     StoredNewChunk,
-    ChunkQueryResponseReceviedFromAdult,
+    DataResponseReceviedFromAdult,
     ChunkQueryReceviedAtElder,
     ChunkQueryReceviedAtAdult,
     // Data reorganisation

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -112,14 +112,8 @@ impl ReplicatedData {
                 Ok(CmdResponse::EditRegister(Err(error)))
             }
             Self::SpentbookWrite(_) => Ok(CmdResponse::SpendKey(Err(error))),
-            Self::SpentbookLog(_) => Err(Error::InvalidOperation(
-                "There is no CmdResponse for the SpentbookLog variant of ReplicatedData."
-                    .to_string(),
-            )),
-            Self::RegisterLog(_) => Err(Error::InvalidOperation(
-                "There is no CmdResponse for the RegisterLog variant of ReplicatedData."
-                    .to_string(),
-            )),
+            Self::SpentbookLog(_) => Err(Error::NoCmdResponseForTheVariant), // should be unreachable, since `SpentbookLog` is not resulting from a cmd.
+            Self::RegisterLog(_) => Err(Error::NoCmdResponseForTheVariant), // should be unreachable, since `RegisterLog` is not resulting from a cmd.,
         }
     }
 }

--- a/sn_node/examples/routing_stress.rs
+++ b/sn_node/examples/routing_stress.rs
@@ -9,7 +9,7 @@
 #![recursion_limit = "256"]
 
 use sn_interface::{
-    messaging::system::{NodeCmd, NodeMsg},
+    messaging::system::{NodeDataCmd, NodeMsg},
     types::Cache,
 };
 use sn_node::node::{
@@ -435,7 +435,7 @@ impl Network {
         // section health to appear lower than it actually is.
 
         // just some valid message
-        let msg = NodeMsg::NodeCmd(NodeCmd::ReplicateData(vec![]));
+        let msg = NodeMsg::NodeDataCmd(NodeDataCmd::ReplicateData(vec![]));
 
         let recipients = node.our_elders().await;
 

--- a/sn_node/src/comm/listener.rs
+++ b/sn_node/src/comm/listener.rs
@@ -76,7 +76,9 @@ impl MsgListener {
 
                     let src_name = match wire_msg.kind() {
                         MsgKind::Client(auth) => auth.public_key.into(),
-                        MsgKind::Node(name) | MsgKind::ClientMsgResponse(name) => *name,
+                        MsgKind::Node(name)
+                        | MsgKind::ClientDataResponse(name)
+                        | MsgKind::NodeDataResponse(name) => *name,
                     };
 
                     if first {

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -413,8 +413,9 @@ impl<'a> Joiner<'a> {
                 }) => return Ok((*resp, sender)),
                 Ok(
                     MsgType::Client { msg_id, .. }
-                    | MsgType::ClientMsgResponse { msg_id, .. }
-                    | MsgType::Node { msg_id, .. },
+                    | MsgType::Node { msg_id, .. }
+                    | MsgType::ClientDataResponse { msg_id, .. }
+                    | MsgType::NodeDataResponse { msg_id, .. },
                 ) => {
                     trace!("Bootstrap message discarded: sender: {sender:?} msg_id: {msg_id:?}");
                 }

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -14,7 +14,7 @@ use crate::node::{
 };
 
 use sn_interface::{
-    messaging::system::{NodeCmd, NodeMsg},
+    messaging::system::{NodeDataCmd, NodeMsg},
     types::log_markers::LogMarker,
 };
 
@@ -398,7 +398,7 @@ impl FlowCtrl {
                     data_recipients,
                 );
 
-                let msg = NodeMsg::NodeCmd(NodeCmd::ReplicateData(vec![data_to_send]));
+                let msg = NodeMsg::NodeDataCmd(NodeDataCmd::ReplicateData(vec![data_to_send]));
 
                 return Ok(Some(MyNode::send_system_msg(
                     msg,

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -6,7 +6,7 @@ use sn_interface::{
     messaging::{
         data::ClientMsg,
         serialisation::WireMsg,
-        system::{JoinResponse, NodeCmd, NodeMsg},
+        system::{JoinResponse, NodeDataCmd, NodeMsg},
         AuthorityProof, ClientAuth, MsgId,
     },
     network_knowledge::{
@@ -184,8 +184,8 @@ impl Cmd {
     pub(crate) fn get_replicated_data(&self) -> Result<ReplicatedData> {
         match self {
             Cmd::SendMsg { msg, .. } => match msg {
-                NodeMsg::NodeCmd(node_cmd) => match node_cmd {
-                    NodeCmd::ReplicateData(data) => {
+                NodeMsg::NodeDataCmd(node_cmd) => match node_cmd {
+                    NodeDataCmd::ReplicateData(data) => {
                         if data.len() != 1 {
                             return Err(eyre!("Only 1 replicated data instance is expected"));
                         }
@@ -199,8 +199,8 @@ impl Cmd {
         }
     }
 
-    // /// Get a `ClientMsgResponse` from a `Cmd::SendMsg` enum variant.
-    // pub(crate) fn get_client_msg_resp(&self) -> Result<ClientMsgResponse> {
+    // /// Get a `ClientDataResponse` from a `Cmd::SendMsg` enum variant.
+    // pub(crate) fn get_client_msg_resp(&self) -> Result<ClientDataResponse> {
     //     match self {
     //         Cmd::SendMsg { msg, .. } => match msg {
     //             OutgoingMsg::Client(client_msg) => Ok(client_msg.clone()),
@@ -215,11 +215,11 @@ impl Cmd {
     //     match self {
     //         Cmd::SendMsg { msg, .. } => match msg {
     //             OutgoingMsg::Client(client_msg) => match client_msg {
-    //                 ClientMsgResponse::CmdResponse { response, .. } => match response.result() {
+    //                 ClientDataResponse::CmdResponse { response, .. } => match response.result() {
     //                     Ok(_) => Err(eyre!("A CmdResponse error was expected")),
     //                     Err(error) => Ok(error.clone()),
     //                 },
-    //                 _ => Err(eyre!("A ClientMsgResponse::CmdResponse variant was expected")),
+    //                 _ => Err(eyre!("A ClientDataResponse::CmdResponse variant was expected")),
     //             },
     //             _ => Err(eyre!("A OutgoingMsg::Client variant was expected")),
     //         },

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -32,7 +32,7 @@ use sn_interface::{
     elder_count, init_logger,
     messaging::{
         data::{ClientMsg, DataCmd, SpentbookCmd},
-        system::{AntiEntropyKind, JoinAsRelocatedRequest, NodeCmd, NodeMsg, SectionSigned},
+        system::{AntiEntropyKind, JoinAsRelocatedRequest, NodeDataCmd, NodeMsg, SectionSigned},
         Dst, MsgType, WireMsg,
     },
     network_knowledge::{
@@ -669,7 +669,7 @@ async fn msg_to_self() -> Result<()> {
     let info = node.info();
     let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)));
 
-    let node_msg = NodeMsg::NodeCmd(NodeCmd::ReplicateData(vec![]));
+    let node_msg = NodeMsg::NodeDataCmd(NodeDataCmd::ReplicateData(vec![]));
 
     // don't use the cmd collection fn, as it skips Cmd::SendMsg
     let cmds = dispatcher

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -15,7 +15,7 @@ use itertools::Itertools;
 use qp2p::{SendStream, UsrMsgBytes};
 use sn_interface::{
     messaging::{
-        system::{AntiEntropyKind, NodeCmd, NodeMsg, SectionSigned},
+        system::{AntiEntropyKind, NodeDataCmd, NodeMsg, SectionSigned},
         MsgId, MsgType, WireMsg,
     },
     network_knowledge::{NodeState, SectionTreeUpdate},
@@ -80,7 +80,7 @@ impl MyNode {
     pub(crate) fn send_metadata_updates(&self, recipients: BTreeSet<Peer>, prefix: &Prefix) -> Cmd {
         let metadata = self.get_metadata_of(prefix);
         MyNode::send_system_msg(
-            NodeMsg::NodeCmd(NodeCmd::ReceiveMetadata { metadata }),
+            NodeMsg::NodeDataCmd(NodeDataCmd::ReceiveMetadata { metadata }),
             Peers::Multiple(recipients),
         )
     }

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -19,10 +19,10 @@ use sn_interface::{
     data_copy_count,
     messaging::{
         data::{
-            ClientMsg, ClientMsgResponse, DataCmd, DataQueryVariant, EditRegister,
+            ClientDataResponse, ClientMsg, DataCmd, DataQueryVariant, EditRegister,
             SignedRegisterEdit, SpentbookCmd,
         },
-        system::{NodeMsg, OperationId},
+        system::{NodeDataResponse, OperationId},
         AuthorityProof, ClientAuth, MsgId,
     },
     network_knowledge::section_keys::build_spent_proof_share,
@@ -48,7 +48,7 @@ impl MyNode {
         correlation_id: MsgId,
         send_stream: Arc<Mutex<SendStream>>,
     ) -> Result<()> {
-        let the_error_msg = ClientMsgResponse::QueryResponse {
+        let the_error_msg = ClientDataResponse::QueryResponse {
             response: query.to_error_response(error.into()),
             correlation_id,
         };
@@ -74,7 +74,7 @@ impl MyNode {
         correlation_id: MsgId,
         send_stream: Arc<Mutex<SendStream>>,
     ) -> Result<()> {
-        let client_msg = ClientMsgResponse::CmdResponse {
+        let client_msg = ClientDataResponse::CmdResponse {
             response: cmd.to_error_response(error.into()),
             correlation_id,
         };
@@ -110,12 +110,12 @@ impl MyNode {
             .await;
 
         trace!("data query response at adult is: {:?}", response);
-        let msg = NodeMsg::NodeQueryResponse {
+        let msg = NodeDataResponse::QueryResponse {
             response,
             operation_id,
         };
 
-        let (kind, payload) = MyNode::serialize_node_msg(context.name, msg)?;
+        let (kind, payload) = MyNode::serialize_node_msg_response(context.name, msg)?;
 
         let bytes = MyNode::form_usr_msg_bytes_to_node(
             context.network_knowledge.section_key(),

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -176,10 +176,18 @@ impl MyNode {
                 )
                 .await
             }
-            other @ MsgType::ClientMsgResponse { .. } => {
+            other @ MsgType::ClientDataResponse { .. } => {
                 error!(
-                    "Client msg response {msg_id:?}, from {}, has been dropped since it's not \
+                    "Client data response {msg_id:?}, from {}, has been dropped since it's not \
                     meant to be handled by a node: {other:?}",
+                    origin.addr()
+                );
+                Ok(vec![])
+            }
+            other @ MsgType::NodeDataResponse { .. } => {
+                error!(
+                    "Node data response {msg_id:?}, from {}, has been dropped since it's not \
+                    meant to be handled this way (it is directly forwarded to client): {other:?}",
                     origin.addr()
                 );
                 Ok(vec![])

--- a/sn_node/src/node/messaging/serialize.rs
+++ b/sn_node/src/node/messaging/serialize.rs
@@ -8,7 +8,11 @@
 
 use crate::node::{MyNode, Result};
 
-use sn_interface::messaging::{data::ClientMsgResponse, system::NodeMsg, MsgKind, WireMsg};
+use sn_interface::messaging::{
+    data::ClientDataResponse,
+    system::{NodeDataResponse, NodeMsg},
+    MsgKind, WireMsg,
+};
 
 use bytes::Bytes;
 use xor_name::XorName;
@@ -17,11 +21,10 @@ impl MyNode {
     /// Serialize a message for a Client
     pub(crate) fn serialize_client_msg_response(
         our_node_name: XorName,
-        msg: ClientMsgResponse,
+        msg: ClientDataResponse,
     ) -> Result<(MsgKind, Bytes)> {
         let payload = WireMsg::serialize_msg_payload(&msg)?;
-        let kind = MsgKind::ClientMsgResponse(our_node_name);
-
+        let kind = MsgKind::ClientDataResponse(our_node_name);
         Ok((kind, payload))
     }
 
@@ -32,7 +35,16 @@ impl MyNode {
     ) -> Result<(MsgKind, Bytes)> {
         let payload = WireMsg::serialize_msg_payload(&msg)?;
         let kind = MsgKind::Node(our_node_name);
+        Ok((kind, payload))
+    }
 
+    /// Serialize a message for a Node
+    pub(crate) fn serialize_node_msg_response(
+        our_node_name: XorName,
+        msg: NodeDataResponse,
+    ) -> Result<(MsgKind, Bytes)> {
+        let payload = WireMsg::serialize_msg_payload(&msg)?;
+        let kind = MsgKind::NodeDataResponse(our_node_name);
         Ok((kind, payload))
     }
 }

--- a/sn_node/src/node/messaging/update_section.rs
+++ b/sn_node/src/node/messaging/update_section.rs
@@ -10,7 +10,7 @@ use crate::node::{core::NodeContext, flow_ctrl::cmds::Cmd, messaging::Peers, MyN
 
 use sn_interface::{
     data_copy_count,
-    messaging::system::{NodeCmd, NodeMsg},
+    messaging::system::{NodeDataCmd, NodeMsg},
     types::{log_markers::LogMarker, DataAddress, Peer},
 };
 
@@ -113,7 +113,7 @@ impl MyNode {
             trace!("Sending our data list to: {:?}", target_members);
         }
 
-        let msg = NodeMsg::NodeCmd(NodeCmd::SendAnyMissingRelevantData(data_i_have));
+        let msg = NodeMsg::NodeDataCmd(NodeDataCmd::SendAnyMissingRelevantData(data_i_have));
         MyNode::send_system_msg(msg, Peers::Multiple(target_members))
     }
 }


### PR DESCRIPTION
- Returns the correct response type corresponding to the cmd.
- Adds the data address in question to the ack.
- Renames `ClientMsgResponse` to `ClientDataResponse`.
- Adds `NodeDataResponse` and aligns it to the pattern of `ClientDataResponse`.
- Moves data write acks to `NodeDataReponse`.
- Makes `NodeEvent` only be Adult to Elder notifications.
- Removes the `NodeQueryResponse` dead code path from `NodeMsg`.
- Removes some unnecessary derive macros from `QueryResponse`, `CmdResponse` and `sn_interface::messaging::data::Error`, 
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
