### PR TITLE
ci: version bump on push to main

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,13 +1,13 @@
-name: Nightly Release Run
+name: Version Bump
 
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: "30 4 * * *"
+  push:
+    branches:
+      - main
 
 jobs:
   bump_version:
-    if: github.repository_owner == 'maidsafe' && github.ref_name == 'main'
+    if: github.repository_owner == 'maidsafe'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The version bumping process will run on a push to `main`.

This will generate a `chore(release):` commit, which will be pushed to `main`, which will then kick off the release workflow.
