### PR TITLE
chore(node): warn if dysf channels are closed

### DIFF
--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -404,7 +404,7 @@ impl MyNode {
             .send(DysCmds::RetainNodes(members))
             .await
         {
-            error!("Could not send RetainNodes through dysfunctional_cmds_tx: {error}");
+            warn!("Could not send RetainNodes through dysfunctional_cmds_tx: {error}");
         };
     }
 
@@ -417,7 +417,7 @@ impl MyNode {
             .send(DysCmds::AddNode(adult))
             .await
         {
-            error!("Could not send AddNode through dysfunctional_cmds_tx: {error}");
+            warn!("Could not send AddNode through dysfunctional_cmds_tx: {error}");
         };
     }
 

--- a/sn_node/src/node/flow_ctrl/dysfunction.rs
+++ b/sn_node/src/node/flow_ctrl/dysfunction.rs
@@ -57,7 +57,7 @@ impl FlowCtrl {
                             .send(dysfunction.get_dysfunctional_nodes())
                             .await
                         {
-                            error!("Could not send dysfunctional nodes through the mpsc channel: {error:?}");
+                            warn!("Could not send dysfunctional nodes through the mpsc channel: {error:?}");
                         }
                     }
                 }
@@ -85,7 +85,7 @@ impl FlowCtrl {
             {
                 dysfunctional_nodes
             } else {
-                error!("dysfunctional_nodes_rx channel closed?");
+                warn!("dysfunctional_nodes_rx channel closed?");
                 BTreeSet::new()
             }
         }

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -647,7 +647,7 @@ mod core {
             let _handle = tokio::spawn(async move {
                 if let Err(error) = dysf_sender.send(DysCmds::TrackIssue(name, issue)).await {
                     // Log the issue, and error. We need to be wary of actually hitting this.
-                    error!("Could not send DysCmds through dysfunctional_cmds_tx: {error}");
+                    warn!("Could not send DysCmds through dysfunctional_cmds_tx: {error}");
                 }
             });
         }
@@ -660,7 +660,7 @@ mod core {
             // TODO: do we need to kill the node if we fail tracking dysf?
             let _handle = tokio::spawn(async move {
                 if let Err(error) = dysf_sender.send(DysCmds::UntrackIssue(name, issue)).await {
-                    error!("Could not send DysCmds through dysfunctional_cmds_tx: {error}");
+                    warn!("Could not send DysCmds through dysfunctional_cmds_tx: {error}");
                 }
             });
         }


### PR DESCRIPTION
- Prevents the logs from getting printed to the stdout while running node unit tests