### PR TITLE
ci: use s3_deploy user for nightly and release workflows

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -10,6 +10,16 @@ on:
         description: number of nodes for the testnet
         required: true
         default: 15
+      testnet-tool-repo-branch:
+        description: >
+          The branch for the testnet tool repository. This is to enable using forks to test changes to
+          the testnet tool. Will default to the `main` branch.
+        default: main
+      testnet-tool-repo-user:
+        description: >
+          The user or organisation for the testnet tool repository. This is to enable using forks to
+          test changes to the testnet tool. Will default to the `maidsafe` organisation.
+        default: maidsafe
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
@@ -19,6 +29,7 @@ env:
   POWERSHELL_INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.ps1
   TESTNET_NIGHTLY_LOGS_BUCKET: s3://sn-node/nightly_testnet_logs
   TESTNET_NIGHTLY_LOGS_BUCKET_URL: https://sn-node.s3.eu-west-2.amazonaws.com/nightly_testnet_logs
+  TESTNET_TOOL_BUCKET_URL: https://sn-node.s3.eu-west-2.amazonaws.com/testnet_tool
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
 
 jobs:
@@ -166,6 +177,8 @@ jobs:
           node-count: ${{ github.event.inputs.node-count || 30 }}
           node-path: /tmp/sn_node
           testnet-id: ${{ env.TESTNET_ID }}
+          testnet-tool-repo-branch: ${{ github.event.inputs.testnet-tool-repo-branch }}
+          testnet-tool-repo-user: ${{ github.event.inputs.testnet-tool-repo-user }}
       # The other jobs in the workflow have the testnet launch as a dependency, but they go ahead
       # even if this job fails. It would be better if the whole workflow is abandoned if we don't
       # have a testnet to run the tests against.
@@ -208,10 +221,11 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.safe/network_contacts
-          curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-network-contacts > ~/.safe/network_contacts/default
+          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}-network-contacts > \
+            ~/.safe/network_contacts/default
 
       - name: Build all client tests before running
-        run: cd sn_client && cargo test --no-run --release
+        run: cargo test --no-run --release --package sn_client
         timeout-minutes: 25
 
       - name: Run client tests
@@ -249,12 +263,13 @@ jobs:
       - name: Set TESTNET_ID env
         shell: bash
         run: echo "TESTNET_ID=gha-testnet-$(echo ${{ github.event.pull_request.head.sha || github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
-      - name: Download network contacts file
+
+      - name: Download network config
         shell: bash
         run: |
           mkdir -p ~/.safe/network_contacts
-          curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-network-contacts \
-            > ~/.safe/network_contacts/default
+          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}-network-contacts > \
+            ~/.safe/network_contacts/default
 
       - uses: Swatinem/rust-cache@v1
         continue-on-error: true
@@ -263,13 +278,13 @@ jobs:
           sharedKey: ${{github.run_id}}
 
       - name: Build all sn_api tests
-        run: cd sn_api && cargo test --no-run --release --lib
+        run: cargo test --no-run --release --lib --package sn_api
         timeout-minutes: 25
 
       - name: Download genesis DBC
         shell: bash
         run: |
-          curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-genesis-dbc \
+          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}-genesis-dbc \
             > /tmp/genesis_dbc
 
       - name: Run API tests
@@ -313,11 +328,12 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.safe/network_contacts
-          curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-network-contacts > ~/.safe/network_contacts/default
+          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}-network-contacts > \
+            ~/.safe/network_contacts/default
       - name: Download genesis DBC
         shell: bash
         run: |
-          curl https://safe-testnet-tool.s3.eu-west-2.amazonaws.com/${{ env.TESTNET_ID }}-genesis-dbc \
+          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}-genesis-dbc \
             > /tmp/genesis_dbc
 
       - name: Build all CLI tests

--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -3,7 +3,7 @@ name: Nightly Release Run
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '30 4 * * *'
+    - cron: "30 4 * * *"
   workflow_dispatch:
     inputs:
       node-count:
@@ -12,12 +12,13 @@ on:
         default: 15
 
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_DEFAULT_REGION: 'eu-west-2'
+  AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: "eu-west-2"
   INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.sh
   POWERSHELL_INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.ps1
-  TESTNET_BUCKET_URL: https://safe-testnet-tool.s3.eu-west-2.amazonaws.com
+  TESTNET_NIGHTLY_LOGS_BUCKET: s3://sn-node/nightly_testnet_logs
+  TESTNET_NIGHTLY_LOGS_BUCKET_URL: https://sn-node.s3.eu-west-2.amazonaws.com/nightly_testnet_logs
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
 
 jobs:
@@ -159,8 +160,8 @@ jobs:
         uses: maidsafe/sn_testnet_action@main
         with:
           do-token: ${{ secrets.DO_TOKEN }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+          aws-access-key-secret: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
           ssh-secret-key: ${{ secrets.SSH_SECRET_KEY  }}
           node-count: ${{ github.event.inputs.node-count || 30 }}
           node-path: /tmp/sn_node
@@ -352,9 +353,9 @@ jobs:
         uses: maidsafe/sn_testnet_action@main
         with:
           do-token: ${{ secrets.DO_TOKEN }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          action: 'destroy'
+          aws-access-key-id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+          aws-access-key-secret: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
+          action: "destroy"
           testnet-id: ${{ env.TESTNET_ID }}
 
   bump_version:
@@ -363,7 +364,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
           token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
       - uses: actions-rs/toolchain@v1
         id: toolchain
@@ -417,16 +418,16 @@ jobs:
           chmod 0600 ~/.ssh/id_rsa
           cd /tmp
           aws s3 cp \
-            "s3://safe-testnet-tool/$TESTNET_ID-ip-list" \
+            "$TESTNET_NIGHTLY_LOGS_BUCKET/$TESTNET_ID-ip-list" \
             "$TESTNET_ID-ip-list"
           aws s3 cp \
-            "s3://safe-testnet-tool/$TESTNET_ID-genesis-dbc" \
+            "$TESTNET_NIGHTLY_LOGS_BUCKET/$TESTNET_ID-genesis-dbc" \
             "$TESTNET_ID-genesis-dbc"
           aws s3 cp \
-            "s3://safe-testnet-tool/$TESTNET_ID-genesis-key" \
+            "$TESTNET_NIGHTLY_LOGS_BUCKET/$TESTNET_ID-genesis-key" \
             "$TESTNET_ID-genesis-key"
           aws s3 cp \
-            "s3://safe-testnet-tool/$TESTNET_ID-network-contacts" \
+            "$TESTNET_NIGHTLY_LOGS_BUCKET/$TESTNET_ID-network-contacts" \
             "$TESTNET_ID-network-contacts"
 
           wget https://raw.githubusercontent.com/maidsafe/sn_testnet_tool/main/scripts/logs-sync.sh
@@ -440,24 +441,24 @@ jobs:
             "$TESTNET_ID-run.tar.gz" \
             "s3://safe-testnet-tool/$TESTNET_ID-run.tar.gz" \
             --acl public-read
-          echo "The logs should be available at $TESTNET_BUCKET_URL/$TESTNET_ID-run.tar.gz"
+          echo "The logs should be available at $TESTNET_NIGHTLY_LOGS_BUCKET_URL/$TESTNET_ID-run.tar.gz"
 
       - name: post notification to slack
         if: always()
         uses: bryannice/gitactions-slack-notification@2.0.0
         env:
           SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
-          SLACK_MESSAGE: 'Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}'
-          SLACK_TITLE: 'Nightly Run Failed'
+          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+          SLACK_TITLE: "Nightly Run Failed"
 
       - name: Kill testnet
         if: always()
         uses: maidsafe/sn_testnet_action@main
         with:
           do-token: ${{ secrets.DO_TOKEN }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          action: 'destroy'
+          aws-access-key-id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+          aws-access-key-secret: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
+          action: "destroy"
           testnet-id: ${{ env.TESTNET_ID }}
       - name: Upload event file
         uses: actions/upload-artifact@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,20 +136,20 @@ jobs:
       - uses: shallwefootball/s3-upload-action@master
         name: upload sn_node artifacts to s3
         with:
-          aws_key_id: AKIAVVODCRMSJ5MV63VB
-          aws_secret_access_key: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
+          aws_key_id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
           aws_bucket: sn-node
           source_dir: deploy/prod/sn_node
-          destination_dir: ''
+          destination_dir: ""
 
       - uses: shallwefootball/s3-upload-action@master
         name: upload safe artifacts to s3
         with:
-          aws_key_id: AKIAVVODCRMSJ5MV63VB
-          aws_secret_access_key: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
+          aws_key_id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
           aws_bucket: sn-cli
           source_dir: deploy/prod/safe
-          destination_dir: ''
+          destination_dir: ""
 
       # Now repackage and upload the artifacts using 'latest' for the version.
       - shell: bash
@@ -163,20 +163,20 @@ jobs:
       - uses: shallwefootball/s3-upload-action@master
         name: upload sn_node artifacts to s3
         with:
-          aws_key_id: AKIAVVODCRMSJ5MV63VB
-          aws_secret_access_key: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
+          aws_key_id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
           aws_bucket: sn-node
           source_dir: deploy/prod/sn_node
-          destination_dir: ''
+          destination_dir: ""
 
       - uses: shallwefootball/s3-upload-action@master
         name: upload safe artifacts to s3
         with:
-          aws_key_id: AKIAVVODCRMSJ5MV63VB
-          aws_secret_access_key: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
+          aws_key_id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
           aws_bucket: sn-cli
           source_dir: deploy/prod/safe
-          destination_dir: ''
+          destination_dir: ""
 
   publish:
     name: publish
@@ -188,7 +188,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
- 590df4d1b **ci: use s3_deploy user for nightly and release workflows**

  In the nightly workflow, this user gets used to launch the testnet (really just reading the tfstate
  file) and to upload node logs to the `sn-node` bucket when a run fails.

  In the release workflow it's used to upload the built artifacts to the same `sn-node` bucket.

  The names of the variables were changed to make it more specific about which user we were referring
  to.

  The keys being used previously have been deleted.

- f6d4cdd32 **ci: specify branch/user for testnet tool on nightly**

  This allows forks of the testnet tool to be tried and tested.

  Also fix references to S3 buckets in the nightly workflow.

