### PR TITLE
chore(node): remove Membership from NodeContext.

### DIFF
--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -311,11 +311,11 @@ impl MyNode {
             }
             NodeMsg::MembershipAE(gen) => {
                 debug!("[NODE READ]: membership ae read ");
-                let snapshopt = node.read().await.context();
+                let membership_context = node.read().await.membership.clone();
                 debug!("[NODE READ]: membership ae read got");
 
                 Ok(
-                    MyNode::handle_membership_anti_entropy(&snapshopt, sender, gen)
+                    MyNode::handle_membership_anti_entropy(membership_context, sender, gen)
                         .into_iter()
                         .collect(),
                 )

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -158,7 +158,6 @@ mod core {
         pub(crate) comm: Comm,
         pub(crate) event_sender: EventSender,
         pub(crate) joins_allowed: bool,
-        pub(crate) membership: Option<Membership>,
     }
 
     impl NodeContext {
@@ -190,7 +189,6 @@ mod core {
                 comm: self.comm.clone(),
                 event_sender: self.event_sender.clone(),
                 joins_allowed: self.joins_allowed,
-                membership: self.membership.clone(),
                 data_storage: self.data_storage.clone(),
             }
         }


### PR DESCRIPTION
Heaptracking has shown this to be ~80% of mem used, and moost of the time membership in the context is unused. Instead we now manually clone membership as/when we need it.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
