### PR TITLE
fix: adapt logging to be less confusing

### DIFF
--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -300,10 +300,9 @@ impl FlowCtrl {
 
             if let Some(time) = last_received_dkg_message {
                 if time.elapsed() >= MISSING_DKG_MSG_INTERVAL {
-                    debug!("Dkg voting appears stalled...");
                     let cmds = node.dkg_gossip_msgs();
                     if !cmds.is_empty() {
-                        trace!("Dkg msg resending cmd");
+                        debug!("Dkg msg resending cmd, as Dkg voting appears stalled...");
                     }
 
                     for cmd in cmds {


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

Move a DKG stalled msg to where it should be! Should declutter the logs. 