### PR TITLE
fix(client): set default keep-alive interval to be 1/2 of idle_timeout value set

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -215,7 +215,7 @@ jobs:
         id: section-startup
         env:
           SN_ADULT_RESPONSE_TIMEOUT: 70
-          RUST_LOG: "sn_node,sn_consensus,sn_dysfunction=trace,sn_interface=trace"
+          RUST_LOG: "sn_node,sn_consensus,sn_dysfunction,sn_interface=trace"
 
       - name: Wait for all nodes to join
         shell: bash
@@ -232,10 +232,10 @@ jobs:
           SN_QUERY_TIMEOUT: 90
           RUST_LOG: "sn_client=trace,qp2p=debug"
         run: cd sn_client && cargo test --release --features check-replicas -- --test-threads=1
-        timeout-minutes: 50
+        timeout-minutes: 7
 
       - name: Run example app for file API against local network
-        timeout-minutes: 10
+        timeout-minutes: 2
         shell: bash
         run: cd sn_client && cargo run --release --example client_files
 
@@ -606,7 +606,7 @@ jobs:
         env:
           RUST_LOG: "sn_client=trace"
         run: cd sn_api && cargo test --release --features check-replicas
-        timeout-minutes: 30
+        timeout-minutes: 7
 
       - name: Are nodes still running...?
         shell: bash
@@ -725,7 +725,7 @@ jobs:
 
       - name: Run CLI tests
         run: cd sn_cli && cargo test --release --features check-replicas -- --test-threads=1
-        timeout-minutes: 50
+        timeout-minutes: 7
 
       - name: Are nodes still running...?
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -897,8 +897,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
 dependencies = [
- "prost 0.11.3",
- "prost-types 0.11.2",
+ "prost 0.11.5",
+ "prost-types 0.11.5",
  "tonic 0.8.3",
  "tracing-core",
 ]
@@ -915,7 +915,7 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "humantime",
- "prost-types 0.11.2",
+ "prost-types 0.11.5",
  "serde",
  "serde_json",
  "thread_local",
@@ -1865,6 +1865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,9 +2253,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2491,11 +2500,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -2811,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bdd679d533107e090c2704a35982fc06302e30898e63ffa26a81155c012e92"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "ppv-lite86"
@@ -2928,12 +2937,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
+checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
 dependencies = [
  "bytes",
- "prost-derive 0.11.2",
+ "prost-derive 0.11.5",
 ]
 
 [[package]]
@@ -2971,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
+checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2994,12 +3003,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
 dependencies = [
  "bytes",
- "prost 0.11.3",
+ "prost 0.11.5",
 ]
 
 [[package]]
@@ -3024,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "qp2p"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbb644fbe34b976649f3cbdb1d4b534b83e845dba1f4bafe696834d61adeb18"
+checksum = "565b5f8a239def75dad631fe787a591929a18bd848d05bbf5f3be03973701c1e"
 dependencies = [
  "bincode",
  "bytes",
@@ -3597,9 +3606,9 @@ checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -3615,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3647,9 +3656,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f77be7305dac4f250891d2f7444276315f3c288176d35746b6a4ca786dacb3"
+checksum = "3611210d2d67e3513204742004d6ac6f589e521861dabb0f649b070eea8bed9e"
 dependencies = [
  "serde",
 ]
@@ -4625,8 +4634,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.3",
- "prost-derive 0.11.2",
+ "prost 0.11.5",
+ "prost-derive 0.11.5",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.4",

--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -34,8 +34,6 @@ pub const ENV_QUERY_TIMEOUT: &str = "SN_QUERY_TIMEOUT";
 pub const ENV_MAX_BACKOFF_INTERVAL: &str = "SN_MAX_BACKOFF_INTERVAL";
 /// Environment variable used to convert into [`ClientBuilder::cmd_timeout`] (seconds)
 pub const ENV_CMD_TIMEOUT: &str = "SN_CMD_TIMEOUT";
-/// Environment variable used to convert into [`ClientBuilder::cmd_ack_wait`] (seconds)
-pub const ENV_AE_WAIT: &str = "SN_AE_WAIT";
 
 /// Bind by default to all network interfaces on a OS assigned port
 pub const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
@@ -44,8 +42,10 @@ pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(90);
 /// Max amount of time for an operation backoff (time between attempts). In Seconds.
 pub const DEFAULT_MAX_QUERY_CMD_BACKOFF_INTERVAL: Duration = Duration::from_secs(3);
 
-// Default interval at which to send (QUIC) keep-alives msgs to maintain otherwise idle connections.
-const DEFAULT_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(3);
+// Divisor of `idle_timeout` to calculate the default interval at which to send (QUIC)
+// keep-alive msgs to maintain otherwise idle connections. E.g. if the `idle_timeout`
+// value is set to 18secs, a ratio of 0.5 would set keep-alive interval to 9secs.
+const DEFAULT_KEEP_ALIVE_INTERVAL_DIVISOR: u32 = 2;
 // In the absence of any (QUIC) keep-alive messages, connections will be closed
 // if they remain idle for at least this duration.
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(18);
@@ -60,7 +60,6 @@ pub struct ClientBuilder {
     query_timeout: Option<Duration>,
     max_backoff_interval: Option<Duration>,
     cmd_timeout: Option<Duration>,
-    cmd_ack_wait: Option<Duration>,
     network_contacts: Option<SectionTree>,
 }
 
@@ -115,12 +114,6 @@ impl ClientBuilder {
         self
     }
 
-    /// Time to wait after a cmd is sent for AE flows to complete
-    pub fn cmd_ack_wait(mut self, time: impl Into<Option<Duration>>) -> Self {
-        self.cmd_ack_wait = time.into();
-        self
-    }
-
     /// SectionTree used to bootstrap the client on the network
     pub fn network_contacts(mut self, pm: impl Into<Option<SectionTree>>) -> Self {
         self.network_contacts = pm.into();
@@ -131,7 +124,6 @@ impl ClientBuilder {
     /// - [`Self::query_timeout()`] from [`ENV_QUERY_TIMEOUT`]
     /// - [`Self::max_backoff_interval()`] from [`ENV_MAX_BACKOFF_INTERVAL`]
     /// - [`Self::cmd_timeout()`] from [`ENV_CMD_TIMEOUT`]
-    /// - [`Self::cmd_ack_wait()`] from [`ENV_AE_WAIT`]
     pub fn from_env(mut self) -> Self {
         if let Ok(Some(v)) = env_parse(ENV_QUERY_TIMEOUT) {
             self.query_timeout = Some(Duration::from_secs(v));
@@ -141,9 +133,6 @@ impl ClientBuilder {
         }
         if let Ok(Some(v)) = env_parse(ENV_CMD_TIMEOUT) {
             self.cmd_timeout = Some(Duration::from_secs(v));
-        }
-        if let Ok(Some(v)) = env_parse(ENV_AE_WAIT) {
-            self.cmd_ack_wait = Some(Duration::from_secs(v));
         }
 
         self
@@ -175,14 +164,20 @@ impl ClientBuilder {
         };
 
         let mut qp2p = self.qp2p.unwrap_or_default();
-        if qp2p.idle_timeout.is_none() {
-            qp2p.idle_timeout = Some(DEFAULT_IDLE_TIMEOUT);
-        }
+        let idle_timeout = match qp2p.idle_timeout {
+            Some(t) => t,
+            None => {
+                qp2p.idle_timeout = Some(DEFAULT_IDLE_TIMEOUT);
+                DEFAULT_IDLE_TIMEOUT
+            }
+        };
 
         if qp2p.keep_alive_interval.is_none() {
-            qp2p.keep_alive_interval = Some(DEFAULT_KEEP_ALIVE_INTERVAL);
-            debug!("Session config w/ keep alive: {:?}", qp2p);
+            qp2p.keep_alive_interval =
+                idle_timeout.checked_div(DEFAULT_KEEP_ALIVE_INTERVAL_DIVISOR);
         }
+
+        debug!("Session config: {:?}", qp2p);
 
         let session = Session::new(
             qp2p,

--- a/sn_client/src/connections/link.rs
+++ b/sn_client/src/connections/link.rs
@@ -65,8 +65,8 @@ impl Link {
         let _handle = tokio::spawn(async move {
             // Attempt to gracefully terminate the stream.
             // If this errors it does _not_ mean our message has not been sent
-            let _ = send_stream.finish().await;
-            debug!("{msg_id:?} to {peer:?} bidi finished");
+            let result = send_stream.finish().await;
+            debug!("{msg_id:?} to {peer:?} bidi finished: {result:?}");
         });
 
         Ok(recv_stream)

--- a/sn_client/src/sessions/messaging.rs
+++ b/sn_client/src/sessions/messaging.rs
@@ -77,9 +77,9 @@ impl Session {
 
         let elders_len = elders.len();
         let msg_id = MsgId::new();
-
         debug!(
-            "Sending cmd w/id {msg_id:?}, from {}, to {elders_len} Elders w/ dst: {dst_address:?}",
+            "Sending cmd with {msg_id:?}, dst: {dst_address:?}, from {}, \
+            to {elders_len} Elders: {elders:?}",
             endpoint.public_addr(),
         );
 
@@ -136,9 +136,9 @@ impl Session {
             match result {
                 Ok(()) => {
                     let preexisting = !received_acks.insert(src) || received_errors.contains(&src);
-                    debug!(
-                        "ACK from {src:?} read from set for {msg_id:?} - preexisting??: {preexisting:?}",
-                    );
+                    if preexisting {
+                        warn!("ACK from {src:?} for {msg_id:?} was received more than once");
+                    }
 
                     if received_acks.len() >= expected_acks {
                         trace!("{msg_id:?} Good! We're at or above {expected_acks} expected_acks");

--- a/sn_interface/src/types/log_markers.rs
+++ b/sn_interface/src/types/log_markers.rs
@@ -107,6 +107,7 @@ pub enum LogMarker {
     // Connections
     ConnectionOpened,
     ConnectionClosed,
+    IncomingConnection,
     ReceiveCompleted,
     ConnectionReused,
     // Relocation

--- a/sn_node/src/comm/mod.rs
+++ b/sn_node/src/comm/mod.rs
@@ -21,7 +21,7 @@ use qp2p::{Connection, SendStream, UsrMsgBytes};
 
 use sn_interface::{
     messaging::{MsgId, WireMsg},
-    types::Peer,
+    types::{log_markers::LogMarker, Peer},
 };
 
 use dashmap::DashMap;
@@ -417,7 +417,8 @@ fn listen_for_incoming_msgs(
     let _ = task::spawn(async move {
         while let Some((connection, incoming_msgs)) = incoming_connections.next().await {
             trace!(
-                "incoming_connection from {:?} with connection_id {:?}",
+                "{}: from {:?} with connection_id {}",
+                LogMarker::IncomingConnection,
                 connection.remote_address(),
                 connection.id()
             );


### PR DESCRIPTION
- By default the sn_client keep_alive msgs interval will now be set to 1/2 the value set for the
idle_timeout value.
- Removing unused ClientBuilder::cmd_ack_wait config value.
- Decreasing the CI timeout for sn_client, sn_api, and CLI tests, to 7mins.
- New LogMarker::IncomingConnection logged by sn_node.
- Minor improvements to some log msgs.

With PR #1927 we may be able to actually remove keep-alive msgs from client (if testing is successful), but this PR already introduces an improvement by reducing the amount of QUIC msgs sent to the network.