### PR TITLE
Misc Nightly Run Modifications

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -168,46 +168,6 @@ jobs:
           workflow_id: ${{ github.run_id }}
           access_token: ${{ github.token }}
 
-  #launch-testnet:
-  #name: launch testnet
-  #needs: build-node
-  #runs-on: ubuntu-latest
-  #steps:
-  #- uses: actions/download-artifact@master
-  #with:
-  #name: sn_node-x86_64-unknown-linux-musl
-  #path: sn_node
-  #- shell: bash
-  #name: copy node to temp location
-  #run: cp sn_node/sn_node /tmp
-  #- name: Set TESTNET_ID env
-  #shell: bash
-  #run: |
-  #short_commit_hash=$(echo "${{ github.event.pull_request.head.sha || github.sha }}" | cut -c 1-7)
-  #echo "TESTNET_ID=gha-testnet-$short_commit_hash" >> $GITHUB_ENV
-  #- name: launch testnet
-  #uses: maidsafe/sn_testnet_action@main
-  #with:
-  #do-token: ${{ secrets.DO_TOKEN }}
-  #aws-access-key-id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
-  #aws-access-key-secret: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
-  #ssh-secret-key: ${{ secrets.SSH_SECRET_KEY  }}
-  #node-count: ${{ inputs.node-count }}
-  #node-path: /tmp/sn_node
-  #testnet-id: ${{ env.TESTNET_ID }}
-  #testnet-tool-repo-branch: ${{ inputs.testnet-tool-repo-branch }}
-  #testnet-tool-repo-user: ${{ inputs.testnet-tool-repo-user }}
-  ## The other jobs in the workflow have the testnet launch as a dependency, but they go ahead
-  ## even if this job fails. It would be better if the whole workflow is abandoned if we don't
-  ## have a testnet to run the tests against.
-  #- name: cancel workflow if testnet launch fails
-  #uses: vishnudxb/cancel-workflow@v1.2
-  #if: failure()
-  #with:
-  #repo: octocat/hello-world
-  #workflow_id: ${{ github.run_id }}
-  #access_token: ${{ github.token }}
-
   client:
     name: client tests
     runs-on: ${{ matrix.os }}
@@ -255,6 +215,7 @@ jobs:
           package: sn_client
           release: true
           filters: client
+          features: check-replicas
           test-threads: 2
         timeout-minutes: 25
 
@@ -313,7 +274,8 @@ jobs:
           junit-path: junit.xml
           package: sn_api
           release: true
-          test-threads: 10
+          test-threads: 1
+          features: check-replicas
         timeout-minutes: 60
         env:
           TEST_ENV_GENESIS_DBC_PATH: /tmp/genesis_dbc
@@ -368,7 +330,8 @@ jobs:
           junit-path: junit.xml
           package: sn_cli
           release: true
-          test-threads: 10
+          test-threads: 1
+          features: check-replicas
         timeout-minutes: 60
         env:
           TEST_ENV_GENESIS_DBC_PATH: /tmp/genesis_dbc
@@ -393,6 +356,7 @@ jobs:
           testnet-id: ${{ env.TESTNET_ID }}
 
   bump_version:
+    if: github.repository_owner == 'maidsafe' && github.ref_name == 'main'
     runs-on: ubuntu-22.04
     needs: kill-testnet
     steps:

--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -127,41 +127,19 @@ jobs:
           }
 
   build-node:
-    name: build node
-    runs-on: ubuntu-latest
+    name: build node and launch testnet
+    runs-on: self-hosted
+    env:
+      CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
+      CARGO_HOME: /mnt/data/cargo
+      TMPDIR: /mnt/data/tmp
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        id: toolchain
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - shell: bash
         name: build node
         run: |
-          sudo apt update -y
-          sudo apt install -y musl-tools
-          rustup target add x86_64-unknown-linux-musl
-          cargo build --release --target x86_64-unknown-linux-musl --bin sn_node
-      - uses: actions/upload-artifact@main
-        with:
-          name: sn_node-x86_64-unknown-linux-musl
-          path: |
-            target/x86_64-unknown-linux-musl/release
-
-  launch-testnet:
-    name: launch testnet
-    needs: build-node
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@master
-        with:
-          name: sn_node-x86_64-unknown-linux-musl
-          path: sn_node
-      - shell: bash
-        name: copy node to temp location
-        run: cp sn_node/sn_node /tmp
+          cargo build --release --bin sn_node
+          cp ./target/x86_64-unknown-linux-musl/release/sn_node /tmp/sn_node
       - name: Set TESTNET_ID env
         shell: bash
         run: |
@@ -190,13 +168,53 @@ jobs:
           workflow_id: ${{ github.run_id }}
           access_token: ${{ github.token }}
 
+  #launch-testnet:
+  #name: launch testnet
+  #needs: build-node
+  #runs-on: ubuntu-latest
+  #steps:
+  #- uses: actions/download-artifact@master
+  #with:
+  #name: sn_node-x86_64-unknown-linux-musl
+  #path: sn_node
+  #- shell: bash
+  #name: copy node to temp location
+  #run: cp sn_node/sn_node /tmp
+  #- name: Set TESTNET_ID env
+  #shell: bash
+  #run: |
+  #short_commit_hash=$(echo "${{ github.event.pull_request.head.sha || github.sha }}" | cut -c 1-7)
+  #echo "TESTNET_ID=gha-testnet-$short_commit_hash" >> $GITHUB_ENV
+  #- name: launch testnet
+  #uses: maidsafe/sn_testnet_action@main
+  #with:
+  #do-token: ${{ secrets.DO_TOKEN }}
+  #aws-access-key-id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+  #aws-access-key-secret: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
+  #ssh-secret-key: ${{ secrets.SSH_SECRET_KEY  }}
+  #node-count: ${{ inputs.node-count }}
+  #node-path: /tmp/sn_node
+  #testnet-id: ${{ env.TESTNET_ID }}
+  #testnet-tool-repo-branch: ${{ inputs.testnet-tool-repo-branch }}
+  #testnet-tool-repo-user: ${{ inputs.testnet-tool-repo-user }}
+  ## The other jobs in the workflow have the testnet launch as a dependency, but they go ahead
+  ## even if this job fails. It would be better if the whole workflow is abandoned if we don't
+  ## have a testnet to run the tests against.
+  #- name: cancel workflow if testnet launch fails
+  #uses: vishnudxb/cancel-workflow@v1.2
+  #if: failure()
+  #with:
+  #repo: octocat/hello-world
+  #workflow_id: ${{ github.run_id }}
+  #access_token: ${{ github.token }}
+
   client:
     name: client tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-    needs: launch-testnet
+    needs: build-node
     steps:
       - uses: actions/checkout@v2
         with:
@@ -247,7 +265,7 @@ jobs:
   api:
     name: api tests
     runs-on: ${{ matrix.os }}
-    needs: [client, launch-testnet]
+    needs: [client, build-node]
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -303,7 +321,7 @@ jobs:
   cli:
     name: cli tests
     runs-on: ${{ matrix.os }}
-    needs: [api, launch-testnet]
+    needs: [api, build-node]
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -358,7 +376,7 @@ jobs:
   kill-testnet:
     name: kill testnet
     runs-on: ubuntu-latest
-    needs: [launch-testnet, client, api, cli]
+    needs: [build-node, client, api, cli]
     steps:
       - name: Set TESTNET_ID env
         shell: bash
@@ -417,7 +435,7 @@ jobs:
        needs.client.result=='failure' ||
        needs.api.result=='failure' ||
        needs.cli.result=='failure')
-    needs: [launch-testnet, client, api, cli]
+    needs: [build-node, client, api, cli]
     env:
       SSH_SECRET_KEY: ${{ secrets.SSH_SECRET_KEY  }}
     steps:

--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -9,7 +9,7 @@ on:
       node-count:
         description: number of nodes for the testnet
         required: true
-        default: 15
+        default: 30
       testnet-tool-repo-branch:
         description: >
           The branch for the testnet tool repository. This is to enable using forks to test changes to
@@ -174,11 +174,11 @@ jobs:
           aws-access-key-id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
           aws-access-key-secret: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
           ssh-secret-key: ${{ secrets.SSH_SECRET_KEY  }}
-          node-count: ${{ github.event.inputs.node-count || 30 }}
+          node-count: ${{ inputs.node-count }}
           node-path: /tmp/sn_node
           testnet-id: ${{ env.TESTNET_ID }}
-          testnet-tool-repo-branch: ${{ github.event.inputs.testnet-tool-repo-branch }}
-          testnet-tool-repo-user: ${{ github.event.inputs.testnet-tool-repo-user }}
+          testnet-tool-repo-branch: ${{ inputs.testnet-tool-repo-branch }}
+          testnet-tool-repo-user: ${{ inputs.testnet-tool-repo-user }}
       # The other jobs in the workflow have the testnet launch as a dependency, but they go ahead
       # even if this job fails. It would be better if the whole workflow is abandoned if we don't
       # have a testnet to run the tests against.


### PR DESCRIPTION
- 0ee62251a **ci: reference inputs correctly**

  It looks like these inputs were always referenced incorrectly. A recent change for passing the user
  and branch for the testnet tool has exposed this, because null values were being passed and causing
  the testnet launch to fail.

- 8d2088c23 **ci: run node build job on ec2 for nightly**

  This job is quite slow on the GHA infrastructure, particularly when debugging the workflow. This
  seems like a good place to make use of an EC2 instance.

- 4126a08b6 **ci: use single thread for cli/api tests**

  There are issues on Windows with the `fs::rename` function when the test suite is running with
  multiple threads.

  Code in the CLI related to the config file is calling this API to rename a temporary file to
  `config.json` and on Windows you get an access denied error when there are multiple threads doing
  this in quick succession.

  The real solution here is probably to isolate the config directory for each test, because I don't
  think it's a realistic user scenario for multiple instances of the CLI to be running at the same
  time on the same machine in such close time proximity that a user would actually run into issues
  here.

  There are also issues with ACK messages not being returned correctly that may have something to do
  with running the test suite with multiple threads, so the API tests are also set to use a single
  thread.