### PR TITLE
feat(join): prevent joins from nodes behind NAT

### DIFF
--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -18,6 +18,14 @@ use std::net::SocketAddr;
 pub struct JoinRequest {
     /// The public key of the section to join.
     pub section_key: bls::PublicKey,
+    /// The public address the node expects to have.
+    ///
+    /// This is used to detect if the joining node is behind a NAT. If this
+    /// addr does not match the addr of the connection we received this
+    /// join request on, then we reject the request.
+    ///
+    /// NAT hole punching is a can of worms we're punting on right now.
+    pub addr: SocketAddr,
 }
 
 impl JoinRequest {

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -135,7 +135,8 @@ impl<'a> Joiner<'a> {
 
         let mut target_sap = self.join_target_sap()?;
         let section_key = target_sap.section_key();
-        let msg = NodeMsg::JoinRequest(JoinRequest { section_key });
+        let addr = self.node.addr;
+        let msg = NodeMsg::JoinRequest(JoinRequest { section_key, addr });
         self.send(msg, &target_sap.elders_vec(), section_key, false)
             .await?;
 
@@ -207,7 +208,8 @@ impl<'a> Joiner<'a> {
                         info!("Retrying with new name: {}", self.node.name());
 
                         let section_key = target_sap.section_key();
-                        let msg = NodeMsg::JoinRequest(JoinRequest { section_key });
+                        let addr = self.node.addr;
+                        let msg = NodeMsg::JoinRequest(JoinRequest { section_key, addr });
                         self.send(msg, &target_sap.elders_vec(), section_key, true)
                             .await?;
                     }
@@ -245,8 +247,9 @@ impl<'a> Joiner<'a> {
 
                     let target_sap = self.join_target_sap()?;
                     let section_key = target_sap.section_key();
+                    let addr = self.node.addr;
 
-                    let msg = NodeMsg::JoinRequest(JoinRequest { section_key });
+                    let msg = NodeMsg::JoinRequest(JoinRequest { section_key, addr });
                     self.send(msg, &target_sap.elders_vec(), section_key, true)
                         .await?;
                 }

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -538,7 +538,7 @@ mod tests {
 
             itertools::assert_equal(recipients, next_sap.elders());
             assert_eq!(dst.section_key, next_section_key);
-            assert_matches!(node_msg, NodeMsg::JoinRequest(JoinRequest{ section_key }) => {
+            assert_matches!(node_msg, NodeMsg::JoinRequest(JoinRequest{ section_key, .. }) => {
                 assert_eq!(section_key, next_section_key);
             });
 
@@ -666,7 +666,7 @@ mod tests {
             itertools::assert_equal(recipients, new_sap.elders());
 
             assert_eq!(dst.section_key, new_sap.section_key());
-            assert_matches!(node_msg, NodeMsg::JoinRequest(JoinRequest{ section_key }) => {
+            assert_matches!(node_msg, NodeMsg::JoinRequest(JoinRequest{ section_key, .. }) => {
                 assert_eq!(section_key, new_sap.section_key());
             });
 


### PR DESCRIPTION
This PR adds the joining nodes address to the join request.

If the address is different from the connection address, then this node is behind NAT 🙅 