### PR TITLE
chore(faults): Remove OpId for failed request tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,8 +4019,6 @@ dependencies = [
  "itertools",
  "proptest",
  "rand 0.8.5",
- "sn_interface",
- "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/sn_fault_detection/Cargo.toml
+++ b/sn_fault_detection/Cargo.toml
@@ -16,11 +16,9 @@ default = []
 [dependencies]
 eyre = "~0.6.5"
 rand = "~0.8"
-thiserror = "1.0.23"
 tokio = { version = "1.0.23", features = [ "sync" ] }
 tracing = "~0.1.26"
 xor_name = "~5.0.0"
-sn_interface = { path = "../sn_interface", version = "^0.16.0" }
 
 [dev-dependencies]
 proptest = "~1.0.0"

--- a/sn_node/src/node/flow_ctrl/fault_detection.rs
+++ b/sn_node/src/node/flow_ctrl/fault_detection.rs
@@ -46,9 +46,6 @@ impl FlowCtrl {
                         match issue {
                             IssueType::AeProbeMsg => tracker.ae_update_msg_received(&node),
                             IssueType::Dkg => tracker.dkg_ack_fulfilled(&node),
-                            IssueType::RequestOperation(op_id) => {
-                                let _ = tracker.request_operation_fulfilled(&node, op_id);
-                            }
                             _ => {}
                         };
                     }


### PR DESCRIPTION
We use bidi now, so we can report after any failure, no need for double accounting

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
