### PR TITLE
ci: prevent version bump running on release commit

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   bump_version:
-    if: github.repository_owner == 'maidsafe'
+    if: |
+      github.repository_owner == 'maidsafe' &&
+      !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This should only run when we do *not* have a release commit.
