### PR TITLE
chore(client): disabling keep-alive msgs from client to nodes

### DIFF
--- a/sn_node/src/node/cfg/config_handler.rs
+++ b/sn_node/src/node/cfg/config_handler.rs
@@ -25,6 +25,10 @@ const CONFIG_FILE: &str = "node.config";
 const DEFAULT_ROOT_DIR_NAME: &str = "root_dir";
 const DEFAULT_MAX_CAPACITY: usize = 1024 * 1024 * 1024; // 1gb
 
+// In the absence of any (QUIC) keep-alive messages, connections will be closed
+// if they remain idle for at least this duration.
+const DEFAULT_IDLE_TIMEOUT_MSEC: u64 = 70_000;
+
 /// Node configuration
 #[derive(Default, Clone, Debug, Serialize, Deserialize, clap::StructOpt)]
 #[clap(rename_all = "kebab-case", bin_name = "sn_node", version)]
@@ -244,8 +248,9 @@ impl Config {
             self.max_msg_size_allowed = config.max_msg_size_allowed;
         }
 
-        if config.idle_timeout_msec.is_some() {
-            self.idle_timeout_msec = config.idle_timeout_msec;
+        match config.idle_timeout_msec {
+            Some(t) => self.idle_timeout_msec = Some(t),
+            None => self.idle_timeout_msec = Some(DEFAULT_IDLE_TIMEOUT_MSEC),
         }
 
         if config.keep_alive_interval_msec.is_some() {

--- a/sn_node/src/storage/register_store.rs
+++ b/sn_node/src/storage/register_store.rs
@@ -117,11 +117,14 @@ impl RegisterStore {
         };
 
         if !path.exists() {
-            trace!("Register log does not exist yet: {}", path.display());
+            trace!(
+                "Register log path for {addr:?} does not exist yet: {}",
+                path.display()
+            );
             return Ok(stored_reg);
         }
 
-        trace!("Register log path exists: {}", path.display());
+        trace!("Register log path for {addr:?} exists: {}", path.display());
         for filepath in list_files_in(&path) {
             match read(&filepath)
                 .await
@@ -143,7 +146,7 @@ impl RegisterStore {
                 }
                 other => {
                     warn!(
-                        "Ignoring corrupted register cmd from storage found at {}: {other:?}",
+                        "Ignoring corrupted Register cmd from storage, for {addr:?}, found at {}: {other:?}",
                         filepath.display()
                     )
                 }


### PR DESCRIPTION
- Setting sn_node idle-timeout to 70secs (to match ADULT_RESPONSE_TIMEOUT), which allows the node to keep client connections a bit longer since it may need more time (when under stress) to send back a response before closing them.
- Setting sn_client default idle_timeout to match query/cmd timeout values.