### PR TITLE
fix: provide link to workflow run on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
+
 jobs:
   build:
     if: |

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - main
 
+env:
+  WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs
+
 jobs:
   bump_version:
     if: |


### PR DESCRIPTION
It looks like Github have removed `WORKFLOW_URL` as a pre-defined variable.
