### PR TITLE
feat(client): retry once if connection was lost when trying to send on a bi-stream

### DIFF
--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -253,7 +253,10 @@ impl Client {
             response
         })
         .await
-        .map_err(|_| Error::ChunkUploadValidationTimeout(address))??;
+        .map_err(|_| Error::ChunkUploadValidationTimeout {
+            elapsed: self.query_timeout,
+            address,
+        })??;
 
         Ok(())
     }

--- a/sn_client/src/connections/listeners.rs
+++ b/sn_client/src/connections/listeners.rs
@@ -209,11 +209,14 @@ impl Session {
 
             debug!("{msg_id:?} AE bounced msg going out again. Resending original message (sent to index {src_peer_index:?} peer: {src_peer:?}) to new section elder {elder:?}");
 
-            let link = self.peer_links.get_or_create_link(elder, false).await;
+            let link = self
+                .peer_links
+                .get_or_create_link(elder, false, Some(correlation_id))
+                .await;
             let new_recv_stream = link
                 .send_bi(bytes, msg_id)
                 .await
-                .map_err(|_| Error::FailedToInitateBiDiStream(msg_id))?;
+                .map_err(|error| Error::FailedToInitateBiDiStream { msg_id, error })?;
 
             Ok(MsgResent {
                 new_peer: *elder,

--- a/sn_interface/src/types/connections/link.rs
+++ b/sn_interface/src/types/connections/link.rs
@@ -135,7 +135,7 @@ impl Link {
             .await
             .map_err(SendToOneError::Connection)?;
 
-        debug!("conn creating done {:?}", self.peer);
+        debug!("{msg_id:?} conn creating done {:?}", self.peer);
         trace!(
             "{} to {} (id: {})",
             LogMarker::ConnectionOpened,


### PR DESCRIPTION
Also, adding more context info to sn_client `Error::FailedToInitateBiDiStream` and `Error::ChunkUploadValidationTimeout` error variants.