### PR TITLE
fix(client): retry only once when check-replicas test query fails due to diff responses

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -233,7 +233,7 @@ jobs:
           SN_CMD_TIMEOUT: 90
           SN_QUERY_TIMEOUT: 90
           RUST_LOG: "sn_client=trace,qp2p=debug"
-        run: cd sn_client && cargo test --release --features check-replicas -- --test-threads=1
+        run: cd sn_client && cargo test --release --features check-replicas
         timeout-minutes: 7
 
       - name: Run example app for file API against local network

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,16 +879,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "5556015fe3aad8b968e5d4124980fbe2f6aaee7aeec6b749de1faaa2ca5d0a4c"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size",
  "unicode-width",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2641,9 +2640,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "69dc4ec9e7e12502579e09e8a53c6a305b3aceb62ad5c307a62f7c3eada78324"
 
 [[package]]
 name = "pairing"
@@ -3033,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "qp2p"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565b5f8a239def75dad631fe787a591929a18bd848d05bbf5f3be03973701c1e"
+checksum = "835efee474b5ed566ef0afc0e119bd8e5bfa2b2c480a6c7c27f0d7f76d0956f2"
 dependencies = [
  "bincode",
  "bytes",
@@ -4349,16 +4348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/sn_client/src/connections/link.rs
+++ b/sn_client/src/connections/link.rs
@@ -61,13 +61,11 @@ impl Link {
             .map_err(LinkError::Send)?;
         debug!("{msg_id:?} bidi msg sent to {peer:?}");
 
-        // move finish off thread as it's not strictly related to the sending of the msg.
-        let _handle = tokio::spawn(async move {
-            // Attempt to gracefully terminate the stream.
-            // If this errors it does _not_ mean our message has not been sent
-            let result = send_stream.finish().await;
-            debug!("{msg_id:?} to {peer:?} bidi finished: {result:?}");
-        });
+        // Attempt to gracefully terminate the stream.
+        // If this errors it does _not_ necessarily mean our message has not been sent,
+        // but we'll be retrying anyways...
+        send_stream.finish().await.map_err(LinkError::Send)?;
+        debug!("{msg_id:?} to {peer:?} bidi finished");
 
         Ok(recv_stream)
     }


### PR DESCRIPTION
- Re-enabling e2e sn_client tests multi-threaded mode.
- If a connection times out right after we sent a msg, but before we try to finish the stream, since we don’t await for the `finish` result we miss the chance to detect it and retry with new conn. This was made this way to avoid the await, but it seems, that at least for the client, we may want to wait for the `finish` result so we can retry in such scenarios.
- Retrying a test query only once, and only if the failure was due to receiving different responses from the data replicas, which may be due to a temporary out of sync. We've seen this very occasionally in CI with Register queries/entries.