### PR TITLE
feat(join): add infant handling to node

### DIFF
--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -58,3 +58,24 @@ pub enum JoinRejectionReason {
     /// The requesting node is not externally reachable
     NodeNotReachable(SocketAddr),
 }
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum InfantJoinResponse {
+    /// Message sent to joining infant
+    Approved,
+    /// Join was rejected
+    Rejected(InfantJoinRejectionReason),
+}
+
+/// Reason of a join request being rejected
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum InfantJoinRejectionReason {
+    /// No new infants are currently accepted for joining.
+    Full,
+    /// The provided name/key does not match the section.
+    WrongSection,
+    /// The called node is not an Elder.
+    WrongNodeCalled,
+    /// The age encoded in the infant name/key does not equal the expected age for new infants.
+    InvalidAge { provided: u8, expected: u8 },
+}

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -60,6 +60,8 @@ pub(crate) enum Cmd {
     SetJoinsAllowed(bool),
     /// Allows joining of new nodes until the section splits.
     SetJoinsAllowedUntilSplit(bool),
+    /// Removes an infant.
+    RemoveInfant(XorName),
     /// Add an issue to the tracking of a node's faults
     TrackNodeIssue { name: XorName, issue: IssueType },
     UpdateNetworkAndHandleValidClientMsg {
@@ -221,6 +223,7 @@ impl Cmd {
             Cmd::EnqueueDataForReplication { .. } => State::Replication,
             Cmd::SetJoinsAllowed { .. } => State::Data,
             Cmd::SetJoinsAllowedUntilSplit { .. } => State::Data,
+            Cmd::RemoveInfant(_) => State::Data,
         }
     }
 }
@@ -256,6 +259,7 @@ impl fmt::Display for Cmd {
             Cmd::ProposeVoteNodesOffline(_) => write!(f, "ProposeOffline"),
             Cmd::SetJoinsAllowed { .. } => write!(f, "SetJoinsAllowed"),
             Cmd::SetJoinsAllowedUntilSplit { .. } => write!(f, "SetJoinsAllowedUntilSplit"),
+            Cmd::RemoveInfant(_) => write!(f, "RemoveInfant"),
         }
     }
 }

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -227,6 +227,12 @@ impl Dispatcher {
                 debug!("[NODE WRITE]: propose offline write got");
                 node.cast_offline_proposals(&names)
             }
+            Cmd::RemoveInfant(name) => {
+                let mut node = self.node.write().await;
+                debug!("[NODE WRITE]: Removing infant..");
+                node.infants.remove(name);
+                Ok(vec![])
+            }
             Cmd::SetJoinsAllowed(joins_allowed) => {
                 let mut node = self.node.write().await;
                 debug!("[NODE WRITE]: Setting joins allowed..");

--- a/sn_node/src/node/infants.rs
+++ b/sn_node/src/node/infants.rs
@@ -1,0 +1,69 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use sn_interface::{
+    messaging::system::{
+        InfantJoinRejectionReason as RejectionReason, InfantJoinResponse as Response,
+    },
+    types::Peer,
+};
+use std::collections::BTreeSet;
+use xor_name::XorName;
+
+const MAX_NUM_INFANTS: usize = 200;
+const MIN_INFANT_AGE: u8 = 5;
+
+/// The handling of the infant nodes,
+/// i.e. the newly joined nodes in the network.
+///
+/// NB: This is a side-by-side impl and
+/// does not interfere with current join logic.
+#[derive(Clone, Debug)]
+pub(crate) struct Infants {
+    set: BTreeSet<Peer>,
+}
+
+impl Infants {
+    /// Returns a new empty instance of `Infants`.
+    pub(super) fn new() -> Self {
+        Self {
+            set: BTreeSet::new(),
+        }
+    }
+
+    /// Adds an infant.
+    pub(super) fn add(&mut self, infant: Peer) -> Response {
+        if self.is_full() {
+            return Response::Rejected(RejectionReason::Full);
+        } else if infant.age() != MIN_INFANT_AGE {
+            return Response::Rejected(RejectionReason::InvalidAge {
+                provided: infant.age(),
+                expected: MIN_INFANT_AGE,
+            });
+        }
+
+        let _ = self.set.insert(infant);
+
+        Response::Approved
+    }
+
+    /// Removes an infant.
+    pub(super) fn remove(&mut self, name: XorName) {
+        self.set.retain(|peer| peer.name() != name);
+    }
+
+    /// Returns if we've already got the max number of infants.
+    pub(super) fn is_full(&self) -> bool {
+        self.set.len() >= MAX_NUM_INFANTS
+    }
+
+    /// Returns if the name exists among our infants.
+    pub(super) fn exists(&self, name: XorName) -> bool {
+        self.set.iter().any(|peer| peer.name() == name)
+    }
+}

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -19,6 +19,7 @@ mod dkg;
 pub(crate) mod error;
 mod flow_ctrl;
 mod handover;
+mod infants;
 mod logging;
 mod membership;
 mod messaging;
@@ -57,6 +58,7 @@ mod core {
             dkg::DkgVoter,
             flow_ctrl::{cmds::Cmd, fault_detection::FaultsCmd},
             handover::Handover,
+            infants::Infants,
             membership::{elder_candidates, try_split_dkg, Membership},
             messaging::Peers,
             DataStorage, Error, Result, XorName,
@@ -116,6 +118,7 @@ mod core {
         pub(crate) relocate_state: Option<Box<JoiningAsRelocated>>,
         // ======================== Elder only ========================
         pub(crate) membership: Option<Membership>,
+        pub(crate) infants: Infants,
         // Section handover consensus state (Some for Elders, None for others)
         pub(crate) handover_request_aggregator: SignatureAggregator,
         pub(crate) handover_voting: Option<Handover>,
@@ -142,6 +145,7 @@ mod core {
         pub(crate) joins_allowed_until_split: bool,
         #[debug(skip)]
         pub(crate) fault_cmds_sender: mpsc::Sender<FaultsCmd>,
+        pub(crate) infants: Infants,
     }
 
     impl NodeContext {
@@ -189,6 +193,7 @@ mod core {
                 joins_allowed_until_split: self.joins_allowed_until_split,
                 data_storage: self.data_storage.clone(),
                 fault_cmds_sender: self.fault_cmds_sender.clone(),
+                infants: self.infants.clone(),
             }
         }
 
@@ -258,6 +263,7 @@ mod core {
                 data_storage,
                 fault_cmds_sender,
                 membership,
+                infants: Infants::new(),
                 elder_promotion_aggregator: SignatureAggregator::default(),
                 handover_request_aggregator: SignatureAggregator::default(),
                 section_proposal_aggregator: SignatureAggregator::default(),


### PR DESCRIPTION
- Rudimentary handling, this is meant to be refined and optimised.
- This does not interfere with current join flow, it merely adds the handling of the infant nodes.
- This still lacks the path to call the network to join as an infant.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
