### PR TITLE
feat(node)!: adding more context info to some node Error types

### DIFF
--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -47,7 +47,10 @@ impl Client {
                 .await
         })
         .await
-        .map_err(|_| Error::CmdAckValidationTimeout(dst_address))?
+        .map_err(|_| Error::CmdAckValidationTimeout {
+            elapsed: self.cmd_timeout,
+            dst_address,
+        })?
     }
 
     /// Public API to send a `DataCmd` to the network.

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -187,6 +187,9 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_spentbook_spend_dbc() -> Result<()> {
+        init_logger();
+        let _outer_span = tracing::info_span!("test__spentbook_spend_dbc").entered();
+
         let (
             client,
             SpendDetails {
@@ -212,6 +215,12 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn spentbook_spend_spent_proof_with_invalid_pk_should_return_spentbook_error(
     ) -> Result<()> {
+        init_logger();
+        let _outer_span = tracing::info_span!(
+            "test__spentbook_spend_spent_proof_with_invalid_pk_should_return_spentbook_error"
+        )
+        .entered();
+
         let (
             client,
             SpendDetails {
@@ -263,6 +272,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn spentbook_spend_spent_proof_with_key_not_in_section_chain_should_return_cmd_error_response(
     ) -> Result<()> {
+        init_logger();
+        let _outer_span = tracing::info_span!("test__spentbook_spend_spent_proof_with_key_not_in_section_chain_should_return_cmd_error_response").entered();
+
         let (
             client,
             SpendDetails {
@@ -300,6 +312,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn spentbook_spend_spent_proofs_do_not_relate_to_input_dbcs_should_return_spentbook_error(
     ) -> Result<()> {
+        init_logger();
+        let _outer_span = tracing::info_span!("test__spentbook_spend_spent_proofs_do_not_relate_to_input_dbcs_should_return_spentbook_error").entered();
+
         let (client, SpendDetails { genesis_dbc, .. }) = setup(false).await?;
 
         // The idea for this test case is to pass the wrong spent proofs and transactions for
@@ -373,6 +388,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn spentbook_spend_with_random_key_image_should_return_spentbook_error() -> Result<()> {
+        init_logger();
+        let _outer_span = tracing::info_span!(
+            "test__spentbook_spend_with_random_key_image_should_return_spentbook_error"
+        )
+        .entered();
+
         let (
             client,
             SpendDetails {

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -17,7 +17,7 @@ use sn_interface::{
 
 use bls::PublicKey;
 use sn_dbc::KeyImage;
-use std::io;
+use std::{io, time::Duration};
 use thiserror::Error;
 use xor_name::XorName;
 
@@ -147,8 +147,13 @@ pub enum Error {
         peers: Vec<Peer>,
     },
     /// Timeout when awaiting command ACK from Elders.
-    #[error("Timeout when awaiting command ACK from Elders for data address {0}")]
-    CmdAckValidationTimeout(XorName),
+    #[error("Timeout after {elapsed:?} when awaiting command ACK from Elders for data address {dst_address}")]
+    CmdAckValidationTimeout {
+        /// Time elapsed before timing out
+        elapsed: Duration,
+        /// Address name of the data the ACK was expected for
+        dst_address: XorName,
+    },
     /// Unexpected query response received
     #[error("Unexpected response received for {query:?}. Received: {response:?}")]
     UnexpectedQueryResponse {

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -149,11 +149,8 @@ impl PeerSessionWorker {
 
     async fn run(mut self, mut channel: mpsc::Receiver<SessionCmd>) {
         while let Some(session_cmd) = channel.recv().await {
-            trace!(
-                "Processing session {:?} cmd: {:?}",
-                self.link.peer(),
-                session_cmd
-            );
+            let peer = *self.link.peer();
+            trace!("Processing session {peer:?} cmd: {session_cmd:?}");
 
             let status = match session_cmd {
                 SessionCmd::Send(job) => {
@@ -164,23 +161,25 @@ impl PeerSessionWorker {
                             let stream_prio = 10;
                             let mut send_stream = send_stream.lock().await;
                             send_stream.set_priority(stream_prio);
+                            let stream_id = send_stream.id();
                             if let Err(error) = send_stream.send_user_msg(job.bytes).await {
                                 error!(
-                                    "Could not send msg {:?} over response stream: {error:?}",
+                                    "Could not send msg {:?} over response {stream_id} to {peer:?}: {error:?}",
                                     job.msg_id
                                 );
 
-                                job.reporter.send(SendStatus::TransientError(
-                                    "Could not send msg on stream".to_string(),
-                                ));
+                                job.reporter.send(SendStatus::TransientError(format!(
+                                    "Could not send msg on response {stream_id} to {peer:?} for {:?}", job.msg_id
+                                )));
                             } else if let Err(error) = send_stream.finish().await {
                                 error!(
-                                    "Could not close response stream for {:?}: {error:?}",
+                                    "Could not close response {stream_id} with {peer:?}, for {:?}: {error:?}",
                                     job.msg_id
                                 );
-                                job.reporter.send(SendStatus::TransientError(
-                                    "Could not close stream".to_string(),
-                                ));
+                                job.reporter.send(SendStatus::TransientError(format!(
+                                    "Could not close response {stream_id} with {peer:?} for {:?}",
+                                    job.msg_id
+                                )));
                             } else {
                                 job.reporter.send(SendStatus::Sent);
                             }

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -340,15 +340,17 @@ impl MyNode {
                 "Could not send query response {original_msg_id:?} to \
                 peer {target_peer:?} over response stream {stream_id}: {error:?}"
             );
-            return Err(Error::from(error));
+            return Err(error.into());
         }
 
         trace!("Msg away for {original_msg_id:?} to {target_peer:?}");
         if let Err(error) = send_stream.finish().await {
+            // Let's report the error since we cannot guarantee the msg was received/acknowledged by recipient
             error!(
                 "Could not close response stream {stream_id} for {original_msg_id:?} to \
                 peer {target_peer:?}: {error:?}"
             );
+            return Err(error.into());
         }
 
         debug!("Sent the msg {original_msg_id:?} over stream {stream_id} to {target_peer:?}");

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -130,17 +130,12 @@ impl MyNode {
             let stream_prio = 10;
             let mut send_stream = send_stream.lock().await;
             send_stream.set_priority(stream_prio);
+            let stream_id = send_stream.id();
             if let Err(error) = send_stream.send_user_msg(bytes).await {
-                error!(
-                    "Could not send msg {:?} over response stream: {error:?}",
-                    msg_id
-                );
+                error!("Could not send msg {msg_id:?} over response {stream_id} to {requesting_elder:?}: {error:?}");
             }
             if let Err(error) = send_stream.finish().await {
-                error!(
-                    "Could not close response stream for {:?}: {error:?}",
-                    msg_id
-                );
+                error!("Could not close response {stream_id} with {requesting_elder:?}, for {msg_id:?}: {error:?}");
             }
         } else {
             error!("Send stream missing from {requesting_elder:?}, data request response was not sent out.")


### PR DESCRIPTION
- Initialising logger in sn_client spentbook API tests.
- Including stream id in log messages.
- Report the error when a stream couldn't be finished when sending a response since that could mean the recipient didn't received it.
