### PR TITLE
refactor(node): simplify logic retrieve qp2p config from sn_node::Config

### DIFF
--- a/sn_node/examples/config_handling.rs
+++ b/sn_node/examples/config_handling.rs
@@ -25,13 +25,11 @@ async fn main() -> Result<()> {
     let file_config = Config::new().await?;
 
     // TODO: Uncomment the below lines once we enable reading config from disk
-    // file_config.network_config.local_ip = Some(
-    //     "192.168.0.1"
-    //         .parse()
-    //         .map_err(|_| anyhow!("Invalid IP address format"))?,
-    // );
-    // file_config.network_config.local_port = Some(0);
-    // file_config.network_config.external_port = Some(12345);
+    // file_config.local_addr = Some("127.0.0.1".parse()?);
+    // file_config.public_addr = Some(std::net::SocketAddr::from((
+    //     std::net::Ipv4Addr::UNSPECIFIED,
+    //     12345,
+    // )));
     file_config.write_to_disk().await?;
 
     // This should load the config from disk and
@@ -98,12 +96,12 @@ async fn main() -> Result<()> {
         assert_eq!(command_line_args.public_addr, config.public_addr);
     } else {
         assert_eq!(
-            file_config.network_config.external_ip,
-            config.network_config.external_ip
+            file_config.network_config().external_ip,
+            config.network_config().external_ip
         );
         assert_eq!(
-            file_config.network_config.external_port,
-            config.network_config.external_port
+            file_config.network_config().external_port,
+            config.network_config().external_port
         );
     }
 
@@ -124,12 +122,12 @@ async fn main() -> Result<()> {
             command_line_args
                 .idle_timeout_msec
                 .map(Duration::from_millis),
-            config.network_config.idle_timeout
+            config.network_config().idle_timeout
         )
     } else {
         assert_eq!(
-            file_config.network_config.idle_timeout,
-            config.network_config.idle_timeout
+            file_config.network_config().idle_timeout,
+            config.network_config().idle_timeout
         )
     }
 
@@ -138,12 +136,12 @@ async fn main() -> Result<()> {
             command_line_args
                 .keep_alive_interval_msec
                 .map(|i| Duration::from_millis(i.into())),
-            config.network_config.keep_alive_interval
+            config.network_config().keep_alive_interval
         )
     } else {
         assert_eq!(
-            file_config.network_config.keep_alive_interval,
-            config.network_config.keep_alive_interval
+            file_config.network_config().keep_alive_interval,
+            config.network_config().keep_alive_interval
         )
     }
 

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -145,7 +145,7 @@ async fn bootstrap_node(
 
     let comm = Comm::new(
         config.local_addr(),
-        config.network_config().clone(),
+        config.network_config(),
         incoming_msg_pipe,
     )
     .await?;


### PR DESCRIPTION
- We used to keep an instance of qp2p::Config within sn_node::Config which required to keep in sync when modifying/reading network related config, we now simply build a qp2p::Config just when is queried from sn_node::Config.