### PR TITLE
fix: remove dummy SectionTree update

### DIFF
--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -62,7 +62,7 @@ authd_client = [ ]
 app = [ ]
 check-replicas = [ "sn_client/check-replicas" ]
 limit-client-upload-size = ["sn_client/limit-client-upload-size"]
-test-utils = [ "sn_client/test-utils", "anyhow", "async_once", "tracing-subscriber" ]
+test-utils = [ "sn_interface/test-utils", "sn_client/test-utils", "anyhow", "async_once", "tracing-subscriber" ]
 default = [ "authenticator", "authd_client", "app" ]
 
 [dev-dependencies]
@@ -74,5 +74,6 @@ hex = "~0.4"
 predicates = "2.0"
 proptest = "1.0.0"
 sn_client = { path = "../sn_client", version = "^0.77.2", features = ["test-utils"] }
+sn_interface = { path = "../sn_interface", version = "^0.16.3", features = ["test-utils"] }
 tokio = { version = "1.6.0", features = ["macros"] }
 tracing-subscriber = "~0.3.1"

--- a/sn_api/src/app/test_helpers.rs
+++ b/sn_api/src/app/test_helpers.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+pub use sn_interface::test_utils::TestSectionTree;
+
 use crate::{Safe, SafeUrl};
 
 use sn_client::utils::test_utils::read_genesis_dbc_from_first_node;

--- a/sn_cli/src/operations/config.rs
+++ b/sn_cli/src/operations/config.rs
@@ -663,7 +663,7 @@ pub mod test_utils {
     use assert_fs::{prelude::*, TempDir};
     use color_eyre::{eyre::eyre, Result};
     use httpmock::{Method, MockServer};
-    use sn_api::{SectionTree, DEFAULT_NETWORK_CONTACTS_FILE_NAME};
+    use sn_api::{test_helpers::TestSectionTree, SectionTree, DEFAULT_NETWORK_CONTACTS_FILE_NAME};
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
     use tokio::fs;
@@ -676,8 +676,7 @@ pub mod test_utils {
         let mut dummy_network_contacts: Vec<SectionTree> = Vec::new();
 
         for _ in 0..n_network_contacts {
-            let sk = bls::SecretKey::random();
-            let network_contacts = SectionTree::new(sk.public_key());
+            let (network_contacts, _) = TestSectionTree::random_tree();
             let filename = format!("{:?}", network_contacts.genesis_key());
 
             network_contacts

--- a/sn_client/src/sessions/messaging.rs
+++ b/sn_client/src/sessions/messaging.rs
@@ -524,14 +524,17 @@ mod tests {
     use eyre::Result;
     use qp2p::Config;
     use std::net::{Ipv4Addr, SocketAddr};
+    use xor_name::Prefix;
 
     fn new_network_network_contacts() -> (SectionTree, bls::SecretKey, bls::PublicKey) {
-        let genesis_sk = bls::SecretKey::random();
+        let (genesis_sap, genesis_sk_set, ..) = TestSapBuilder::new(Prefix::default()).build();
+
+        let genesis_sk = genesis_sk_set.secret_key();
         let genesis_pk = genesis_sk.public_key();
+        let genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap);
+        let tree = SectionTree::new(genesis_sap).expect("SAP belongs to the genesis prefix");
 
-        let map = SectionTree::new(genesis_pk);
-
-        (map, genesis_sk, genesis_pk)
+        (tree, genesis_sk, genesis_pk)
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -156,8 +156,7 @@ pub fn init_logger() {
 pub mod test_utils {
     pub use crate::{
         network_knowledge::{
-            section_authority_provider::test_utils::*, test_utils::*, test_utils_nw::*,
-            test_utils_st::*,
+            section_authority_provider::test_utils::*, test_utils::*, test_utils_st::*,
         },
         types::keys::test_utils::*,
     };

--- a/sn_interface/src/network_knowledge/errors.rs
+++ b/sn_interface/src/network_knowledge/errors.rs
@@ -27,6 +27,8 @@ pub enum Error {
     /// Failed to deserialise a section tree.
     #[error("Failed to deserialise section tree: {0}")]
     Deserialisation(String),
+    #[error("The provided SAP must belong to the genesis prefix")]
+    NonGenesisSap,
     #[error("The provided signature cannot be verified while inserting into the SectionsDAG")]
     InvalidSignature,
     #[error("Key not found in the SectionsDAG: {0:?}")]

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -154,10 +154,10 @@ impl NetworkKnowledge {
     /// Creates a new `NetworkKnowledge` instance. The prefix is used to choose the
     /// `signed_sap` from the provided SectionTree
     pub fn new(prefix: Prefix, section_tree: SectionTree) -> Result<Self, Error> {
-        let signed_sap = match section_tree.get_signed(&prefix) {
-            Some(signed_sap) => signed_sap.clone(),
-            None => return Err(Error::NoMatchingSection),
-        };
+        let signed_sap = section_tree
+            .get_signed(&prefix)
+            .cloned()
+            .ok_or(Error::NoMatchingSection)?;
         Ok(Self {
             signed_sap,
             section_peers: SectionPeers::default(),

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -200,10 +200,10 @@ impl NetworkKnowledge {
     }
 
     /// update all section info for our new section
-    pub fn relocated_to(&mut self, new_network_knowledge: Self) -> Result<()> {
-        debug!("Node was relocated to {:?}", new_network_knowledge);
-        self.signed_sap = new_network_knowledge.signed_sap();
-        let _updated = self.merge_members(new_network_knowledge.section_signed_members())?;
+    pub fn relocated_to(&mut self, new_name: XorName) -> Result<()> {
+        let signed_sap = self.section_tree().get_signed_by_name(&new_name)?;
+        debug!("Node was relocated to {:?}", signed_sap.section_key());
+        self.signed_sap = signed_sap;
 
         Ok(())
     }

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -151,20 +151,13 @@ pub struct NetworkKnowledge {
 }
 
 impl NetworkKnowledge {
-    /// Creates a minimal `NetworkKnowledge` with the provided SectionTree and SAP
-    pub fn new(
-        section_tree: SectionTree,
-        section_tree_update: SectionTreeUpdate,
-    ) -> Result<Self, Error> {
-        let mut section_tree = section_tree;
-        let signed_sap = section_tree_update.signed_sap.clone();
-
-        // Update fails if the proof chain's genesis key is not part of the SectionTree's dag.
-        if let Err(err) = section_tree.update(section_tree_update.clone()) {
-            debug!("Failed to update SectionTree with {section_tree_update:?} upon creating new NetworkKnowledge instance: {err:?}");
-            return Err(err);
-        }
-
+    /// Creates a new `NetworkKnowledge` instance. The prefix is used to choose the
+    /// `signed_sap` from the provided SectionTree
+    pub fn new(prefix: Prefix, section_tree: SectionTree) -> Result<Self, Error> {
+        let signed_sap = match section_tree.get_signed(&prefix) {
+            Some(signed_sap) => signed_sap.clone(),
+            None => return Err(Error::NoMatchingSection),
+        };
         Ok(Self {
             signed_sap,
             section_peers: SectionPeers::default(),
@@ -180,17 +173,13 @@ impl NetworkKnowledge {
         let public_key_set = genesis_sk_set.public_keys();
         let secret_key_index = 0u8;
         let secret_key_share = genesis_sk_set.secret_key_share(secret_key_index as u64);
-        let genesis_key = public_key_set.public_key();
 
-        let section_tree_update = {
-            let section_auth =
+        let section_tree = {
+            let genesis_signed_sap =
                 create_first_section_authority_provider(&public_key_set, &secret_key_share, peer)?;
-            SectionTreeUpdate::new(section_auth, SectionsDAG::new(genesis_key))
+            SectionTree::new(genesis_signed_sap)?
         };
-        let mut network_knowledge = Self::new(
-            SectionTree::new(section_tree_update.signed_sap.clone())?,
-            section_tree_update,
-        )?;
+        let mut network_knowledge = Self::new(Prefix::default(), section_tree)?;
 
         for peer in network_knowledge.signed_sap.elders() {
             let node_state = NodeState::joined(*peer, None);
@@ -566,52 +555,6 @@ fn create_first_sig<T: Serialize>(
     })
 }
 
-#[cfg(any(test, feature = "test-utils"))]
-pub mod test_utils_nw {
-    use super::{MyNodeInfo, NetworkKnowledge, NodeState, SectionTree, SectionsDAG};
-    use crate::{test_utils::TestSapBuilder, types::keys::test_utils::TestKeys};
-    use xor_name::Prefix;
-
-    /// `NetworkKnowledge` related utils for testing
-    pub struct TestNetworkKnowledge {}
-
-    impl TestNetworkKnowledge {
-        /// Generate a random `NetworkKnowledge` (section) for testing.
-        pub fn random_section_with_key(
-            prefix: Prefix,
-            elder_count: usize,
-            adult_count: usize,
-            sk_set: &bls::SecretKeySet,
-        ) -> (NetworkKnowledge, Vec<MyNodeInfo>) {
-            let pk_set = sk_set.public_keys();
-            let (sap, _, mut elders, adults) = TestSapBuilder::new(prefix)
-                .elder_count(elder_count)
-                .adult_count(adult_count)
-                .sk_set(sk_set)
-                .build();
-            let signed_sap = TestKeys::get_section_signed(&sk_set.secret_key(), sap);
-            let section_tree_update = super::SectionTreeUpdate::new(
-                signed_sap.clone(),
-                SectionsDAG::new(pk_set.public_key()),
-            );
-            let mut network_knowledge = NetworkKnowledge::new(
-                SectionTree::new(signed_sap).expect("SAP belongs to the prefix section"),
-                section_tree_update,
-            )
-            .expect("Failed to create NetworkKnowledge");
-
-            // update the sap members
-            for peer in network_knowledge.signed_sap.elders() {
-                let node_state = NodeState::joined(*peer, None);
-                let signed_state = TestKeys::get_section_signed(&sk_set.secret_key(), node_state);
-                let _changed = network_knowledge.section_peers.update(signed_state);
-            }
-            elders.extend(adults.into_iter());
-            (network_knowledge, elders)
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{supermajority, NetworkKnowledge};
@@ -619,6 +562,7 @@ mod tests {
         test_utils::{gen_addr, prefix, TestKeys, TestSapBuilder, TestSectionTree},
         types::Peer,
     };
+
     use bls::SecretKeySet;
     use eyre::Result;
     use proptest::prelude::*;

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -47,12 +47,17 @@ pub struct SectionTree {
 }
 
 impl SectionTree {
-    /// Create an empty container
-    pub fn new(genesis_pk: BlsPublicKey) -> Self {
-        Self {
-            sections: BTreeMap::new(),
-            sections_dag: SectionsDAG::new(genesis_pk),
+    /// Create a `SectionTree` with just the genesis section
+    pub fn new(genesis_sap: SectionSigned<SectionAuthorityProvider>) -> Result<Self> {
+        if genesis_sap.prefix() != Prefix::default() {
+            return Err(Error::NonGenesisSap);
         }
+
+        let genesis_pk = genesis_sap.public_key_set().public_key();
+        Ok(Self {
+            sections: BTreeMap::from([(Prefix::default(), genesis_sap)]),
+            sections_dag: SectionsDAG::new(genesis_pk),
+        })
     }
 
     /// Create a new SectionTree deserialised from bytes
@@ -168,6 +173,29 @@ impl SectionTree {
             .find(|&signed_sap| signed_sap.public_key_set().public_key() == *section_key)
     }
 
+    /// Returns the section authority provider for the prefix that matches `name`.
+    /// In case there is no prefix matches the `name`, we shall return the one with longest
+    /// common bits. i.e. for the name of `00xxx`, if we have `01` and `1`, then we shall return
+    /// with `01`.
+    pub fn get_signed_by_name(
+        &self,
+        name: &XorName,
+    ) -> Result<SectionSigned<SectionAuthorityProvider>> {
+        self.sections
+            .iter()
+            .max_by_key(|&(prefix, _)| prefix.common_prefix(name))
+            .ok_or(Error::NoMatchingSection)
+            .map(|(_, sap)| sap.clone())
+    }
+
+    /// Get the section that matches `prefix`. In case of multiple matches, returns the
+    /// one with the longest prefix.
+    pub fn get_signed_by_prefix(
+        &self,
+        prefix: &Prefix,
+    ) -> Result<SectionSigned<SectionAuthorityProvider>> {
+        self.get_signed_by_name(&prefix.name())
+    }
     /// Update our `SectionTree` if the provided update can be verified
     /// Returns true if an update was made
     pub fn update(&mut self, section_tree_update: SectionTreeUpdate) -> Result<bool> {
@@ -213,7 +241,7 @@ impl SectionTree {
         // the incoming prefix. If elder_count() is smaller at _all_ we
         // should warn! something so we can track this.
         if !incoming_prefix.is_empty() {
-            match self.section_by_prefix(incoming_prefix) {
+            match self.get_signed_by_prefix(incoming_prefix) {
                 Ok(sap) => {
                     let current_sap_elder_count = sap.elder_count();
                     let proposed_sap_elder_count = signed_sap.elder_count();
@@ -318,24 +346,6 @@ impl SectionTree {
             signed_sap,
             proof_chain,
         })
-    }
-
-    /// Returns the section authority provider for the prefix that matches `name`.
-    /// In case there is no prefix matches the `name`, we shall return the one with longest
-    /// common bits. i.e. for the name of `00xxx`, if we have `01` and `1`, then we shall return
-    /// with `01`.
-    pub fn section_by_name(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
-        self.sections
-            .iter()
-            .max_by_key(|&(prefix, _)| prefix.common_prefix(name))
-            .ok_or(Error::NoMatchingSection)
-            .map(|(_, sap)| sap.value.clone())
-    }
-
-    /// Get the section that matches `prefix`. In case of multiple matches, returns the
-    /// one with the longest prefix.
-    pub fn section_by_prefix(&self, prefix: &Prefix) -> Result<SectionAuthorityProvider> {
-        self.section_by_name(&prefix.name())
     }
 
     /// Get total number of known sections
@@ -476,8 +486,14 @@ impl SectionTreeUpdate {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils {
+
     use super::{SectionTree, SectionTreeUpdate, SectionsDAG};
-    use crate::{messaging::system::SectionSigned, test_utils::TestKeys, SectionAuthorityProvider};
+    use crate::{
+        messaging::system::SectionSigned,
+        test_utils::{TestKeys, TestSapBuilder},
+        SectionAuthorityProvider,
+    };
+    use xor_name::Prefix;
 
     /// `SectionTree` related utils for testing
     pub struct TestSectionTree {}
@@ -485,10 +501,11 @@ pub mod test_utils {
     impl TestSectionTree {
         /// Get a random `SectionTree`
         pub fn random_tree() -> (SectionTree, bls::SecretKey) {
-            let genesis_sk = bls::SecretKey::random();
-            let tree = SectionTree::new(genesis_sk.public_key());
+            let (gen_sap, gen_sk_set, ..) = TestSapBuilder::new(Prefix::default()).build();
+            let gen_sap = TestKeys::get_section_signed(&gen_sk_set.secret_key(), gen_sap);
+            let tree = SectionTree::new(gen_sap).expect("SAP belongs to the genesis prefix");
 
-            (tree, genesis_sk)
+            (tree, gen_sk_set.secret_key())
         }
 
         /// Generate a `SectionTreeUpdate` where the SAP's section key is appended to the proof chain
@@ -589,8 +606,8 @@ mod tests {
         let _changed = tree.insert(sap0.clone());
 
         assert_eq!(
-            tree.section_by_name(&p1.substituted_in(xor_name::rand::random()))?,
-            sap0.value
+            tree.get_signed_by_name(&p1.substituted_in(xor_name::rand::random()))?,
+            sap0
         );
 
         // There are no matching prefixes, so return an opposite prefix.
@@ -679,34 +696,34 @@ mod tests {
         let _changed = tree.insert(sap.clone());
 
         assert_eq!(
-            tree.section_by_name(&p0.substituted_in(xor_name::rand::random()))?,
-            sap.value
+            tree.get_signed_by_name(&p0.substituted_in(xor_name::rand::random()))?,
+            sap
         );
 
         let _changed = tree.insert(sap0.clone());
 
         assert_eq!(
-            tree.section_by_name(&p1.substituted_in(xor_name::rand::random()))?,
-            sap0.value
+            tree.get_signed_by_name(&p1.substituted_in(xor_name::rand::random()))?,
+            sap0
         );
 
         let _changed = tree.insert(sap1);
         let _changed = tree.insert(sap10.clone());
 
         assert_eq!(
-            tree.section_by_name(&p0.substituted_in(xor_name::rand::random()))?,
-            sap0.value
+            tree.get_signed_by_name(&p0.substituted_in(xor_name::rand::random()))?,
+            sap0
         );
 
         // sap1 get pruned once sap10 inserted.
         assert_eq!(
-            tree.section_by_name(&prefix("11").substituted_in(xor_name::rand::random()))?,
-            sap10.value
+            tree.get_signed_by_name(&prefix("11").substituted_in(xor_name::rand::random()))?,
+            sap10
         );
 
         assert_eq!(
-            tree.section_by_name(&p10.substituted_in(xor_name::rand::random()))?,
-            sap10.value
+            tree.get_signed_by_name(&p10.substituted_in(xor_name::rand::random()))?,
+            sap10
         );
 
         Ok(())
@@ -727,14 +744,14 @@ mod tests {
         let _changed = tree.insert(sap1);
         let _changed = tree.insert(sap10.clone());
 
-        assert_eq!(tree.section_by_prefix(&p0)?, sap0.value);
+        assert_eq!(tree.get_signed_by_prefix(&p0)?, sap0);
 
         // sap1 get pruned once sap10 inserted.
-        assert_eq!(tree.section_by_prefix(&prefix("11"))?, sap10.value);
+        assert_eq!(tree.get_signed_by_prefix(&prefix("11"))?, sap10);
 
-        assert_eq!(tree.section_by_prefix(&p10)?, sap10.value);
+        assert_eq!(tree.get_signed_by_prefix(&p10)?, sap10);
 
-        assert_eq!(tree.section_by_prefix(&prefix("101"))?, sap10.value);
+        assert_eq!(tree.get_signed_by_prefix(&prefix("101"))?, sap10);
 
         Ok(())
     }
@@ -867,8 +884,8 @@ mod tests {
         })]
         #[test]
         #[allow(clippy::unwrap_used)]
-        fn proptest_section_tree_fields_should_stay_in_sync((main_dag, list_of_proof_chains) in arb_sections_dag_and_proof_chains(100, true)) {
-            let mut section_tree = SectionTree::new(*main_dag.genesis_key());
+        fn proptest_section_tree_fields_should_stay_in_sync((genesis_sap, main_dag, list_of_proof_chains) in arb_sections_dag_and_proof_chains(100, true)) {
+            let mut section_tree = SectionTree::new(genesis_sap).expect("SAP belongs to the genesis prefix");
             for (proof_chain, sap) in &list_of_proof_chains {
                 let tree_update = SectionTreeUpdate::new(sap.clone(), proof_chain.clone());
                 assert!(section_tree.update(tree_update)?);

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -1059,7 +1059,7 @@ pub(crate) mod tests {
         })]
         #[test]
         #[allow(clippy::unwrap_used)]
-        fn proptest_merge_sections_dag((main_dag, list_of_partial_dags) in arb_sections_dag_and_proof_chains(100, false)) {
+        fn proptest_merge_sections_dag((_, main_dag, list_of_partial_dags) in arb_sections_dag_and_proof_chains(100, false)) {
                 let mut dag = SectionsDAG::new(main_dag.genesis_key);
                 for (partial_dag, _last_key_sap) in list_of_partial_dags {
                     dag.merge(partial_dag).unwrap();
@@ -1120,6 +1120,7 @@ pub(crate) mod tests {
         new_information_only: bool,
     ) -> impl Strategy<
         Value = (
+            SectionSigned<SectionAuthorityProvider>,
             SectionsDAG,
             Vec<(SectionsDAG, SectionSigned<SectionAuthorityProvider>)>,
         ),
@@ -1185,7 +1186,8 @@ pub(crate) mod tests {
                 let last_key_sap = map.get(&rand_to).unwrap();
                 list_of_part_dags.push((partial_dag, last_key_sap.clone()));
             }
-            (main_dag, list_of_part_dags)
+            let gen_sap = map.get(main_dag.genesis_key()).unwrap().clone();
+            (gen_sap, main_dag, list_of_part_dags)
         })
     }
 

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -27,6 +27,7 @@ use ed25519_dalek::Keypair;
 use sn_dbc::Dbc;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::mpsc;
+use xor_name::XorName;
 
 impl MyNode {
     pub(crate) async fn first_node(
@@ -63,13 +64,9 @@ impl MyNode {
         Ok((node, genesis_dbc))
     }
 
-    pub(crate) fn relocate(
-        &mut self,
-        new_keypair: Arc<Keypair>,
-        new_section: NetworkKnowledge,
-    ) -> Result<()> {
-        // we first try to relocate section info.
-        self.network_knowledge.relocated_to(new_section)?;
+    pub(crate) fn relocate(&mut self, new_keypair: Arc<Keypair>, new_name: XorName) -> Result<()> {
+        // try to relocate to the section that matches our current name
+        self.network_knowledge.relocated_to(new_name)?;
 
         self.keypair = new_keypair;
 

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -176,13 +176,8 @@ impl<'a> Joiner<'a> {
                         target_sap.prefix(),
                     );
 
-                    // TODO: NetworkKnowledge::new(..) should not be taking the section_tree_update
-                    let section_tree_update = self
-                        .section_tree
-                        .generate_section_tree_update(&target_sap.prefix())?;
-
                     let network_knowledge =
-                        NetworkKnowledge::new(self.section_tree, section_tree_update)?;
+                        NetworkKnowledge::new(target_sap.prefix(), self.section_tree)?;
 
                     return Ok((self.node, network_knowledge));
                 }

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -712,8 +712,7 @@ mod tests {
         );
 
         let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone());
-        let mut tree = SectionTree::new(genesis_pk);
-        assert!(tree.insert_without_chain(signed_genesis_sap));
+        let tree = SectionTree::new(signed_genesis_sap).expect("Failed to create SectionTree");
 
         let state = Joiner::new(node.clone(), send_tx, &mut recv_rx, tree.clone());
 

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -12,7 +12,7 @@ use crate::node::{messages::WireMsgUtils, Error, Result, STANDARD_CHANNEL_SIZE};
 
 use sn_interface::{
     messaging::{
-        system::{JoinRejectionReason, JoinRequest, JoinResponse, NodeMsg},
+        system::{JoinRejectionReason, JoinRequest, JoinResponse, NodeMsg, SectionSigned},
         Dst, MsgType, WireMsg,
     },
     network_knowledge::{
@@ -122,15 +122,15 @@ impl<'a> Joiner<'a> {
             })?
     }
 
-    fn join_target_sap(&self) -> Result<SectionAuthorityProvider> {
+    fn join_target_sap(&self) -> Result<SectionSigned<SectionAuthorityProvider>> {
         let our_name = self.node.name();
-        let sap = self.section_tree.section_by_name(&our_name)?;
+        let sap = self.section_tree.get_signed_by_name(&our_name)?;
         Ok(sap)
     }
 
     #[tracing::instrument(skip(self))]
     async fn join(mut self, response_timeout: Duration) -> Result<(MyNodeInfo, NetworkKnowledge)> {
-        self.bootstrap_section_tree(self.join_target_sap()?, response_timeout)
+        self.bootstrap_section_tree(self.join_target_sap()?.value, response_timeout)
             .await?;
 
         let target_sap = self.join_target_sap()?;
@@ -198,7 +198,7 @@ impl<'a> Joiner<'a> {
                         self.retry_responses_cache = Default::default();
 
                         trace!("Bootstrapping section tree for retry");
-                        self.bootstrap_section_tree(target_sap, response_timeout)
+                        self.bootstrap_section_tree(target_sap.value, response_timeout)
                             .await?;
                         let target_sap = self.join_target_sap()?;
 
@@ -304,7 +304,7 @@ impl<'a> Joiner<'a> {
 
             if any_new_information {
                 // Update the target sap since we've received new information and try again.
-                target_sap = self.join_target_sap()?;
+                target_sap = self.join_target_sap()?.value;
                 info!("Received new information in last AEProbe, updating target sap to {target_sap:?}");
             } else {
                 // We are up to date with these nodes so we can end the bootstrap
@@ -483,7 +483,7 @@ mod tests {
     const JOIN_TIMEOUT_SEC: u64 = 15;
 
     #[tokio::test]
-    async fn join_as_adult() {
+    async fn join_as_adult() -> Result<()> {
         init_logger();
 
         let join_timeout = Duration::from_secs(JOIN_TIMEOUT_SEC);
@@ -501,8 +501,7 @@ mod tests {
         );
 
         let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone());
-        let mut tree = SectionTree::new(genesis_pk);
-        assert!(tree.insert_without_chain(signed_genesis_sap));
+        let tree = SectionTree::new(signed_genesis_sap)?;
 
         let state = Joiner::new(node.clone(), send_tx, &mut recv_rx, tree);
 
@@ -576,6 +575,8 @@ mod tests {
         assert_eq!(section.section_auth(), next_sap);
         assert_eq!(section.section_key(), next_section_key);
         assert_eq!(node.age(), MIN_ADULT_AGE);
+
+        Ok(())
     }
 
     #[tokio::test]
@@ -597,8 +598,7 @@ mod tests {
         );
 
         let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone());
-        let mut tree = SectionTree::new(genesis_pk);
-        assert!(tree.insert_without_chain(signed_genesis_sap));
+        let tree = SectionTree::new(signed_genesis_sap)?;
 
         let state = Joiner::new(node, send_tx, &mut recv_rx, tree.clone());
 
@@ -820,7 +820,6 @@ mod tests {
         let (genesis_sap, genesis_sk_set, genesis_nodes, _) =
             TestSapBuilder::new(Prefix::default()).build();
         let genesis_sk = genesis_sk_set.secret_key();
-        let genesis_pk = genesis_sk.public_key();
 
         let node = MyNodeInfo::new(
             ed25519::gen_keypair(&Prefix::default().range_inclusive(), MIN_ADULT_AGE),
@@ -828,8 +827,7 @@ mod tests {
         );
 
         let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone());
-        let mut tree = SectionTree::new(genesis_pk);
-        assert!(tree.insert_without_chain(signed_genesis_sap));
+        let tree = SectionTree::new(signed_genesis_sap)?;
 
         let state = Joiner::new(node, send_tx, &mut recv_rx, tree.clone());
 
@@ -913,7 +911,6 @@ mod tests {
         let (genesis_sap, genesis_sk_set, genesis_nodes, _) =
             TestSapBuilder::new(Prefix::default()).build();
         let genesis_sk = genesis_sk_set.secret_key();
-        let genesis_pk = genesis_sk.public_key();
 
         let node = MyNodeInfo::new(
             ed25519::gen_keypair(&Prefix::default().range_inclusive(), MIN_ADULT_AGE),
@@ -921,8 +918,7 @@ mod tests {
         );
 
         let signed_genesis_sap = TestKeys::get_section_signed(&genesis_sk, genesis_sap.clone());
-        let mut tree = SectionTree::new(genesis_pk);
-        assert!(tree.insert_without_chain(signed_genesis_sap));
+        let tree = SectionTree::new(signed_genesis_sap)?;
 
         let state = Joiner::new(node, send_tx, &mut recv_rx, tree.clone());
 

--- a/sn_node/src/node/flow_ctrl/tests/network_builder.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_builder.rs
@@ -345,9 +345,10 @@ impl<R: RngCore> TestNetworkBuilder<R> {
         let gen_prefix = &sections
             .get(&Prefix::default())
             .expect("Genesis section is absent. Provide at-least a single SAP");
-        let gen_sk = gen_prefix[0].1.secret_key();
+        let gen_sap = gen_prefix[0].0.clone();
 
-        let mut section_tree = SectionTree::new(gen_sk.public_key());
+        let mut section_tree =
+            SectionTree::new(gen_sap).expect("gen_sap belongs to the genesis prefix");
         let mut completed = BTreeSet::new();
         // need to insert the default prefix first
         let prefix_iter = if max_prefixes.contains(&Prefix::default()) {
@@ -874,20 +875,28 @@ impl TestNetwork {
         sap: &SectionSigned<SectionAuthorityProvider>,
         sk_set: &SecretKeySet,
     ) -> NetworkKnowledge {
-        let gen = self.section_tree.genesis_key();
+        let gen_sap = self
+            .get_sap_single_churn(Prefix::default(), Some(0))
+            .0
+            .clone();
+        assert_eq!(&gen_sap.section_key(), self.section_tree.genesis_key());
+        let gen = gen_sap.section_key();
         let section_key = sap.section_key();
-        let proof_chain = if *gen == section_key {
-            SectionsDAG::new(*gen)
+        let proof_chain = if gen == section_key {
+            SectionsDAG::new(gen)
         } else {
             self.section_tree
                 .get_sections_dag()
-                .partial_dag(gen, &sap.section_key())
+                .partial_dag(&gen, &sap.section_key())
                 .expect("failed to create proof chain")
         };
         let update = SectionTreeUpdate::new(sap.clone(), proof_chain);
 
-        let mut nw = NetworkKnowledge::new(SectionTree::new(*gen), update)
-            .expect("Failed to create NetworkKnowledge");
+        let mut nw = NetworkKnowledge::new(
+            SectionTree::new(gen_sap).expect("gen_sap belongs to the genesis prefix"),
+            update,
+        )
+        .expect("Failed to create NetworkKnowledge");
 
         for node_state in sap.members().cloned() {
             let sig = TestKeys::get_section_sig(&sk_set.secret_key(), &node_state);

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -211,12 +211,11 @@ impl MyNode {
                             );
 
                             let section_tree = node.network_knowledge.section_tree().clone();
-                            let section_tree_update = node
-                                .network_knowledge
-                                .section_tree()
-                                .generate_section_tree_update(&Prefix::default())?; // TODO: remove this dummy update
+                            let prefix = section_tree
+                                .get_signed_by_prefix(&Prefix::default())?
+                                .prefix();
                             let new_network_knowledge =
-                                NetworkKnowledge::new(section_tree, section_tree_update)?;
+                                NetworkKnowledge::new(prefix, section_tree)?;
 
                             // TODO: confirm whether carry out the switch immediately here
                             //       or still using the cmd pattern.

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -21,13 +21,12 @@ use sn_interface::{
         system::{JoinResponse, NodeDataCmd, NodeDataQuery, NodeDataResponse, NodeEvent, NodeMsg},
         MsgId,
     },
-    network_knowledge::NetworkKnowledge,
     types::{log_markers::LogMarker, Keypair, Peer, PublicKey, ReplicatedData},
 };
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
-use xor_name::{Prefix, XorName};
+use xor_name::XorName;
 
 impl MyNode {
     /// Send a (`NodeMsg`) message to all Elders in our section
@@ -210,18 +209,11 @@ impl MyNode {
                                 previous_name, new_name, new_keypair
                             );
 
-                            let section_tree = node.network_knowledge.section_tree().clone();
-                            let prefix = section_tree
-                                .get_signed_by_prefix(&Prefix::default())?
-                                .prefix();
-                            let new_network_knowledge =
-                                NetworkKnowledge::new(prefix, section_tree)?;
-
                             // TODO: confirm whether carry out the switch immediately here
                             //       or still using the cmd pattern.
                             //       As the sending of the JoinRequest as notification
                             //       may require the `node` to be switched to new already.
-                            node.relocate(new_keypair, new_network_knowledge)?;
+                            node.relocate(new_keypair, new_name)?;
 
                             trace!("{}", LogMarker::RelocateEnd);
                         } else {

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -187,8 +187,10 @@ mod tests {
             SectionTreeUpdate::new(signed_sap, SectionsDAG::new(genesis_pk))
         };
 
-        let mut network_knowledge =
-            NetworkKnowledge::new(SectionTree::new(genesis_pk), section_tree_update)?;
+        let mut network_knowledge = NetworkKnowledge::new(
+            SectionTree::new(section_tree_update.signed_sap.clone())?,
+            section_tree_update,
+        )?;
 
         for peer in &peers {
             let info = NodeState::joined(*peer, None);

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -123,9 +123,7 @@ mod tests {
 
     use sn_interface::{
         elder_count,
-        network_knowledge::{
-            SectionAuthorityProvider, SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
-        },
+        network_knowledge::{SectionAuthorityProvider, SectionTree, MIN_ADULT_AGE},
         test_utils::TestKeys,
         types::Peer,
     };
@@ -134,7 +132,6 @@ mod tests {
     use itertools::Itertools;
     use proptest::{collection::SizeRange, prelude::*};
     use rand::{rngs::SmallRng, thread_rng, Rng, SeedableRng};
-    use sn_interface::network_knowledge::SectionTree;
     use std::net::SocketAddr;
     use xor_name::{Prefix, XOR_NAME_LEN};
 
@@ -166,11 +163,10 @@ mod tests {
     fn proptest_actions_impl(peers: Vec<Peer>, signature_trailing_zeros: u8) -> Result<()> {
         let sk_set = bls::SecretKeySet::random(0, &mut thread_rng());
         let sk = sk_set.secret_key();
-        let genesis_pk = sk.public_key();
 
         // Create `Section` with `peers` as its members and set the `elder_count()` oldest peers as
         // the elders.
-        let section_auth = SectionAuthorityProvider::new(
+        let sap = SectionAuthorityProvider::new(
             peers
                 .iter()
                 .sorted_by_key(|peer| peer.age())
@@ -182,15 +178,9 @@ mod tests {
             sk_set.public_keys(),
             0,
         );
-        let section_tree_update = {
-            let signed_sap = TestKeys::get_section_signed(&sk, section_auth);
-            SectionTreeUpdate::new(signed_sap, SectionsDAG::new(genesis_pk))
-        };
-
-        let mut network_knowledge = NetworkKnowledge::new(
-            SectionTree::new(section_tree_update.signed_sap.clone())?,
-            section_tree_update,
-        )?;
+        let sap = TestKeys::get_section_signed(&sk, sap);
+        let tree = SectionTree::new(sap)?;
+        let mut network_knowledge = NetworkKnowledge::new(Prefix::default(), tree)?;
 
         for peer in &peers {
             let info = NodeState::joined(*peer, None);


### PR DESCRIPTION
Fixes https://github.com/maidsafe/safe_network/issues/1810 
Fixes https://github.com/maidsafe/safe_network/issues/1798

- fix(section_tree): genesis_sap is required to create the `SectionTree`
  - The fields of the tree are assumed to be in sync. But it is not the case for a newly created tree.
  - This can be fixed by accepting the genesis sap while creating the tree.
- refactor(network_knowledge): rework constructor
  - Allows us to create a minimal `NetworkKnowledge` by just providing the genesis SAP. This will be set as our current `signed_sap`. A new `SectionTree` is also created with the provided SAP.
  - Optionally, we can provide a `SectionTree` which will replace our current tree. In this case, the provided SAP is considered to be part of the tree and is set as our current `signed_sap`

