### PR TITLE
feat: limit registers to 1024 entries

### DIFF
--- a/sn_interface/src/types/register/mod.rs
+++ b/sn_interface/src/types/register/mod.rs
@@ -30,7 +30,7 @@ use xor_name::XorName;
 const MAX_REG_ENTRY_SIZE: usize = MIN_ENCRYPTABLE_BYTES / 3; // 1024 bytes
 
 /// Maximum number of entries of a register.
-const MAX_REG_NUM_ENTRIES: u16 = u16::MAX;
+const MAX_REG_NUM_ENTRIES: u16 = 1024;
 
 /// Register mutation operation to apply to Register.
 pub type RegisterOp<T> = CrdtOperation<T>;


### PR DESCRIPTION
With the 1024 bytes per entry, that's 1mb per reg tops

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
