### PR TITLE
fix(comms): send_out_bytes was not reporting send failures

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -183,6 +183,10 @@ jobs:
           RUST_LOG: sn_fault_detection
         run: cd sn_fault_detection && cargo test --release
 
+      - name: Run sn_comms tests
+        timeout-minutes: 10
+        run: cargo test --release -p sn_comms
+
       - name: Build sn_node tests before running
         run: cd sn_node && cargo test --no-run --release
         timeout-minutes: 50

--- a/.github/workflows/run_pr_checks.yml
+++ b/.github/workflows/run_pr_checks.yml
@@ -121,6 +121,10 @@ jobs:
         timeout-minutes: 15
         run: cd sn_fault_detection && cargo test --release
 
+      - name: Run sn_comms tests
+        timeout-minutes: 10
+        run: cargo test --release -p sn_comms
+
       - name: Build sn_node tests before running
         run: cd sn_node && cargo test --no-run --release
         timeout-minutes: 50

--- a/sn_comms/src/peer_session.rs
+++ b/sn_comms/src/peer_session.rs
@@ -44,7 +44,7 @@ impl PeerSession {
         }
     }
 
-    /// Sends out a UsrMsg on a bidi connection and awaits response bytes
+    /// Sends out a UsrMsg on a bidi connection and awaits response bytes.
     /// As such this may be long running if response is returned slowly.
     /// This manages retries over bidi connection attempts
     pub(crate) async fn send_with_bi_return_response(
@@ -63,11 +63,7 @@ impl PeerSession {
     }
 
     #[instrument(skip(self, bytes))]
-    pub(crate) async fn send_using_session(
-        &self,
-        msg_id: MsgId,
-        bytes: UsrMsgBytes,
-    ) -> Result<SendWatcher> {
+    pub(crate) async fn send(&self, msg_id: MsgId, bytes: UsrMsgBytes) -> Result<SendWatcher> {
         let (watcher, reporter) = status_watching();
 
         let job = SendJob {

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -246,11 +246,10 @@ impl Dispatcher {
                         continue;
                     }
                 }
-                context
-                    .comm
-                    .send_out_bytes_sync(peer, msg_id, msg_bytes)
-                    .await;
-                info!("Sent {msg} to {}", peer.name());
+
+                if let Err(err) = context.comm.send_out_bytes(peer, msg_id, msg_bytes).await {
+                    info!("Failed to send {msg} to {}: {err:?}", peer.name());
+                }
             }
         } else {
             panic!("mock_send_msg expects Cmd::SendMsg, got {cmd:?}");


### PR DESCRIPTION
- `sn_comms::Comm::send_out_bytes` was spawning a task when sending a msg, now it's the caller's duty to do so if required.
- Run sn_comms unit tests in CI/Bors.