### PR TITLE
feat(relocation): add retry for relocating node

### DIFF
--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -43,6 +43,7 @@ pub enum JoinResponse {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum JoinRejectReason {
     /// No new peers are currently accepted for joining
+    /// NB: Relocated nodes that try to join, are accepted even if joins are disallowed.
     JoinsDisallowed,
     /// The requesting node is not externally reachable
     NodeNotReachable(SocketAddr),

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -40,9 +40,11 @@ use tokio::sync::{mpsc, RwLock};
 use xor_name::XorName;
 
 /// Sent via the rejoin_network_tx to restart the join process.
+/// This would only occur when joins are not allowed, or non-recoverable states.
 #[derive(Debug)]
 pub enum RejoinReason {
     /// Happens when trying to join; we will wait a moment and then try again.
+    /// NB: Relocated nodes that try to join, are accepted even if joins are disallowed.
     JoinsDisallowed,
     /// Happens when already part of the network; we need to start from scratch.
     RemovedFromSection,

--- a/sn_node/src/node/messaging/joining_nodes.rs
+++ b/sn_node/src/node/messaging/joining_nodes.rs
@@ -63,6 +63,7 @@ impl MyNode {
             // Verify the age..
             MyNode::verify_relocated_age(&peer, &proof)?;
 
+            // NB: Relocated nodes that try to join, are accepted even if joins are disallowed.
             Some(proof.previous_name())
         } else {
             // New node ->

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -280,6 +280,8 @@ impl MyNode {
                             .filter(|n| n.name() == context.name)
                             .any(|n| n.previous_name().is_some())
                         {
+                            // We could clear the cached relocation proof here,
+                            // but we have the periodic check doing it, so no need to duplicate the logic.
                             trace!("{}", LogMarker::RelocateEnd);
                         }
 

--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -117,13 +117,10 @@ impl MyNode {
             original_info.name(),
         );
 
-        Ok(MyNode::try_join_section(
-            self.context(),
-            Some(RelocationProof::new(
-                info,
-                node_sig,
-                original_info.keypair.public,
-            )),
-        ))
+        let proof = RelocationProof::new(info, node_sig, original_info.keypair.public);
+        // we cache the proof so that we can retry if the join times out
+        self.relocation_proof = Some(proof.clone());
+
+        Ok(MyNode::try_join_section(self.context(), Some(proof)))
     }
 }

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -70,8 +70,8 @@ mod core {
             AuthorityProof, SectionSig,
         },
         network_knowledge::{
-            supermajority, MyNodeInfo, NetworkKnowledge, NodeState, SectionAuthorityProvider,
-            SectionKeyShare, SectionKeysProvider,
+            supermajority, MyNodeInfo, NetworkKnowledge, NodeState, RelocationProof,
+            SectionAuthorityProvider, SectionKeyShare, SectionKeysProvider,
         },
         types::{keys::ed25519::Digest256, log_markers::LogMarker},
     };
@@ -121,6 +121,7 @@ mod core {
         pub(crate) fault_cmds_sender: mpsc::Sender<FaultsCmd>,
         // Section administration
         pub(crate) section_proposal_aggregator: SignatureAggregator,
+        pub(crate) relocation_proof: Option<RelocationProof>,
     }
 
     #[derive(custom_debug::Debug, Clone)]
@@ -139,6 +140,7 @@ mod core {
         pub(crate) joins_allowed_until_split: bool,
         #[debug(skip)]
         pub(crate) fault_cmds_sender: mpsc::Sender<FaultsCmd>,
+        pub(crate) relocation_proof: Option<RelocationProof>,
     }
 
     impl NodeContext {
@@ -203,6 +205,7 @@ mod core {
                 joins_allowed_until_split: self.joins_allowed_until_split,
                 data_storage: self.data_storage.clone(),
                 fault_cmds_sender: self.fault_cmds_sender.clone(),
+                relocation_proof: self.relocation_proof.clone(),
             }
         }
 
@@ -275,6 +278,7 @@ mod core {
                 elder_promotion_aggregator: SignatureAggregator::default(),
                 handover_request_aggregator: TotalParticipationAggregator::default(),
                 section_proposal_aggregator: SignatureAggregator::default(),
+                relocation_proof: None,
             };
 
             let context = &node.context();


### PR DESCRIPTION
When a node is joining with a relocation proof, they could be rejected by one reason only: `AddressNotReachable`. This is because the other reject reason, `JoinsDisallowed`, does not apply to relocated nodes, making this state `unreachable`.

Address not reachable is an irrecoverable error, and therefore a node has to change their port configuration before starting a node again. However, this specific issue should be validated long before a relocation, by which this state is also considered `unreachable`.

Beyond those, and tampered proofs, it's just regular timeouts. 

So this feature allows a joining node with a relocation proof, to retry when the join times out.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
