### PR TITLE
fix(storage): make data exists not be an error

### DIFF
--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -41,9 +41,6 @@ pub enum Error {
         /// Actual number of Adults found to hold the data.
         found: u8,
     },
-    /// Provided data already exists on the network
-    #[error("Data provided already exists: {0:?}")]
-    DataExists(DataAddress),
     /// Entry could not be found on the data
     #[error("Requested entry not found {0}")]
     NoSuchEntry(EntryHash),

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -14,7 +14,6 @@ use sn_dbc::Error as DbcError;
 use sn_interface::{
     dbcs::Error as GenesisError,
     messaging::{data::Error as ErrorMsg, system::DkgSessionId},
-    types::DataAddress,
 };
 
 use ed25519::Signature;
@@ -128,9 +127,6 @@ pub enum Error {
     /// We don't have a dkg state for this dkg session id
     #[error("No dkg state for session: {0:?}")]
     NoDkgStateForSession(DkgSessionId),
-    /// Chunk already exists for this node
-    #[error("Data already exists at this node: {0:?}")]
-    DataExists(DataAddress),
     /// I/O error.
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
@@ -232,7 +228,6 @@ impl From<Error> for ErrorMsg {
                 expected,
                 found,
             },
-            Error::DataExists(address) => ErrorMsg::DataExists(address),
             Error::SpentProofUnknownSectionKey(unknown_section_key) => {
                 ErrorMsg::SpentProofUnknownSectionKey(unknown_section_key)
             }

--- a/sn_node/src/storage/chunks.rs
+++ b/sn_node/src/storage/chunks.rs
@@ -10,7 +10,7 @@ use super::{list_files_in, prefix_tree_path, used_space::StorageLevel, Error, Re
 
 use sn_interface::{
     messaging::system::NodeQueryResponse,
-    types::{log_markers::LogMarker, Chunk, ChunkAddress, DataAddress},
+    types::{log_markers::LogMarker, Chunk, ChunkAddress},
 };
 
 use bytes::Bytes;
@@ -127,7 +127,7 @@ impl ChunkStorage {
                 self, addr
             );
             // Nothing more to do here
-            return Err(Error::DataExists(DataAddress::Bytes(*addr)));
+            return Ok(StorageLevel::NoChange);
         }
 
         // Cheap extra security check for space (prone to race conditions)

--- a/sn_node/src/storage/errors.rs
+++ b/sn_node/src/storage/errors.rs
@@ -32,9 +32,6 @@ pub enum Error {
     /// Chunk not found.
     #[error("Chunk not found: {0:?}")]
     ChunkNotFound(XorName),
-    /// Data already exists for this node
-    #[error("Data already exists at this node: {0:?}")]
-    DataExists(DataAddress),
     /// Storage not supported for type of data address
     #[error("Storage not supported for type of data address: {0:?}")]
     UnsupportedDataType(DataAddress),
@@ -83,7 +80,6 @@ impl From<Error> for ErrorMsg {
             Error::ChunkNotFound(xorname) => {
                 ErrorMsg::DataNotFound(DataAddress::Bytes(ChunkAddress(xorname)))
             }
-            Error::DataExists(address) => ErrorMsg::DataExists(address),
             Error::NetworkData(error) => error.into(),
             other => ErrorMsg::InvalidOperation(format!("Failed to perform operation: {other:?}")),
         }


### PR DESCRIPTION
- The data storage is idempotent, and it's not an error that data already exists.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
