### PR TITLE
Misc Release Process Updates

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -11,7 +11,7 @@ concurrency:
   group: "main-modifying-workflow"
 
 env:
-  CARGO_INCREMENTAL: 0  # bookkeeping for incremental builds has overhead, not useful in CI.
+  CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
   NODE_COUNT: 15
 
 jobs:
@@ -69,14 +69,14 @@ jobs:
   #   - uses: EmbarkStudios/cargo-deny-action@v1
 
   lint:
-      runs-on: ubuntu-latest
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      steps:
-        - uses: actions/checkout@v2
-          with:
-            fetch-depth: 0
-        - uses: wagoid/commitlint-github-action@f114310111fdbd07e99f47f9ca13d62b3ec98372
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@f114310111fdbd07e99f47f9ca13d62b3ec98372
 
   checks:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
@@ -103,11 +103,39 @@ jobs:
       - shell: bash
         run: cargo clippy --all-targets --all-features -- -Dwarnings
 
-
       - name: Check documentation
         # Deny certain `rustdoc` lints that are unwanted.
         # See https://doc.rust-lang.org/rustdoc/lints.html for lints that are 'warning' by default.
         run: RUSTDOCFLAGS="--deny=warnings" cargo doc --no-deps
+
+  build-arm:
+    name: build arm
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: arm-unknown-linux-musleabi
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - shell: bash
+        run: make gha-build-${{ matrix.target }}
+      - uses: actions/upload-artifact@main
+        with:
+          name: safe_network-${{ matrix.target }}
+          path: |
+            artifacts
+            !artifacts/.cargo-lock
 
   unit:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
@@ -148,7 +176,7 @@ jobs:
       - name: Run sn_fault_detection tests
         timeout-minutes: 15
         env:
-           RUST_LOG: sn_fault_detection
+          RUST_LOG: sn_fault_detection
         run: cd sn_fault_detection && cargo test --release
 
       - name: Build sn_node tests before running
@@ -493,7 +521,6 @@ jobs:
         if: failure()
         continue-on-error: true
 
-
   # e2e-split:
   #   #if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
   #   # disabled temporarily since `self-hosted-ubuntu` runner not available for NodeRefactorBranch branch
@@ -519,17 +546,17 @@ jobs:
   #         cache-on-failure: true
   #         sharedKey: ${{github.run_id}}
 
-      # - name: install ripgrep ubuntu
-      #   run: sudo apt-get install ripgrep
-      #   if: matrix.os == 'ubuntu-latest'
+  # - name: install ripgrep ubuntu
+  #   run: sudo apt-get install ripgrep
+  #   if: matrix.os == 'ubuntu-latest'
 
-      # - name: install ripgrep mac
-      #   run: brew install ripgrep
-      #   if: matrix.os == 'macos-latest'
+  # - name: install ripgrep mac
+  #   run: brew install ripgrep
+  #   if: matrix.os == 'macos-latest'
 
-      # - name: install ripgrep windows
-      #   run: choco install ripgrep
-      #   if: matrix.os == 'windows-latest'
+  # - name: install ripgrep windows
+  #   run: choco install ripgrep
+  #   if: matrix.os == 'windows-latest'
 
   #     - name: Build sn bins
   #       run: cd sn_node && cargo build --release --bins
@@ -551,11 +578,9 @@ jobs:
   #       env:
   #         RUST_LOG: "sn_node,sn_client,sn_comms,sn_consensus,sn_fault_detection=trace,sn_interface=trace"
 
-
   #     # - name: Print Network Stats after churn test
   #     #   shell: bash
   #     #   run: ./target/release/log_cmds_inspector $HOME/.safe/node/local-test-network
-
 
   #     # - name: Cleanup churn test
   #     #   run: |
@@ -570,7 +595,6 @@ jobs:
   #     #   run: cargo run --release --example network_split
   #     #   env:
   #     #     RUST_LOG: "sn_node,sn_client,sn_comms,sn_consensus,sn_fault_detection=trace"
-
 
   #     # - name: Print Network Log Stats at start
   #     #   shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,3 +237,15 @@ jobs:
           if [[ $commit_message == *"sn_cli-"* ]]; then
             ./resources/scripts/publish_crate_with_retries.sh "sn_cli"
           fi
+
+  notify-if-failure:
+    name: send slack notification on failure
+    if: ${{ failure() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: post notification to slack on failure
+        uses: bryannice/gitactions-slack-notification@2.0.0
+        env:
+          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+          SLACK_TITLE: "Version Bumping Failed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,12 @@ jobs:
           if [[ $commit_message == *"sn_fault_detection"* ]]; then
             ./resources/scripts/publish_crate_with_retries.sh "sn_fault_detection"
           fi
+      - name: publish sn_comms
+        run: |
+          commit_message="${{ github.event.head_commit.message }}"
+          if [[ $commit_message == *"sn_comms"* ]]; then
+            ./resources/scripts/publish_crate_with_retries.sh "sn_comms"
+          fi
       - name: publish sn_node
         run: |
           commit_message="${{ github.event.head_commit.message }}"

--- a/.github/workflows/run_pr_checks.yml
+++ b/.github/workflows/run_pr_checks.yml
@@ -51,6 +51,34 @@ jobs:
       - name: Run cargo-udeps
         run: cargo +nightly udeps --all-targets
 
+  build-arm:
+    name: build arm
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: arm-unknown-linux-musleabi
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - shell: bash
+        run: make gha-build-${{ matrix.target }}
+      - uses: actions/upload-artifact@main
+        with:
+          name: safe_network-${{ matrix.target }}
+          path: |
+            artifacts
+            !artifacts/.cargo-lock
 
   checks:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"

--- a/.github/workflows/run_pr_checks.yml
+++ b/.github/workflows/run_pr_checks.yml
@@ -51,35 +51,6 @@ jobs:
       - name: Run cargo-udeps
         run: cargo +nightly udeps --all-targets
 
-  build-arm:
-    name: build arm
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: arm-unknown-linux-musleabi
-          - os: ubuntu-latest
-            target: armv7-unknown-linux-musleabihf
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        id: toolchain
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - shell: bash
-        run: make gha-build-${{ matrix.target }}
-      - uses: actions/upload-artifact@main
-        with:
-          name: safe_network-${{ matrix.target }}
-          path: |
-            artifacts
-            !artifacts/.cargo-lock
-
   checks:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Various checks

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -41,8 +41,14 @@ jobs:
           github_token: ${{ secrets.VERSION_BUMP_COMMIT_PAT }}
           branch: main
           tags: true
-      - name: Upload event file
-        uses: actions/upload-artifact@main
-        with:
-          name: event-file
-          path: ${{ github.event_path }}
+  notify-if-failure:
+    name: send slack notification on failure
+    if: ${{ failure() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: post notification to slack on failure
+        uses: bryannice/gitactions-slack-notification@2.0.0
+        env:
+          SLACK_INCOMING_WEBHOOK: ${{ secrets.SLACK_GH_ACTIONS_WEBHOOK_URL }}
+          SLACK_MESSAGE: "Please check the logs for the run at ${{ env.WORKFLOW_URL }}/${{ github.run_id }}"
+          SLACK_TITLE: "Version Bumping Failed"

--- a/resources/scripts/bump_version.sh
+++ b/resources/scripts/bump_version.sh
@@ -4,12 +4,14 @@ dry_run_output=""
 commit_message=""
 sn_fault_detection_version=""
 sn_interface_version=""
+sn_comms_version=""
 sn_client_version=""
 sn_node_version=""
 sn_api_version=""
 sn_cli_version=""
 sn_fault_detection_has_changes="false"
 sn_interface_has_changes="false"
+sn_comms_has_changes="false"
 sn_client_has_changes="false"
 sn_node_has_changes="false"
 sn_api_has_changes="false"
@@ -24,7 +26,7 @@ function perform_smart_release_dry_run() {
     --no-changelog-preview \
     --allow-fully-generated-changelogs \
     --no-changelog-github-release \
-    "sn_fault_detection" "sn_interface" "sn_node" "sn_client" "sn_api" "sn_cli" 2>&1)
+    "sn_fault_detection" "sn_interface" "sn_comms" "sn_node" "sn_client" "sn_api" "sn_cli" 2>&1)
   echo "Dry run output for smart-release:"
   echo $dry_run_output
 }
@@ -53,6 +55,12 @@ function determine_which_crates_have_changes() {
     sn_interface_has_changes="true"
   fi
 
+  has_changes=$(crate_has_changes "sn_comms")
+  if [[ $has_changes == "true" ]]; then
+    echo "smart-release has determined sn_comms crate has changes"
+    sn_comms_has_changes="true"
+  fi
+
   has_changes=$(crate_has_changes "sn_node")
   if [[ $has_changes == "true" ]]; then
     echo "smart-release has determined sn_node crate has changes"
@@ -79,6 +87,7 @@ function determine_which_crates_have_changes() {
 
   if [[ $sn_fault_detection_has_changes == "false" ]] && \
      [[ $sn_interface_has_changes == "false" ]] && \
+     [[ $sn_comms_has_changes == "false" ]] && \
      [[ $sn_client_has_changes == "false" ]] && \
      [[ $sn_node_has_changes == "false" ]] && \
      [[ $sn_api_has_changes == "false" ]] && \
@@ -98,7 +107,7 @@ function generate_version_bump_commit() {
     --allow-fully-generated-changelogs \
     --no-changelog-github-release \
     --execute \
-    "sn_fault_detection" "sn_interface" "sn_node" "sn_client" "sn_api" "sn_cli"
+    "sn_fault_detection" "sn_interface" "sn_comms" "sn_node" "sn_client" "sn_api" "sn_cli"
   exit_code=$?
   if [[ $exit_code -ne 0 ]]; then
     echo "smart-release did not run successfully. Exiting with failure code."
@@ -111,6 +120,7 @@ function generate_new_commit_message() {
     grep "^version" < sn_interface/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
   sn_fault_detection_version=$( \
     grep "^version" < sn_fault_detection/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+  sn_comms_version=$(grep "^version" < sn_comms/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
   sn_client_version=$(grep "^version" < sn_client/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
   sn_node_version=$(grep "^version" < sn_node/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
   sn_api_version=$(grep "^version" < sn_api/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
@@ -122,6 +132,9 @@ function generate_new_commit_message() {
   fi
   if [[ $sn_fault_detection_has_changes == "true" ]]; then
     commit_message="${commit_message}sn_fault_detection-${sn_fault_detection_version}/"
+  fi
+  if [[ $sn_comms_has_changes == "true" ]]; then
+    commit_message="${commit_message}sn_comms-${sn_comms_version}/"
   fi
   if [[ $sn_client_has_changes == "true" ]]; then
     commit_message="${commit_message}sn_client-${sn_client_version}/"
@@ -152,6 +165,7 @@ function amend_tags() {
   if [[ $sn_fault_detection_has_changes == "true" ]]; then
     git tag "sn_fault_detection-v${sn_fault_detection_version}" -f
   fi
+  if [[ $sn_comms_has_changes == "true" ]]; then git tag "sn_comms-v${sn_comms_version}" -f; fi
   if [[ $sn_client_has_changes == "true" ]]; then git tag "sn_client-v${sn_client_version}" -f; fi
   if [[ $sn_node_has_changes == "true" ]]; then git tag "sn_node-v${sn_node_version}" -f; fi
   if [[ $sn_api_has_changes == "true" ]]; then git tag "sn_api-v${sn_api_version}" -f; fi

--- a/resources/scripts/get_release_description.sh
+++ b/resources/scripts/get_release_description.sh
@@ -4,6 +4,8 @@ sn_fault_detection_version=$( \
   grep "^version" < sn_fault_detection/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
 sn_interface_version=$( \
   grep "^version" < sn_interface/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+sn_comms_version=$( \
+  grep "^version" < sn_comms/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
 sn_client_version=$( \
   grep "^version" < sn_client/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
 sn_node_version=$(grep "^version" < sn_node/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
@@ -13,8 +15,9 @@ sn_cli_version=$(grep "^version" < sn_cli/Cargo.toml | head -n 1 | awk '{ print 
 # The single quotes around EOF is to stop attempted variable and backtick expansion.
 read -r -d '' release_description << 'EOF'
 This release of Safe Network consists of:
-* Safe Node Fault Detection v__sn_fault_detection_VERSION__
+* Safe Node Fault Detection v__SN_FAULT_DETECTION_VERSION__
 * Safe Network Interface v__SN_INTERFACE_VERSION__
+* Safe Node Comms v__SN_COMMS_VERSION__
 * Safe Client v__SN_CLIENT_VERSION__
 * Safe Node v__SN_NODE_VERSION__
 * Safe API v__SN_API_VERSION__
@@ -26,7 +29,11 @@ __SN_INTERFACE_CHANGELOG_TEXT__
 
 ## Safe Node Fault Detection Changelog
 
-__sn_fault_detection_CHANGELOG_TEXT__
+__SN_FAULT_DETECTION_CHANGELOG_TEXT__
+
+## Safe Node Comms Changelog
+
+__SN_COMMS_CHANGELOG_TEXT__
 
 ## Safe Node Changelog
 
@@ -173,8 +180,9 @@ sn_cli_tar_aarch64_checksum=$(sha256sum \
     "./deploy/prod/safe/sn_cli-$sn_cli_version-aarch64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 
-release_description=$(sed "s/__sn_fault_detection_VERSION__/$sn_fault_detection_version/g" <<< "$release_description")
+release_description=$(sed "s/__SN_FAULT_DETECTION_VERSION__/$sn_fault_detection_version/g" <<< "$release_description")
 release_description=$(sed "s/__SN_INTERFACE_VERSION__/$sn_interface_version/g" <<< "$release_description")
+release_description=$(sed "s/__SN_COMMS_CHANGELOG_TEXT__/$sn_comms_version/g" <<< "$release_description")
 release_description=$(sed "s/__SN_CLIENT_VERSION__/$sn_client_version/g" <<< "$release_description")
 release_description=$(sed "s/__SN_NODE_VERSION__/$sn_node_version/g" <<< "$release_description")
 release_description=$(sed "s/__SN_API_VERSION__/$sn_api_version/g" <<< "$release_description")

--- a/resources/scripts/insert_changelog_entry.py
+++ b/resources/scripts/insert_changelog_entry.py
@@ -31,6 +31,7 @@ def insert_changelog_entry(entry, pattern):
 def main(
         sn_interface_version,
         sn_fault_detection_version,
+        sn_comms_version,
         sn_client_version,
         sn_node_version,
         sn_api_version,
@@ -38,9 +39,12 @@ def main(
     if sn_interface_version:
         sn_node_changelog_entry = get_changelog_entry("sn_interface/CHANGELOG.md", sn_interface_version)
         insert_changelog_entry(sn_node_changelog_entry, "__SN_INTERFACE_CHANGELOG_TEXT__")
+    if sn_comms_version:
+        sn_node_changelog_entry = get_changelog_entry("sn_comms/CHANGELOG.md", sn_comms_version)
+        insert_changelog_entry(sn_node_changelog_entry, "__SN_COMMS_CHANGELOG_TEXT__")
     if sn_fault_detection_version:
         sn_node_changelog_entry = get_changelog_entry("sn_fault_detection/CHANGELOG.md", sn_fault_detection_version)
-        insert_changelog_entry(sn_node_changelog_entry, "__sn_fault_detection_CHANGELOG_TEXT__")
+        insert_changelog_entry(sn_node_changelog_entry, "__SN_FAULT_DETECTION_CHANGELOG_TEXT__")
     if sn_client_version:
         sn_client_changelog_entry = get_changelog_entry("sn_client/CHANGELOG.md", sn_client_version)
         insert_changelog_entry(sn_client_changelog_entry, "__SN_CLIENT_CHANGELOG_TEXT__")
@@ -57,6 +61,7 @@ def main(
 if __name__ == "__main__":
     sn_interface_version = get_crate_version("sn_interface")
     sn_fault_detection_version = get_crate_version("sn_fault_detection")
+    sn_comms_version = get_crate_version("sn_comms")
     sn_client_version = get_crate_version("sn_client")
     sn_node_version = get_crate_version("sn_node")
     sn_api_version = get_crate_version("sn_api")
@@ -64,6 +69,7 @@ if __name__ == "__main__":
     main(
         sn_interface_version,
         sn_fault_detection_version,
+        sn_comms_version,
         sn_client_version,
         sn_node_version,
         sn_api_version,

--- a/resources/scripts/output_versioning_info.sh
+++ b/resources/scripts/output_versioning_info.sh
@@ -2,6 +2,7 @@
 
 sn_fault_detection_version=""
 sn_interface_version=""
+sn_comms_version=""
 sn_client_version=""
 sn_node_version=""
 sn_api_version=""
@@ -12,6 +13,8 @@ function get_crate_versions() {
     grep "^version" < sn_fault_detection/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
   sn_interface_version=$( \
     grep "^version" < sn_interface/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+  sn_comms_version=$( \
+    grep "^version" < sn_comms/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
   sn_client_version=$( \
     grep "^version" < sn_client/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
   sn_node_version=$(grep "^version" < sn_node/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
@@ -22,6 +25,7 @@ function get_crate_versions() {
 function build_release_name() {
   gh_release_name="Safe Network v$sn_fault_detection_version/"
   gh_release_name="${gh_release_name}v$sn_interface_version/"
+  gh_release_name="${gh_release_name}v$sn_comms_version/"
   gh_release_name="${gh_release_name}v$sn_client_version/"
   gh_release_name="${gh_release_name}v$sn_node_version/"
   gh_release_name="${gh_release_name}v$sn_api_version/"
@@ -31,6 +35,7 @@ function build_release_name() {
 function build_release_tag_name() {
   gh_release_tag_name="$sn_interface_version-"
   gh_release_tag_name="${gh_release_tag_name}$sn_fault_detection_version-"
+  gh_release_tag_name="${gh_release_tag_name}$sn_comms_version-"
   gh_release_tag_name="${gh_release_tag_name}$sn_client_version-"
   gh_release_tag_name="${gh_release_tag_name}$sn_node_version-"
   gh_release_tag_name="${gh_release_tag_name}$sn_api_version-"
@@ -40,6 +45,7 @@ function build_release_tag_name() {
 function output_version_info() {
   echo "::set-output name=sn_fault_detection_version::$sn_fault_detection_version"
   echo "::set-output name=sn_interface_version::$sn_interface_version"
+  echo "::set-output name=sn_comms_version::$sn_comms_version"
   echo "::set-output name=sn_client_version::$sn_client_version"
   echo "::set-output name=sn_node_version::$sn_node_version"
   echo "::set-output name=sn_api_version::$sn_api_version"


### PR DESCRIPTION
- 2badf68d6 **ci: add arm builds to merge workflow**

  We seen a failure on a release because an ARM build failed. The failure occurred because the `cross`
  utility (which we use for cross compilation) wouldn't build correctly. Strangely, I wasn't able to
  reproduce this problem, but I think it highlights the need for building on ARM before we merge. If
  we are going to release on every merge, we will need to check that we can build on ARM.
  
- bfc96acdc **ci: slack notifications for workflow failures**

  We didn't become aware of our latest release workflow failure for weeks after the event, so I've
  enabled notifications for failures of either the version bumping or release workflows.
  
- d14f34bde **ci: add sn_comms crate to the release process**

  This new crate is added to all the necessary mechanisms for the release process.  