### PR TITLE
refactor(comms): removing Comm::members and unnecessary private types

### DIFF
--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -313,7 +313,7 @@ impl MyNode {
 
         debug!("[NODE READ] Latest context read");
         // mut here to update comms
-        let mut latest_context = node.read().await.context();
+        let latest_context = node.read().await.context();
         debug!("[NODE READ] Latest context got.");
 
         // Only trigger reorganize data when there is a membership change happens.

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -211,7 +211,7 @@ mod core {
 
         #[allow(clippy::too_many_arguments)]
         pub(crate) async fn new(
-            mut comm: Comm,
+            comm: Comm,
             keypair: Arc<Keypair>, //todo: Keypair, only test design blocks this
             network_knowledge: NetworkKnowledge,
             section_key_share: Option<SectionKeyShare>,


### PR DESCRIPTION
- We now use Comm::sessions as the list of members we keep sessions with, which is updated only when the user wants to update the set of known peers.
- Removing unnecessary PeerSession's SessionStatus, disconnect fn, and SessionCmd.
- Never remove sessions from Comm::sessions unless the set of known members is updated/changed by the user. Even if we failed to send using all peer session's connections, we keep the session since it's been set as a known and connectable peer.