### PR TITLE
fix: pass defaults for testnet action inputs

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -26,10 +26,13 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: "eu-west-2"
   INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.sh
+  NODE_COUNT: 30
   POWERSHELL_INSTALL_SCRIPT_URL: https://raw.githubusercontent.com/maidsafe/safe_network/main/resources/scripts/install.ps1
   TESTNET_NIGHTLY_LOGS_BUCKET: s3://sn-node/nightly_testnet_logs
   TESTNET_NIGHTLY_LOGS_BUCKET_URL: https://sn-node.s3.eu-west-2.amazonaws.com/nightly_testnet_logs
   TESTNET_TOOL_BUCKET_URL: https://sn-node.s3.eu-west-2.amazonaws.com/testnet_tool
+  TESTNET_TOOL_REPO_BRANCH: main
+  TESTNET_TOOL_REPO_USER: maidsafe
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
 
 jobs:
@@ -152,11 +155,11 @@ jobs:
           aws-access-key-id: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
           aws-access-key-secret: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
           ssh-secret-key: ${{ secrets.SSH_SECRET_KEY  }}
-          node-count: ${{ inputs.node-count }}
+          node-count: ${{ inputs.node-count || env.NODE_COUNT }}
           node-path: /tmp/sn_node
           testnet-id: ${{ env.TESTNET_ID }}
-          testnet-tool-repo-branch: ${{ inputs.testnet-tool-repo-branch }}
-          testnet-tool-repo-user: ${{ inputs.testnet-tool-repo-user }}
+          testnet-tool-repo-branch: ${{ inputs.testnet-tool-repo-branch || env.TESTNET_TOOL_REPO_BRANCH }}
+          testnet-tool-repo-user: ${{ inputs.testnet-tool-repo-user || env.TESTNET_TOOL_REPO_USER }}
       # The other jobs in the workflow have the testnet launch as a dependency, but they go ahead
       # even if this job fails. It would be better if the whole workflow is abandoned if we don't
       # have a testnet to run the tests against.


### PR DESCRIPTION
On the scheduled run the defaults from the `workflow_dispatch` inputs are not provided.
