### PR TITLE
refactor(client): use internal send_query API to send initial probe msg to the network

### DIFF
--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -101,7 +101,7 @@ impl Client {
 
             // There should not be more than a certain amount of adults holding
             // copies of the data. Retry the closest adult again.
-            if query.adult_index >= data_copy_count() - 1 {
+            if !retry || query.adult_index >= data_copy_count() - 1 {
                 // we don't want to retry beyond data_copy_count Adults
                 return res;
             }

--- a/sn_client/src/connections/mod.rs
+++ b/sn_client/src/connections/mod.rs
@@ -48,7 +48,7 @@ impl QueryResult {
 #[derive(Clone, Debug)]
 pub(super) struct Session {
     // Session endpoint.
-    endpoint: Endpoint,
+    pub(super) endpoint: Endpoint,
     /// All elders we know about from AE messages
     pub(super) network: Arc<RwLock<SectionTree>>,
     /// Links to nodes


### PR DESCRIPTION
It also fixes the private `send_query_without_retry` API which is currently ignoring the no-retry flag.