### PR TITLE
feat(dkg): try trigger when split or elders needed

### DIFF
--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -85,6 +85,13 @@ pub fn recommended_section_size() -> usize {
     2 * elder_count()
 }
 
+/// The section will keep adding nodes when requested by the upper layers, until it can split.
+/// A split happens at earliest after this threshold is passed, if both post-split sections would
+/// have `recommended_section_size` number of nodes.
+pub fn split_threshold() -> usize {
+    2 * recommended_section_size()
+}
+
 /// `SuperMajority` of a given group (i.e. > 2/3)
 #[inline]
 pub const fn supermajority(group_size: usize) -> usize {


### PR DESCRIPTION
Only when not enough elders, or enough members to split, do we try to trigger dkg.
This is one more step towards something `stable set`-ish.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
