### PR TITLE
feat(knowledge): update sibling on split

### DIFF
--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -124,6 +124,8 @@ pub enum NodeMsg {
         proposal: Proposal,
         /// BLS signature share of an Elder
         sig_share: SectionSigShare,
+        /// BLS signature share of an Elder if Proposal::NewSectionsAgreement
+        optional_sig_share: Option<SectionSigShare>,
     },
     #[cfg(any(feature = "chunks", feature = "registers"))]
     /// Node events are Adult to Elder events about something that happened on an Adult.

--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -80,6 +80,17 @@ pub enum SapCandidate {
     ),
 }
 
+impl SapCandidate {
+    pub fn elders(&self) -> Vec<Peer> {
+        match self {
+            SapCandidate::ElderHandover(sap) => sap.elders_vec(),
+            SapCandidate::SectionSplit(sap1, sap2) => {
+                [sap1.elders_vec(), sap2.elders_vec()].concat().to_vec()
+            }
+        }
+    }
+}
+
 impl Debug for SectionAuthorityProvider {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         #[derive(Debug)]

--- a/sn_interface/src/types/log_markers.rs
+++ b/sn_interface/src/types/log_markers.rs
@@ -80,6 +80,7 @@ pub enum LogMarker {
     DkgComplete,
     HandlingDkgSuccessfulOutcome,
     HandlingNewEldersAgreement,
+    HandlingNewSectionsAgreement,
     NewSignedSap,
     NewKeyShareStored,
     TriggeringPromotionAndDemotion,

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -83,6 +83,13 @@ pub(crate) enum Cmd {
         new_elders: SectionSigned<SectionAuthorityProvider>,
         sig: SectionSig,
     },
+    /// Handle agree on new sections. This blocks node message processing until complete.
+    HandleNewSectionsAgreement {
+        sap1: SectionSigned<SectionAuthorityProvider>,
+        sig1: SectionSig,
+        sap2: SectionSigned<SectionAuthorityProvider>,
+        sig2: SectionSig,
+    },
     /// Handle the outcome of a DKG session where we are one of the participants (that is, one of
     /// the proposed new elders).
     HandleDkgOutcome {
@@ -177,6 +184,7 @@ impl Cmd {
             Cmd::HandleMembershipDecision(_) => State::Membership,
             Cmd::ProposeVoteNodesOffline(_) => State::Membership,
             Cmd::HandleNewEldersAgreement { .. } => State::Handover,
+            Cmd::HandleNewSectionsAgreement { .. } => State::Handover,
             Cmd::HandleDkgOutcome { .. } => State::Dkg,
             Cmd::EnqueueDataForReplication { .. } => State::Replication,
         }
@@ -211,6 +219,7 @@ impl fmt::Display for Cmd {
             }
             Cmd::HandleAgreement { .. } => write!(f, "HandleAgreement"),
             Cmd::HandleNewEldersAgreement { .. } => write!(f, "HandleNewEldersAgreement"),
+            Cmd::HandleNewSectionsAgreement { .. } => write!(f, "HandleNewSectionsAgreement"),
             Cmd::HandleMembershipDecision(_) => write!(f, "HandleMembershipDecision"),
             Cmd::HandleDkgOutcome { .. } => write!(f, "HandleDkgOutcome"),
             Cmd::SendMsg { .. } => write!(f, "SendMsg"),

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -175,6 +175,18 @@ impl Dispatcher {
                 debug!("[NODE WRITE]: new elders decision agreements write got...");
                 node.handle_new_elders_agreement(new_elders, sig).await
             }
+            Cmd::HandleNewSectionsAgreement {
+                sap1,
+                sig1,
+                sap2,
+                sig2,
+            } => {
+                debug!("[NODE WRITE]: new sections decision agreements write...");
+                let mut node = self.node.write().await;
+                debug!("[NODE WRITE]: new sections decision agreements write got...");
+                node.handle_new_sections_agreement(sap1, sig1, sap2, sig2)
+                    .await
+            }
             Cmd::HandleFailedSendToNode { peer, msg_id } => {
                 warn!("Message sending failed to {peer}, for {msg_id:?}");
                 let node = self.node.read().await;

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -1111,13 +1111,15 @@ async fn spentbook_spend_with_updated_network_knowledge_should_update_the_node()
 fn get_single_sig(proposal: &Proposal) -> Result<Vec<u8>> {
     match proposal.as_signable_bytes()? {
         itertools::Either::Left(bytes) => Ok(bytes),
-        itertools::Either::Right(_) => bail!("Invalid expectations! Use another proposal variant."),
+        itertools::Either::Right(_) => {
+            panic!("Invalid expectations! Use another proposal variant.")
+        }
     }
 }
 
 fn get_double_sig(proposal: &Proposal) -> Result<(Vec<u8>, Vec<u8>)> {
     match proposal.as_signable_bytes()? {
-        itertools::Either::Left(_) => bail!("Invalid expectations! Use another proposal variant."),
+        itertools::Either::Left(_) => panic!("Invalid expectations! Use another proposal variant."),
         itertools::Either::Right((bytes1, bytes2)) => Ok((bytes1, bytes2)),
     }
 }

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -33,8 +33,8 @@ impl MyNode {
             Proposal::RequestHandover(sap) => {
                 cmds.extend(self.handle_request_handover_agreement(sap, sig).await?);
             }
-            Proposal::NewElders(_) | Proposal::NewSections { .. } => {
-                error!("Elders agreement should be handled in a separate blocking fashion");
+            Proposal::HandoverCompleted(_) => {
+                error!("Handover completed should be handled in a separate blocking fashion");
             }
             Proposal::JoinsAllowed(joins_allowed) => {
                 self.joins_allowed = joins_allowed;
@@ -167,9 +167,8 @@ impl MyNode {
             .handle_new_elders_agreement(our_sap, sig_over_us)
             .await?;
 
-        // Finally we update our network knowledge with our sibling
-        // section SAP and chain if the new SAP's prefix matches our name
-        // We need to generate the proof chain to connect our current chain to new SAP.
+        // Finally we update our network knowledge with our sibling section SAP.
+        // We use the parent proof chain to connect our current chain to sibling SAP.
         match parent_section_chain.insert(
             &parent_key,
             their_sap.section_key(),

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -302,6 +302,7 @@ impl MyNode {
             NodeMsg::Propose {
                 proposal,
                 sig_share,
+                optional_sig_share,
             } => {
                 let mut node = node.write().await;
                 debug!("[NODE WRITE]: PROPOSE write gottt...");
@@ -315,7 +316,7 @@ impl MyNode {
                     msg_id
                 );
 
-                node.handle_proposal(msg_id, proposal, sig_share, sender)
+                node.handle_proposal(msg_id, proposal, sig_share, optional_sig_share, sender)
             }
             NodeMsg::DkgStart(session_id, elder_sig) => {
                 trace!(

--- a/sn_node/src/node/messaging/proposal.rs
+++ b/sn_node/src/node/messaging/proposal.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{flow_ctrl::cmds::Cmd, messaging::Peers, MyNode, Proposal, Result};
+use itertools::Either;
 use sn_interface::messaging::system::SectionSigShare;
 
 use sn_interface::{
@@ -50,16 +51,20 @@ impl MyNode {
     ) -> Result<Vec<Cmd>> {
         trace!("Propose {proposal:?}, key_share: {key_share:?}, aggregators: {recipients:?}");
 
-        let sig_share = proposal.sign_with_key_share(
+        let (sig_share, optional_sig_share) = match proposal.sign_with_key_share(
             key_share.public_key_set.clone(),
             key_share.index,
             &key_share.secret_key_share,
-        )?;
+        )? {
+            Either::Left(sig_share) => (sig_share, None),
+            Either::Right((sig_share1, sig_share2)) => (sig_share1, Some(sig_share2)),
+        };
 
         // Broadcast the proposal to the rest of the section elders.
         let msg = NodeMsg::Propose {
             proposal: proposal.clone(),
             sig_share: sig_share.clone(),
+            optional_sig_share: optional_sig_share.clone(),
         };
 
         let msg_id = MsgId::new();
@@ -73,6 +78,7 @@ impl MyNode {
                     msg_id,
                     proposal.clone(),
                     sig_share.clone(),
+                    optional_sig_share.clone(),
                     peer,
                 )?)
             }
@@ -98,6 +104,7 @@ impl MyNode {
         msg_id: MsgId,
         proposal: Proposal,
         sig_share: SectionSigShare,
+        optional_sig_share: Option<SectionSigShare>,
         sender: Peer,
     ) -> Result<Vec<Cmd>> {
         let sig_share_pk = &sig_share.public_key_set.public_key();
@@ -147,7 +154,7 @@ impl MyNode {
                 "Failed to serialise proposal from {}, {:?}: {:?}",
                 sender, msg_id, error
             ),
-            Ok(serialised_proposal) => {
+            Ok(Either::Left(serialised_proposal)) => {
                 match self
                     .proposal_aggregator
                     .try_aggregate(&serialised_proposal, sig_share)
@@ -170,6 +177,57 @@ impl MyNode {
                             "Failed to add proposal from {}, {:?}: {:?}",
                             sender, msg_id, error
                         );
+                    }
+                }
+            }
+            Ok(Either::Right((serialised_proposal_1, serialised_proposal_2))) => {
+                let sig_share2 = if let Some(sig) = optional_sig_share {
+                    sig
+                } else {
+                    error!("Second sig share is missing! {}, {:?}", sender, msg_id,);
+                    return Ok(cmds); // TODO: return error here
+                };
+
+                let res1 = self
+                    .proposal_aggregator
+                    .try_aggregate(&serialised_proposal_1, sig_share);
+                let res2 = self
+                    .proposal_aggregator
+                    .try_aggregate(&serialised_proposal_2, sig_share2);
+                let res = (res1, res2);
+
+                match res {
+                    (Ok(Some(sig1)), Ok(Some(sig2))) => match proposal {
+                        Proposal::NewSections { sap1, sap2 } => {
+                            cmds.push(Cmd::HandleNewSectionsAgreement {
+                                sap1,
+                                sig1,
+                                sap2,
+                                sig2,
+                            })
+                        }
+                        _ => error!(
+                            "Inconsistent results when aggregating proposal from {}, {:?}",
+                            sender, msg_id,
+                        ),
+                    },
+                    (Ok(None), Ok(None)) => {
+                        trace!(
+                            "Proposals from {} inserted in aggregator, not enough sig shares yet: {serialised_proposal_1:?} and {serialised_proposal_2:?} {:?}",
+                            sender,
+                            msg_id);
+                    }
+                    (_, Err(error)) | (Err(error), _) => {
+                        error!(
+                            "Failed to add proposal from {}, {:?}: {:?}",
+                            sender, msg_id, error
+                        );
+                    }
+                    (Ok(Some(_)), Ok(None)) | (Ok(None), Ok(Some(_))) => {
+                        warn!(
+                            "Unexpected aggregation result from {} {:?}: one sig is aggregated while the other is not. This should not happen.",
+                            sender,
+                            msg_id);
                     }
                 }
             }

--- a/sn_node/src/node/messaging/proposal.rs
+++ b/sn_node/src/node/messaging/proposal.rs
@@ -207,28 +207,12 @@ impl MyNode {
                                 sig2,
                             }),
                         _ => error!(
-                            "Inconsistent results when aggregating proposal from {}, {:?}",
-                            sender, msg_id,
-                        ),
+                            "Inconsistent results when aggregating proposal from {sender}, {msg_id:?}"),
                     },
-                    (Ok(None), Ok(None)) => {
-                        trace!(
-                            "Proposals from {} inserted in aggregator, not enough sig shares yet: {serialised_proposal_1:?} and {serialised_proposal_2:?} {:?}",
-                            sender,
-                            msg_id);
-                    }
-                    (_, Err(error)) | (Err(error), _) => {
-                        error!(
-                            "Failed to add proposal from {}, {:?}: {:?}",
-                            sender, msg_id, error
-                        );
-                    }
-                    (Ok(Some(_)), Ok(None)) | (Ok(None), Ok(Some(_))) => {
-                        warn!(
-                            "Unexpected aggregation result from {} {:?}: one sig is aggregated while the other is not. This should not happen.",
-                            sender,
-                            msg_id);
-                    }
+                    (Ok(None), Ok(None)) => trace!(
+                            "Proposals from {sender} inserted in aggregator, not enough sig shares yet: {serialised_proposal_1:?} and {serialised_proposal_2:?} {msg_id:?}"),
+                    (_, Err(error)) | (Err(error), _) => error!("Failed to add proposal from {sender}, {msg_id:?}: {error:?}"),
+                    (Ok(Some(_)), Ok(None)) | (Ok(None), Ok(Some(_))) => warn!("Unexpected aggregation result from {sender} {msg_id:?}: one sig is aggregated while the other is not. This should not happen."),
                 }
             }
         }


### PR DESCRIPTION
This PR lets both children get the sibling sap at split.

When sending a msg that was intended for the sibling, and expecting an ae update with the sibling sap, it would instead return the sap of the first section itself (because it didn't know its sibling).

With the changes, both children are aware of each other from start, and we now get the sibling sap returned in the ae update.
