### PR TITLE
chore: Revert change split detection instead of size

### DIFF
--- a/sn_node/src/node/membership/mod.rs
+++ b/sn_node/src/node/membership/mod.rs
@@ -90,9 +90,7 @@ pub(crate) fn try_split_dkg(
         membership_gen,
     };
 
-    // Some((zero_id, one_id))
-    info!("We should have split in a real network: {zero_id:?}, {one_id:?}");
-    None // TODO: switch this back after Dec 15 2022 testnet
+    Some((zero_id, one_id))
 }
 
 /// Returns the nodes that should be candidates to become the next elders, sorted by names.


### PR DESCRIPTION
This reverts commit 38ebca089ed7134a63d9fefbf69f4f791b5858fb.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
