### PR TITLE
feat(client): expose a public API to query chunks to specific data replicas

### DIFF
--- a/sn_cli/src/subcommands/dog.rs
+++ b/sn_cli/src/subcommands/dog.rs
@@ -13,7 +13,7 @@ use super::{
     OutputFmt,
 };
 use clap::Args;
-use color_eyre::Result;
+use color_eyre::{eyre::eyre, Help, Result};
 use sn_api::{
     resolver::{ContentType, SafeData},
     Safe, SafeUrl,
@@ -24,12 +24,16 @@ use tracing::debug;
 pub struct DogCommands {
     /// The safe:// location to inspect
     location: Option<String>,
+    /// Query all the data replicas matching the given indexes to check they hold a
+    /// copy of the content. E.g. -r0 -r2 will query replicas at index 0 and 2.
+    #[clap(short = 'r', long = "replicas")]
+    replicas: Vec<usize>,
 }
 
 pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe) -> Result<()> {
     let link = get_from_arg_or_stdin(cmd.location, None)?;
     let url = get_target_url(&link)?;
-    debug!("Running dog for: {}", &url);
+    debug!("Running dog for: {url}");
 
     let resolved_content = safe.inspect(&url.to_string()).await?;
     if OutputFmt::Pretty != output_fmt {
@@ -38,6 +42,8 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
             serialise_output(&(url.to_string(), resolved_content), output_fmt)
         );
     } else {
+        let num_of_resolutions = resolved_content.len();
+        let replicas_indexes = cmd.replicas;
         for (i, ref content) in resolved_content.iter().enumerate() {
             println!();
             println!("== URL resolution step {} ==", i + 1);
@@ -51,13 +57,13 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
                     ..
                 } => {
                     println!("= NRS Map Container =");
-                    println!("XOR-URL: {}", xorurl);
-                    println!("Type tag: {}", type_tag);
+                    println!("XOR-URL: {xorurl}");
+                    println!("Type tag: {type_tag}");
                     println!("XOR name: 0x{}", xorname_to_hex(xorname));
-                    println!("Native data type: {}", data_type);
+                    println!("Native data type: {data_type}");
                     let mut safeurl = SafeUrl::from_url(xorurl)?;
                     safeurl.set_content_type(ContentType::Raw)?;
-                    println!("Native data XOR-URL: {}", safeurl);
+                    println!("Native data XOR-URL: {safeurl}");
                     print_nrs_map(nrs_map);
                 }
                 SafeData::NrsEntry {
@@ -68,12 +74,12 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
                     resolved_from,
                     version,
                 } => {
-                    println!("Resolved from: {}", resolved_from);
+                    println!("Resolved from: {resolved_from}");
                     println!("= NrsEntry =");
-                    println!("Public name: {}", public_name);
-                    println!("Target XOR-URL: {}", xorurl);
-                    println!("Target native data type: {}", data_type);
-                    println!("Resolves into: {}", resolves_into);
+                    println!("Public name: {public_name}");
+                    println!("Target XOR-URL: {xorurl}");
+                    println!("Target native data type: {data_type}");
+                    println!("Resolves into: {resolves_into}");
                     println!(
                         "Version: {}",
                         version.map_or("none".to_string(), |v| v.to_string())
@@ -88,19 +94,19 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
                     resolved_from,
                     ..
                 } => {
-                    println!("Resolved from: {}", resolved_from);
+                    println!("Resolved from: {resolved_from}");
                     println!("= FilesContainer =");
-                    println!("XOR-URL: {}", xorurl);
+                    println!("XOR-URL: {xorurl}");
                     println!(
                         "Version: {}",
                         version.map_or("none".to_string(), |v| v.to_string())
                     );
-                    println!("Type tag: {}", type_tag);
+                    println!("Type tag: {type_tag}");
                     println!("XOR name: 0x{}", xorname_to_hex(xorname));
-                    println!("Native data type: {}", data_type);
+                    println!("Native data type: {data_type}");
                     let mut safeurl = SafeUrl::from_url(xorurl)?;
                     safeurl.set_content_type(ContentType::Raw)?;
-                    println!("Native data XOR-URL: {}", safeurl);
+                    println!("Native data XOR-URL: {safeurl}");
                 }
                 SafeData::PublicFile {
                     xorurl,
@@ -109,9 +115,9 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
                     resolved_from,
                     ..
                 } => {
-                    println!("Resolved from: {}", resolved_from);
+                    println!("Resolved from: {resolved_from}");
                     println!("= File =");
-                    println!("XOR-URL: {}", xorurl);
+                    println!("XOR-URL: {xorurl}");
                     println!("XOR name: 0x{}", xorname_to_hex(xorname));
                     println!("Native data type: PublicFile");
                     println!(
@@ -130,14 +136,14 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
                     ..
                 } => {
                     let safeurl = SafeUrl::from_xorurl(xorurl)?;
-                    println!("Resolved from: {}", resolved_from);
+                    println!("Resolved from: {resolved_from}");
                     if safeurl.content_type() == ContentType::Wallet {
                         println!("= Wallet =");
                     } else {
                         println!("= Multimap =");
                     }
-                    println!("XOR-URL: {}", xorurl);
-                    println!("Type tag: {}", type_tag);
+                    println!("XOR-URL: {xorurl}");
+                    println!("Type tag: {type_tag}");
                     println!("XOR name: 0x{}", xorname_to_hex(xorname));
                     println!("Native data type: Register");
                 }
@@ -148,12 +154,45 @@ pub async fn dog_commander(cmd: DogCommands, output_fmt: OutputFmt, safe: &Safe)
                     type_tag,
                     ..
                 } => {
-                    println!("Resolved from: {}", resolved_from);
+                    println!("Resolved from: {resolved_from}");
                     println!("= Register =");
-                    println!("XOR-URL: {}", xorurl);
-                    println!("Type tag: {}", type_tag);
+                    println!("XOR-URL: {xorurl}");
+                    println!("Type tag: {type_tag}");
                     println!("XOR name: 0x{}", xorname_to_hex(xorname));
                     println!("Native data type: Register");
+                }
+            }
+
+            // If this is the last resolution step, and a set of replicas indexes was provided,
+            // then query all data replicas and print out a report.
+            if !replicas_indexes.is_empty() && i == num_of_resolutions - 1 {
+                println!();
+                println!("== Checking data replicas of resolved content ==");
+                let xorurl = content.xorurl();
+                println!("XOR-URL: {xorurl}");
+                let replicated_content = safe
+                    .check_replicas(&xorurl, &replicas_indexes)
+                    .await
+                    .map_err(|err| {
+                        eyre!(err)
+                            .wrap_err(format!(
+                                "Could not check data replicas for content at {xorurl}."
+                            ))
+                            .suggestion("Try the command again with an appropriate Url.")
+                    })?;
+
+                println!("Replicas indexes queried: {replicas_indexes:?}");
+                println!("Content composed of {} chunk/s:", replicated_content.len());
+                for content in replicated_content {
+                    println!("= Chunk at XOR name 0x{} =", xorname_to_hex(&content.name));
+                    for (replica_index, outcome) in content.outcomes {
+                        if let Err(err) = outcome {
+                            println!("Replica #{replica_index}: {err}");
+                        } else {
+                            println!("Replica #{replica_index}: Ok!");
+                        }
+                    }
+                    println!();
                 }
             }
         }

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -22,12 +22,23 @@ use bytes::Bytes;
 use futures::future::join_all;
 use itertools::Itertools;
 use self_encryption::{self, ChunkInfo, DataMap, EncryptedChunk};
+use std::collections::BTreeMap;
 use tokio::{task, time::sleep};
 use tracing::trace;
 use xor_name::XorName;
 
 // Maximum number of concurrent chunks to be uploaded/retrieved for a file
 const CHUNKS_BATCH_MAX_SIZE: usize = 5;
+
+/// List of results obtained when querying a chunk to several replicas.
+// TODO: expand this definition to support other types of data like Registers.
+#[derive(Debug)]
+pub struct QueriedDataReplicas {
+    /// Name of the chunk queried
+    pub name: XorName,
+    /// List of indexes of the replicas queried and their corresponding outcome
+    pub outcomes: BTreeMap<usize, Result<()>>,
+}
 
 impl Client {
     #[instrument(skip(self), level = "debug")]
@@ -42,6 +53,31 @@ impl Client {
             // if an error occurs, we assume it's a SmallFile
             Ok(chunk.value().clone())
         }
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    /// Reads [`Bytes`] from the network, querying each of the data
+    /// replicas which match any of the indexes provided.
+    pub async fn read_bytes_from_replicas(
+        &self,
+        name: XorName,
+        replicas: &[usize],
+    ) -> Result<Vec<QueriedDataReplicas>> {
+        let (datamap_replicas, found_chunk) = self.get_chunk_from_replicas(name, replicas).await?;
+        let mut chunks_replicas = vec![datamap_replicas];
+
+        if let Some(chunk) = found_chunk {
+            // first try to deserialize a LargeFile, if it works, retrieve all unpacked chunks.
+            // if an error occurs, we assume it's a SmallFile
+            if let Ok(data_map) = self.unpack_chunk(chunk).await {
+                chunks_replicas.extend(
+                    self.get_chunks_from_replicas(data_map.infos(), replicas)
+                        .await?,
+                );
+            }
+        }
+
+        Ok(chunks_replicas)
     }
 
     /// Read bytes from the network. The contents are spread across
@@ -258,7 +294,7 @@ impl Client {
     // Gets and decrypts chunks from the network using nothing else but the data map,
     // then returns the raw data.
     async fn read_all(&self, data_map: DataMap) -> Result<Bytes> {
-        let encrypted_chunks = Self::try_get_chunks(self, data_map.infos()).await?;
+        let encrypted_chunks = self.try_get_chunks(data_map.infos()).await?;
         let bytes = self_encryption::decrypt_full_set(&data_map, &encrypted_chunks)?;
         Ok(bytes)
     }
@@ -271,14 +307,14 @@ impl Client {
         let range = &info.index_range;
         let all_infos = data_map.infos();
 
-        let encrypted_chunks = Self::try_get_chunks(
-            self,
-            (range.start..range.end + 1)
-                .clone()
-                .map(|i| all_infos[i].clone())
-                .collect_vec(),
-        )
-        .await?;
+        let encrypted_chunks = self
+            .try_get_chunks(
+                (range.start..range.end + 1)
+                    .clone()
+                    .map(|i| all_infos[i].clone())
+                    .collect_vec(),
+            )
+            .await?;
 
         let bytes =
             self_encryption::decrypt_range(&data_map, &encrypted_chunks, info.relative_pos, len)?;
@@ -287,15 +323,12 @@ impl Client {
     }
 
     #[instrument(skip_all, level = "trace")]
-    async fn try_get_chunks(
-        client: &Self,
-        chunks_info: Vec<ChunkInfo>,
-    ) -> Result<Vec<EncryptedChunk>> {
+    async fn try_get_chunks(&self, chunks_info: Vec<ChunkInfo>) -> Result<Vec<EncryptedChunk>> {
         let expected_count = chunks_info.len();
         let mut retrieved_chunks = vec![];
         for next_batch in chunks_info.chunks(CHUNKS_BATCH_MAX_SIZE) {
             let tasks = next_batch.iter().cloned().map(|chunk_info| {
-                let client = client.clone();
+                let client = self.clone();
                 task::spawn(async move {
                     match client.get_chunk(&chunk_info.dst_hash).await {
                         Ok(chunk) => Ok(EncryptedChunk {
@@ -304,8 +337,8 @@ impl Client {
                         }),
                         Err(err) => {
                             warn!(
-                                "Reading chunk {} from network, resulted in error {:?}.",
-                                chunk_info.dst_hash, err
+                                "Reading chunk {} from network, resulted in error {err:?}.",
+                                chunk_info.dst_hash
                             );
                             Err(err)
                         }
@@ -326,6 +359,66 @@ impl Client {
         } else {
             Ok(retrieved_chunks)
         }
+    }
+
+    async fn get_chunk_from_replicas(
+        &self,
+        name: XorName,
+        replicas: &[usize],
+    ) -> Result<(QueriedDataReplicas, Option<Chunk>)> {
+        let mut chunk_replicas = QueriedDataReplicas {
+            name,
+            outcomes: BTreeMap::new(),
+        };
+        let mut found_chunk = None;
+
+        let query = DataQueryVariant::GetChunk(ChunkAddress(name));
+        let results = self.send_query_to_replicas(query.clone(), replicas).await?;
+        for (replica_index, res) in results {
+            let outcome = res.map(|query_result| match query_result.response {
+                QueryResponse::GetChunk(Ok(chunk)) => {
+                    found_chunk = Some(chunk);
+                    Ok(())
+                }
+                QueryResponse::GetChunk(Err(err)) => Err(Error::ErrorMsg { source: err }),
+                other => Err(Error::UnexpectedQueryResponse {
+                    query: query.clone(),
+                    response: other,
+                }),
+            })?;
+
+            let _ = chunk_replicas.outcomes.insert(replica_index, outcome);
+        }
+
+        Ok((chunk_replicas, found_chunk))
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    async fn get_chunks_from_replicas(
+        &self,
+        chunks_info: Vec<ChunkInfo>,
+        replicas: &[usize],
+    ) -> Result<Vec<QueriedDataReplicas>> {
+        let mut chunks_replicas = vec![];
+        for next_batch in chunks_info.chunks(CHUNKS_BATCH_MAX_SIZE) {
+            let tasks = next_batch.iter().cloned().map(|chunk_info| {
+                let client = self.clone();
+                let replicas_indexes = replicas.to_vec();
+                task::spawn(async move {
+                    let name = chunk_info.dst_hash;
+                    client
+                        .get_chunk_from_replicas(name, &replicas_indexes)
+                        .await
+                        .map(|(chunk_replicas, _)| chunk_replicas)
+                })
+            });
+
+            for result in join_all(tasks).await.into_iter().flatten() {
+                chunks_replicas.push(result?);
+            }
+        }
+
+        Ok(chunks_replicas)
     }
 
     /// Extracts a file DataMapLevel from a chunk.

--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -16,9 +16,13 @@ mod register_apis;
 mod spentbook_apis;
 
 pub use client_builder::ClientBuilder;
+pub use file_apis::QueriedDataReplicas;
 pub use register_apis::RegisterWriteAheadLog;
 
-use crate::{errors::Error, sessions::Session};
+use crate::{
+    errors::{Error, Result},
+    sessions::Session,
+};
 
 use sn_dbc::Owner;
 use sn_interface::{
@@ -69,7 +73,7 @@ impl Client {
     /// In case of an existing SecretKey the client will attempt to retrieve the history
     /// of the key's balance in order to be ready for any token operations.
     #[instrument(skip_all, level = "debug")]
-    pub async fn connect(&self) -> Result<(), Error> {
+    pub async fn connect(&self) -> Result<()> {
         // TODO: The message being sent below is a temporary solution to fetch network info for
         // the client. Ideally the client should be able to send proper AE-Probe messages to
         // trigger the AE flows.

--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -8,7 +8,7 @@
 
 use super::Client;
 
-use crate::Error;
+use crate::{Error, Result};
 
 use sn_interface::{
     messaging::data::{
@@ -41,7 +41,7 @@ impl Client {
     /// Incrementing the WAL index as successful writes are sent out. Stops at the first error.
     /// Starts publishing from the index when called again with the same WAL.
     #[instrument(skip(self), level = "debug")]
-    pub async fn publish_register_ops(&self, wal: RegisterWriteAheadLog) -> Result<(), Error> {
+    pub async fn publish_register_ops(&self, wal: RegisterWriteAheadLog) -> Result<()> {
         for cmd in &wal {
             self.send_cmd(cmd.clone()).await?;
         }
@@ -61,7 +61,7 @@ impl Client {
         name: XorName,
         tag: u64,
         policy: Policy,
-    ) -> Result<(Address, RegisterWriteAheadLog), Error> {
+    ) -> Result<(Address, RegisterWriteAheadLog)> {
         let address = Address { name, tag };
 
         let op = CreateRegister { name, tag, policy };
@@ -93,7 +93,7 @@ impl Client {
         address: Address,
         entry: Entry,
         children: BTreeSet<EntryHash>,
-    ) -> Result<(EntryHash, RegisterWriteAheadLog), Error> {
+    ) -> Result<(EntryHash, RegisterWriteAheadLog)> {
         // First we fetch it so we can get the causality info,
         // either from local CRDT replica or from the network if not found
         debug!("Writing to register at {:?}", address);
@@ -130,7 +130,7 @@ impl Client {
 
     /// Get the entire Register from the Network
     #[instrument(skip(self), level = "debug")]
-    pub async fn get_register(&self, address: Address) -> Result<Register, Error> {
+    pub async fn get_register(&self, address: Address) -> Result<Register> {
         // Let's fetch the Register from the network
         let query = DataQueryVariant::Register(RegisterQuery::Get(address));
         let query_result = self.send_query(query.clone()).await?;
@@ -147,10 +147,7 @@ impl Client {
 
     /// Get the latest entry (or entries if branching)
     #[instrument(skip(self), level = "debug")]
-    pub async fn read_register(
-        &self,
-        address: Address,
-    ) -> Result<BTreeSet<(EntryHash, Entry)>, Error> {
+    pub async fn read_register(&self, address: Address) -> Result<BTreeSet<(EntryHash, Entry)>> {
         let query = DataQueryVariant::Register(RegisterQuery::Read(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
@@ -164,11 +161,7 @@ impl Client {
 
     /// Get an entry from a Register on the Network by its hash
     #[instrument(skip(self), level = "debug")]
-    pub async fn get_register_entry(
-        &self,
-        address: Address,
-        hash: EntryHash,
-    ) -> Result<Entry, Error> {
+    pub async fn get_register_entry(&self, address: Address, hash: EntryHash) -> Result<Entry> {
         let query = DataQueryVariant::Register(RegisterQuery::GetEntry { address, hash });
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
@@ -188,7 +181,7 @@ impl Client {
 
     /// Get the owner of a Register.
     #[instrument(skip(self), level = "debug")]
-    pub async fn get_register_owner(&self, address: Address) -> Result<User, Error> {
+    pub async fn get_register_owner(&self, address: Address) -> Result<User> {
         let query = DataQueryVariant::Register(RegisterQuery::GetOwner(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
@@ -212,7 +205,7 @@ impl Client {
         &self,
         address: Address,
         user: User,
-    ) -> Result<Permissions, Error> {
+    ) -> Result<Permissions> {
         let query = DataQueryVariant::Register(RegisterQuery::GetUserPermissions { address, user });
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {
@@ -228,7 +221,7 @@ impl Client {
 
     /// Get the Policy of a Register.
     #[instrument(skip(self), level = "debug")]
-    pub async fn get_register_policy(&self, address: Address) -> Result<Policy, Error> {
+    pub async fn get_register_policy(&self, address: Address) -> Result<Policy> {
         let query = DataQueryVariant::Register(RegisterQuery::GetPolicy(address));
         let query_result = self.send_query(query.clone()).await?;
         match query_result.response {

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -8,7 +8,7 @@
 
 use super::Client;
 
-use crate::Error;
+use crate::{Error, Result};
 
 use sn_dbc::{KeyImage, RingCtTransaction, SpentProof, SpentProofShare};
 use sn_interface::{
@@ -47,7 +47,7 @@ impl Client {
         tx: RingCtTransaction,
         spent_proofs: BTreeSet<SpentProof>,
         spent_transactions: BTreeSet<RingCtTransaction>,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let mut network_knowledge = None;
         let mut attempts = 1;
 
@@ -106,10 +106,7 @@ impl Client {
 
     /// Return the set of spent proof shares if the provided DBC's key image is spent
     #[instrument(skip(self), level = "debug")]
-    pub async fn spent_proof_shares(
-        &self,
-        key_image: KeyImage,
-    ) -> Result<Vec<SpentProofShare>, Error> {
+    pub async fn spent_proof_shares(&self, key_image: KeyImage) -> Result<Vec<SpentProofShare>> {
         let address = SpentbookAddress::new(XorName::from_content(&key_image.to_bytes()));
         let query = DataQueryVariant::Spentbook(SpentbookQuery::SpentProofShares(address));
         let query_result = self.send_query(query.clone()).await?;

--- a/sn_client/src/lib.rs
+++ b/sn_client/src/lib.rs
@@ -58,7 +58,9 @@ mod connections;
 mod errors;
 
 // Export public API.
-pub use api::{Client, RegisterWriteAheadLog, DEFAULT_NETWORK_CONTACTS_FILE_NAME};
+pub use api::{
+    Client, QueriedDataReplicas, RegisterWriteAheadLog, DEFAULT_NETWORK_CONTACTS_FILE_NAME,
+};
 pub use connections::LinkError;
 pub use errors::{Error, Result};
 pub use qp2p::Config as QuicP2pConfig;


### PR DESCRIPTION
- Exposing also an `sn_api` public API to fetch a file from a specified set of data replicas indexes and a `SafeUrl`.
- Adding `--replicas` arg to CLI `dog` command which allows the user to perform a check on several data replicas for the content being targeted by specifying their indexes.
- It currently supports querying data replicas only for `Files`, either with a `File`'s `XorUrl` or with any `SafeUrl` which resolves to a File.
- Non-pretty printing is also supported for the data replicas report, i.e. when passing `--output <format>` arg.

Example output from CLI querying `my-file.txt` linked from a FilesContainer to replicas with indexes 0, 2, 3, and 10 (index out of range of actual replicas), when some chunks were not found in any replica:
```
$ safe dog safe://hyryyrytx4imnzxfrwydbuy7fmtru56q5mjhnw1ig4ro6o1ea7u43adwh6wnra/my-file.txt -r0 -r2 -r3 -r10

== URL resolution step 1 ==
Resolved from: safe://hyryyrytx4imnzxfrwydbuy7fmtru56q5mjhnw1ig4ro6o1ea7u43adwh6wnra
= FilesContainer =
XOR-URL: safe://hyryyrytx4imnzxfrwydbuy7fmtru56q5mjhnw1ig4ro6o1ea7u43adwh6wnra
Version: hxhtb38edw54getr4onmjrrndmp1ry6ohne5m9f71iofe474h91hy
Type tag: 1100
XOR name: 0x2fd5562bbca4a0061983a55c493df9db5a782a4aa6d121e84918ecf59c0e9cf5
Native data type: Register
Native data XOR-URL: safe://hyryyyytx4imnzxfrwydbuy7fmtru56q5mjhnw1ig4ro6o1ea7u43adwh6wnra

== URL resolution step 2 ==
Resolved from: safe://hyryyyyxwih81u5xiwhtk9hfo47qyrnjpusryucx1barp7nkrfn7uqdkkfr
= File =
XOR-URL: safe://hyryyyyxwih81u5xiwhtk9hfo47qyrnjpusryucx1barp7nkrfn7uqdkkfr
XOR name: 0xf4af0f29edf5a722aff0b0d75c02092d9d8809b1f20e08de894428bb370d4a29
Native data type: PublicFile
Media type: Unknown

== Checking data replicas of resolved content ==
XOR-URL: safe://hyryyyyxwih81u5xiwhtk9hfo47qyrnjpusryucx1barp7nkrfn7uqdkkfr
Replicas indexes queried: [0, 2, 3, 10]
Content composed of 4 chunk/s:
= Chunk at XOR name 0xf4af0f29edf5a722aff0b0d75c02092d9d8809b1f20e08de894428bb370d4a29 =
Replica #0: Ok!
Replica #2: Ok!
Replica #3: Ok!
Replica #10: Error received from the network: InsufficientNodeCount { prefix: Prefix(), expected: 11, found: 4 }

= Chunk at XOR name 0x7086f5f1570884db5d062cb4a0d1334d88db83a5dda8263aa74cc2bc81bbc4d9 =
Replica #0: Ok!
Replica #2: Error received from the network: DataNotFound(Bytes(ChunkAddress(7086f5(01110000)..)))
Replica #3: Ok!
Replica #10: Error received from the network: InsufficientNodeCount { prefix: Prefix(), expected: 11, found: 4 }

= Chunk at XOR name 0xb1551a74e9a3404f0afa086c511f11e0d797eaa80143c5206dcce0875b2af52b =
Replica #0: Ok!
Replica #2: Ok!
Replica #3: Ok!
Replica #10: Error received from the network: InsufficientNodeCount { prefix: Prefix(), expected: 11, found: 4 }

= Chunk at XOR name 0x53127c013fdd0fa1d2b385d55d30843e8b0fbd0752fe43db4a93d41dd7af9aeb =
Replica #0: Error received from the network: DataNotFound(Bytes(ChunkAddress(53127c(01010011)..)))
Replica #2: Ok!
Replica #3: Ok!
Replica #10: Error received from the network: InsufficientNodeCount { prefix: Prefix(), expected: 11, found: 4 }
```