### PR TITLE
feat(comm): only cache conns of members

### DIFF
--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -262,6 +262,11 @@ impl MyNode {
         self.log_section_stats();
         self.log_network_stats();
 
+        // updates comm with new members and removes connections that are not from our members
+        self.comm
+            .update_members(self.network_knowledge.members())
+            .await;
+
         Ok(cmds)
     }
 

--- a/sn_node/src/node/messaging/promotion.rs
+++ b/sn_node/src/node/messaging/promotion.rs
@@ -198,6 +198,11 @@ impl MyNode {
             info!("Updated our network knowledge for {:?}", their_prefix);
             info!("Writing updated knowledge to disk");
             MyNode::write_section_tree(&context);
+
+            // updates comm with new members and removes connections that are not from our members
+            self.comm
+                .update_members(self.network_knowledge.members())
+                .await;
         }
         Ok(cmds)
     }

--- a/sn_node/src/node/messaging/promotion.rs
+++ b/sn_node/src/node/messaging/promotion.rs
@@ -242,7 +242,11 @@ impl MyNode {
                 self.network_knowledge.section_tree()
             );
 
-            self.update_on_elder_change(&context).await
+            let cmds = self.update_on_elder_change(&context).await;
+            // updates comm with new members and removes connections that are not from our members
+            self.comm.update(self.network_knowledge.members());
+
+            cmds
         } else {
             Ok(vec![])
         }

--- a/sn_node/src/node/messaging/promotion.rs
+++ b/sn_node/src/node/messaging/promotion.rs
@@ -244,7 +244,9 @@ impl MyNode {
 
             let cmds = self.update_on_elder_change(&context).await;
             // updates comm with new members and removes connections that are not from our members
-            self.comm.update(self.network_knowledge.members());
+            self.comm
+                .update_members(self.network_knowledge.members())
+                .await;
 
             cmds
         } else {

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -266,7 +266,7 @@ async fn bootstrap_normal_node(
     )
     .await?;
 
-    comm.update(network_knowledge.members());
+    comm.update_members(network_knowledge.members()).await;
 
     let node = MyNode::new(
         comm,

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -235,7 +235,7 @@ async fn bootstrap_genesis_node(
 #[allow(clippy::too_many_arguments)]
 async fn bootstrap_normal_node(
     config: &Config,
-    comm: Comm,
+    mut comm: Comm,
     incoming_msg_receiver: &mut tokio::sync::mpsc::Receiver<MsgFromPeer>,
     join_timeout: Duration,
     used_space: UsedSpace,
@@ -265,6 +265,9 @@ async fn bootstrap_normal_node(
         join_timeout,
     )
     .await?;
+
+    comm.update(network_knowledge.members());
+
     let node = MyNode::new(
         comm,
         info.keypair.clone(),


### PR DESCRIPTION
- Updates comms on member changes.
- Only adds connections to local cache if from a member.

Supersedes #1965.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
