### PR TITLE
refactor(node): pass NodeContext within Cmd::UpdateNetworkAndHandleValidClientMsg

### DIFF
--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -71,6 +71,8 @@ pub(crate) enum Cmd {
         send_stream: SendStream,
         /// Requester's authority over this message
         auth: AuthorityProof<ClientAuth>,
+        #[debug(skip)]
+        context: NodeContext,
     },
     /// Handle peer that's been detected as lost.
     HandleFailedSendToNode { peer: Peer, msg_id: MsgId },


### PR DESCRIPTION
This also checks if the network knowledge provided in a `SpentbookCmd::Spend` cmd has any update against the `NodeContext`, before trying to update the actual node's network knowledge by triggering the internal `Cmd::UpdateNetworkAndHandleValidClientMsg`.