### PR TITLE
feat(ack): remove dataaddress from ack

### DIFF
--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Client;
-use crate::Error;
+use crate::{Error, Result};
 
 use sn_interface::{
     messaging::{
@@ -35,7 +35,7 @@ impl Client {
         client_pk: PublicKey,
         serialised_cmd: Bytes,
         signature: Signature,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let auth = ClientAuth {
             public_key: client_pk,
             signature,
@@ -54,7 +54,7 @@ impl Client {
     /// The provided `DataCmd` is serialised and signed with the
     /// keypair this Client instance has been setup with.
     #[instrument(skip_all, level = "debug", name = "client-api send cmd")]
-    pub async fn send_cmd(&self, cmd: DataCmd) -> Result<(), Error> {
+    pub async fn send_cmd(&self, cmd: DataCmd) -> Result<()> {
         let client_pk = self.public_key();
         let dst_name = cmd.dst_name();
 

--- a/sn_client/src/connections/messaging.rs
+++ b/sn_client/src/connections/messaging.rs
@@ -137,14 +137,14 @@ impl Session {
             };
 
             match result {
-                Ok(address) => {
+                Ok(()) => {
                     let preexisting = !received_acks.insert(src) || received_errors.contains(&src);
                     debug!(
-                        "ACK of {address:?} from {src:?} read from set for msg_id {msg_id:?} - preexisting??: {preexisting:?}",
+                        "ACK from {src:?} read from set for msg_id {msg_id:?} - preexisting??: {preexisting:?}",
                     );
 
                     if received_acks.len() >= expected_acks {
-                        trace!("Good! We've at or above {expected_acks} expected_acks");
+                        trace!("Good! We're at or above {expected_acks} expected_acks");
                         return Ok(());
                     }
                 }

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
 use crate::network_knowledge::SectionTreeUpdate;
 use crate::types::{
     register::{Entry, EntryHash, Permissions, Policy, Register, User},
-    Chunk, DataAddress,
+    Chunk,
 };
 use crate::{
     messaging::{
@@ -230,33 +230,33 @@ pub enum CmdResponse {
     // ===== Chunk =====
     //
     /// Response to DataCmd::StoreChunk
-    StoreChunk(Result<DataAddress>),
+    StoreChunk(Result<()>),
     //
     // ===== Register Data =====
     //
     /// Response to RegisterCmd::Create.
-    CreateRegister(Result<DataAddress>),
+    CreateRegister(Result<()>),
     /// Response to RegisterCmd::Edit.
-    EditRegister(Result<DataAddress>),
+    EditRegister(Result<()>),
     //
     // ===== Spentbook Data =====
     //
     /// Response to SpentbookCmd::Spend.
-    SpendKey(Result<DataAddress>),
+    SpendKey(Result<()>),
 }
 
 impl CmdResponse {
     #[allow(clippy::result_large_err)]
     pub fn ok(data: ReplicatedData) -> Result<CmdResponse> {
         let res = match &data {
-            ReplicatedData::Chunk(_) => CmdResponse::StoreChunk(Ok(data.address())),
+            ReplicatedData::Chunk(_) => CmdResponse::StoreChunk(Ok(())),
             ReplicatedData::RegisterWrite(RegisterCmd::Create { .. }) => {
-                CmdResponse::CreateRegister(Ok(data.address()))
+                CmdResponse::CreateRegister(Ok(()))
             }
             ReplicatedData::RegisterWrite(RegisterCmd::Edit { .. }) => {
-                CmdResponse::EditRegister(Ok(data.address()))
+                CmdResponse::EditRegister(Ok(()))
             }
-            ReplicatedData::SpentbookWrite(_) => CmdResponse::SpendKey(Ok(data.address())),
+            ReplicatedData::SpentbookWrite(_) => CmdResponse::SpendKey(Ok(())),
             ReplicatedData::RegisterLog(_) => return Err(Error::NoCorrespondingCmdError), // this should be unreachable, since `RegisterLog` is not resulting from a cmd.
             ReplicatedData::SpentbookLog(_) => return Err(Error::NoCorrespondingCmdError), // this should be unreachable, since `SpentbookLog` is not resulting from a cmd.
         };
@@ -269,7 +269,7 @@ impl CmdResponse {
     }
 
     /// Returns the result
-    pub fn result(&self) -> &Result<DataAddress> {
+    pub fn result(&self) -> &Result<()> {
         use CmdResponse::*;
         match self {
             StoreChunk(result)


### PR DESCRIPTION
Client should keep track of this, no need to burdon the network with more data transmission.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
