### PR TITLE
fix(relocation): skip the propose NodeIsOffline flow for relocations.

### DIFF
--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -10,7 +10,7 @@ use crate::node::{
     bootstrap::JoiningAsRelocated,
     flow_ctrl::cmds::Cmd,
     relocation::{find_nodes_to_relocate, ChurnId},
-    MyNode, Result, SectionStateVote,
+    MyNode, Result,
 };
 
 use sn_interface::{
@@ -56,9 +56,8 @@ impl MyNode {
                 relocate_details.dst,
             );
 
-            cmds.extend(self.propose_section_state(SectionStateVote::NodeIsOffline(
-                node_state.relocate(relocate_details),
-            ))?);
+            let relocated_node_state = node_state.relocate(relocate_details);
+            cmds.extend(self.propose_membership_change(relocated_node_state));
         }
 
         Ok(cmds)


### PR DESCRIPTION
Currently node relocations first go through a NodeIsOffline proposal flow. This flow was originally intended to check that enough elders agree that a node is faulty, i.e. detecting network connection errors, etc.

It's not needed for relocations since the relocation details has all the information we need to verify if a relocation request is valid.

This PR drops the NodeIsOffline proposal in favor of simply triggering the membership change directly.

This should allow us to more easily retry failed relocations