### PR TITLE
Ae lock reduction2

### DIFF
--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -147,7 +147,7 @@ impl MyNode {
         match section_chain.insert(&last_key, signed_sap.section_key(), section_sig.signature) {
             Ok(()) => {
                 let section_tree_update = SectionTreeUpdate::new(signed_sap, section_chain);
-                match self.update_network_knowledge(section_tree_update, None) {
+                match self.update_network_knowledge(&self.context(), section_tree_update, None) {
                     Ok(true) => {
                         info!("Updated our network knowledge for {:?}", prefix);
                         info!("Writing updated knowledge to disk");

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -183,8 +183,6 @@ impl MyNode {
     ///   Ok(true) if the update had new valid information
     ///   Ok(false) if the update was valid but did not contain new information
     ///   Err(_) if the update was invalid
-    ///
-    /// Operates on the context mutably
     pub(crate) fn would_we_update_network_knowledge(
         context: &NodeContext,
         section_tree_update: SectionTreeUpdate,
@@ -246,7 +244,7 @@ impl MyNode {
     #[instrument(skip_all)]
     pub(crate) async fn handle_anti_entropy_msg(
         node: Arc<RwLock<MyNode>>,
-        context: &NodeContext,
+        context: NodeContext,
         section_tree_update: SectionTreeUpdate,
         kind: AntiEntropyKind,
         sender: Peer,
@@ -266,7 +264,7 @@ impl MyNode {
         // block off the write lock
         let updated = {
             let should_update = MyNode::would_we_update_network_knowledge(
-                context,
+                &context,
                 section_tree_update.clone(),
                 members.clone(),
             )?;
@@ -274,7 +272,7 @@ impl MyNode {
                 let mut write_locked_node = node.write().await;
                 debug!("[NODE WRITE]: handling AE write gottt...");
                 let updated = write_locked_node.update_network_knowledge(
-                    context,
+                    &context,
                     section_tree_update,
                     members,
                 )?;

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -159,7 +159,7 @@ impl MyNode {
                 let context = node.read().await.context();
                 // as we've data storage reqs inside here for reorganisation, we have async calls to
                 // the fs
-                MyNode::handle_anti_entropy_msg(node, &context, section_tree_update, kind, sender)
+                MyNode::handle_anti_entropy_msg(node, context, section_tree_update, kind, sender)
                     .await
             }
             // Respond to a probe msg


### PR DESCRIPTION
previously we locked on handling _all_ anti entropy messages. now we pass in the `Arc<RwLock<MyNode>>` and only take the write lock if there _would_ be an update.

This should reduce the amount of write locks needed significantly as we have many more anti entropy messages that go out and may do _nothing_ (as only the first received for any message sent out will trigger an update... and we send messages to many nodes at once)