### PR TITLE
refactor(node): removing mutex from SendStream

### DIFF
--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -10,7 +10,7 @@ use super::wire_msg_header::WireMsgHeader;
 use crate::messaging::{
     data::{ClientDataResponse, ClientMsg},
     system::{NodeDataResponse, NodeMsg},
-    AuthorityProof, ClientAuth, Dst, Error, MsgId, MsgKind, MsgType, Result,
+    AuthorityProof, Dst, Error, MsgId, MsgKind, MsgType, Result,
 };
 
 use bytes::{BufMut, Bytes, BytesMut};
@@ -249,11 +249,6 @@ impl WireMsg {
     /// bytes, returning the deserialized message.
     pub fn deserialize(bytes: UsrMsgBytes) -> Result<MsgType> {
         Self::from(bytes)?.into_msg()
-    }
-
-    /// Convenience function which validates the signature on a `ClientMsg`.
-    pub fn verify_sig(auth: ClientAuth, msg: ClientMsg) -> Result<AuthorityProof<ClientAuth>> {
-        Self::serialize_msg_payload(&msg).and_then(|payload| AuthorityProof::verify(auth, &payload))
     }
 }
 

--- a/sn_node/src/comm/listener.rs
+++ b/sn_node/src/comm/listener.rs
@@ -15,10 +15,7 @@ use sn_interface::{
 
 use qp2p::ConnectionIncoming;
 use std::sync::Arc;
-use tokio::{
-    sync::{mpsc, Mutex},
-    task,
-};
+use tokio::{sync::mpsc, task};
 use tracing::Instrument;
 
 #[derive(Debug)]
@@ -121,7 +118,7 @@ impl MsgListener {
                         .send(MsgFromPeer {
                             sender: peer,
                             wire_msg,
-                            send_stream: send_stream.map(|s| Arc::new(Mutex::new(s))),
+                            send_stream,
                         })
                         .await
                     {

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -28,10 +28,7 @@ use dashmap::DashMap;
 use qp2p::{Endpoint, IncomingConnections};
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{
-    sync::{
-        mpsc::{self, Receiver, Sender},
-        Mutex,
-    },
+    sync::mpsc::{self, Receiver, Sender},
     task,
 };
 
@@ -100,10 +97,10 @@ impl Comm {
         peer: Peer,
         msg_id: MsgId,
         bytes: UsrMsgBytes,
-        send_stream: Option<Arc<Mutex<SendStream>>>,
+        send_stream: Option<SendStream>,
     ) -> Result<()> {
         let stream_info = if let Some(stream) = &send_stream {
-            format!(" on {}", stream.lock().await.id())
+            format!(" on {}", stream.id())
         } else {
             "".to_string()
         };
@@ -338,7 +335,7 @@ impl Comm {
         recipient: Peer,
         msg_id: MsgId,
         bytes: UsrMsgBytes,
-        send_stream: Option<Arc<Mutex<SendStream>>>,
+        send_stream: Option<SendStream>,
     ) -> Result<Option<SendWatcher>> {
         let bytes_len = {
             let (h, d, p) = bytes.clone();
@@ -432,7 +429,7 @@ fn listen_for_incoming_msgs(
 pub(crate) struct MsgFromPeer {
     pub(crate) sender: Peer,
     pub(crate) wire_msg: WireMsg,
-    pub(crate) send_stream: Option<Arc<Mutex<SendStream>>>,
+    pub(crate) send_stream: Option<SendStream>,
 }
 
 #[cfg(test)]

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -22,9 +22,7 @@ use sn_interface::{
 };
 
 use custom_debug::Debug;
-use std::sync::Arc;
 use std::{collections::BTreeSet, fmt, time::SystemTime};
-use tokio::sync::Mutex;
 
 /// A struct for the job of controlling the flow
 /// of a [`Cmd`] in the system.
@@ -56,7 +54,7 @@ pub(crate) enum Cmd {
     HandleMsg {
         origin: Peer,
         wire_msg: WireMsg,
-        send_stream: Option<Arc<Mutex<SendStream>>>,
+        send_stream: Option<SendStream>,
     },
     /// Allows joining of new nodes.
     SetJoinsAllowed(bool),
@@ -70,7 +68,7 @@ pub(crate) enum Cmd {
         msg_id: MsgId,
         msg: ClientMsg,
         origin: Peer,
-        send_stream: Arc<Mutex<SendStream>>,
+        send_stream: SendStream,
         /// Requester's authority over this message
         auth: AuthorityProof<ClientAuth>,
     },
@@ -112,7 +110,7 @@ pub(crate) enum Cmd {
         msg: NodeMsg,
         msg_id: MsgId,
         recipients: Peers,
-        send_stream: Option<Arc<Mutex<SendStream>>>,
+        send_stream: Option<SendStream>,
         #[debug(skip)]
         context: NodeContext,
     },
@@ -125,7 +123,7 @@ pub(crate) enum Cmd {
         msg: NodeMsg,
         msg_id: MsgId,
         recipients: Peers,
-        send_stream: Option<Arc<Mutex<SendStream>>>,
+        send_stream: Option<SendStream>,
     },
     /// Proposes peers as offline
     ProposeVoteNodesOffline(BTreeSet<XorName>),
@@ -160,7 +158,7 @@ impl Cmd {
     pub(crate) fn send_msg_via_response_stream(
         msg: NodeMsg,
         recipients: Peers,
-        send_stream: Option<Arc<Mutex<SendStream>>>,
+        send_stream: Option<SendStream>,
         context: NodeContext,
     ) -> Self {
         Cmd::SendMsg {

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -79,6 +79,8 @@ pub(crate) async fn handle_online_cmd(
     Ok(status)
 }
 
+// Process commands, allowing the user to inspect each and all of the intermediate
+// commands that are being returned by the Cmd dispatcher.
 pub(crate) struct ProcessAndInspectCmds<'a> {
     pending_cmds: VecDeque<Cmd>,
     cmds_to_inspect: VecDeque<usize>,
@@ -99,8 +101,14 @@ impl<'a> ProcessAndInspectCmds<'a> {
         _peer: Peer,
         dispatcher: &'a Dispatcher,
     ) -> crate::node::error::Result<Self> {
+        // TODO: decide how to impl this, w/r/t client response stream, to re-enable
+        // the currently ignored/disabled Spentbook tests. This used to work by
+        // calling `MyNode::handle_valid_client_msg` using the provided ClientMsg,
+        // and use the outcome (commands) as the starting set of cmds to process.
+        let pending_cmds = VecDeque::default();
+
         Ok(Self {
-            pending_cmds: VecDeque::default(),
+            pending_cmds,
             cmds_to_inspect: VecDeque::default(),
             dispatcher,
         })

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -22,7 +22,7 @@ use sn_interface::{
 };
 use std::collections::BTreeSet;
 use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::RwLock;
 
 impl MyNode {
     /// Send a (`NodeMsg`) message to all Elders in our section
@@ -42,7 +42,7 @@ impl MyNode {
     pub(crate) async fn store_data_and_respond(
         context: &NodeContext,
         data: ReplicatedData,
-        response_stream: Option<Arc<Mutex<SendStream>>>,
+        response_stream: Option<SendStream>,
         target: Peer,
         original_msg_id: MsgId,
     ) -> Result<Vec<Cmd>> {
@@ -125,7 +125,7 @@ impl MyNode {
         msg_id: MsgId,
         msg: NodeMsg,
         sender: Peer,
-        send_stream: Option<Arc<Mutex<SendStream>>>,
+        send_stream: Option<SendStream>,
     ) -> Result<Vec<Cmd>> {
         trace!("{:?}: {msg_id:?}", LogMarker::NodeMsgToBeHandled);
 


### PR DESCRIPTION
Each `SendStream` is now moved into either `Cmd`s or functions instead of being shared using a `Mutex` around it.