### PR TITLE
fix: workspace folders are now used on S3

### DIFF
--- a/.github/workflows/daily_droplet_run.yml
+++ b/.github/workflows/daily_droplet_run.yml
@@ -202,7 +202,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.safe/network_contacts
-          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}-network-contacts > \
+          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}/network-contacts > \
             ~/.safe/network_contacts/default
 
       - name: Build all client tests before running
@@ -250,7 +250,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.safe/network_contacts
-          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}-network-contacts > \
+          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}/network-contacts > \
             ~/.safe/network_contacts/default
 
       - uses: Swatinem/rust-cache@v1
@@ -266,7 +266,7 @@ jobs:
       - name: Download genesis DBC
         shell: bash
         run: |
-          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}-genesis-dbc \
+          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}/genesis-dbc > \
             > /tmp/genesis_dbc
 
       - name: Run API tests
@@ -311,12 +311,12 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.safe/network_contacts
-          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}-network-contacts > \
+          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}/network-contacts > \
             ~/.safe/network_contacts/default
       - name: Download genesis DBC
         shell: bash
         run: |
-          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}-genesis-dbc \
+          curl $TESTNET_TOOL_BUCKET_URL/${{ env.TESTNET_ID }}/genesis-dbc > \
             > /tmp/genesis_dbc
 
       - name: Build all CLI tests


### PR DESCRIPTION
The workspace name is appended to the URL when the network contacts and genesis DBC are retrieved.
