### PR TITLE
[test] chore(node): remove connection storage altogether

### DIFF
--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -271,8 +271,6 @@ impl Comm {
         if let Some(entry) = self.sessions.get(peer) {
             // peer already exists
             let peer_session = entry.value();
-            // add to it
-            peer_session.add(conn).await;
         } else {
             let link = Link::new_with(
                 *peer,


### PR DESCRIPTION
Trying again as we've expanded/changed the flow for a lot of the cmd channel stuff to hopefully be non-blocking.

So perhaps that was a contributing factor to the slowdown/connection batching?