### PR TITLE
feat(node): introducing Cmd::SendNodeMsgResponse for NodeMsg responses to nodes over streams

### DIFF
--- a/sn_comms/src/peer_session.rs
+++ b/sn_comms/src/peer_session.rs
@@ -8,7 +8,7 @@
 
 use super::{Error, Link, Result, STANDARD_CHANNEL_SIZE};
 
-use qp2p::{SendStream, UsrMsgBytes};
+use qp2p::UsrMsgBytes;
 use sn_interface::messaging::MsgId;
 
 use custom_debug::Debug;
@@ -96,11 +96,10 @@ impl PeerSession {
     }
 
     #[instrument(skip(self, bytes))]
-    pub(crate) async fn send_using_session_or_stream(
+    pub(crate) async fn send_using_session(
         &self,
         msg_id: MsgId,
         bytes: UsrMsgBytes,
-        send_stream: Option<SendStream>,
     ) -> Result<SendWatcher> {
         let (watcher, reporter) = status_watching();
 
@@ -109,7 +108,6 @@ impl PeerSession {
             bytes,
             connection_retries: 0,
             reporter,
-            send_stream,
         };
 
         self.channel
@@ -157,36 +155,6 @@ impl PeerSessionWorker {
             trace!("Processing session {peer:?} cmd: {session_cmd:?}");
 
             let status = match session_cmd {
-                SessionCmd::Send(SendJob {
-                    msg_id,
-                    bytes,
-                    reporter,
-                    send_stream: Some(mut send_stream),
-                    ..
-                }) => {
-                    // send response on the stream
-                    let _handle = tokio::spawn(async move {
-                        let stream_prio = 10;
-                        send_stream.set_priority(stream_prio);
-                        let stream_id = send_stream.id();
-                        debug!("Sending on {stream_id} via PeerSessionWorker");
-                        if let Err(error) = send_stream.send_user_msg(bytes).await {
-                            error!("Could not send msg {msg_id:?} over response {stream_id} to {peer:?}: {error:?}");
-                            reporter.send(SendStatus::TransientError(format!("Could not send msg on response {stream_id} to {peer:?} for {msg_id:?}")));
-                        } else {
-                            // Attempt to gracefully terminate the stream.
-                            // If this errors it does _not_ mean our message has not been sent
-                            let result = send_stream.finish().await;
-                            trace!(
-                                "bidi {stream_id} finished for {msg_id:?} to {peer:?}: {result:?}"
-                            );
-
-                            reporter.send(SendStatus::Sent);
-                        }
-                    });
-
-                    SessionStatus::Ok
-                }
                 SessionCmd::Send(job) => match self.send_over_peer_connection(job).await {
                     Ok(status) => status,
                     Err(error) => {
@@ -328,7 +296,6 @@ pub(crate) struct SendJob {
     bytes: UsrMsgBytes,
     connection_retries: usize, // TAI: Do we need this if we are using QP2P's retry
     reporter: StatusReporting,
-    send_stream: Option<SendStream>,
 }
 
 impl PartialEq for SendJob {

--- a/sn_node/src/node/bootstrap/join.rs
+++ b/sn_node/src/node/bootstrap/join.rs
@@ -464,7 +464,7 @@ async fn send_messages(
             let msg_id = msg.msg_id();
 
             let bytes = msg.serialize()?;
-            match comm.send_out_bytes(peer, msg_id, bytes, None).await {
+            match comm.send_out_bytes(peer, msg_id, bytes).await {
                 Ok(()) => trace!("Msg {msg_id:?} sent on {dst:?}"),
                 Err(error) => {
                     warn!("Error in comms when sending msg {msg_id:?} to peer {peer:?}: {error}")

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -57,7 +57,6 @@ impl Dispatcher {
                     msg,
                     msg_id,
                     recipients,
-                    send_stream: None,
                     context,
                 }])
             }
@@ -65,9 +64,15 @@ impl Dispatcher {
                 msg,
                 msg_id,
                 recipients,
+                context,
+            } => MyNode::send_msg(msg, msg_id, recipients, context).await,
+            Cmd::SendNodeMsgResponse {
+                msg,
+                msg_id,
+                recipient,
                 send_stream,
                 context,
-            } => MyNode::send_msg(msg, msg_id, recipients, send_stream, context).await,
+            } => MyNode::send_node_msg_response(msg, msg_id, recipient, context, send_stream).await,
             Cmd::SendClientResponse {
                 msg,
                 correlation_id,
@@ -82,23 +87,25 @@ impl Dispatcher {
                     context,
                     source_client,
                 )
-                .await
+                .await?;
+                Ok(vec![])
             }
-            Cmd::SendNodeResponse {
+            Cmd::SendNodeDataResponse {
                 msg,
                 correlation_id,
                 send_stream,
                 context,
                 requesting_peer,
             } => {
-                MyNode::send_node_response(
+                MyNode::send_node_data_response(
                     msg,
                     correlation_id,
                     send_stream,
                     context,
                     requesting_peer,
                 )
-                .await
+                .await?;
+                Ok(vec![])
             }
             Cmd::SendMsgAndAwaitResponse {
                 msg_id,

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -248,11 +248,9 @@ impl Dispatcher {
             msg,
             msg_id,
             recipients,
-            send_stream,
             context,
         } = cmd
         {
-            let _ = send_stream;
             let peer_msgs = into_msg_bytes(
                 &context.network_knowledge,
                 context.name,

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -65,14 +65,15 @@ impl MyNode {
             };
 
             if let Some(ae_msg) = ae_msg {
-                let ae_cmd = if send_stream.is_some() {
+                let ae_cmd = if let Some(send_stream) = send_stream {
                     debug!("Sending AE response over send_stream for {msg_id:?}");
-                    Cmd::send_msg_via_response_stream(
-                        ae_msg,
-                        Peers::Single(origin),
+                    Cmd::SendNodeMsgResponse {
+                        msg: ae_msg,
+                        msg_id,
                         send_stream,
+                        recipient: origin,
                         context,
-                    )
+                    }
                 } else {
                     debug!("Sending AE response over fresh conn for {msg_id:?}");
                     Cmd::send_msg(ae_msg, Peers::Single(origin), context)

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -107,7 +107,7 @@ impl MyNode {
                 operation_id,
             };
 
-            vec![Cmd::SendNodeResponse {
+            vec![Cmd::SendNodeDataResponse {
                 msg,
                 correlation_id: msg_id,
                 send_stream,


### PR DESCRIPTION
- Having this internal sn_node::Cmd to handle sending msg responses to nodes over a response bi-stream allows us to decouple such logic from the rest, but it also allows us to have unit tests within sn_node which verify the outcome of processing Cmds without sending any msg over the wire.
- We are here also changing Cmd::SendMsg to make/restricting it exclusively for sending msgs to nodes over uni-streams.