### PR TITLE
chore(node): Remove locks in data replication flows.

### DIFF
--- a/sn_client/examples/churn.rs
+++ b/sn_client/examples/churn.rs
@@ -33,7 +33,7 @@ const SAFE_NODE_EXECUTABLE: &str = "sn_node";
 const SAFE_NODE_EXECUTABLE: &str = "sn_node.exe";
 
 const NODES_DIR: &str = "local-test-network";
-const INTERVAL_IN_MS: &str = "100";
+const INTERVAL_IN_MS: &str = "3000";
 const RUST_LOG: &str = "RUST_LOG";
 const ADDITIONAL_NODES: u64 = 12;
 const FILES_TO_PUT: i32 = 40;

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -39,7 +39,7 @@ pub enum Error {
     PeerSessionChannel,
     /// SendChannel error for the data replication flow. This is a critical error and the node no longer functions.
     #[error("Data replication channel could not be sent to. This means the receiver has been dropped, the node can no longer replicate data and must shut down.")]
-    DataReplicationChanel,
+    DataReplicationChannel,
     /// This peer has no connections, and none will be created
     #[error("Peer link has no connections ")]
     NoConnectionsForPeer,

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     /// This Peer SendJob could not be sent. We should remove this peer
     #[error("Peer channel errored")]
     PeerSessionChannel,
+    /// SendChannel error for the data replication flow. This is a critical error and the node no longer functions.
+    #[error("Data replication channel could not be sent to. This means the receiver has been dropped, the node can no longer replicate data and must shut down.")]
+    DataReplicationChanel,
     /// This peer has no connections, and none will be created
     #[error("Peer link has no connections ")]
     NoConnectionsForPeer,

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -23,6 +23,7 @@ use tokio::sync::{
     RwLock,
 };
 use xor_name::XorName;
+
 // Cmd Dispatcher.
 pub(crate) struct Dispatcher {
     node: Arc<RwLock<MyNode>>,
@@ -194,25 +195,7 @@ impl Dispatcher {
                 self.data_replication_sender
                     .send((data_batch, recipient))
                     .await
-                    .map_err(|_| Error::DataReplicationChanel)?;
-
-                // // we should queue this
-                // for data in data_batch {
-                //     trace!("data being enqueued for replication {:?}", data);
-                //     let mut node = self.node.write().await;
-                //     debug!("[NODE WRITE]: data for repl write got");
-                //     if let Some(peers_set) = node.pending_data_to_replicate_to_peers.get_mut(&data)
-                //     {
-                //         debug!("data already queued, adding peer");
-                //         let _existed = peers_set.insert(recipient);
-                //     } else {
-                //         let mut peers_set = BTreeSet::new();
-                //         let _existed = peers_set.insert(recipient);
-                //         let _existed = node
-                //             .pending_data_to_replicate_to_peers
-                //             .insert(data, peers_set);
-                //     };
-                // }
+                    .map_err(|_| Error::DataReplicationChannel)?;
                 Ok(vec![])
             }
             Cmd::ProposeVoteNodesOffline(names) => {

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -22,6 +22,7 @@ use periodic_checks::PeriodicChecksTimestamps;
 use sn_interface::messaging::system::{NodeDataCmd, NodeMsg};
 use sn_interface::types::log_markers::LogMarker;
 use sn_interface::types::{DataAddress, Peer};
+
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
 

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -8,15 +8,9 @@
 
 use super::FlowCtrl;
 
-use crate::node::{
-    core::NodeContext, flow_ctrl::cmds::Cmd, messaging::Peers, node_starter::CmdChannel, MyNode,
-    Result,
-};
+use crate::node::{core::NodeContext, flow_ctrl::cmds::Cmd, node_starter::CmdChannel, MyNode};
 
-use sn_interface::{
-    messaging::system::{NodeDataCmd, NodeMsg},
-    types::log_markers::LogMarker,
-};
+use sn_interface::{messaging::system::NodeMsg, types::log_markers::LogMarker};
 
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use tokio::{sync::RwLock, time::Instant};
@@ -25,7 +19,6 @@ const PROBE_INTERVAL: Duration = Duration::from_secs(30);
 const MISSING_VOTE_INTERVAL: Duration = Duration::from_secs(5);
 const MISSING_DKG_MSG_INTERVAL: Duration = Duration::from_secs(5);
 const SECTION_PROBE_INTERVAL: Duration = Duration::from_secs(300);
-const DATA_BATCH_INTERVAL: Duration = Duration::from_millis(50);
 const DYSFUNCTION_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 // 30 adult nodes checked per minute., so each node should be queried 10x in 10 mins
 // Which should hopefully trigger dysfunction if we're not getting responses back
@@ -39,7 +32,6 @@ pub(super) struct PeriodicChecksTimestamps {
     last_elder_health_check: Instant,
     last_vote_check: Instant,
     last_dkg_msg_check: Instant,
-    last_data_batch_check: Instant,
     last_dysfunction_check: Instant,
 }
 
@@ -52,7 +44,6 @@ impl PeriodicChecksTimestamps {
             last_elder_health_check: Instant::now(),
             last_vote_check: Instant::now(),
             last_dkg_msg_check: Instant::now(),
-            last_data_batch_check: Instant::now(),
             last_dysfunction_check: Instant::now(),
         }
     }
@@ -65,9 +56,6 @@ impl FlowCtrl {
         let context = &self.node.read().await.context();
         debug!("[NODE READ]: periodic msg lock got");
 
-        self.enqueue_cmds_for_standard_periodic_checks(context)
-            .await;
-
         if !context.is_elder {
             self.enqueue_cmds_for_adult_periodic_checks(context).await;
 
@@ -77,34 +65,6 @@ impl FlowCtrl {
         }
 
         self.enqueue_cmds_for_elder_periodic_checks(context).await;
-    }
-
-    /// Periodic tasks run for elders and adults alike
-    async fn enqueue_cmds_for_standard_periodic_checks(&mut self, context: &NodeContext) {
-        let now = Instant::now();
-        let mut cmds = vec![];
-
-        // if we've passed enough time, batch outgoing data
-        if self.timestamps.last_data_batch_check.elapsed() > DATA_BATCH_INTERVAL {
-            self.timestamps.last_data_batch_check = now;
-            if let Some(cmd) = match Self::replicate_queued_data(self.node.clone(), context).await {
-                Ok(cmd) => cmd,
-                Err(error) => {
-                    error!(
-                        "Error handling getting cmds for data queued for replication: {error:?}"
-                    );
-                    None
-                }
-            } {
-                cmds.push(cmd);
-            }
-        }
-
-        for cmd in cmds {
-            if let Err(error) = self.cmd_sender_channel.send((cmd, vec![])).await {
-                error!("Error queuing std periodic check: {error:?}");
-            }
-        }
     }
 
     /// Periodic tasks run for adults only
@@ -346,68 +306,6 @@ impl FlowCtrl {
                 }
             }
         });
-    }
-
-    /// Periodically loop over any pending data batches and queue up `send_msg` for those
-    async fn replicate_queued_data(
-        node: Arc<RwLock<MyNode>>,
-        context: &NodeContext,
-    ) -> Result<Option<Cmd>> {
-        use rand::seq::IteratorRandom;
-        let mut rng = rand::rngs::OsRng;
-        let data_queued = {
-            debug!("[NODE READ]: queued data msg lock got");
-            let node = node.read().await;
-            debug!("[NODE READ]: queued data lock got");
-
-            // choose a data to replicate at random
-            let data_queued = node
-                .pending_data_to_replicate_to_peers
-                .iter()
-                .choose(&mut rng)
-                .map(|(address, _)| *address);
-
-            data_queued
-        };
-
-        if let Some(address) = data_queued {
-            trace!("Data found in queue to send out");
-
-            let target_peer = {
-                // careful now, if we're holding any ref into the read above we'll lock here.
-                debug!("[NODE WRITE]: periodic queue data offline write...");
-
-                let mut node = node.write().await;
-                debug!("[NODE WRITE]: periodic queue data write gottt...");
-                node.pending_data_to_replicate_to_peers.remove(&address)
-            };
-
-            if let Some(data_recipients) = target_peer {
-                debug!("Data queued to be replicated");
-
-                if data_recipients.is_empty() {
-                    return Ok(None);
-                }
-
-                let data_to_send = context.data_storage.get_from_local_store(&address).await?;
-
-                debug!(
-                    "{:?} Data {:?} to: {:?}",
-                    LogMarker::SendingMissingReplicatedData,
-                    address,
-                    data_recipients,
-                );
-
-                let msg = NodeMsg::NodeDataCmd(NodeDataCmd::ReplicateData(vec![data_to_send]));
-
-                return Ok(Some(MyNode::send_system_msg(
-                    msg,
-                    Peers::Multiple(data_recipients),
-                )));
-            }
-        }
-
-        Ok(None)
     }
 
     async fn check_for_dysfunction(node: Arc<RwLock<MyNode>>) -> Vec<Cmd> {

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -458,7 +458,7 @@ async fn ae_msg_from_the_future_is_handled() -> Result<()> {
     node.section_keys_provider
         .insert(TestKeys::get_section_key_share(&sk_set2, 0));
 
-    let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)));
+    let (dispatcher, _) = Dispatcher::new(Arc::new(RwLock::new(node)));
 
     let _cmds = run_and_collect_cmds(
         Cmd::ValidateMsg {
@@ -608,7 +608,7 @@ async fn relocation(relocated_peer_role: RelocatedPeerRole) -> Result<()> {
         root_storage_dir,
     )
     .await?;
-    let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)));
+    let (dispatcher, _) = Dispatcher::new(Arc::new(RwLock::new(node)));
 
     let relocated_peer = match relocated_peer_role {
         RelocatedPeerRole::Elder => *sap.elders().nth(1).expect("too few elders"),
@@ -667,7 +667,7 @@ async fn msg_to_self() -> Result<()> {
     )
     .await?;
     let info = node.info();
-    let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)));
+    let (dispatcher, _) = Dispatcher::new(Arc::new(RwLock::new(node)));
 
     let node_msg = NodeMsg::NodeDataCmd(NodeDataCmd::ReplicateData(vec![]));
 
@@ -775,7 +775,7 @@ async fn handle_elders_update() -> Result<()> {
     node.section_keys_provider
         .insert(TestKeys::get_section_key_share(&sk_set1, 0));
 
-    let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)));
+    let (dispatcher, _) = Dispatcher::new(Arc::new(RwLock::new(node)));
 
     let cmds = run_and_collect_cmds(
         Cmd::HandleNewEldersAgreement {
@@ -923,7 +923,7 @@ async fn handle_demote_during_split() -> Result<()> {
             .insert(TestKeys::get_section_key_share(&sk_set_v1_p1, 0));
     }
 
-    let dispatcher = Dispatcher::new(Arc::new(RwLock::new(node)));
+    let (dispatcher, _) = Dispatcher::new(Arc::new(RwLock::new(node)));
 
     // Create agreement on `OurElder` for both sub-sections
     let create_our_elders_cmd = |signed_sap: SectionSigned<SectionAuthorityProvider>| -> Result<_> {

--- a/sn_node/src/node/flow_ctrl/tests/network_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_utils.rs
@@ -303,7 +303,7 @@ impl TestNodeBuilder {
         )
         .await?;
         let node = Arc::new(RwLock::new(node));
-        let dispatcher = Dispatcher::new(node);
+        let (dispatcher, _) = Dispatcher::new(node);
         Ok((dispatcher, section, peer, sk_set))
     }
 }

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -86,7 +86,7 @@ mod core {
             supermajority, MyNodeInfo, NetworkKnowledge, NodeState, SectionAuthorityProvider,
             SectionKeyShare, SectionKeysProvider,
         },
-        types::{keys::ed25519::Digest256, log_markers::LogMarker, DataAddress, Peer},
+        types::{keys::ed25519::Digest256, log_markers::LogMarker},
     };
 
     use ed25519_dalek::Keypair;
@@ -122,10 +122,6 @@ mod core {
         root_storage_dir: PathBuf,
         pub(crate) data_storage: DataStorage, // Adult only before cache
         pub(crate) keypair: Arc<Keypair>,
-        /// queue up all batch data to be replicated (as a result of churn events atm)
-        // TODO: This can probably be reworked into the general per peer msg queue, but as
-        // we need to pull data first before we form the WireMsg, we won't do that just now
-        pub(crate) pending_data_to_replicate_to_peers: BTreeMap<DataAddress, BTreeSet<Peer>>,
         // Network resources
         pub(crate) section_keys_provider: SectionKeysProvider,
         pub(crate) network_knowledge: NetworkKnowledge,
@@ -279,7 +275,6 @@ mod core {
                 data_storage,
                 capacity: Capacity::default(),
                 dysfunction_tracking: node_dysfunction_detector,
-                pending_data_to_replicate_to_peers: BTreeMap::new(),
                 membership,
             };
 

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -170,8 +170,9 @@ async fn bootstrap_node(
     };
 
     let node = Arc::new(RwLock::new(node));
-    let cmd_ctrl = CmdCtrl::new(Dispatcher::new(node.clone()));
-    let cmd_channel = FlowCtrl::start(cmd_ctrl, connection_event_rx);
+    let (dispatcher, data_replication_receiver) = Dispatcher::new(node.clone());
+    let cmd_ctrl = CmdCtrl::new(dispatcher);
+    let cmd_channel = FlowCtrl::start(cmd_ctrl, connection_event_rx, data_replication_receiver);
 
     Ok((node, cmd_channel, event_receiver))
 }


### PR DESCRIPTION
Moves the replication flow to be outwith of node, using channels to gather data and send it in another thread entirely. This should remove another cause of serious node.write().lock usage

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
