### PR TITLE
chore: remove qp2p::SendStream::finish calls

### DIFF
--- a/sn_api/src/authd_client/notifs_endpoint.rs
+++ b/sn_api/src/authd_client/notifs_endpoint.rs
@@ -106,11 +106,6 @@ async fn handle_request(
         .await
         .map_err(|e| format!("Failed to send response: {}", e))?;
 
-    // Gracefully terminate the stream
-    send.finish()
-        .await
-        .map_err(|e| format!("Failed to shutdown stream: {}", e))?;
-
     info!("Request complete");
     Ok(())
 }

--- a/sn_client/src/connections/link.rs
+++ b/sn_client/src/connections/link.rs
@@ -58,9 +58,6 @@ impl Link {
             .map_err(LinkError::Send)?;
         debug!("{msg_id:?} bidi msg sent");
 
-        send_stream.finish().await.map_err(LinkError::Send)?;
-
-        debug!("{msg_id:?} bidi finished");
         Ok(recv_stream)
     }
 

--- a/sn_node/src/comm/link.rs
+++ b/sn_node/src/comm/link.rs
@@ -157,20 +157,6 @@ impl Link {
         }
 
         trace!("{msg_id:?} sent on {stream_id} to: {:?}", self.peer);
-        send_stream.finish().await.or_else(|err| match err {
-            qp2p::SendError::StreamLost(qp2p::StreamError::Stopped(_)) => Ok(()),
-            _ => {
-                error!("{msg_id:?} Error finishing up stream {stream_id}: {err:?}");
-                // remove that broken conn
-                let _conn = self.connections.remove(&conn_id);
-                Err(SendToOneError::Send(err))
-            }
-        })?;
-
-        trace!(
-            "bidi {stream_id} finished for {msg_id:?} to: {:?}",
-            self.peer
-        );
 
         recv_stream
             .next()

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -180,15 +180,6 @@ impl PeerSessionWorker {
                                 job.reporter.send(SendStatus::TransientError(format!(
                                     "Could not send msg on response {stream_id} to {peer:?} for {:?}", job.msg_id
                                 )));
-                            } else if let Err(error) = send_stream.finish().await {
-                                error!(
-                                    "Could not close response {stream_id} with {peer:?}, for {:?}: {error:?}",
-                                    job.msg_id
-                                );
-                                job.reporter.send(SendStatus::TransientError(format!(
-                                    "Could not close response {stream_id} with {peer:?} for {:?}",
-                                    job.msg_id
-                                )));
                             } else {
                                 job.reporter.send(SendStatus::Sent);
                             }

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -372,16 +372,6 @@ impl MyNode {
             return Err(error.into());
         }
 
-        trace!("Msg away for {original_msg_id:?} to {target_peer:?}");
-        if let Err(error) = send_stream.finish().await {
-            // Let's report the error since we cannot guarantee the msg was received/acknowledged by recipient
-            error!(
-                "Could not close response {stream_id} for {original_msg_id:?} to \
-                peer {target_peer:?}: {error:?}"
-            );
-            return Err(error.into());
-        }
-
         debug!("Sent the msg {original_msg_id:?} over {stream_id} to {target_peer:?}");
 
         Ok(())

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -136,11 +136,7 @@ impl MyNode {
                 error!("Could not send msg {msg_id:?} over response {stream_id} to {requesting_elder:?}: {error:?}");
                 return Err(error.into());
             }
-            if let Err(error) = send_stream.finish().await {
-                // Let's report the error since we cannot guarantee the msg was received/acknowledged by recipient
-                error!("Could not close response {stream_id} with {requesting_elder:?}, for {msg_id:?}: {error:?}");
-                return Err(error.into());
-            }
+
             trace!("{msg_id:?} Response sent: to {requesting_elder:?}");
         } else {
             error!("Send stream missing from {requesting_elder:?}, data request response was not sent out.")


### PR DESCRIPTION
qp2p tests show they are not needed
and it's the finish call that appears to be
most brittle

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
