### PR TITLE
Minor fixes on post merge reviews

### DIFF
--- a/sn_interface/src/network_knowledge/errors.rs
+++ b/sn_interface/src/network_knowledge/errors.rs
@@ -40,7 +40,7 @@ pub enum Error {
     #[error("Proof chain cannot be trusted: {0}")]
     UntrustedProofChain(String),
     #[error("Provided proof_chain doesn't cover the SAP's key we currently know: {0}")]
-    ProofChainNotCovered(String),
+    SAPKeyNotCoveredByProofChain(String),
     #[error("Section authority provider cannot be trusted: {0}")]
     UntrustedSectionAuthProvider(String),
     #[error("The genesis key of the provided SectionTree is invalid: {0:?}")]

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -200,7 +200,7 @@ impl NetworkKnowledge {
     }
 
     /// update all section info for our new section
-    pub fn relocated_to(&mut self, new_name: XorName) -> Result<()> {
+    pub fn relocate_to(&mut self, new_name: XorName) -> Result<()> {
         let signed_sap = self.section_tree().get_signed_by_name(&new_name)?;
         debug!("Node was relocated to {:?}", signed_sap.section_key());
         self.signed_sap = signed_sap;

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -279,7 +279,7 @@ impl SectionTree {
                     // As an outdated node will got updated via AE triggered by other messages,
                     // there is no need to bounce back here (assuming the sender is outdated) to
                     // avoid potential looping.
-                    return Err(Error::ProofChainNotCovered(format!(
+                    return Err(Error::SAPKeyNotCoveredByProofChain(format!(
                         "{proof_chain:?}, {:?}",
                         sap.value
                     )));
@@ -845,7 +845,7 @@ mod tests {
             TestSectionTree::get_section_tree_update(&sap0_same, &proof_chain, &genesis_sk);
         assert!(matches!(
             tree.update_the_section_tree(tree_update),
-            Err(Error::ProofChainNotCovered(_))
+            Err(Error::SAPKeyNotCoveredByProofChain(_))
         ));
 
         Ok(())
@@ -871,7 +871,7 @@ mod tests {
         // node receives an outdated AE update for sap0
         assert!(matches!(
             tree.update_the_section_tree(tree_update_outdated),
-            Err(Error::ProofChainNotCovered(_))
+            Err(Error::SAPKeyNotCoveredByProofChain(_))
         ));
 
         Ok(())

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -66,7 +66,7 @@ impl MyNode {
 
     pub(crate) fn relocate(&mut self, new_keypair: Arc<Keypair>, new_name: XorName) -> Result<()> {
         // try to relocate to the section that matches our current name
-        self.network_knowledge.relocated_to(new_name)?;
+        self.network_knowledge.relocate_to(new_name)?;
 
         self.keypair = new_keypair;
 

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -503,7 +503,6 @@ impl MyNode {
         let has_replicated_data_in = !data_collection.is_empty();
 
         for data in data_collection {
-            // grab the write lock each time in the loop to not hold it over large data sets
             let store_result = context
                 .data_storage
                 .store(&data, section_pk, node_keypair.clone())

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -324,7 +324,7 @@ impl MyNode {
         if updated && !latest_context.is_elder {
             // only done if adult, since as an elder we dont want to get any more
             // data for our name (elders will eventually be caching data in general)
-            cmds.push(MyNode::ask_for_any_new_data(&latest_context, None).await);
+            cmds.push(MyNode::ask_for_any_new_data(&latest_context).await);
         }
 
         if updated {

--- a/sn_node/src/node/messaging/update_section.rs
+++ b/sn_node/src/node/messaging/update_section.rs
@@ -91,10 +91,7 @@ impl MyNode {
     /// These nodes should send back anything missing (in batches).
     /// Relevant nodes should be all _prior_ neighbours + _new_ elders.
     #[instrument(skip(context))]
-    pub(crate) async fn ask_for_any_new_data(
-        context: &NodeContext,
-        prev_peer: Option<Peer>,
-    ) -> Cmd {
+    pub(crate) async fn ask_for_any_new_data(context: &NodeContext) -> Cmd {
         trace!("{:?}", LogMarker::DataReorganisationUnderway);
         debug!("Querying section for any new data");
         let data_i_have = context.data_storage.data_addrs().await;


### PR DESCRIPTION
- [chore(errors): fix naming](https://github.com/maidsafe/safe_network/commit/224a669222396827336248f80eed9e2ffeda3079) 
-> There was an aiming error in the sentence structure. It's not the
proof chain that is not covered, it's the key that is not covered.

- [chore(unused): remove unused argument](https://github.com/maidsafe/safe_network/commit/f001f1d1bb26e15b8a8b4ccc03a23fa9a86ef161)

- [fix(name): rename from interrogative to imperative](https://github.com/maidsafe/safe_network/commit/98e051ec3f89b58d0304170f2e6433dfc835efb6) 
-> The naming was confusing as to what the method actually did.

- [chore(comments): remove outdated comment](https://github.com/maidsafe/safe_network/commit/70442ff64963ba46c4ec62e2fac5850ece26c2ee)
