### PR TITLE
tests: replace msg_queue with `Comm`

### DIFF
--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -234,7 +234,7 @@ impl Dispatcher {
 // Serializes and signs the msg if it's a Client message,
 // and produces one [`WireMsg`] instance per recipient -
 // the last step before passing it over to comms module.
-fn into_msg_bytes(
+pub(crate) fn into_msg_bytes(
     network_knowledge: &NetworkKnowledge,
     our_node_name: XorName,
     msg: NodeMsg,

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -1,7 +1,11 @@
-use crate::node::{flow_ctrl::dispatcher::Dispatcher, messaging::Peers, Cmd};
-use assert_matches::assert_matches;
-use eyre::eyre;
-use eyre::Result;
+use crate::{
+    comm::MsgFromPeer,
+    node::{
+        flow_ctrl::dispatcher::{into_msg_bytes, Dispatcher},
+        messaging::Peers,
+        Cmd,
+    },
+};
 use sn_interface::{
     messaging::{
         data::ClientMsg,
@@ -12,7 +16,12 @@ use sn_interface::{
     network_knowledge::{test_utils::*, MembershipState, NodeState, RelocateDetails},
     types::{Keypair, Peer, ReplicatedData},
 };
+
+use assert_matches::assert_matches;
+use eyre::{eyre, Result};
 use std::collections::BTreeSet;
+use tokio::sync::mpsc::{self, error::TryRecvError};
+use xor_name::XorName;
 
 pub(crate) struct HandleOnlineStatus {
     pub(crate) node_approval_sent: bool,
@@ -216,4 +225,55 @@ impl Cmd {
     //         _ => Err(eyre!("A Cmd::SendMsg variant was expected")),
     //     }
     // }
+}
+
+impl Dispatcher {
+    // Sends out `NodeMsgs` to others synchronously, (process_cmd() spawns tasks to do it).
+    // Optionally drop the msgs to the provided set of peers.
+    pub(crate) async fn mock_send_msg(&self, cmd: Cmd, filter_recp: Option<BTreeSet<XorName>>) {
+        if let Cmd::SendMsg {
+            msg,
+            msg_id,
+            recipients,
+            send_stream,
+            context,
+        } = cmd
+        {
+            let _ = send_stream;
+            let peer_msgs = {
+                into_msg_bytes(
+                    &context.network_knowledge,
+                    context.name,
+                    msg.clone(),
+                    msg_id,
+                    recipients,
+                )
+                .expect("cannot convert msg into bytes")
+            };
+
+            for (peer, msg_bytes) in peer_msgs {
+                if let Some(filter) = &filter_recp {
+                    if filter.contains(&peer.name()) {
+                        continue;
+                    }
+                }
+                context
+                    .comm
+                    .send_out_bytes_sync(peer, msg_id, msg_bytes)
+                    .await;
+                info!("Sent {msg} to {}", peer.name());
+            }
+        } else {
+            panic!("mock_send_msg expects Cmd::SendMsg, got {cmd:?}");
+        }
+    }
+}
+
+// Receive the next `MsgFromPeer` if the buffer is not empty. Returns None if the buffer is currently empty
+pub(crate) fn get_next_msg(comm_rx: &mut mpsc::Receiver<MsgFromPeer>) -> Option<MsgFromPeer> {
+    match comm_rx.try_recv() {
+        Ok(msg) => Some(msg),
+        Err(TryRecvError::Empty) => None,
+        Err(TryRecvError::Disconnected) => panic!("the comm_rx channel is closed"),
+    }
 }


### PR DESCRIPTION
- **fix(network_builder): fix edge case while calculating max_prefixes**
  - When `max_bit_count == 0 (or) 1`, the logic for calculating the permutations failed, this fixes it.
- **feat(test): synchronously send `NodeMsg` to other nodes**
  - This allows us to control the flow of msgs in certain tests allowing us to avoid using custom msg queues.
- **refactor(test): pass `NodeMsgs` via the `Comm` module**
  - The dkg tests bypassed the `Comm` module and used a queue to pass along the `NodeMsgs` for testing. This was due to the fact that the msgs were sent asynchronously, preventing any control of the flow.
  - Hence using the test-only synchronous msg sender allows us to do the above without using any extra queues.
