### PR TITLE
chore(node): lighten the CouldNotStoreData flow

### DIFF
--- a/sn_interface/src/messaging/system/node_msgs.rs
+++ b/sn_interface/src/messaging/system/node_msgs.rs
@@ -51,8 +51,8 @@ pub enum NodeEvent {
     CouldNotStoreData {
         /// Node Id
         node_id: PublicKey,
-        /// The data that the Adult couldn't store
-        data: ReplicatedData,
+        /// The data that the Node couldn't store
+        data_address: DataAddress,
         /// Whether store failed due to full
         full: bool,
     },

--- a/sn_node/src/comm/peer_session.rs
+++ b/sn_node/src/comm/peer_session.rs
@@ -263,8 +263,9 @@ impl PeerSessionWorker {
                     job.connection_retries += 1;
                 }
 
-                job.reporter
-                    .send(SendStatus::TransientError(format!("{error:?}")));
+                job.reporter.send(SendStatus::TransientError(format!(
+                    "Issue getting connection from Link: {error:?}"
+                )));
 
                 // we await here in case the connection is fresh and has not yet been added
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;

--- a/sn_node/src/node/data/records.rs
+++ b/sn_node/src/node/data/records.rs
@@ -524,7 +524,7 @@ impl MyNode {
                     let node_id = PublicKey::from(context.keypair.public);
                     let msg = NodeMsg::NodeEvent(NodeEvent::CouldNotStoreData {
                         node_id,
-                        data,
+                        data_address: data.address(),
                         full: true,
                     });
                     is_full = true;

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -77,7 +77,7 @@ impl MyNode {
                 error!("Not enough space to store data {data_addr:?}");
                 let msg = NodeMsg::NodeEvent(NodeEvent::CouldNotStoreData {
                     node_id: PublicKey::from(context.keypair.public),
-                    data: data.clone(),
+                    data_address: data.address(),
                     full: true,
                 });
 
@@ -385,13 +385,10 @@ impl MyNode {
             }
             NodeMsg::NodeEvent(NodeEvent::CouldNotStoreData {
                 node_id,
-                data,
+                data_address,
                 full,
             }) => {
-                info!(
-                    "Processing CouldNotStoreData event with MsgId: {:?}",
-                    msg_id
-                );
+                info!("Processing CouldNotStoreData event with {msg_id:?} at : {data_address:?}");
 
                 if !context.is_elder {
                     error!("Received unexpected message while Adult");
@@ -406,14 +403,10 @@ impl MyNode {
                     if changed {
                         // ..then we accept a new node in place of the full node
                         write_locked_node.joins_allowed = true;
+
+                        context.log_node_issue(node_id.into(), IssueType::Communication);
                     }
                 }
-
-                let targets = MyNode::target_data_holders(&context, data.name());
-
-                // TODO: handle responses where replication failed...
-                let _results =
-                    MyNode::replicate_data_to_adults(&context, data, msg_id, targets).await?;
 
                 Ok(vec![])
             }


### PR DESCRIPTION
Dont return the full data, just the address. No
need to fill up other nodes as removing this one will trigger that flow

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
