### PR TITLE
ci: prevent bors/bump version running concurrently

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -5,9 +5,10 @@ on:
   push:
     branches: [staging, trying]
 
+# this should prevent bors merge run, and main release/commits from running concurrently
+#(as long as both are sporting this check)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: "main-modifying-workflow"
 
 env:
   CARGO_INCREMENTAL: 0  # bookkeeping for incremental builds has overhead, not useful in CI.

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,5 +1,10 @@
 name: Version Bump
 
+# this should prevent bors merge run, and main release/commits from running concurrently
+#(as long as both are sporting this check)
+concurrency:
+  group: "main-modifying-workflow"
+
 on:
   push:
     branches:


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
