### PR TITLE
ci: allow bors staging/trying to run concurrently

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -7,8 +7,12 @@ on:
 
 # this should prevent bors merge run, and main release/commits from running concurrently
 #(as long as both are sporting this check)
+# ${GITHUB_REF##*/} here should result in "staging" or "trying", we'll only want "staging"
+# to prevent runs here or in main, so we hard-set that there.
+# This should also mean that staging/trying branch runs do not conflict (and so `bors try`
+# is no longer blocked by `bors r+`)
 concurrency:
-  group: "main-modifying-workflow"
+  group: "main-${GITHUB_REF##*/}-workflow"
 
 env:
   CARGO_INCREMENTAL: 0  # bookkeeping for incremental builds has overhead, not useful in CI.

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -2,8 +2,11 @@ name: Version Bump
 
 # this should prevent bors merge run, and main release/commits from running concurrently
 #(as long as both are sporting this check)
+# this group name is referencing the bors "staging" branch, whose name we use in merge.yml
+# this means that we should _not_ run this flow if a bors/staging flow is underway
+# (but we can run if a `bors try` is underway)
 concurrency:
-  group: "main-modifying-workflow"
+  group: "main-staging-workflow"
 
 on:
   push:


### PR DESCRIPTION
but still prevent versin bumps + bors r+ runs

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
