### PR TITLE
fix(network_knowledge): avoid reverifying for partial dag creation

### DIFF
--- a/sn_interface/src/network_knowledge/section_peers.rs
+++ b/sn_interface/src/network_knowledge/section_peers.rs
@@ -158,7 +158,7 @@ mod tests {
             section_peers.update(node.clone());
         });
         let sig = TestKeys::sign(&sk_1, &sk_2.public_key());
-        proof_chain.insert(&sk_1.public_key(), sk_2.public_key(), sig)?;
+        proof_chain.verify_and_insert(&sk_1.public_key(), sk_2.public_key(), sig)?;
         // 1 -> 2 should be retained
         section_peers.prune_members_archive(&proof_chain, &sk_2.public_key())?;
         assert_lists(
@@ -173,7 +173,7 @@ mod tests {
             section_peers.update(node.clone());
         });
         let sig = TestKeys::sign(&sk_2, &sk_3.public_key());
-        proof_chain.insert(&sk_2.public_key(), sk_3.public_key(), sig)?;
+        proof_chain.verify_and_insert(&sk_2.public_key(), sk_3.public_key(), sig)?;
         // 1 -> 2 -> 3 should be retained
         section_peers.prune_members_archive(&proof_chain, &sk_3.public_key())?;
         assert_lists(
@@ -188,7 +188,7 @@ mod tests {
             section_peers.update(node.clone());
         });
         let sig = TestKeys::sign(&sk_3, &sk_4.public_key());
-        proof_chain.insert(&sk_3.public_key(), sk_4.public_key(), sig)?;
+        proof_chain.verify_and_insert(&sk_3.public_key(), sk_4.public_key(), sig)?;
         //  2 -> 3 -> 4 should be retained
         section_peers.prune_members_archive(&proof_chain, &sk_4.public_key())?;
         assert_lists(
@@ -206,7 +206,7 @@ mod tests {
             section_peers.update(node.clone());
         });
         let sig = TestKeys::sign(&sk_3, &sk_5.public_key());
-        proof_chain.insert(&sk_3.public_key(), sk_5.public_key(), sig)?;
+        proof_chain.verify_and_insert(&sk_3.public_key(), sk_5.public_key(), sig)?;
         // 2 -> 3 -> 5 should be retained
         section_peers.prune_members_archive(&proof_chain, &sk_5.public_key())?;
         assert_lists(

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -525,7 +525,7 @@ pub mod test_utils {
             let signed_key = TestKeys::get_section_signed(parent_sk, sap.section_key());
             let mut proof_chain = proof_chain.clone();
             proof_chain
-                .insert(
+                .verify_and_insert(
                     &parent_sk.public_key(),
                     signed_key.value,
                     signed_key.sig.signature,
@@ -544,7 +544,7 @@ pub mod test_utils {
             for key in other_keys {
                 let sig = parent.sign(key.public_key().to_bytes());
                 proof_chain
-                    .insert(&parent.public_key(), key.public_key(), sig)
+                    .verify_and_insert(&parent.public_key(), key.public_key(), sig)
                     .expect("Failed to insert into proof_chain");
                 parent = key.clone();
             }

--- a/sn_interface/src/network_knowledge/sections_dag.rs
+++ b/sn_interface/src/network_knowledge/sections_dag.rs
@@ -112,7 +112,7 @@ impl<'de> Deserialize<'de> for SectionsDAG {
         let inter: Intermediate = Deserialize::deserialize(deserializer)?;
         let mut dag = SectionsDAG::new(inter.genesis_key);
         for (parent, info) in inter.sections {
-            dag.insert(&parent, info.key, info.sig)
+            dag.verify_and_insert(&parent, info.key, info.sig)
                 .map_err(D::Error::custom)?;
         }
         Ok(dag)
@@ -160,7 +160,7 @@ impl SectionsDAG {
 
     /// Insert new key into the DAG. `parent_key` must exist in the DAG and must validate
     /// `signature`, otherwise error is returned.
-    pub fn insert(
+    pub fn verify_and_insert(
         &mut self,
         parent_key: &bls::PublicKey,
         key: bls::PublicKey,
@@ -170,6 +170,17 @@ impl SectionsDAG {
             return Err(Error::InvalidSignature);
         }
 
+        self.insert_trusted_key(parent_key, key, signature)
+    }
+
+    /// Insert new key into the DAG. Does not verify the keys in the dag. This is expected to be called
+    /// for partial dag creation only (where the source is already verified + trusted)
+    fn insert_trusted_key(
+        &mut self,
+        parent_key: &bls::PublicKey,
+        key: bls::PublicKey,
+        signature: bls::Signature,
+    ) -> Result<()> {
         let parent = if *parent_key == self.genesis_key {
             self.dag_root.insert(key);
             BTreeSet::new()
@@ -196,7 +207,7 @@ impl SectionsDAG {
     /// Insert new key into the DAG. `parent_key` must exist in the DAG and must validate
     /// `signature`, otherwise error is returned.
     fn insert_node(&mut self, parent_key: &bls::PublicKey, node: Node<SectionInfo>) -> Result<()> {
-        self.insert(parent_key, node.value.key, node.value.sig)
+        self.verify_and_insert(parent_key, node.value.key, node.value.sig)
     }
 
     /// Get a partial `SectionsDAG` from the `from` key to the `to` key
@@ -243,7 +254,7 @@ impl SectionsDAG {
         let mut parent = *from;
         for node in crdt_ops.into_iter().rev() {
             let key = node.value.key;
-            dag.insert_node(&parent, node)?;
+            dag.insert_trusted_key(&parent, node.value.key, node.value.sig)?;
             parent = key;
         }
         Ok(dag)
@@ -273,7 +284,7 @@ impl SectionsDAG {
             // TODO: allow to select which branch ??
             .get(0)
         {
-            partial_dag.insert(
+            partial_dag.verify_and_insert(
                 &last_key,
                 child_node.value.key,
                 child_node.value.sig.clone(),
@@ -542,7 +553,7 @@ pub(crate) mod tests {
             let last_pk = &expected_keys[expected_keys.len() - 1];
             let (sk, info) = gen_signed_keypair(&last_sk);
 
-            dag.insert(last_pk, info.key, info.sig)?;
+            dag.verify_and_insert(last_pk, info.key, info.sig)?;
 
             expected_keys.push(info.key);
             last_sk = sk;
@@ -564,9 +575,9 @@ pub(crate) mod tests {
         let (_, info_b) = gen_signed_keypair(&sk_gen);
 
         let mut dag = SectionsDAG::new(pk_gen);
-        dag.insert(&pk_gen, info_a1.key, info_a1.sig)?;
-        dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
-        dag.insert(&pk_gen, info_b.key, info_b.sig)?;
+        dag.verify_and_insert(&pk_gen, info_a1.key, info_a1.sig)?;
+        dag.verify_and_insert(&info_a1.key, info_a2.key, info_a2.sig)?;
+        dag.verify_and_insert(&pk_gen, info_b.key, info_b.sig)?;
 
         assert_lists(dag.keys(), [pk_gen, info_a1.key, info_a2.key, info_b.key]);
 
@@ -612,7 +623,7 @@ pub(crate) mod tests {
         assert_lists(partial_gen.keys(), [pk_gen]);
 
         // let's insert only a1 into the DAG for now
-        dag.insert(&pk_gen, info_a1.key, info_a1.sig)?;
+        dag.verify_and_insert(&pk_gen, info_a1.key, info_a1.sig)?;
 
         // branch from genesis or a1 is a partial DAG with [genesis key, a1]
         let (partial_gen, last_key_gen) = dag.single_branch_dag_for_key(&pk_gen)?;
@@ -625,7 +636,7 @@ pub(crate) mod tests {
         assert_lists(partial_a1.keys(), partial_gen.keys());
 
         // let's now insert a2 into the DAG
-        dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
+        dag.verify_and_insert(&info_a1.key, info_a2.key, info_a2.sig)?;
 
         // branch from genesis, a1 or a2 is a partial DAG with [genesis key, a1, a2]
         let (partial_gen, last_key_gen) = dag.single_branch_dag_for_key(&pk_gen)?;
@@ -642,10 +653,10 @@ pub(crate) mod tests {
         assert_lists(partial_a2.keys(), partial_gen.keys());
 
         // let's now insert the other two branches (b and c) into the DAG
-        dag.insert(&pk_gen, info_b1.key, info_b1.sig)?;
-        dag.insert(&info_b1.key, info_b2.key, info_b2.sig)?;
-        dag.insert(&info_b2.key, info_b3.key, info_b3.sig)?;
-        dag.insert(&info_b2.key, info_c.key, info_c.sig)?;
+        dag.verify_and_insert(&pk_gen, info_b1.key, info_b1.sig)?;
+        dag.verify_and_insert(&info_b1.key, info_b2.key, info_b2.sig)?;
+        dag.verify_and_insert(&info_b2.key, info_b3.key, info_b3.sig)?;
+        dag.verify_and_insert(&info_b2.key, info_c.key, info_c.sig)?;
         assert!(dag.self_verify());
         assert_lists(
             dag.keys(),
@@ -762,8 +773,12 @@ pub(crate) mod tests {
         let (_, info_a) = gen_signed_keypair(&sk_gen);
 
         let mut dag = SectionsDAG::new(pk_gen);
-        assert!(dag.insert(&pk_gen, info_a.key, info_a.sig.clone()).is_ok());
-        assert!(dag.insert(&pk_gen, info_a.key, info_a.sig).is_ok());
+        assert!(dag
+            .verify_and_insert(&pk_gen, info_a.key, info_a.sig.clone())
+            .is_ok());
+        assert!(dag
+            .verify_and_insert(&pk_gen, info_a.key, info_a.sig)
+            .is_ok());
         assert_lists(dag.keys(), [info_a.key, pk_gen]);
 
         Ok(())
@@ -776,7 +791,9 @@ pub(crate) mod tests {
         let (_, info_a) = gen_signed_keypair(&bad_sk_gen);
 
         let mut dag = SectionsDAG::new(pk_gen);
-        assert!(dag.insert(&pk_gen, info_a.key, info_a.sig).is_err());
+        assert!(dag
+            .verify_and_insert(&pk_gen, info_a.key, info_a.sig)
+            .is_err());
     }
 
     #[test]
@@ -788,12 +805,12 @@ pub(crate) mod tests {
         let mut dag = SectionsDAG::new(pk_gen);
         // inserting child before parent
         assert!(dag
-            .insert(&info_a1.key, info_a2.key, info_a2.sig.clone())
+            .verify_and_insert(&info_a1.key, info_a2.key, info_a2.sig.clone())
             .is_err());
         assert_lists(dag.keys(), [pk_gen]);
 
-        dag.insert(&pk_gen, info_a1.key, info_a1.sig)?;
-        dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
+        dag.verify_and_insert(&pk_gen, info_a1.key, info_a1.sig)?;
+        dag.verify_and_insert(&info_a1.key, info_a2.key, info_a2.sig)?;
         assert_lists(dag.keys(), [pk_gen, info_a1.key, info_a2.key]);
 
         Ok(())
@@ -808,12 +825,12 @@ pub(crate) mod tests {
 
         // main_dag: 0->1->2->3
         let mut main_dag = SectionsDAG::new(pk_gen);
-        main_dag.insert(&pk_gen, info_a1.key, info_a1.sig)?;
+        main_dag.verify_and_insert(&pk_gen, info_a1.key, info_a1.sig)?;
         let mut dag_01 = main_dag.clone();
         let mut dag_01_err = main_dag.clone();
-        main_dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
+        main_dag.verify_and_insert(&info_a1.key, info_a2.key, info_a2.sig)?;
         let mut dag_012 = main_dag.clone();
-        main_dag.insert(&info_a2.key, info_a3.key, info_a3.sig)?;
+        main_dag.verify_and_insert(&info_a2.key, info_a3.key, info_a3.sig)?;
         let mut dag_0123 = main_dag.clone();
 
         // main_dag: 0->1->2->3
@@ -877,13 +894,13 @@ pub(crate) mod tests {
 
         let mut main_dag = SectionsDAG::new(pk_gen);
         // gen->pk_a1->pk_a2
-        main_dag.insert(&pk_gen, info_a1.key, info_a1.sig)?;
-        main_dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
+        main_dag.verify_and_insert(&pk_gen, info_a1.key, info_a1.sig)?;
+        main_dag.verify_and_insert(&info_a1.key, info_a2.key, info_a2.sig)?;
         // gen->pk_b1->pk_b2
-        main_dag.insert(&pk_gen, info_b1.key, info_b1.sig)?;
-        main_dag.insert(&info_b1.key, info_b2.key, info_b2.sig)?;
+        main_dag.verify_and_insert(&pk_gen, info_b1.key, info_b1.sig)?;
+        main_dag.verify_and_insert(&info_b1.key, info_b2.key, info_b2.sig)?;
         // pk_b1->pk_c
-        main_dag.insert(&info_b1.key, info_c.key, info_c.sig)?;
+        main_dag.verify_and_insert(&info_b1.key, info_c.key, info_c.sig)?;
 
         let mut dag = SectionsDAG::new(pk_gen);
         // merge from gen till pk_c
@@ -914,9 +931,9 @@ pub(crate) mod tests {
         //                   |
         //                   +-> pk_b
         let mut dag_a = SectionsDAG::new(pk_gen);
-        dag_a.insert(&pk_gen, info_a.key, info_a.sig)?;
+        dag_a.verify_and_insert(&pk_gen, info_a.key, info_a.sig)?;
         let mut dag_b = SectionsDAG::new(pk_gen);
-        dag_b.insert(&pk_gen, info_b.key, info_b.sig)?;
+        dag_b.verify_and_insert(&pk_gen, info_b.key, info_b.sig)?;
 
         let dag_from_a = dag_a.partial_dag(&pk_gen, &info_a.key)?;
         let dag_from_b = dag_b.partial_dag(&pk_gen, &info_b.key)?;
@@ -943,8 +960,8 @@ pub(crate) mod tests {
         //    |
         //    +->3->4
         let mut dag = SectionsDAG::new(pk_gen);
-        dag.insert(&pk_gen, info1.key, info1.sig.clone())?;
-        dag.insert(&info1.key, info2.key, info2.sig)?;
+        dag.verify_and_insert(&pk_gen, info1.key, info1.sig.clone())?;
+        dag.verify_and_insert(&info1.key, info2.key, info2.sig)?;
         // insert section3 manually with corrupted sig
         info3.sig = info1.sig; // use a random section's sig
         let hash1 = dag.get_hash(&info1.key)?;
@@ -953,7 +970,7 @@ pub(crate) mod tests {
         dag.hashes.insert(info3.key, node3.hash());
         dag.dag.apply(node3);
         // continue inserting section 4
-        dag.insert(&info3.key, info4.key, info4.sig)?;
+        dag.verify_and_insert(&info3.key, info4.key, info4.sig)?;
 
         assert!(!dag.self_verify());
         Ok(())
@@ -966,8 +983,8 @@ pub(crate) mod tests {
         let (_, info_b) = gen_signed_keypair(&sk_gen);
 
         let mut dag = SectionsDAG::new(pk_gen);
-        dag.insert(&pk_gen, info_a.key, info_a.sig)?;
-        dag.insert(&pk_gen, info_b.key, info_b.sig)?;
+        dag.verify_and_insert(&pk_gen, info_a.key, info_a.sig)?;
+        dag.verify_and_insert(&pk_gen, info_b.key, info_b.sig)?;
 
         assert_eq!(
             dag.get_parent_key(&info_a.key)?,
@@ -984,8 +1001,8 @@ pub(crate) mod tests {
         let (_, info_a2) = gen_signed_keypair(&sk_a1);
 
         let mut dag = SectionsDAG::new(pk_gen);
-        dag.insert(&pk_gen, info_a1.key, info_a1.sig)?;
-        dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
+        dag.verify_and_insert(&pk_gen, info_a1.key, info_a1.sig)?;
+        dag.verify_and_insert(&info_a1.key, info_a2.key, info_a2.sig)?;
 
         assert!(matches!(dag.get_parent_key(&info_a2.key)?, Some(key) if key == info_a1.key));
         assert!(matches!(dag.get_parent_key(&info_a1.key)?, Some(key) if key == pk_gen));
@@ -1001,9 +1018,9 @@ pub(crate) mod tests {
         let (_, info_b2) = gen_signed_keypair(&sk_b1);
 
         let mut dag = SectionsDAG::new(pk_gen);
-        dag.insert(&pk_gen, info_a.key, info_a.sig)?;
-        dag.insert(&pk_gen, info_b1.key, info_b1.sig)?;
-        dag.insert(&info_b1.key, info_b2.key, info_b2.sig)?;
+        dag.verify_and_insert(&pk_gen, info_a.key, info_a.sig)?;
+        dag.verify_and_insert(&pk_gen, info_b1.key, info_b1.sig)?;
+        dag.verify_and_insert(&info_b1.key, info_b2.key, info_b2.sig)?;
 
         assert_lists(dag.get_child_keys(&pk_gen)?, [info_a.key, info_b1.key]);
         assert_lists(dag.get_child_keys(&info_b1.key)?, [info_b2.key]);
@@ -1019,9 +1036,9 @@ pub(crate) mod tests {
         let (_, info_b2) = gen_signed_keypair(&sk_b1);
 
         let mut sections_dag = SectionsDAG::new(pk_gen);
-        sections_dag.insert(&pk_gen, info_a.key, info_a.sig)?;
-        sections_dag.insert(&pk_gen, info_b1.key, info_b1.sig)?;
-        sections_dag.insert(&info_b1.key, info_b2.key, info_b2.sig)?;
+        sections_dag.verify_and_insert(&pk_gen, info_a.key, info_a.sig)?;
+        sections_dag.verify_and_insert(&pk_gen, info_b1.key, info_b1.sig)?;
+        sections_dag.verify_and_insert(&info_b1.key, info_b2.key, info_b2.sig)?;
 
         assert_lists(sections_dag.leaf_keys(), [info_a.key, info_b2.key]);
         Ok(())
@@ -1036,9 +1053,9 @@ pub(crate) mod tests {
         let (_, info_a3) = gen_signed_keypair(&sk_a2);
 
         let mut dag = SectionsDAG::new(pk_gen);
-        dag.insert(&pk_gen, info_a1.key, info_a1.sig)?;
-        dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
-        dag.insert(&info_a2.key, info_a3.key, info_a3.sig)?;
+        dag.verify_and_insert(&pk_gen, info_a1.key, info_a1.sig)?;
+        dag.verify_and_insert(&info_a1.key, info_a2.key, info_a2.sig)?;
+        dag.verify_and_insert(&info_a2.key, info_a3.key, info_a3.sig)?;
 
         assert_lists(
             dag.get_ancestors(&info_a3.key)?,
@@ -1083,11 +1100,11 @@ pub(crate) mod tests {
         let (_, info_c) = gen_signed_keypair(&sk_b1);
 
         let mut dag = SectionsDAG::new(pk_gen);
-        dag.insert(&pk_gen, info_a1.key, info_a1.sig)?;
-        dag.insert(&info_a1.key, info_a2.key, info_a2.sig)?;
-        dag.insert(&pk_gen, info_b1.key, info_b1.sig)?;
-        dag.insert(&info_b1.key, info_b2.key, info_b2.sig)?;
-        dag.insert(&info_b1.key, info_c.key, info_c.sig)?;
+        dag.verify_and_insert(&pk_gen, info_a1.key, info_a1.sig)?;
+        dag.verify_and_insert(&info_a1.key, info_a2.key, info_a2.sig)?;
+        dag.verify_and_insert(&pk_gen, info_b1.key, info_b1.sig)?;
+        dag.verify_and_insert(&info_b1.key, info_b2.key, info_b2.sig)?;
+        dag.verify_and_insert(&info_b1.key, info_c.key, info_c.sig)?;
 
         let dag_string = serde_json::to_string(&dag)?;
         let dag_from_string = serde_json::from_str::<SectionsDAG>(dag_string.as_str())?;
@@ -1238,7 +1255,7 @@ pub(crate) mod tests {
             let sap = TestKeys::get_section_signed(&sk_set.secret_key(), sap);
             let key = sap.public_key_set().public_key();
             let sig = TestKeys::sign(parent_sk, &key);
-            dag.insert(&parent_sk.public_key(), sap.section_key(), sig)?;
+            dag.verify_and_insert(&parent_sk.public_key(), sap.section_key(), sig)?;
             sections_map.insert(sap.section_key(), (sk_set.secret_key(), sap));
             Ok(())
         }

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -657,7 +657,7 @@ mod tests {
             let mut proof_chain = SectionsDAG::new(genesis_pk);
 
             proof_chain
-                .insert(
+                .verify_and_insert(
                     &genesis_pk,
                     new_sap.section_key(),
                     TestKeys::get_section_signed(&genesis_sk, new_sap.section_key())
@@ -767,7 +767,7 @@ mod tests {
             // Create SectionTreeUpdate with newer sap
             let mut proof_chain = SectionsDAG::new(genesis_pk);
             proof_chain
-                .insert(
+                .verify_and_insert(
                     &genesis_pk,
                     new_sap.section_key(),
                     TestKeys::get_section_signed(&genesis_sk, new_sap.section_key())

--- a/sn_node/src/node/flow_ctrl/tests/network_builder.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_builder.rs
@@ -422,7 +422,7 @@ impl<R: RngCore> TestNetworkBuilder<R> {
                     let sig = TestKeys::sign(&parent, &sk.public_key());
                     let mut proof_chain = SectionsDAG::new(parent.public_key());
                     proof_chain
-                        .insert(&parent.public_key(), sk.public_key(), sig)
+                        .verify_and_insert(&parent.public_key(), sk.public_key(), sig)
                         .expect("should not fail");
                     let update =
                         TestSectionTree::get_section_tree_update(sap, &proof_chain, &parent);

--- a/sn_node/src/node/messaging/agreement.rs
+++ b/sn_node/src/node/messaging/agreement.rs
@@ -169,7 +169,7 @@ impl MyNode {
 
         // Finally we update our network knowledge with our sibling section SAP.
         // We use the parent proof chain to connect our current chain to sibling SAP.
-        parent_section_chain.insert(
+        parent_section_chain.verify_and_insert(
             &parent_key,
             their_sap.section_key(),
             sig_over_them.signature,
@@ -208,7 +208,11 @@ impl MyNode {
         // Let's update our network knowledge, including our
         // section SAP and chain if the new SAP's prefix matches our name
         // We need to generate the proof chain to connect our current chain to new SAP.
-        section_chain.insert(&last_key, signed_sap.section_key(), section_sig.signature)?;
+        section_chain.verify_and_insert(
+            &last_key,
+            signed_sap.section_key(),
+            section_sig.signature,
+        )?;
         let update = SectionTreeUpdate::new(signed_sap, section_chain);
         let name = self.context().name;
         let updated = self

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -943,7 +943,7 @@ mod tests {
                                     &initial_sk_set.secret_key(),
                                     &new_sap.section_key(),
                                 );
-                                dag.insert(&parent, new_sap.section_key(), sig)?;
+                                dag.verify_and_insert(&parent, new_sap.section_key(), sig)?;
                                 dag
                             };
                             TestSectionTree::get_section_tree_update(


### PR DESCRIPTION
AE back and forth and other messaging can mean we make a good amount of partial_dags. Before this, we were pulling from a verified section_dag and verifying _every_ insert into our fresh partial dag.

This was costly. So now we avoid it.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
