### PR TITLE
ignore qp2p::SendStream::finish errors, make the call non-blocking

### DIFF
--- a/.github/workflows/run_pr_checks.yml
+++ b/.github/workflows/run_pr_checks.yml
@@ -211,13 +211,13 @@ jobs:
       - name: Run client test of limit-client-upload-size feature
         env:
           RUST_LOG: "sn_client,sn_interface"
-        run: cargo test --release --features limit-client-upload-size --package sn_client -- --test-threads=1 limits_upload_size
+        run: cargo test --release --features limit-client-upload-size --package sn_client -- limits_upload_size
         timeout-minutes: 5
 
       - name: Run client tests
         env:
           RUST_LOG: "sn_client,sn_interface"
-        run: cargo test --release --features check-replicas --package sn_client -- --test-threads=1
+        run: cargo test --release --features check-replicas --package sn_client
         timeout-minutes: 50
 
       - name: Run example app for file API against local network

--- a/sn_api/src/authd_client/notifs_endpoint.rs
+++ b/sn_api/src/authd_client/notifs_endpoint.rs
@@ -106,10 +106,9 @@ async fn handle_request(
         .await
         .map_err(|e| format!("Failed to send response: {}", e))?;
 
-    // Gracefully terminate the stream
-    send.finish()
-        .await
-        .map_err(|e| format!("Failed to shutdown stream: {}", e))?;
+    // Attempt to gracefully terminate the stream.
+    // If this errors it does _not_ mean our message has not been sent
+    let _ = send.finish().await;
 
     info!("Request complete");
     Ok(())

--- a/sn_client/src/connections/link.rs
+++ b/sn_client/src/connections/link.rs
@@ -58,7 +58,9 @@ impl Link {
             .map_err(LinkError::Send)?;
         debug!("{msg_id:?} bidi msg sent");
 
-        send_stream.finish().await.map_err(LinkError::Send)?;
+        // Attempt to gracefully terminate the stream.
+        // If this errors it does _not_ mean our message has not been sent
+        let _ = send_stream.finish().await;
 
         debug!("{msg_id:?} bidi finished");
         Ok(recv_stream)

--- a/sn_client/src/connections/link.rs
+++ b/sn_client/src/connections/link.rs
@@ -50,19 +50,22 @@ impl Link {
         debug!("connection got {msg_id:?} to {peer:?}");
         let (mut send_stream, recv_stream) = conn.open_bi().await.map_err(LinkError::Connection)?;
 
-        debug!("{msg_id:?} bidi opened");
+        debug!("{msg_id:?} to {peer:?} bidi opened");
         send_stream.set_priority(10);
         send_stream
             .send_user_msg(bytes.clone())
             .await
             .map_err(LinkError::Send)?;
-        debug!("{msg_id:?} bidi msg sent");
+        debug!("{msg_id:?} bidi msg sent to {peer:?}");
 
-        // Attempt to gracefully terminate the stream.
-        // If this errors it does _not_ mean our message has not been sent
-        let _ = send_stream.finish().await;
+        // move finish off thread as it's not strictly related to the sending of the msg.
+        let _handle = tokio::spawn(async move {
+            // Attempt to gracefully terminate the stream.
+            // If this errors it does _not_ mean our message has not been sent
+            let _ = send_stream.finish().await;
+            debug!("{msg_id:?} to {peer:?} bidi finished");
+        });
 
-        debug!("{msg_id:?} bidi finished");
         Ok(recv_stream)
     }
 

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -180,16 +180,13 @@ impl PeerSessionWorker {
                                 job.reporter.send(SendStatus::TransientError(format!(
                                     "Could not send msg on response {stream_id} to {peer:?} for {:?}", job.msg_id
                                 )));
-                            }
-                            else {
+                            } else {
                                 // Attempt to gracefully terminate the stream.
                                 // If this errors it does _not_ mean our message has not been sent
                                 let _ = send_stream.finish().await;
 
                                 job.reporter.send(SendStatus::Sent);
                             }
-
-
                         });
 
                         SessionStatus::Ok

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -180,18 +180,16 @@ impl PeerSessionWorker {
                                 job.reporter.send(SendStatus::TransientError(format!(
                                     "Could not send msg on response {stream_id} to {peer:?} for {:?}", job.msg_id
                                 )));
-                            } else if let Err(error) = send_stream.finish().await {
-                                error!(
-                                    "Could not close response {stream_id} with {peer:?}, for {:?}: {error:?}",
-                                    job.msg_id
-                                );
-                                job.reporter.send(SendStatus::TransientError(format!(
-                                    "Could not close response {stream_id} with {peer:?} for {:?}",
-                                    job.msg_id
-                                )));
-                            } else {
+                            }
+                            else {
+                                // Attempt to gracefully terminate the stream.
+                                // If this errors it does _not_ mean our message has not been sent
+                                let _ = send_stream.finish().await;
+
                                 job.reporter.send(SendStatus::Sent);
                             }
+
+
                         });
 
                         SessionStatus::Ok

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -373,14 +373,9 @@ impl MyNode {
         }
 
         trace!("Msg away for {original_msg_id:?} to {target_peer:?}");
-        if let Err(error) = send_stream.finish().await {
-            // Let's report the error since we cannot guarantee the msg was received/acknowledged by recipient
-            error!(
-                "Could not close response {stream_id} for {original_msg_id:?} to \
-                peer {target_peer:?}: {error:?}"
-            );
-            return Err(error.into());
-        }
+        // Attempt to gracefully terminate the stream.
+        // If this errors it does _not_ mean our message has not been sent
+        let _ = send_stream.finish().await;
 
         debug!("Sent the msg {original_msg_id:?} over {stream_id} to {target_peer:?}");
 

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -139,6 +139,7 @@ impl MyNode {
             // Attempt to gracefully terminate the stream.
             // If this errors it does _not_ mean our message has not been sent
             let _ = send_stream.finish().await;
+
             trace!("{msg_id:?} Response sent: to {requesting_elder:?}");
         } else {
             error!("Send stream missing from {requesting_elder:?}, data request response was not sent out.")

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -136,11 +136,9 @@ impl MyNode {
                 error!("Could not send msg {msg_id:?} over response {stream_id} to {requesting_elder:?}: {error:?}");
                 return Err(error.into());
             }
-            if let Err(error) = send_stream.finish().await {
-                // Let's report the error since we cannot guarantee the msg was received/acknowledged by recipient
-                error!("Could not close response {stream_id} with {requesting_elder:?}, for {msg_id:?}: {error:?}");
-                return Err(error.into());
-            }
+            // Attempt to gracefully terminate the stream.
+            // If this errors it does _not_ mean our message has not been sent
+            let _ = send_stream.finish().await;
             trace!("{msg_id:?} Response sent: to {requesting_elder:?}");
         } else {
             error!("Send stream missing from {requesting_elder:?}, data request response was not sent out.")


### PR DESCRIPTION
They dont mean a msg was not sent.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
