### PR TITLE
Always update sap in network knowledge when we receive an AE update.

### DIFF
--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -61,19 +61,18 @@ pub const DEFAULT_ELDER_COUNT: usize = 7;
 pub fn elder_count() -> usize {
     // if we have an env var for this, lets override
     match std::env::var(SN_ELDER_COUNT) {
-        Ok(count) => match count.parse() {
-            Ok(count) => {
-                warn!(
-                    "ELDER_COUNT count set from env var SN_ELDER_COUNT: {:?}",
-                    SN_ELDER_COUNT
-                );
-                count
+        Ok(count) => {
+            match count.parse() {
+                Ok(count) => {
+                    warn!("ELDER_COUNT count set from env var SN_ELDER_COUNT: {SN_ELDER_COUNT:?}={count}");
+                    count
+                }
+                Err(error) => {
+                    warn!("There was an error parsing {SN_ELDER_COUNT:?} env var. DEFAULT_ELDER_COUNT={DEFAULT_ELDER_COUNT} will be used: {error:?}");
+                    DEFAULT_ELDER_COUNT
+                }
             }
-            Err(error) => {
-                warn!("There was an error parsing {:?} env var. DEFAULT_ELDER_COUNT will be used: {:?}", SN_ELDER_COUNT, error);
-                DEFAULT_ELDER_COUNT
-            }
-        },
+        }
         Err(_) => DEFAULT_ELDER_COUNT,
     }
 }

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -217,48 +217,6 @@ impl NetworkKnowledge {
         Ok(())
     }
 
-    /// If we already have the signed SAP for the provided key and prefix, we make it the current SAP, and if so, this
-    /// returns 'true'. Note this function assumes we already have the key share for the provided section key.
-    pub fn try_update_current_sap(&mut self, section_key: BlsPublicKey, prefix: &Prefix) -> bool {
-        // Let's try to find the signed SAP corresponding to the provided prefix and section key
-        match self.section_tree.get_signed(prefix) {
-            Some(signed_sap) if signed_sap.value.section_key() == section_key => {
-                let proof_chain = self
-                    .section_tree
-                    .get_sections_dag()
-                    .partial_dag(self.genesis_key(), &section_key);
-                // We have the signed SAP for the provided prefix and section key,
-                // we should be able to update our current SAP and section chain
-                match proof_chain {
-                    Ok(pc) => {
-                        // Remove any peer which doesn't belong to our new section's prefix
-                        self.section_peers.retain(prefix);
-                        // Prune list of archived members
-                        if let Err(e) = self.section_peers.prune_members_archive(&pc, &section_key)
-                        {
-                            error!("Error while pruning member archive with last_key: {section_key:?}, err: {e:?}");
-                        }
-                        // Let's then update our current SAP and section chain
-                        let our_prev_prefix = self.prefix();
-                        self.signed_sap = signed_sap.clone();
-
-                        info!("Switched our section's SAP ({our_prev_prefix:?} to {prefix:?}) with new one: {signed_sap:?}");
-
-                        true
-                    }
-                    Err(err) => {
-                        trace!("We couldn't find section chain for {prefix:?} and section key {section_key:?}: {err:?}");
-                        false
-                    }
-                }
-            }
-            Some(_) | None => {
-                trace!("We yet don't have the signed SAP for {prefix:?} and section key {section_key:?}");
-                false
-            }
-        }
-    }
-
     /// Update our network knowledge with the provided `SectionTreeUpdate`
     pub fn update_knowledge_if_valid(
         &mut self,

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -114,10 +114,10 @@ impl MyNode {
     // Generate a new section info based on the current set of members, but
     // excluding the ones in the provided list. And if the outcome list of candidates
     // differs from the current elders, trigger a DKG.
-    pub(crate) async fn trigger_dkg(&mut self) -> Result<Vec<Cmd>> {
+    pub(crate) fn trigger_dkg(&mut self) -> Result<Vec<Cmd>> {
         debug!("{}", LogMarker::TriggeringPromotionAndDemotion);
         let mut cmds = vec![];
-        for session_id in self.best_elder_candidates().await {
+        for session_id in self.best_elder_candidates() {
             cmds.extend(self.send_dkg_start(session_id)?);
         }
 

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -161,7 +161,7 @@ impl Dispatcher {
                 let mut node = self.node.write().await;
                 debug!("[NODE WRITE]: general agreements node write got");
 
-                node.handle_general_agreements(proposal, sig).await
+                node.handle_general_agreements(proposal, sig)
             }
             Cmd::HandleMembershipDecision(decision) => {
                 debug!("[NODE WRITE]: membership decision agreements write...");

--- a/sn_node/src/node/handover/handover_consensus.rs
+++ b/sn_node/src/node/handover/handover_consensus.rs
@@ -120,6 +120,10 @@ impl Handover {
         self.gen
     }
 
+    pub(crate) fn section_key_set(&self) -> PublicKeySet {
+        self.consensus.elders.clone()
+    }
+
     fn handle_outdated_signed_vote(
         &mut self,
         signed_vote: SignedVote<SapCandidate>,

--- a/sn_node/src/node/membership/mod.rs
+++ b/sn_node/src/node/membership/mod.rs
@@ -162,6 +162,10 @@ impl Membership {
         }
     }
 
+    pub(crate) fn section_key_set(&self) -> PublicKeySet {
+        self.consensus.elders.clone()
+    }
+
     pub(crate) fn last_received_vote_time(&self) -> Option<Instant> {
         self.last_received_vote_time
     }

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -219,8 +219,12 @@ impl MyNode {
         // We need to generate the proof chain to connect our current chain to new SAP.
         match section_chain.insert(&last_key, signed_sap.section_key(), section_sig.signature) {
             Ok(()) => {
-                let section_tree_update = SectionTreeUpdate::new(signed_sap, section_chain);
-                match self.update_network_knowledge(&self.context(), section_tree_update, None) {
+                let update = SectionTreeUpdate::new(signed_sap, section_chain);
+                let name = self.context().name;
+                match self
+                    .network_knowledge
+                    .update_knowledge_if_valid(update, None, &name)
+                {
                     Ok(true) => {
                         info!("Updated our network knowledge for {:?}", prefix);
                         info!("Writing updated knowledge to disk");

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeSet;
 // Agreement
 impl MyNode {
     #[instrument(skip(self), level = "trace")]
-    pub(crate) async fn handle_general_agreements(
+    pub(crate) fn handle_general_agreements(
         &mut self,
         proposal: Proposal,
         sig: SectionSig,
@@ -31,7 +31,7 @@ impl MyNode {
                 cmds.extend(self.handle_offline_agreement(node_state, sig));
             }
             Proposal::RequestHandover(sap) => {
-                cmds.extend(self.handle_request_handover_agreement(sap, sig).await?);
+                cmds.extend(self.handle_request_handover_agreement(sap, sig)?);
             }
             Proposal::HandoverCompleted(_) => {
                 error!("Handover completed should be handled in a separate blocking fashion");
@@ -53,7 +53,7 @@ impl MyNode {
     }
 
     #[instrument(skip(self), level = "trace")]
-    async fn handle_request_handover_agreement(
+    fn handle_request_handover_agreement(
         &mut self,
         sap: SectionAuthorityProvider,
         sig: SectionSig,
@@ -77,7 +77,7 @@ impl MyNode {
         // check if at the given memberhip gen, the elders candidates are matching
         let membership_gen = sap.membership_gen();
         let signed_sap = SectionSigned::new(sap, sig);
-        let dkg_sessions_info = self.best_elder_candidates_at_gen(membership_gen).await;
+        let dkg_sessions_info = self.best_elder_candidates_at_gen(membership_gen);
 
         let elder_candidates = BTreeSet::from_iter(signed_sap.names());
         if dkg_sessions_info

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -223,7 +223,7 @@ impl MyNode {
             cmds.extend(self.relocate_peers(churn_id, excluded_from_relocation)?);
         }
 
-        cmds.extend(self.trigger_dkg().await?);
+        cmds.extend(self.trigger_dkg()?);
         cmds.extend(self.send_ae_update_to_our_section()?);
 
         self.liveness_retain_only(

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -46,6 +46,19 @@ impl Peers {
     }
 }
 
+impl IntoIterator for Peers {
+    type Item = Peer;
+
+    type IntoIter = Box<dyn Iterator<Item = Self::Item>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Peers::Single(p) => Box::new(std::iter::once(p)),
+            Peers::Multiple(ps) => Box::new(ps.into_iter()),
+        }
+    }
+}
+
 // Message handling
 impl MyNode {
     #[instrument(skip(node))]

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -315,7 +315,7 @@ mod core {
 
         /// Generates section infos for the best elder candidate among the members at the given generation
         /// Returns a set of candidate `DkgSessionId`'s.
-        pub(crate) async fn best_elder_candidates_at_gen(
+        pub(crate) fn best_elder_candidates_at_gen(
             &self,
             membership_gen: u64,
         ) -> Vec<DkgSessionId> {
@@ -417,9 +417,9 @@ mod core {
 
         /// Generates section infos for the current best elder candidate among the current members
         /// Returns a set of candidate `DkgSessionId`'s.
-        pub(crate) async fn best_elder_candidates(&self) -> Vec<DkgSessionId> {
+        pub(crate) fn best_elder_candidates(&self) -> Vec<DkgSessionId> {
             match self.membership.as_ref() {
-                Some(m) => self.best_elder_candidates_at_gen(m.generation()).await,
+                Some(m) => self.best_elder_candidates_at_gen(m.generation()),
                 None => {
                     error!("Attempted to find best elder candidates when we don't have a membership instance");
                     vec![]
@@ -532,7 +532,7 @@ mod core {
                 if let Ok(key) = self.section_keys_provider.key_share(&sap.section_key()) {
                     // The section-key has changed, we are now able to function as an elder.
                     if self.initialize_elder_state(key) {
-                        cmds.extend(self.trigger_dkg().await?);
+                        cmds.extend(self.trigger_dkg()?);
 
                         // Whenever there is an elders change, casting a round of joins_allowed
                         // proposals to sync this particular state.

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -538,6 +538,8 @@ mod core {
                         // proposals to sync this particular state.
                         cmds.extend(self.propose(Proposal::JoinsAllowed(self.joins_allowed))?);
                     }
+                } else {
+                    warn!("We're an elder but are missing our section key share, delaying elder state initialization until we receive it: sap={sap:?}");
                 }
 
                 self.log_network_stats();

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -430,6 +430,9 @@ mod core {
         fn initialize_membership(&mut self, key: SectionKeyShare) -> bool {
             let sap = self.network_knowledge.signed_sap().value;
 
+            // IDEMPOTENCY CHECK: Check if this membership instance has already been
+            // initialized for the current SAP, this allows this function to be
+            // safely called everytime we process an AE update.
             if let Some(m) = self.membership.as_ref() {
                 if m.section_key_set().public_key() == sap.section_key() {
                     return false;
@@ -449,6 +452,9 @@ mod core {
         fn initialize_handover(&mut self, key: SectionKeyShare) -> bool {
             let sap = self.network_knowledge.signed_sap().value;
 
+            // IDEMPOTENCY CHECK: Check if this handover instance has already been
+            // initialized for the current SAP, this allows this function to be
+            // safely called everytime we process an AE update.
             if let Some(h) = self.handover_voting.as_ref() {
                 if h.section_key_set().public_key() == sap.section_key() {
                     return false;


### PR DESCRIPTION
Currently we have logic that avoids updating the signed sap in Network-knowledge if we were an elder and we had not received our section key share yet.

This PR removes this logic as it was preventing other changes I was trying to make and it doesn't actually seem to be what we want: If a SAP update has occurred, then hanging on to the old SAP until we finish DKG does little to help the network as the other elders will update soon if they hadn't already, any signature shares this elder is creating with the old section key will only have a potential to be aggregated for that short period while we still have a threshold of old elders around still using the old SAP.

On a more philosophical point, we probably don't want elders to be signing anything after we've agreed to a handover.
