### PR TITLE
chore(node): reduce write locks for dysfunction checks

### DIFF
--- a/sn_dysfunction/src/detection.rs
+++ b/sn_dysfunction/src/detection.rs
@@ -238,7 +238,8 @@ impl DysfunctionDetection {
         final_scores
     }
 
-    fn cleanup_time_sensistive_checks(&mut self) -> Result<()> {
+    /// Cleanup those time sensitive checks
+    pub fn cleanup_time_sensistive_checks(&mut self) {
         for issues in &mut self.communication_issues.values_mut() {
             issues.retain(|time| time.elapsed() < RECENT_ISSUE_DURATION);
         }
@@ -254,17 +255,13 @@ impl DysfunctionDetection {
         for issues in &mut self.dkg_issues.values_mut() {
             issues.retain(|time| time.elapsed() < RECENT_ISSUE_DURATION);
         }
-
-        Ok(())
     }
 
     /// Get a list of nodes whose score is  DYSFUNCTION_SCORE_THRESHOLD
     /// TODO: order these to act upon _most_ dysfunctional first
     /// (the nodes must all `ProposeOffline` over a dysfunctional node and then _immediately_ vote it off. So any other membershipn changes in flight could block this.
     /// thus, we need to be callling this function often until nodes are removed.)
-    pub fn get_dysfunctional_nodes(&mut self) -> Result<BTreeSet<XorName>> {
-        self.cleanup_time_sensistive_checks()?;
-
+    pub fn get_dysfunctional_nodes(&self) -> Result<BTreeSet<XorName>> {
         let mut dysfunctional_nodes = BTreeSet::new();
 
         let final_scores = self.get_weighted_scores();

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -343,10 +343,15 @@ mod core {
         }
 
         /// returns names that are relatively dysfunctional
-        pub(crate) fn get_dysfunctional_node_names(&mut self) -> Result<BTreeSet<XorName>> {
+        pub(crate) fn get_dysfunctional_node_names(&self) -> Result<BTreeSet<XorName>> {
             self.dysfunction_tracking
                 .get_dysfunctional_nodes()
                 .map_err(Error::from)
+        }
+
+        /// returns names that are relatively dysfunctional
+        pub(crate) fn cleanup_time_sensitive_dysfunction(&mut self) {
+            self.dysfunction_tracking.cleanup_time_sensistive_checks()
         }
 
         /// Log an issue in dysfunction


### PR DESCRIPTION
Moves the time sensitive cleanup into its own function, which we call over a longer period.

The get_dysfunctional_nodes call can now happen with a node read

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
