### PR TITLE
refactor(node): sending client data cmds and queries to holders through Cmd::SendMsgAndAwaitResponse

### DIFF
--- a/sn_comms/src/error.rs
+++ b/sn_comms/src/error.rs
@@ -28,7 +28,7 @@ pub enum Error {
     FailedSend(Peer),
     /// Error Sending Cmd in to node for processing
     #[error("Error sending Cmd to node {0:?} for processing.")]
-    CmdSendError(Peer),
+    SendError(Peer),
 }
 
 impl From<qp2p::ClientEndpointError> for Error {

--- a/sn_comms/src/peer_session.rs
+++ b/sn_comms/src/peer_session.rs
@@ -87,11 +87,9 @@ impl PeerSession {
             .send_on_new_bi_di_stream(bytes, msg_id)
             .await
             .map_err(|err| {
-                error!(
-                    "Failed sending {msg_id:?} to {:?} {err:?}",
-                    self.link.peer()
-                );
-                Error::CmdSendError(*self.link.peer())
+                let peer = *self.link.peer();
+                error!("Failed sending {msg_id:?} to {peer:?} {err:?}");
+                Error::SendError(peer)
             })
     }
 

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -151,7 +151,7 @@ pub(crate) enum Cmd {
         msg: NodeMsg,
         #[debug(skip)]
         context: NodeContext,
-        recipient: Peer,
+        targets: BTreeSet<Peer>,
         client_stream: SendStream,
         source_client: Peer,
     },

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -111,7 +111,7 @@ impl Dispatcher {
                 msg_id,
                 msg,
                 context,
-                recipient,
+                targets,
                 client_stream,
                 source_client,
             } => {
@@ -119,7 +119,7 @@ impl Dispatcher {
                     msg_id,
                     msg,
                     context,
-                    recipient,
+                    targets,
                     client_stream,
                     source_client,
                 )

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -8,7 +8,7 @@
 
 use crate::node::{
     flow_ctrl::dispatcher::Dispatcher,
-    messaging::{streams::into_msg_bytes, Peers},
+    messaging::{node_msgs::into_msg_bytes, Peers},
     Cmd,
 };
 

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -13,13 +13,13 @@ mod dkg;
 mod handover;
 mod join;
 mod membership;
-mod node_msgs;
+pub(crate) mod node_msgs;
 mod promotion;
 mod relocation;
 mod section_state;
 mod serialize;
 mod signature;
-pub(crate) mod streams;
+mod streams;
 mod update_section;
 
 use crate::node::{flow_ctrl::cmds::Cmd, Error, MyNode, Result};

--- a/sn_node/src/node/messaging/serialize.rs
+++ b/sn_node/src/node/messaging/serialize.rs
@@ -21,9 +21,9 @@ impl MyNode {
     /// Serialize a message for a Client
     pub(crate) fn serialize_client_msg_response(
         our_node_name: XorName,
-        msg: ClientDataResponse,
+        msg: &ClientDataResponse,
     ) -> Result<(MsgKind, Bytes)> {
-        let payload = WireMsg::serialize_msg_payload(&msg)?;
+        let payload = WireMsg::serialize_msg_payload(msg)?;
         let kind = MsgKind::ClientDataResponse(our_node_name);
         Ok((kind, payload))
     }
@@ -31,9 +31,9 @@ impl MyNode {
     /// Serialize a message for a Node
     pub(crate) fn serialize_node_msg(
         our_node_name: XorName,
-        msg: NodeMsg,
+        msg: &NodeMsg,
     ) -> Result<(MsgKind, Bytes)> {
-        let payload = WireMsg::serialize_msg_payload(&msg)?;
+        let payload = WireMsg::serialize_msg_payload(msg)?;
         let kind = MsgKind::Node {
             name: our_node_name,
             is_join: matches!(msg, NodeMsg::JoinRequest(_)),
@@ -42,11 +42,11 @@ impl MyNode {
     }
 
     /// Serialize a message for a Node
-    pub(crate) fn serialize_node_msg_response(
+    pub(crate) fn serialize_node_data_response(
         our_node_name: XorName,
-        msg: NodeDataResponse,
+        msg: &NodeDataResponse,
     ) -> Result<(MsgKind, Bytes)> {
-        let payload = WireMsg::serialize_msg_payload(&msg)?;
+        let payload = WireMsg::serialize_msg_payload(msg)?;
         let kind = MsgKind::NodeDataResponse(our_node_name);
         Ok((kind, payload))
     }


### PR DESCRIPTION
- Unifying and simplifying logic to send client data cmds and queries to holders so in both cases the sn_node `Cmd::SendMsgAndAwaitResponse` is used.
- Renaming `sn_comms::Error::CmdSendError` to `SendError` since it's not specific for cmds but for any msg.
- Some internal sn_node helper functions were moved to different files/mods so they are closer to the logic making use of them.