### PR TITLE
Require total participation for handover requests

### DIFF
--- a/sn_interface/src/messaging/signature_aggregator.rs
+++ b/sn_interface/src/messaging/signature_aggregator.rs
@@ -95,13 +95,73 @@ impl SignatureAggregator {
     }
 }
 
+/// Aggregator for signature shares for arbitrary payloads.
+/// Like the SignatureAggregator, but requires total participation.
+#[derive(Debug, Default)]
+pub struct TotalParticipationAggregator {
+    map: BTreeMap<Digest256, BTreeSet<SectionSigShare>>,
+}
+
+impl TotalParticipationAggregator {
+    /// Add new share into the aggregator. If `total_participants` valid signature shares were collected, returns
+    /// the aggregated signature: `Some(SectionSig)` else returns None.
+    /// Checks if the signature are valid
+    /// Resets current shares upon completion of a signature so we don't accumulate finished aggregations endlessly
+    pub fn try_aggregate(
+        &mut self,
+        payload: &[u8],
+        sig_share: SectionSigShare,
+        total_participants: usize,
+    ) -> Result<Option<SectionSig>, AggregatorError> {
+        if !sig_share.verify(payload) {
+            return Err(AggregatorError::InvalidSigShare);
+        }
+
+        // Use the hash of the payload + the public key as the key in the map to avoid mixing
+        // entries that have the same payload but are signed using different keys.
+        let public_key = sig_share.public_key_set.public_key();
+
+        let mut hasher = Sha3::v256();
+        let mut hash = Digest256::default();
+        hasher.update(payload);
+        hasher.update(&public_key.to_bytes());
+        hasher.finalize(&mut hash);
+
+        // save the sig share
+        let current_shares = self.map.entry(hash).or_default();
+        let _ = current_shares.insert(sig_share.clone());
+
+        // try aggregate if we have all the shares
+        if current_shares.len() == total_participants {
+            let signature = sig_share
+                .public_key_set
+                .combine_signatures(
+                    current_shares
+                        .iter()
+                        .map(|s| (s.index, s.signature_share.clone())),
+                )
+                .map_err(AggregatorError::FailedToCombineSigShares)?;
+            let section_sig = SectionSig {
+                public_key,
+                signature,
+            };
+
+            // reset current shares upon completion
+            self.map.remove(&hash);
+            Ok(Some(section_sig))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use rand::thread_rng;
 
     #[test]
-    fn smoke() -> Result<(), AggregatorError> {
+    fn test_signature_aggregator() -> Result<(), AggregatorError> {
         let mut rng = thread_rng();
         let threshold = 3;
         let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
@@ -129,6 +189,43 @@ mod tests {
         // Extra shares start another round
         let sig_share = create_sig_share(&sk_set, threshold + 1, payload);
         let result = aggregator.try_aggregate(payload, sig_share);
+
+        match result {
+            Ok(None) => Ok(()),
+            _ => panic!("unexpected result: {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_total_participation_aggregator() -> Result<(), AggregatorError> {
+        let mut rng = thread_rng();
+        let threshold = 3;
+        let total_participation = 5;
+        let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
+
+        let mut aggregator = TotalParticipationAggregator::default();
+        let payload = b"hello";
+
+        // Not enough shares yet
+        for index in 0..total_participation - 1 {
+            let sig_share = create_sig_share(&sk_set, index, payload);
+            let result = aggregator.try_aggregate(payload, sig_share, total_participation);
+
+            match result {
+                Ok(None) => (),
+                _ => panic!("unexpected result: {:?}", result),
+            }
+        }
+
+        // Enough shares now
+        let sig_share = create_sig_share(&sk_set, total_participation, payload);
+        let sig = aggregator.try_aggregate(payload, sig_share, total_participation)?;
+
+        assert!(sig.expect("some key").verify(payload));
+
+        // Extra shares start another round
+        let sig_share = create_sig_share(&sk_set, total_participation + 1, payload);
+        let result = aggregator.try_aggregate(payload, sig_share, total_participation);
 
         match result {
             Ok(None) => Ok(()),

--- a/sn_node/src/node/messaging/handover.rs
+++ b/sn_node/src/node/messaging/handover.rs
@@ -42,14 +42,16 @@ impl MyNode {
         }
 
         // try aggregate
+        let total_participants = sap.elder_count();
         let serialised_sap = bincode::serialize(&sap).map_err(|err| {
             error!("Failed to serialise handover request {msg_id:?} from {sender}: {err:?}");
             err
         })?;
-        match self
-            .handover_request_aggregator
-            .try_aggregate(&serialised_sap, sig_share)
-        {
+        match self.handover_request_aggregator.try_aggregate(
+            &serialised_sap,
+            sig_share,
+            total_participants,
+        ) {
             Ok(Some(sig)) => {
                 trace!("Handover request {msg_id:?} successfully aggregated");
                 self.handle_request_handover_agreement(sap, sig)

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -66,7 +66,7 @@ mod core {
     use sn_fault_detection::IssueType;
     use sn_interface::{
         messaging::{
-            signature_aggregator::SignatureAggregator,
+            signature_aggregator::{SignatureAggregator, TotalParticipationAggregator},
             system::{DkgSessionId, SectionSigned, SectionStateVote},
             AuthorityProof, SectionSig,
         },
@@ -116,7 +116,7 @@ mod core {
         // ======================== Elder only ========================
         pub(crate) membership: Option<Membership>,
         // Section handover consensus state (Some for Elders, None for others)
-        pub(crate) handover_request_aggregator: SignatureAggregator,
+        pub(crate) handover_request_aggregator: TotalParticipationAggregator,
         pub(crate) handover_voting: Option<Handover>,
         pub(crate) joins_allowed: bool,
         pub(crate) joins_allowed_until_split: bool,
@@ -258,7 +258,7 @@ mod core {
                 fault_cmds_sender,
                 membership,
                 elder_promotion_aggregator: SignatureAggregator::default(),
-                handover_request_aggregator: SignatureAggregator::default(),
+                handover_request_aggregator: TotalParticipationAggregator::default(),
                 section_proposal_aggregator: SignatureAggregator::default(),
             };
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

An attempt to fix DKG selfish termination by requiring total participation before going to Handover. 