### PR TITLE
refactor(comms): remove use of dashmap

### DIFF
--- a/sn_comms/Cargo.toml
+++ b/sn_comms/Cargo.toml
@@ -17,12 +17,13 @@ test = []
 [dependencies]
 custom_debug = "~0.5.0"
 dashmap = {version = "5.1.0", features = [ "serde" ]}
-tokio = { version = "1.0.23", features = [ "sync" ] }
-tracing = "~0.1.26"
-xor_name = "~5.0.0"
+futures = "~0.3.13"
 qp2p = "~0.35.0"
 sn_interface = { path = "../sn_interface", version = "^0.17.4" }
 thiserror = "1.0.23"
+tokio = { version = "1.0.23", features = [ "sync" ] }
+tracing = "~0.1.26"
+xor_name = "~5.0.0"
 
 [dev-dependencies]
 eyre = "~0.6.5"

--- a/sn_comms/src/error.rs
+++ b/sn_comms/src/error.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_interface::types::Peer;
+use sn_interface::messaging::MsgId;
 use thiserror::Error;
 
 /// The type returned by the `sn_routing` message handling methods.
@@ -17,16 +17,16 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[allow(missing_docs)]
 pub enum Error {
     /// Any unknown node comms should be bidi, initiated by the other side
-    #[error("Attempted to create a connection to an unknown node: {0:?}")]
-    CreatingConnectionToUnknownNode(Peer),
+    #[error("Attempted to create a connection for msg {0:?} to unknown node.")]
+    ConnectingToUnknownNode(MsgId),
     #[error("Cannot connect to the endpoint: {0}")]
     CannotConnectEndpoint(#[from] qp2p::EndpointError),
     #[error("Address not reachable: {0}")]
     AddressNotReachable(#[from] qp2p::RpcError),
-    #[error("Content of a received message is inconsistent.")]
-    InvalidMessage,
-    #[error("Failed to send a message to {0}")]
-    FailedSend(Peer),
+    #[error("Content of received msg {0:?} is invalid.")]
+    InvalidMsgReceived(MsgId),
+    #[error("Failed to send msg {0:?}")]
+    FailedSend(MsgId),
 }
 
 impl From<qp2p::SendError> for Error {

--- a/sn_comms/src/lib.rs
+++ b/sn_comms/src/lib.rs
@@ -50,21 +50,67 @@ mod peer_session;
 
 pub use self::error::{Error, Result};
 
-use self::{listener::MsgListener, peer_session::PeerSession};
+use self::peer_session::PeerSession;
 
 use sn_interface::{
-    messaging::{MsgId, WireMsg},
+    messaging::{
+        data::ClientDataResponse as ClientResponse, system::NodeMsgType, Dst, MsgId, MsgKind,
+        MsgType, WireMsg,
+    },
     types::Peer,
 };
 
 use qp2p::{Endpoint, SendStream, UsrMsgBytes};
 
-use dashmap::DashMap;
-use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
-use tokio::sync::mpsc::Sender;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::SocketAddr,
+};
+use tokio::{
+    sync::mpsc::{self, Receiver, Sender},
+    task,
+};
 
 /// Standard channel size, to allow for large swings in throughput
 static STANDARD_CHANNEL_SIZE: usize = 100_000;
+
+/// Events from the comm module.
+#[derive(Debug)]
+pub enum CommEvent {
+    /// A msg was received.
+    Msg(MsgFromPeer),
+    /// A send error occurred.
+    Error {
+        /// The sender/recipient that failed.
+        peer: Peer,
+        /// The failure type.
+        error: Error,
+    },
+}
+
+/// Internal comm cmds.
+#[derive(custom_debug::Debug)]
+enum CommCmd {
+    Send {
+        msg_id: MsgId,
+        peer: Peer,
+        #[debug(skip)]
+        bytes: UsrMsgBytes,
+    },
+    SetTargets(BTreeSet<Peer>),
+    SendWithBiResponse {
+        peer: Peer,
+        msg_id: MsgId,
+        bytes: UsrMsgBytes,
+    },
+    SendAndRespondOnStream {
+        msg_id: MsgId,
+        msg_type: NodeMsgType,
+        #[debug(skip)]
+        node_bytes: BTreeMap<Peer, UsrMsgBytes>,
+        dst_stream: (Dst, SendStream),
+    },
+}
 
 /// A msg received on the wire.
 #[derive(Debug)]
@@ -79,30 +125,42 @@ pub struct MsgFromPeer {
 }
 
 /// Communication component of the node to interact with other nodes.
-#[allow(missing_debug_implementations)]
-#[derive(Clone)]
+///
+/// Any failed sends are tracked via `CommEvent::Error`, which will track issues for any peers
+/// in the section (otherwise ignoring failed send to out of section nodes or clients).
+#[derive(Clone, Debug)]
 pub struct Comm {
     our_endpoint: Endpoint,
-    sessions: Arc<DashMap<Peer, PeerSession>>,
+    cmd_sender: Sender<CommCmd>,
 }
 
 impl Comm {
     /// Creates a new instance of Comm with an endpoint
     /// and starts listening to the incoming messages from other nodes.
     #[tracing::instrument(skip_all)]
-    pub fn new(local_addr: SocketAddr, incoming_msg_pipe: Sender<MsgFromPeer>) -> Result<Self> {
-        let (our_endpoint, incoming_connections) = Endpoint::builder()
+    pub fn new(local_addr: SocketAddr) -> Result<(Self, Receiver<CommEvent>)> {
+        let (our_endpoint, incoming_conns) = Endpoint::builder()
             .addr(local_addr)
             .idle_timeout(70_000)
             .server()?;
 
-        let msg_listener = MsgListener::new(incoming_msg_pipe);
-        msg_listener.listen_for_incoming_msgs(incoming_connections);
+        trace!("Creating comms..");
+        // comm_events_receiver will be used by upper layer to receive all msgs comming in from the network
+        let (comm_events_sender, comm_events_receiver) = mpsc::channel(STANDARD_CHANNEL_SIZE);
+        let (cmd_sender, cmd_receiver) = mpsc::channel(STANDARD_CHANNEL_SIZE);
 
-        Ok(Self {
-            our_endpoint,
-            sessions: Arc::new(DashMap::new()),
-        })
+        // listen for msgs/connections to our endpoint
+        listener::listen_for_connections(comm_events_sender.clone(), incoming_conns);
+
+        process_cmds(our_endpoint.clone(), cmd_receiver, comm_events_sender);
+
+        Ok((
+            Self {
+                our_endpoint,
+                cmd_sender,
+            },
+            comm_events_receiver,
+        ))
     }
 
     /// The socket address of our endpoint.
@@ -120,85 +178,372 @@ impl Comm {
         // We only remove sessions by calling this function,
         // No removals are made even if we failed to send using all peer session's connections,
         // as it's our source of truth for known and connectable peers.
-
-        // Drops sessions that not among the targets.
-        self.sessions.retain(|p, _| targets.contains(p));
-
-        // Adds new sessions for each new target.
-        targets.iter().for_each(|peer| {
-            if self.sessions.get(peer).is_none() {
-                let session = PeerSession::new(*peer, self.our_endpoint.clone());
-                let _ = self.sessions.insert(*peer, session);
-            }
-        });
+        let sender = self.cmd_sender.clone();
+        let _handle = task::spawn(async move { sender.send(CommCmd::SetTargets(targets)).await });
     }
 
     /// Sends the payload on a new or existing connection.
     #[tracing::instrument(skip(self, bytes))]
-    pub async fn send_out_bytes(
-        &self,
-        peer: Peer,
-        msg_id: MsgId,
-        bytes: UsrMsgBytes,
-    ) -> Result<()> {
-        let (h, d, p) = &bytes;
-        let bytes_len = h.len() + d.len() + p.len();
-        trace!("Sending message bytes ({bytes_len} bytes) w/ {msg_id:?} to {peer:?}");
-
-        let peer_session = self.get_session(&peer)?;
-        debug!("Peer session retrieved: {peer:?}");
-
-        let sessions = self.sessions.clone();
-        trace!("Sessions known of: {:?}", sessions.len());
-
-        match peer_session.send(msg_id, bytes).await {
-            Ok(()) => {
-                trace!("Msg {msg_id:?} sent to {peer:?}");
-                Ok(())
-            }
-            Err(error) => {
-                error!("Sending message (msg_id: {msg_id:?}) to {peer:?} failed: {error}");
-                Err(Error::FailedSend(peer))
-            }
-        }
+    pub fn send_out_bytes(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) {
+        let sender = self.cmd_sender.clone();
+        let _handle = task::spawn(async move {
+            sender
+                .send(CommCmd::Send {
+                    msg_id,
+                    peer,
+                    bytes,
+                })
+                .await
+        });
     }
 
     /// Sends the payload on a new bidi-stream and returns the response.
     #[tracing::instrument(skip(self, bytes))]
-    pub async fn send_out_bytes_to_peer_and_return_response(
+    pub fn send_with_bi_response(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) {
+        let sender = self.cmd_sender.clone();
+        let _handle = task::spawn(async move {
+            sender
+                .send(CommCmd::SendWithBiResponse {
+                    msg_id,
+                    peer,
+                    bytes,
+                })
+                .await
+        });
+    }
+
+    /// Sends the payload on a new bidi-stream and returns the response.
+    #[tracing::instrument(skip(node_bytes))]
+    pub fn send_and_respond_on_stream(
         &self,
-        peer: Peer,
         msg_id: MsgId,
-        bytes: UsrMsgBytes,
-    ) -> Result<WireMsg> {
-        // TODO: tweak messaging to just allow passthrough
-        debug!("Trying to get {peer:?} session in order to send: {msg_id:?}");
-
-        let mut session = self.get_session(&peer)?;
-        debug!("Session of {peer:?} retrieved for {msg_id:?}");
-        let adult_response_bytes = session
-            .send_with_bi_return_response(bytes, msg_id)
-            .await
-            .map_err(|err| {
-                error!("Failed sending {msg_id:?} to {peer:?}: {err:?}");
-                Error::FailedSend(peer)
-            })?;
-        debug!("Peer response from {peer:?} is in for {msg_id:?}");
-        WireMsg::from(adult_response_bytes).map_err(|_| Error::InvalidMessage)
+        msg_type: NodeMsgType,
+        node_bytes: BTreeMap<Peer, UsrMsgBytes>,
+        dst_stream: (Dst, SendStream),
+    ) {
+        let sender = self.cmd_sender.clone();
+        let _handle = task::spawn(async move {
+            sender
+                .send(CommCmd::SendAndRespondOnStream {
+                    msg_id,
+                    msg_type,
+                    node_bytes,
+                    dst_stream,
+                })
+                .await
+        });
     }
 
-    /// Get a PeerSession
-    #[instrument(skip(self))]
-    fn get_session(&self, peer: &Peer) -> Result<PeerSession> {
-        debug!("Attempting to get or create peer session to member: {peer:?}");
-        if let Some(entry) = self.sessions.get(peer) {
-            debug!("Session to {peer:?} exists");
-            Ok(entry.value().clone())
-        } else {
-            debug!("Did not attempt to connect to external peer: {peer:?}");
-            Err(Error::CreatingConnectionToUnknownNode(*peer))
+    // /// Sends the payload on a new bidi-stream and returns the response.
+    // #[tracing::instrument(skip(bytes))]
+    // pub async fn send_out_bytes_to_peer_and_return_response(
+    //     &self,
+    //     peer: Peer,
+    //     msg_id: MsgId,
+    //     bytes: UsrMsgBytes,
+    // ) -> Result<WireMsg> {
+    //     let sender = self.cmd_sender.clone();
+    //     let _ = task::spawn(async move {
+    //         sender
+    //             .send(CommCmd::SendAndRespondOnStream {
+    //                 msg_id,
+    //                 node_bytes: BTreeMap::from([(peer, bytes)]),
+    //                 client_stream,
+    //                 dst,
+    //             })
+    //             .await
+    //     });
+
+    //     unimplemented!();
+    // }
+}
+
+fn process_cmds(
+    our_endpoint: Endpoint,
+    mut update_receiver: Receiver<CommCmd>,
+    comm_events: Sender<CommEvent>,
+) {
+    let _handle = task::spawn(async move {
+        let mut sessions = BTreeMap::<Peer, PeerSession>::new();
+        // let sessions = Arc::new(DashMap::<Peer, PeerSession>::new());
+        while let Some(cmd) = update_receiver.recv().await {
+            trace!("Comms cmd handling: {cmd:?}");
+            match cmd {
+                // This is the only place that mutates `sessions`.
+                CommCmd::SetTargets(targets) => {
+                    // Drops sessions that not among the targets.
+                    sessions.retain(|p, _| targets.contains(p));
+                    // Adds new sessions for each new target.
+                    targets.iter().for_each(|peer| {
+                        if sessions.get(peer).is_none() {
+                            let session = PeerSession::new(*peer, our_endpoint.clone());
+                            let _ = sessions.insert(*peer, session);
+                        }
+                    });
+                }
+                CommCmd::Send {
+                    msg_id,
+                    peer,
+                    bytes,
+                } => {
+                    let session = match sessions.get(&peer) {
+                        Some(session) => session.clone(),
+                        None => {
+                            error!(
+                                "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
+                            );
+                            send_error(
+                                peer,
+                                Error::ConnectingToUnknownNode(msg_id),
+                                comm_events.clone(),
+                            );
+                            continue;
+                        }
+                    };
+                    send(msg_id, session, bytes, comm_events.clone());
+                }
+                CommCmd::SendWithBiResponse {
+                    peer,
+                    msg_id,
+                    bytes,
+                } => {
+                    // TODO: use `NODE_RESPONSE_TIMEOUT`
+                    let session = match sessions.get(&peer) {
+                        Some(session) => session.clone(),
+                        None => {
+                            error!(
+                                "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
+                            );
+                            send_error(
+                                peer,
+                                Error::ConnectingToUnknownNode(msg_id),
+                                comm_events.clone(),
+                            );
+                            continue;
+                        }
+                    };
+                    send_with_bi_response(msg_id, session, bytes, comm_events.clone());
+                }
+                CommCmd::SendAndRespondOnStream {
+                    msg_id,
+                    msg_type,
+                    node_bytes,
+                    dst_stream,
+                } => {
+                    let node_bytes = node_bytes
+                        .into_iter()
+                        .filter_map(|(peer, bytes)| {
+                            debug!("Trying to get {peer:?} session in order to send: {msg_id:?}", );
+                            match sessions.get(&peer) {
+                                Some(session) => Some((session.clone(), bytes)),
+                                None => {
+                                    error!(
+                                        "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
+                                    );
+                                    send_error(peer, Error::ConnectingToUnknownNode(msg_id), comm_events.clone());
+                                    None
+                                }
+                            }
+                        }).collect();
+                    send_and_respond_on_stream(
+                        msg_id,
+                        msg_type,
+                        node_bytes,
+                        dst_stream,
+                        comm_events.clone(),
+                    );
+                }
+            }
         }
-    }
+    });
+}
+
+fn send(msg_id: MsgId, session: PeerSession, bytes: UsrMsgBytes, comm_events: Sender<CommEvent>) {
+    let _handle = task::spawn(async move {
+        let (h, d, p) = &bytes;
+        let bytes_len = h.len() + d.len() + p.len();
+        let peer = session.peer();
+        trace!("Sending message bytes ({bytes_len} bytes) w/ {msg_id:?} to {peer:?}");
+        match session.send(msg_id, bytes).await {
+            Ok(()) => {
+                trace!("Msg {msg_id:?} sent to {peer:?}");
+            }
+            Err(error) => {
+                error!("Sending message (msg_id: {msg_id:?}) to {peer:?} failed: {error}");
+                send_error(peer, Error::FailedSend(msg_id), comm_events.clone());
+            }
+        }
+    });
+}
+
+fn send_with_bi_response(
+    msg_id: MsgId,
+    session: PeerSession,
+    bytes: UsrMsgBytes,
+    comm_events: Sender<CommEvent>,
+) {
+    let _handle = task::spawn(async move {
+        let (h, d, p) = &bytes;
+        let bytes_len = h.len() + d.len() + p.len();
+        let peer = session.peer();
+        trace!("Sending message bytes ({bytes_len} bytes) w/ {msg_id:?} to {peer:?}");
+        let node_response_bytes = match session.send_with_bi_return_response(bytes, msg_id).await {
+            Ok(response_bytes) => {
+                debug!("Peer response from {peer:?} is in for {msg_id:?}");
+                response_bytes
+            }
+            Err(error) => {
+                error!("Sending message (msg_id: {msg_id:?}) to {peer:?} failed: {error}");
+                send_error(peer, Error::FailedSend(msg_id), comm_events.clone());
+                return;
+            }
+        };
+        match WireMsg::from(node_response_bytes) {
+            Ok(wire_msg) => {
+                listener::msg_received(wire_msg, peer, None, comm_events.clone());
+            }
+            Err(error) => {
+                error!("Failed sending {msg_id:?} to {peer:?}: {error:?}");
+                send_error(peer, Error::InvalidMsgReceived(msg_id), comm_events.clone());
+            }
+        };
+    });
+}
+
+fn send_and_respond_on_stream(
+    msg_id: MsgId,
+    msg_type: NodeMsgType,
+    node_bytes: Vec<(PeerSession, UsrMsgBytes)>,
+    dst_stream: (Dst, SendStream),
+    comm_events: Sender<CommEvent>,
+) {
+    let _handle = task::spawn(async move {
+        // responses from those we send to
+        let mut all_received = vec![];
+
+        for (session, bytes) in node_bytes {
+            let peer = session.peer();
+            let node_response_bytes =
+                match session.send_with_bi_return_response(bytes, msg_id).await {
+                    Ok(response_bytes) => response_bytes,
+                    Err(error) => {
+                        error!("Failed sending {msg_id:?} to {peer:?}: {error:?}");
+                        send_error(peer, Error::FailedSend(msg_id), comm_events.clone());
+                        // continue with next node
+                        continue;
+                    }
+                };
+
+            debug!("Response from node {peer:?} is in for {msg_id:?}");
+
+            match WireMsg::from(node_response_bytes) {
+                Ok(received) => {
+                    match received.into_msg() {
+                        Ok(msg) => all_received.push((msg, peer)),
+                        Err(_error) => {
+                            send_error(
+                                peer,
+                                Error::InvalidMsgReceived(msg_id),
+                                comm_events.clone(),
+                            );
+                            // continue with next received msg
+                        }
+                    };
+                }
+                Err(error) => {
+                    error!("Failed sending {msg_id:?} to {peer:?}: {error:?}");
+                    send_error(peer, Error::InvalidMsgReceived(msg_id), comm_events.clone());
+                    // continue with next received msg
+                }
+            };
+        }
+
+        let (dst, mut stream) = dst_stream;
+        for (received, peer) in all_received {
+            match map_to_client_response(msg_type, msg_id, received, dst) {
+                Some(bytes) => match stream.send_user_msg(bytes).await {
+                    Ok(()) => (),
+                    Err(error) => {
+                        send_error(peer, Error::from(error), comm_events.clone());
+                        // continue with next received msg
+                    }
+                },
+                None => {
+                    send_error(peer, Error::InvalidMsgReceived(msg_id), comm_events.clone());
+                    // continue with next received msg
+                }
+            }
+        }
+    });
+}
+
+/// Verify what kind of response was received, and if that's the expected type based on
+/// the type of msg sent to the nodes, then return the corresponding response to the client.
+fn map_to_client_response(
+    sent: NodeMsgType,
+    correlation_id: MsgId,
+    received: MsgType,
+    dst: Dst,
+) -> Option<UsrMsgBytes> {
+    let response = match sent {
+        NodeMsgType::DataQuery => {
+            match received {
+                MsgType::ClientDataResponse {
+                    msg: ClientResponse::QueryResponse { response, .. },
+                    ..
+                } => {
+                    // We sent a data query and we received a query response,
+                    // so let's forward it to the client
+                    debug!("{correlation_id:?} sending query response back to client");
+                    ClientResponse::QueryResponse {
+                        response,
+                        correlation_id,
+                    }
+                }
+                other_resp => {
+                    error!("Unexpected response to query from node for {correlation_id:?}: {other_resp:?}");
+                    return None;
+                }
+            }
+        }
+        NodeMsgType::StoreData => {
+            match received {
+                MsgType::ClientDataResponse {
+                    msg: ClientResponse::CmdResponse { response, .. },
+                    ..
+                } => {
+                    // We sent a data cmd to store client data and we received a
+                    // cmd response, so let's forward it to the client
+                    debug!("{correlation_id:?} sending cmd response ACK back to client");
+                    ClientResponse::CmdResponse {
+                        response,
+                        correlation_id,
+                    }
+                }
+                other_resp => {
+                    error!("Unexpected response to cmd from node for {correlation_id:?}: {other_resp:?}");
+                    return None;
+                }
+            }
+        }
+    };
+
+    let kind = MsgKind::ClientDataResponse(dst.name);
+    let payload = WireMsg::serialize_msg_payload(&response).ok()?;
+    let wire_msg = WireMsg::new_msg(correlation_id, payload, kind, dst);
+
+    wire_msg.serialize().ok()
+}
+
+fn send_error(peer: Peer, error: Error, comm_events: Sender<CommEvent>) {
+    let _handle = task::spawn(async move {
+        let error_msg =
+            format!("Failed to send error {error} of peer {peer} on comm event channel ");
+        match comm_events.send(CommEvent::Error { peer, error }).await {
+            Ok(()) => (),
+            Err(err) => error!("{error_msg} due to {err}."),
+        }
+    });
 }
 
 #[cfg(test)]
@@ -227,8 +572,7 @@ mod tests {
 
     #[tokio::test]
     async fn successful_send() -> Result<()> {
-        let (tx, _rx) = mpsc::channel(1);
-        let comm = Comm::new(local_addr(), tx)?;
+        let (comm, _rx) = Comm::new(local_addr())?;
 
         let (peer0, mut rx0) = new_peer().await?;
         let (peer1, mut rx1) = new_peer().await?;
@@ -239,10 +583,8 @@ mod tests {
         let peer0_msg = new_test_msg(dst(peer0))?;
         let peer1_msg = new_test_msg(dst(peer1))?;
 
-        comm.send_out_bytes(peer0, peer0_msg.msg_id(), peer0_msg.serialize()?)
-            .await?;
-        comm.send_out_bytes(peer1, peer1_msg.msg_id(), peer1_msg.serialize()?)
-            .await?;
+        comm.send_out_bytes(peer0, peer0_msg.msg_id(), peer0_msg.serialize()?);
+        comm.send_out_bytes(peer1, peer1_msg.msg_id(), peer1_msg.serialize()?);
 
         if let Some(bytes) = rx0.recv().await {
             assert_eq!(WireMsg::from(bytes)?, peer0_msg);
@@ -257,34 +599,35 @@ mod tests {
 
     #[tokio::test]
     async fn failed_send() -> Result<()> {
-        let (tx, _rx) = mpsc::channel(1);
-        let comm = Comm::new(local_addr(), tx)?;
+        let (comm, mut rx) = Comm::new(local_addr())?;
 
         let invalid_peer = get_invalid_peer().await?;
         let invalid_addr = invalid_peer.addr();
         let msg = new_test_msg(dst(invalid_peer))?;
-        let result = comm
-            .send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?)
-            .await;
+        comm.send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?);
 
-        // the peer is still not set as a known member thus it should have failed
-        assert_matches!(result, Err(Error::CreatingConnectionToUnknownNode(peer)) => assert_eq!(peer.addr(), invalid_addr));
+        if let Some(CommEvent::Error { peer, error }) = rx.recv().await {
+            // the peer is still not set as a known member thus it should have failed
+            assert_matches!(error, Error::ConnectingToUnknownNode(_));
+            assert_eq!(peer.addr(), invalid_addr);
+        }
 
         // let's add the peer as a known member and check again
         comm.set_comm_targets([invalid_peer].into());
 
-        let result = comm
-            .send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?)
-            .await;
-        assert_matches!(result, Err(Error::FailedSend(peer)) => assert_eq!(peer.addr(), invalid_addr));
+        comm.send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?);
+
+        if let Some(CommEvent::Error { peer, error }) = rx.recv().await {
+            assert_matches!(error, Error::FailedSend(_));
+            assert_eq!(peer.addr(), invalid_addr);
+        }
 
         Ok(())
     }
 
     #[tokio::test]
     async fn send_after_reconnect() -> Result<()> {
-        let (tx, _rx) = mpsc::channel(1);
-        let send_comm = Comm::new(local_addr(), tx)?;
+        let (send_comm, _rx) = Comm::new(local_addr())?;
 
         let (recv_endpoint, mut incoming_connections) = Endpoint::builder()
             .addr(local_addr())
@@ -298,9 +641,7 @@ mod tests {
         // add peer as a known member
         send_comm.set_comm_targets([peer].into());
 
-        send_comm
-            .send_out_bytes(peer, msg0.msg_id(), msg0.serialize()?)
-            .await?;
+        send_comm.send_out_bytes(peer, msg0.msg_id(), msg0.serialize()?);
 
         let mut msg0_received = false;
 
@@ -317,9 +658,7 @@ mod tests {
         }
 
         let msg1 = new_test_msg(dst(peer))?;
-        send_comm
-            .send_out_bytes(peer, msg1.msg_id(), msg1.serialize()?)
-            .await?;
+        send_comm.send_out_bytes(peer, msg1.msg_id(), msg1.serialize()?);
 
         let mut msg1_received = false;
 
@@ -337,11 +676,10 @@ mod tests {
 
     #[tokio::test]
     async fn incoming_connection_lost() -> Result<()> {
-        let (tx, mut rx0) = mpsc::channel(1);
-        let comm0 = Comm::new(local_addr(), tx.clone())?;
+        let (comm0, mut rx0) = Comm::new(local_addr())?;
         let addr0 = comm0.socket_addr();
 
-        let comm1 = Comm::new(local_addr(), tx)?;
+        let (comm1, _rx1) = Comm::new(local_addr())?;
 
         let peer = Peer::new(xor_name::rand::random(), addr0);
         let msg = new_test_msg(dst(peer))?;
@@ -350,11 +688,9 @@ mod tests {
         comm1.set_comm_targets([peer].into());
 
         // Send a message to establish the connection
-        comm1
-            .send_out_bytes(peer, msg.msg_id(), msg.serialize()?)
-            .await?;
+        comm1.send_out_bytes(peer, msg.msg_id(), msg.serialize()?);
 
-        assert_matches!(rx0.recv().await, Some(MsgFromPeer { .. }));
+        assert_matches!(rx0.recv().await, Some(CommEvent::Msg(MsgFromPeer { .. })));
 
         // Drop `comm1` to cause connection lost.
         drop(comm1);

--- a/sn_comms/src/lib.rs
+++ b/sn_comms/src/lib.rs
@@ -92,31 +92,6 @@ pub enum CommEvent {
     },
 }
 
-/// Internal comm cmds.
-#[derive(custom_debug::Debug)]
-enum CommCmd {
-    Send {
-        msg_id: MsgId,
-        peer: Peer,
-        #[debug(skip)]
-        bytes: UsrMsgBytes,
-    },
-    SetTargets(BTreeSet<Peer>),
-    SendWithBiResponse {
-        peer: Peer,
-        msg_id: MsgId,
-        bytes: UsrMsgBytes,
-    },
-    SendAndRespondOnStream {
-        msg_id: MsgId,
-        msg_type: NodeMsgType,
-        peer: Peer,
-        #[debug(skip)]
-        bytes: UsrMsgBytes,
-        dst_stream: (Dst, Arc<RwLock<SendStream>>),
-    },
-}
-
 /// A msg received on the wire.
 #[derive(Debug)]
 pub struct MsgFromPeer {
@@ -150,7 +125,7 @@ impl Comm {
             .server()?;
 
         trace!("Creating comms..");
-        // comm_events_receiver will be used by upper layer to receive all msgs comming in from the network
+        // comm_events_receiver will be used by upper layer to receive all msgs coming in from the network
         let (comm_events_sender, comm_events_receiver) = mpsc::channel(STANDARD_CHANNEL_SIZE);
         let (cmd_sender, cmd_receiver) = mpsc::channel(STANDARD_CHANNEL_SIZE);
 
@@ -183,42 +158,31 @@ impl Comm {
         // We only remove sessions by calling this function,
         // No removals are made even if we failed to send using all peer session's connections,
         // as it's our source of truth for known and connectable peers.
-        let sender = self.cmd_sender.clone();
-        let _handle = task::spawn(async move { sender.send(CommCmd::SetTargets(targets)).await });
+        self.send_cmd(CommCmd::SetTargets(targets))
     }
 
     /// Sends the payload on a new or existing connection.
     #[tracing::instrument(skip(self, bytes))]
     pub fn send_out_bytes(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) {
-        let sender = self.cmd_sender.clone();
-        let _handle = task::spawn(async move {
-            sender
-                .send(CommCmd::Send {
-                    msg_id,
-                    peer,
-                    bytes,
-                })
-                .await
-        });
+        self.send_cmd(CommCmd::Send {
+            msg_id,
+            peer,
+            bytes,
+        })
     }
 
     /// Sends the payload on a new bidi-stream and pushes the response onto the comm event channel.
     #[tracing::instrument(skip(self, bytes))]
-    pub fn send_with_bi_response(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) {
-        let sender = self.cmd_sender.clone();
-        let _handle = task::spawn(async move {
-            sender
-                .send(CommCmd::SendWithBiResponse {
-                    msg_id,
-                    peer,
-                    bytes,
-                })
-                .await
-        });
+    pub fn send_and_return_response(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) {
+        self.send_cmd(CommCmd::SendAndReturnResponse {
+            msg_id,
+            peer,
+            bytes,
+        })
     }
 
-    /// Sends the payload on new bidi-streams and sends the responses on the dst stream.
-    #[tracing::instrument(skip(bytes))]
+    /// Sends the payload on new bidi-stream to noe and sends the response on the dst stream.
+    #[tracing::instrument(skip(self, bytes))]
     pub fn send_and_respond_on_stream(
         &self,
         msg_id: MsgId,
@@ -227,34 +191,65 @@ impl Comm {
         bytes: UsrMsgBytes,
         dst_stream: (Dst, Arc<RwLock<SendStream>>),
     ) {
+        self.send_cmd(CommCmd::SendAndRespondOnStream {
+            msg_id,
+            msg_type,
+            peer,
+            bytes,
+            dst_stream,
+        })
+    }
+
+    fn send_cmd(&self, cmd: CommCmd) {
         let sender = self.cmd_sender.clone();
         let _handle = task::spawn(async move {
-            sender
-                .send(CommCmd::SendAndRespondOnStream {
-                    msg_id,
-                    msg_type,
-                    peer,
-                    bytes,
-                    dst_stream,
-                })
-                .await
+            let error_msg = format!("Failed to send {cmd:?} on comm cmd channel ");
+            if let Err(error) = sender.send(cmd).await {
+                error!("{error_msg} due to {error}.");
+            }
         });
     }
 }
 
+/// Internal comm cmds.
+#[derive(custom_debug::Debug)]
+enum CommCmd {
+    Send {
+        msg_id: MsgId,
+        peer: Peer,
+        #[debug(skip)]
+        bytes: UsrMsgBytes,
+    },
+    SetTargets(BTreeSet<Peer>),
+    SendAndReturnResponse {
+        peer: Peer,
+        msg_id: MsgId,
+        #[debug(skip)]
+        bytes: UsrMsgBytes,
+    },
+    SendAndRespondOnStream {
+        msg_id: MsgId,
+        msg_type: NodeMsgType,
+        peer: Peer,
+        #[debug(skip)]
+        bytes: UsrMsgBytes,
+        dst_stream: (Dst, Arc<RwLock<SendStream>>),
+    },
+}
+
 fn process_cmds(
     our_endpoint: Endpoint,
-    mut update_receiver: Receiver<CommCmd>,
+    mut cmd_receiver: Receiver<CommCmd>,
     comm_events: Sender<CommEvent>,
 ) {
     let _handle = task::spawn(async move {
         let mut sessions = BTreeMap::<Peer, PeerSession>::new();
-        while let Some(cmd) = update_receiver.recv().await {
+        while let Some(cmd) = cmd_receiver.recv().await {
             trace!("Comms cmd handling: {cmd:?}");
             match cmd {
                 // This is the only place that mutates `sessions`.
                 CommCmd::SetTargets(targets) => {
-                    // Drops sessions that not among the targets.
+                    // Drops sessions that are not among the targets.
                     sessions.retain(|p, _| targets.contains(p));
                     // Adds new sessions for each new target.
                     targets.iter().for_each(|peer| {
@@ -269,42 +264,20 @@ fn process_cmds(
                     peer,
                     bytes,
                 } => {
-                    let session = match sessions.get(&peer) {
-                        Some(session) => session.clone(),
-                        None => {
-                            error!(
-                                "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
-                            );
-                            send_error(
-                                peer,
-                                Error::ConnectingToUnknownNode(msg_id),
-                                comm_events.clone(),
-                            );
-                            continue;
-                        }
-                    };
-                    send(msg_id, session, bytes, comm_events.clone());
+                    if let Some(session) = get_session(msg_id, peer, &sessions, comm_events.clone())
+                    {
+                        send(msg_id, session, bytes, comm_events.clone())
+                    }
                 }
-                CommCmd::SendWithBiResponse {
+                CommCmd::SendAndReturnResponse {
                     peer,
                     msg_id,
                     bytes,
                 } => {
-                    let session = match sessions.get(&peer) {
-                        Some(session) => session.clone(),
-                        None => {
-                            error!(
-                                "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
-                            );
-                            send_error(
-                                peer,
-                                Error::ConnectingToUnknownNode(msg_id),
-                                comm_events.clone(),
-                            );
-                            continue;
-                        }
-                    };
-                    send_with_bi_response(msg_id, session, bytes, comm_events.clone());
+                    if let Some(session) = get_session(msg_id, peer, &sessions, comm_events.clone())
+                    {
+                        send_and_return_response(msg_id, session, bytes, comm_events.clone())
+                    }
                 }
                 CommCmd::SendAndRespondOnStream {
                     msg_id,
@@ -313,35 +286,41 @@ fn process_cmds(
                     bytes,
                     dst_stream,
                 } => {
-                    debug!("Trying to get {peer:?} session in order to send: {msg_id:?}",);
-                    let session = match sessions.get(&peer) {
-                        Some(session) => session.clone(),
-                        None => {
-                            error!(
-                                "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
-                            );
-                            send_error(
-                                peer,
-                                Error::ConnectingToUnknownNode(msg_id),
-                                comm_events.clone(),
-                            );
-                            continue;
-                        }
-                    };
-                    send_and_respond_on_stream(
-                        msg_id,
-                        msg_type,
-                        session,
-                        bytes,
-                        dst_stream,
-                        comm_events.clone(),
-                    );
+                    if let Some(session) = get_session(msg_id, peer, &sessions, comm_events.clone())
+                    {
+                        send_and_respond_on_stream(
+                            msg_id,
+                            msg_type,
+                            session,
+                            bytes,
+                            dst_stream,
+                            comm_events.clone(),
+                        )
+                    }
                 }
             }
         }
     });
 }
 
+fn get_session(
+    msg_id: MsgId,
+    peer: Peer,
+    sessions: &BTreeMap<Peer, PeerSession>,
+    comm_events: Sender<CommEvent>,
+) -> Option<PeerSession> {
+    debug!("Trying to get {peer:?} session in order to send: {msg_id:?}");
+    match sessions.get(&peer) {
+        Some(session) => Some(session.clone()),
+        None => {
+            error!("Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node.");
+            send_error(peer, Error::ConnectingToUnknownNode(msg_id), comm_events);
+            None
+        }
+    }
+}
+
+#[tracing::instrument(skip_all)]
 fn send(msg_id: MsgId, session: PeerSession, bytes: UsrMsgBytes, comm_events: Sender<CommEvent>) {
     let _handle = task::spawn(async move {
         let (h, d, p) = &bytes;
@@ -360,7 +339,8 @@ fn send(msg_id: MsgId, session: PeerSession, bytes: UsrMsgBytes, comm_events: Se
     });
 }
 
-fn send_with_bi_response(
+#[tracing::instrument(skip_all)]
+fn send_and_return_response(
     msg_id: MsgId,
     session: PeerSession,
     bytes: UsrMsgBytes,
@@ -395,6 +375,7 @@ fn send_with_bi_response(
     });
 }
 
+#[tracing::instrument(skip_all)]
 fn send_and_respond_on_stream(
     msg_id: MsgId,
     msg_type: NodeMsgType,
@@ -453,6 +434,7 @@ fn send_and_respond_on_stream(
 
 /// Verify what kind of response was received, and if that's the expected type based on
 /// the type of msg sent to the nodes, then return the corresponding response to the client.
+#[tracing::instrument(skip_all)]
 fn map_to_client_response(
     sent: NodeMsgType,
     correlation_id: MsgId,
@@ -513,9 +495,8 @@ fn send_error(peer: Peer, error: Error, comm_events: Sender<CommEvent>) {
     let _handle = task::spawn(async move {
         let error_msg =
             format!("Failed to send error {error} of peer {peer} on comm event channel ");
-        match comm_events.send(CommEvent::Error { peer, error }).await {
-            Ok(()) => (),
-            Err(err) => error!("{error_msg} due to {err}."),
+        if let Err(err) = comm_events.send(CommEvent::Error { peer, error }).await {
+            error!("{error_msg} due to {err}.")
         }
     });
 }

--- a/sn_comms/src/listener.rs
+++ b/sn_comms/src/listener.rs
@@ -6,103 +6,108 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::MsgFromPeer;
+use super::{CommEvent, MsgFromPeer};
 
 use sn_interface::{
     messaging::{MsgKind, WireMsg},
     types::{log_markers::LogMarker, Peer},
 };
 
-use qp2p::{ConnectionIncoming, IncomingConnections};
-use tokio::{sync::mpsc, task};
-use tracing::Instrument;
+use qp2p::{Connection, ConnectionIncoming, IncomingConnections};
+use tokio::{sync::mpsc::Sender, task};
 
-#[derive(Clone)]
-pub(crate) struct MsgListener {
-    receive_msg: mpsc::Sender<MsgFromPeer>,
+#[tracing::instrument(skip_all)]
+pub(crate) fn listen_for_connections(
+    comm_events_sender: Sender<CommEvent>,
+    mut incoming_connections: IncomingConnections,
+) {
+    let _handle = task::spawn(async move {
+        while let Some((connection, incoming_msgs)) = incoming_connections.next().await {
+            trace!(
+                "{}: from {:?} with connection_id {}",
+                LogMarker::IncomingConnection,
+                connection.remote_address(),
+                connection.id()
+            );
+
+            let _handle = task::spawn(listen_for_msgs(
+                comm_events_sender.clone(),
+                connection,
+                incoming_msgs,
+            ));
+        }
+    });
 }
 
-impl MsgListener {
-    pub(crate) fn new(receive_msg: mpsc::Sender<MsgFromPeer>) -> Self {
-        Self { receive_msg }
-    }
+#[tracing::instrument(skip_all)]
+pub(crate) async fn listen_for_msgs(
+    comm_events: Sender<CommEvent>,
+    conn: Connection,
+    mut incoming_msgs: ConnectionIncoming,
+) {
+    let conn_id = conn.id();
+    let remote_address = conn.remote_address();
 
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn listen_for_incoming_msgs(self, mut incoming_connections: IncomingConnections) {
-        let _handle = task::spawn(async move {
-            while let Some((connection, incoming_msgs)) = incoming_connections.next().await {
-                trace!(
-                    "{}: from {:?} with connection_id {}",
-                    LogMarker::IncomingConnection,
-                    connection.remote_address(),
-                    connection.id()
+    while let Some(result) = incoming_msgs.next_with_stream().await.transpose() {
+        match result {
+            Ok((msg_bytes, send_stream)) => {
+                let stream_info = if let Some(stream) = &send_stream {
+                    format!(" on {}", stream.id())
+                } else {
+                    "".to_string()
+                };
+                debug!(
+                    "New msg arrived over conn_id={conn_id} from {remote_address:?}{stream_info}"
                 );
 
-                let clone = self.clone();
-                let _handle =
-                    task::spawn(clone.listen(connection, incoming_msgs).in_current_span());
+                let wire_msg = match WireMsg::from(msg_bytes.0) {
+                    Ok(wire_msg) => wire_msg,
+                    Err(error) => {
+                        // TODO: should perhaps rather drop this connection.. as it is a spam vector
+                        debug!("Failed to deserialize message received from {remote_address:?}{stream_info}: {error:?}");
+                        continue;
+                    }
+                };
+
+                let src_name = match wire_msg.kind() {
+                    MsgKind::Client { auth, .. } => auth.public_key.into(),
+                    MsgKind::Node { name, .. } | MsgKind::ClientDataResponse(name) => *name,
+                };
+
+                let peer = Peer::new(src_name, remote_address);
+                let msg_id = wire_msg.msg_id();
+                debug!(
+                    "Msg {msg_id:?} received, over conn_id={conn_id}, from: {peer:?}{stream_info} was: {wire_msg:?}"
+                );
+
+                msg_received(wire_msg, peer, send_stream, comm_events.clone());
             }
-        });
-    }
-
-    #[tracing::instrument(skip_all)]
-    async fn listen(self, conn: qp2p::Connection, mut incoming_msgs: ConnectionIncoming) {
-        let conn_id = conn.id();
-        let remote_address = conn.remote_address();
-
-        while let Some(result) = incoming_msgs.next_with_stream().await.transpose() {
-            match result {
-                Ok((msg_bytes, send_stream)) => {
-                    let stream_info = if let Some(stream) = &send_stream {
-                        format!(" on {}", stream.id())
-                    } else {
-                        "".to_string()
-                    };
-                    debug!(
-                        "New msg arrived over conn_id={conn_id} from {remote_address:?}{stream_info}"
-                    );
-
-                    let wire_msg = match WireMsg::from(msg_bytes.0) {
-                        Ok(wire_msg) => wire_msg,
-                        Err(error) => {
-                            // TODO: should perhaps rather drop this connection.. as it is a spam vector
-                            debug!("Failed to deserialize message received from {remote_address:?}{stream_info}: {error:?}");
-                            continue;
-                        }
-                    };
-
-                    let src_name = match wire_msg.kind() {
-                        MsgKind::Client { auth, .. } => auth.public_key.into(),
-                        MsgKind::Node { name, .. } | MsgKind::ClientDataResponse(name) => *name,
-                    };
-
-                    let peer = Peer::new(src_name, remote_address);
-
-                    let msg_id = wire_msg.msg_id();
-                    debug!(
-                        "Msg {msg_id:?} received, over conn_id={conn_id}, from: {peer:?}{stream_info} was: {wire_msg:?}"
-                    );
-
-                    let msg_sender = self.receive_msg.clone();
-                    let msg = MsgFromPeer {
-                        sender: peer,
-                        wire_msg,
-                        send_stream,
-                    };
-                    // move this channel sending off thread so we don't hold up incoming msgs at all.
-                    let _handle = tokio::spawn(async move {
-                        // handle the message first
-                        if let Err(error) = msg_sender.send(msg).await {
-                            error!("Error pushing msg {msg_id:?} onto internal msg handling channel: {error:?}");
-                        }
-                    });
-                }
-                Err(error) => {
-                    warn!("Error on connection {conn_id} with {remote_address}: {error:?}");
-                }
+            Err(error) => {
+                warn!("Error on connection {conn_id} with {remote_address}: {error:?}");
             }
         }
-
-        trace!(%conn_id, %remote_address, "{}", LogMarker::ConnectionClosed);
     }
+
+    trace!(%conn_id, %remote_address, "{}", LogMarker::ConnectionClosed);
+}
+
+pub(crate) fn msg_received(
+    wire_msg: WireMsg,
+    peer: Peer,
+    send_stream: Option<qp2p::SendStream>,
+    comm_events: Sender<CommEvent>,
+) {
+    let msg_id = wire_msg.msg_id();
+    let msg_event = CommEvent::Msg(MsgFromPeer {
+        sender: peer,
+        wire_msg,
+        send_stream,
+    });
+    // move this channel sending off thread so we don't hold up incoming msgs at all.
+    let _handle = tokio::spawn(async move {
+        // handle the message first
+        if let Err(error) = comm_events.send(msg_event).await {
+            error!("Error pushing msg {msg_id:?} onto internal msg handling channel: {error:?}");
+        }
+    });
 }

--- a/sn_comms/src/peer_session.rs
+++ b/sn_comms/src/peer_session.rs
@@ -67,6 +67,10 @@ impl PeerSession {
         }
     }
 
+    pub(crate) fn peer(&self) -> Peer {
+        self.peer
+    }
+
     /// Sends out a UsrMsg on a bidi connection and awaits response bytes.
     /// As such this may be long running if response is returned slowly.
     /// When sending a msg to a peer, if it fails with an existing
@@ -75,7 +79,7 @@ impl PeerSession {
     /// b. or it cleaned them all up from the cache creating a new connection
     ///    to the peer as last attempt.
     pub(crate) async fn send_with_bi_return_response(
-        &mut self,
+        &self,
         bytes: UsrMsgBytes,
         msg_id: MsgId,
     ) -> Result<UsrMsgBytes, PeerSessionError> {

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -6,14 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{
-    messaging::msg_id,
-    types::{
-        register::{EntryHash, User},
-        DataAddress,
-    },
+use crate::types::{
+    register::{EntryHash, User},
+    DataAddress,
 };
-use msg_id::MsgId;
 use serde::{Deserialize, Serialize};
 use std::result;
 use thiserror::Error;
@@ -26,9 +22,9 @@ pub type Result<T, E = Error> = result::Result<T, E>;
 #[derive(Error, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Error {
-    /// Failure to contact one or more storage nodes (send or receipt of msg).
-    #[error("Msg: {0:?} failed as contact to one or more storage nodes failed.")]
-    CouldNotContactAllStorageNodes(MsgId),
+    /// Inconsistent responses from one or more storage nodes.
+    #[error("Msg failed: One or more of the storage nodes failed to respond or returned inconsistent responses.")]
+    InconsistentStorageNodeResponses,
     /// Access denied for user
     #[error("Access denied for user: {0:?}")]
     AccessDenied(User),

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -67,12 +67,6 @@ pub enum SectionStateVote {
     JoinsAllowed(bool),
 }
 
-#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
-pub enum NodeMsgType {
-    DataQuery,
-    StoreData,
-}
-
 #[derive(Clone, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 #[allow(clippy::large_enum_variant, clippy::derive_partial_eq_without_eq)]
 /// Message sent over the among nodes

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -67,6 +67,12 @@ pub enum SectionStateVote {
     JoinsAllowed(bool),
 }
 
+#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
+pub enum NodeMsgType {
+    DataQuery,
+    StoreData,
+}
+
 #[derive(Clone, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 #[allow(clippy::large_enum_variant, clippy::derive_partial_eq_without_eq)]
 /// Message sent over the among nodes

--- a/sn_interface/src/types/log_markers.rs
+++ b/sn_interface/src/types/log_markers.rs
@@ -38,6 +38,7 @@ pub enum LogMarker {
     VotedOffline,
     // Messaging
     ClientMsgToBeForwarded,
+    MsgReceived,
     ClientMsgToBeHandled,
     NodeMsgToBeHandled,
     // Membership
@@ -64,7 +65,6 @@ pub enum LogMarker {
     RegisterQueryReceivedAtElder,
     RegisterQueryReceivedAtAdult,
     // Routing cmds
-    DispatchHandleMsgCmd,
     CmdHandlingSpawned,
     CmdProcessStart,
     CmdProcessEnd,

--- a/sn_node/src/node/connectivity.rs
+++ b/sn_node/src/node/connectivity.rs
@@ -7,22 +7,41 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{flow_ctrl::cmds::Cmd, MyNode, Result, SectionStateVote};
+
 use sn_fault_detection::IssueType;
-use std::{collections::BTreeSet, net::SocketAddr};
+use sn_interface::types::Peer;
+
+use std::collections::BTreeSet;
 use xor_name::XorName;
 
 impl MyNode {
-    /// Track comms issue if this is a peer we know and care about
-    pub(crate) fn handle_failed_send(&self, addr: &SocketAddr) {
-        let name = if let Some(peer) = self.network_knowledge.find_member_by_addr(addr) {
-            debug!("Lost known peer {}", peer);
-            peer.name()
-        } else {
-            trace!("Lost unknown peer {}", addr);
-            return;
-        };
-
-        self.track_node_issue(name, IssueType::Communication);
+    /// Handle error in communication with peer.
+    pub(crate) fn handle_comms_error(&self, peer: Peer, error: sn_comms::Error) {
+        use sn_comms::Error::*;
+        match error {
+            ConnectingToUnknownNode(msg_id) => {
+                trace!(
+                    "Tried to send msg {msg_id:?} to unknown peer {}. No connection made.",
+                    peer
+                );
+            }
+            CannotConnectEndpoint(_err) => {
+                debug!("Cannot connect to endpoint: {}", peer);
+            }
+            AddressNotReachable(_err) => {
+                debug!("Address not reachable: {}", peer);
+            }
+            FailedSend(msg_id) => {
+                debug!("Could not send {msg_id:?}, lost known peer: {}", peer);
+            }
+            InvalidMsgReceived(msg_id) => {
+                debug!("Invalid msg {msg_id:?} received from {}.", peer);
+            }
+        }
+        // Track comms issue if this is a peer we know and care about
+        if self.network_knowledge.is_section_member(&peer.name()) {
+            self.track_node_issue(peer.name(), IssueType::Communication);
+        }
     }
 
     pub(crate) fn cast_offline_proposals(&mut self, names: &BTreeSet<XorName>) -> Result<Vec<Cmd>> {

--- a/sn_node/src/node/connectivity.rs
+++ b/sn_node/src/node/connectivity.rs
@@ -26,16 +26,16 @@ impl MyNode {
                 );
             }
             CannotConnectEndpoint(_err) => {
-                debug!("Cannot connect to endpoint: {}", peer);
+                trace!("Cannot connect to endpoint: {}", peer);
             }
             AddressNotReachable(_err) => {
-                debug!("Address not reachable: {}", peer);
+                trace!("Address not reachable: {}", peer);
             }
             FailedSend(msg_id) => {
-                debug!("Could not send {msg_id:?}, lost known peer: {}", peer);
+                trace!("Could not send {msg_id:?}, lost known peer: {}", peer);
             }
             InvalidMsgReceived(msg_id) => {
-                debug!("Invalid msg {msg_id:?} received from {}.", peer);
+                trace!("Invalid msg {msg_id:?} received from {}.", peer);
             }
         }
         // Track comms issue if this is a peer we know and care about

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -154,7 +154,7 @@ pub(crate) enum Cmd {
     },
     /// Performs serialisation and sends the msg to the peer node over a new bi-stream,
     /// awaiting for a response which is forwarded to the client.
-    SendMsgAwaitResponseAndRespondToClient {
+    SendAndForwardResponseToClient {
         wire_msg: WireMsg,
         #[debug(skip)]
         context: NodeContext,
@@ -184,8 +184,8 @@ impl Cmd {
             Cmd::SendMsg { .. }
             | Cmd::SendMsgEnqueueAnyResponse { .. }
             | Cmd::SendNodeMsgResponse { .. }
-            | Cmd::SendMsgAwaitResponseAndRespondToClient { .. }
-            | Cmd::SendClientResponse { .. } => State::Comms,
+            | Cmd::SendClientResponse { .. }
+            | Cmd::SendAndForwardResponseToClient { .. } => State::Comms,
             Cmd::HandleCommsError { .. } => State::Comms,
             Cmd::HandleMsg { .. } => State::HandleMsg,
             Cmd::UpdateNetworkAndHandleValidClientMsg { .. } => State::ClientMsg,
@@ -226,8 +226,8 @@ impl fmt::Display for Cmd {
             Cmd::SendMsg { .. } => write!(f, "SendMsg"),
             Cmd::SendMsgEnqueueAnyResponse { .. } => write!(f, "SendMsgEnqueueAnyResponse"),
             Cmd::SendNodeMsgResponse { .. } => write!(f, "SendNodeMsgResponse"),
-            Cmd::SendMsgAwaitResponseAndRespondToClient { .. } => {
-                write!(f, "SendMsgAwaitResponseAndRespondToClient")
+            Cmd::SendAndForwardResponseToClient { .. } => {
+                write!(f, "SendAndForwardResponseToClient")
             }
             Cmd::SendClientResponse { .. } => write!(f, "SendClientResponse"),
             Cmd::EnqueueDataForReplication { .. } => write!(f, "EnqueueDataForReplication"),

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -78,10 +78,10 @@ pub(crate) enum Cmd {
         #[debug(skip)]
         context: NodeContext,
     },
-    /// Handle peer that's been detected as lost.
-    HandleFailedSendToNode {
+    /// Handle comms error.
+    HandleCommsError {
         peer: Peer,
-        msg_id: MsgId,
+        error: sn_comms::Error,
     },
     /// Handle agreement on a proposal.
     HandleSectionDecisionAgreement {
@@ -126,7 +126,7 @@ pub(crate) enum Cmd {
         context: NodeContext,
     },
     /// Performs serialisation and signing and sends the msg over a bidi connection
-    /// and then enqueues any response returned
+    /// and then enqueues any response returned.
     SendMsgEnqueueAnyResponse {
         msg: NodeMsg,
         msg_id: MsgId,
@@ -186,7 +186,7 @@ impl Cmd {
             | Cmd::SendNodeMsgResponse { .. }
             | Cmd::SendMsgAwaitResponseAndRespondToClient { .. }
             | Cmd::SendClientResponse { .. } => State::Comms,
-            Cmd::HandleFailedSendToNode { .. } => State::Comms,
+            Cmd::HandleCommsError { .. } => State::Comms,
             Cmd::HandleMsg { .. } => State::HandleMsg,
             Cmd::UpdateNetworkAndHandleValidClientMsg { .. } => State::ClientMsg,
             Cmd::TrackNodeIssue { .. } => State::FaultDetection,
@@ -213,8 +213,8 @@ impl fmt::Display for Cmd {
             Cmd::UpdateNetworkAndHandleValidClientMsg { msg_id, msg, .. } => {
                 write!(f, "UpdateAndHandleValidClientMsg {msg_id:?}: {msg:?}")
             }
-            Cmd::HandleFailedSendToNode { peer, msg_id } => {
-                write!(f, "HandlePeerFailedSend({:?}, {:?})", peer.name(), msg_id)
+            Cmd::HandleCommsError { peer, error } => {
+                write!(f, "HandleCommsError({:?}, {:?})", peer.name(), error)
             }
             Cmd::HandleSectionDecisionAgreement { .. } => {
                 write!(f, "HandleSectionDecisionAgreement")

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -57,13 +57,19 @@ impl Dispatcher {
                 msg_id,
                 recipients,
                 context,
-            } => MyNode::send_msg(msg, msg_id, recipients, context).await,
+            } => {
+                MyNode::send_msg(msg, msg_id, recipients, context)?;
+                Ok(vec![])
+            }
             Cmd::SendMsgEnqueueAnyResponse {
                 msg,
                 msg_id,
                 recipients,
                 context,
-            } => MyNode::send_msg_enqueue_any_response(msg, msg_id, context, recipients).await,
+            } => {
+                MyNode::send_msg_with_bi_response(msg, msg_id, context, recipients)?;
+                Ok(vec![])
+            }
             Cmd::SendMsgAwaitResponseAndRespondToClient {
                 wire_msg,
                 context,
@@ -77,8 +83,8 @@ impl Dispatcher {
                     targets,
                     client_stream,
                     source_client,
-                )
-                .await
+                )?;
+                Ok(vec![])
             }
             Cmd::SendNodeMsgResponse {
                 msg,
@@ -86,24 +92,28 @@ impl Dispatcher {
                 recipient,
                 send_stream,
                 context,
-            } => MyNode::send_node_msg_response(msg, msg_id, recipient, context, send_stream).await,
+            } => Ok(
+                MyNode::send_node_msg_response(msg, msg_id, recipient, context, send_stream)
+                    .await?
+                    .into_iter()
+                    .collect(),
+            ),
             Cmd::SendClientResponse {
                 msg,
                 correlation_id,
                 send_stream,
                 context,
                 source_client,
-            } => {
-                MyNode::send_client_response(
-                    msg,
-                    correlation_id,
-                    send_stream,
-                    context,
-                    source_client,
-                )
-                .await?;
-                Ok(vec![])
-            }
+            } => Ok(MyNode::send_client_response(
+                msg,
+                correlation_id,
+                send_stream,
+                context,
+                source_client,
+            )
+            .await?
+            .into_iter()
+            .collect()),
             Cmd::TrackNodeIssue { name, issue } => {
                 let node = self.node.read().await;
                 trace!("[NODE READ]: fault tracking read got");
@@ -172,11 +182,11 @@ impl Dispatcher {
                 node.handle_new_sections_agreement(sap1, sig1, sap2, sig2)
                     .await
             }
-            Cmd::HandleFailedSendToNode { peer, msg_id } => {
-                warn!("Message sending failed to {peer}, for {msg_id:?}");
+            Cmd::HandleCommsError { peer, error } => {
+                trace!("Comms error {error}");
                 let node = self.node.read().await;
-                trace!("[NODE READ]: HandleFailedSendToNode agreements read got...");
-                node.handle_failed_send(&peer.addr());
+                debug!("[NODE READ]: HandleCommsError read got...");
+                node.handle_comms_error(peer, error);
                 Ok(vec![])
             }
             Cmd::HandleDkgOutcome {

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -67,17 +67,17 @@ impl Dispatcher {
                 recipients,
                 context,
             } => {
-                MyNode::send_msg_with_bi_response(msg, msg_id, context, recipients)?;
+                MyNode::send_and_enqueue_any_response(msg, msg_id, context, recipients)?;
                 Ok(vec![])
             }
-            Cmd::SendMsgAwaitResponseAndRespondToClient {
+            Cmd::SendAndForwardResponseToClient {
                 wire_msg,
                 context,
                 targets,
                 client_stream,
                 source_client,
             } => {
-                MyNode::send_msg_await_response_and_send_to_client(
+                MyNode::send_and_forward_response_to_client(
                     wire_msg,
                     context,
                     targets,

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -241,7 +241,7 @@ impl FlowCtrl {
                             );
                         } else {
                             trace!(
-                                "{:?} from {sender:?}, unknown length due to serialization issued.",
+                                "{:?} from {sender:?}, unknown length due to serialization issues.",
                                 LogMarker::MsgReceived,
                             );
                         }

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -240,6 +240,7 @@ impl FlowCtrl {
                                 LogMarker::MsgReceived,
                             );
                         } else {
+                            // this should be unreachable
                             trace!(
                                 "{:?} from {sender:?}, unknown length due to serialization issues.",
                                 LogMarker::MsgReceived,

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -169,7 +169,7 @@ impl FlowCtrl {
             if !context.network_knowledge.is_section_member(&context.name) {
                 if self.timestamps.last_relocation_retry_check.elapsed() > RELOCATION_TIMEOUT_SECS {
                     self.timestamps.last_relocation_retry_check = Instant::now();
-                    cmds.push(MyNode::send_msg_to_our_elders_await_responses(
+                    cmds.push(MyNode::send_to_elders_await_responses(
                         context.clone(),
                         NodeMsg::TryJoin(Some(proof.clone())),
                     ));
@@ -299,7 +299,7 @@ impl FlowCtrl {
                     }
                     // we may also be behind, so lets request AE incase that is the case!
                     let msg = NodeMsg::MembershipAE(membership.generation());
-                    cmds.push(MyNode::send_msg_to_our_elders(context, msg));
+                    cmds.push(MyNode::send_to_elders(context, msg));
                 }
             }
         }

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -162,6 +162,7 @@ impl<'a> ProcessAndInspectCmds<'a> {
             if !matches!(
                 cmd,
                 Cmd::SendMsg { .. }
+                    | Cmd::SendAndForwardResponseToClient { .. }
                     | Cmd::SendClientResponse { .. }
                     | Cmd::SendNodeMsgResponse { .. }
             ) {

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -335,7 +335,8 @@ impl Dispatcher {
 }
 
 // Receive the next `MsgFromPeer` if the buffer is not empty. Returns None if the buffer is currently empty
-pub(crate) fn get_next_msg(comm_rx: &mut Receiver<CommEvent>) -> Option<MsgFromPeer> {
+pub(crate) async fn get_next_msg(comm_rx: &mut Receiver<CommEvent>) -> Option<MsgFromPeer> {
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     match comm_rx.try_recv() {
         Ok(CommEvent::Msg(msg)) => Some(msg),
         Ok(_) => None,

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{flow_ctrl::dispatcher::Dispatcher, messaging::Peers, Cmd, MyNode};
-use sn_comms::MsgFromPeer;
+use sn_comms::{CommEvent, MsgFromPeer};
 use sn_interface::{
     messaging::{
         data::ClientMsg,
@@ -103,7 +103,7 @@ impl<'a> ProcessAndInspectCmds<'a> {
     pub(crate) async fn new_from_client_msg(
         msg: ClientMsg,
         dispatcher: &'a Dispatcher,
-        mut comm_rx: Receiver<MsgFromPeer>,
+        mut comm_rx: Receiver<CommEvent>,
     ) -> crate::node::error::Result<ProcessAndInspectCmds> {
         let context = dispatcher.node().read().await.context();
         let (msg_id, serialised_payload, msg_kind, _auth) =
@@ -136,10 +136,10 @@ impl<'a> ProcessAndInspectCmds<'a> {
         send_stream.send_user_msg(user_msg).await?;
 
         match comm_rx.recv().await {
-            Some(MsgFromPeer {
+            Some(CommEvent::Msg(MsgFromPeer {
                 send_stream: Some(send_stream),
                 ..
-            }) => {
+            })) => {
                 let cmds = MyNode::handle_msg(dispatcher.node(), peer, wire_msg, Some(send_stream))
                     .await?;
                 Ok(Self::from(cmds, dispatcher))
@@ -335,9 +335,10 @@ impl Dispatcher {
 }
 
 // Receive the next `MsgFromPeer` if the buffer is not empty. Returns None if the buffer is currently empty
-pub(crate) fn get_next_msg(comm_rx: &mut Receiver<MsgFromPeer>) -> Option<MsgFromPeer> {
+pub(crate) fn get_next_msg(comm_rx: &mut Receiver<CommEvent>) -> Option<MsgFromPeer> {
     match comm_rx.try_recv() {
-        Ok(msg) => Some(msg),
+        Ok(CommEvent::Msg(msg)) => Some(msg),
+        Ok(_) => None,
         Err(TryRecvError::Empty) => None,
         Err(TryRecvError::Disconnected) => panic!("the comm_rx channel is closed"),
     }

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -21,7 +21,7 @@ use crate::node::{
 };
 use cmd_utils::{handle_online_cmd, ProcessAndInspectCmds};
 
-use sn_comms::MsgFromPeer;
+use sn_comms::{CommEvent, MsgFromPeer};
 use sn_consensus::Decision;
 use sn_dbc::Hash;
 use sn_interface::{
@@ -606,7 +606,7 @@ async fn msg_to_self() -> Result<()> {
 
     assert!(cmds.is_empty());
 
-    let msg_type = assert_matches!(comm_rx.recv().await, Some(MsgFromPeer { sender, wire_msg, .. }) => {
+    let msg_type = assert_matches!(comm_rx.recv().await, Some(CommEvent::Msg(MsgFromPeer { sender, wire_msg, .. })) => {
         assert_eq!(sender.addr(), info.addr);
         assert_matches!(wire_msg.into_msg(), Ok(msg_type) => msg_type)
     });

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -868,7 +868,7 @@ async fn spentbook_spend_client_message_should_replicate_to_adults_and_send_ack(
     .await?;
 
     while let Some(cmd) = cmds.next().await? {
-        if let Cmd::SendMsgAwaitResponseAndRespondToClient {
+        if let Cmd::SendAndForwardResponseToClient {
             wire_msg, targets, ..
         } = cmd
         {

--- a/sn_node/src/node/flow_ctrl/tests/network_builder.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_builder.rs
@@ -5,7 +5,7 @@ use crate::{
     UsedSpace,
 };
 
-use sn_comms::{Comm, MsgFromPeer};
+use sn_comms::{Comm, CommEvent};
 use sn_interface::{
     elder_count,
     messaging::system::SectionSigned,
@@ -39,7 +39,7 @@ pub(crate) static TEST_EVENT_CHANNEL_SIZE: usize = 20;
 // The default elder age pattern
 pub(crate) const ELDER_AGE_PATTERN: &[u8] = &[50, 45, 40, 35, 30, 25, 20];
 // the Rx channel for each node
-pub(crate) type TestCommRx = BTreeMap<PublicKey, Option<Receiver<MsgFromPeer>>>;
+pub(crate) type TestCommRx = BTreeMap<PublicKey, Option<Receiver<CommEvent>>>;
 
 #[derive(Clone, Debug)]
 enum TestMemberType {
@@ -143,9 +143,8 @@ impl<R: RngCore> TestNetworkBuilder<R> {
                 TestMemberType::Adult
             };
 
-            let (tx, rx) = mpsc::channel(TEST_EVENT_CHANNEL_SIZE);
             let socket_addr: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
-            let comm = Comm::new(socket_addr, tx).expect("failed to create Comm");
+            let (comm, rx) = Comm::new(socket_addr).expect("failed to create Comm");
             let mut node = node.clone();
             node.addr = comm.socket_addr();
 
@@ -628,7 +627,7 @@ impl TestNetwork {
     /// Take the `mspc::Receiver` for a given node. The receiver will be moved out of the `TestNetwork`.
     ///
     /// Will panic if called more than once for a single node or if the `node_pk` is not part of the `TestNetwork`
-    pub(crate) fn take_comm_rx(&mut self, node_pk: PublicKey) -> Receiver<MsgFromPeer> {
+    pub(crate) fn take_comm_rx(&mut self, node_pk: PublicKey) -> Receiver<CommEvent> {
         match self.receivers.entry(node_pk) {
             Entry::Vacant(_) => {
                 panic!("Something went wrong, the key must be present in self.receivers")
@@ -793,12 +792,11 @@ impl TestNetwork {
     pub(crate) fn gen_info(
         age: u8,
         prefix: Option<Prefix>,
-    ) -> (MyNodeInfo, Comm, Receiver<MsgFromPeer>) {
+    ) -> (MyNodeInfo, Comm, Receiver<CommEvent>) {
         let handle = Handle::current();
         let _ = handle.enter();
-        let (tx, rx) = mpsc::channel(TEST_EVENT_CHANNEL_SIZE);
         let socket_addr: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
-        let comm = Comm::new(socket_addr, tx).expect("failed  to create comm");
+        let (comm, rx) = Comm::new(socket_addr).expect("failed  to create comm");
         let info = MyNodeInfo::new(
             gen_keypair(&prefix.unwrap_or_default().range_inclusive(), age),
             comm.socket_addr(),

--- a/sn_node/src/node/messaging/data.rs
+++ b/sn_node/src/node/messaging/data.rs
@@ -257,7 +257,7 @@ impl MyNode {
                     });
                     is_full = true;
 
-                    cmds.push(MyNode::send_msg_to_our_elders(context, msg))
+                    cmds.push(MyNode::send_to_elders(context, msg))
                 }
                 Err(error) => {
                     // the rest seem to be non-problematic errors.. (?)

--- a/sn_node/src/node/messaging/data.rs
+++ b/sn_node/src/node/messaging/data.rs
@@ -104,7 +104,7 @@ impl MyNode {
             }
         }
 
-        Cmd::SendMsgAwaitResponseAndRespondToClient {
+        Cmd::SendAndForwardResponseToClient {
             wire_msg,
             context,
             targets,
@@ -167,7 +167,7 @@ impl MyNode {
 
         let context = context.clone();
 
-        Ok(vec![Cmd::SendMsgAwaitResponseAndRespondToClient {
+        Ok(vec![Cmd::SendAndForwardResponseToClient {
             wire_msg,
             context,
             targets,

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -907,7 +907,7 @@ mod tests {
                     .ok_or_else(|| eyre!("comm_rx should be present"))?;
                 info!("\n\n NODE: {name}");
 
-                while let Some(msg) = get_next_msg(comm_rx) {
+                while let Some(msg) = get_next_msg(comm_rx).await {
                     let cmds = dispatcher
                         .test_handle_msg_from_peer(msg, msg_counter, None)
                         .await;
@@ -968,7 +968,7 @@ mod tests {
                     .ok_or_else(|| eyre!("comm_rx should be present"))?;
                 info!("\n\n NODE: {name}");
 
-                while let Some(msg) = get_next_msg(comm_rx) {
+                while let Some(msg) = get_next_msg(comm_rx).await {
                     let cmds = dispatcher
                         .test_handle_msg_from_peer(msg, msg_counter, None)
                         .await;
@@ -1022,7 +1022,7 @@ mod tests {
                 // sleep for sometime to get the msgs
                 tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
-                while let Some(msg) = get_next_msg(comm_rx) {
+                while let Some(msg) = get_next_msg(comm_rx).await {
                     let cmds = dispatcher
                         .test_handle_msg_from_peer(msg, msg_counter, None)
                         .await;

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -860,7 +860,7 @@ mod tests {
         },
     };
 
-    use sn_comms::MsgFromPeer;
+    use sn_comms::CommEvent;
     use sn_interface::{
         init_logger,
         messaging::{
@@ -1108,7 +1108,7 @@ mod tests {
         rng: impl RngCore,
     ) -> (
         BTreeMap<XorName, Dispatcher>,
-        BTreeMap<XorName, mpsc::Receiver<MsgFromPeer>>,
+        BTreeMap<XorName, mpsc::Receiver<CommEvent>>,
         SecretKeySet,
     ) {
         let mut env = TestNetworkBuilder::new(rng)

--- a/sn_node/src/node/messaging/handover.rs
+++ b/sn_node/src/node/messaging/handover.rs
@@ -185,7 +185,7 @@ impl MyNode {
         // Deliver each SignedVote to all current Elders
         trace!("Broadcasting Vote msg: {:?}", signed_vote);
 
-        MyNode::send_msg_to_our_elders(context, NodeMsg::HandoverVotes(vec![signed_vote]))
+        MyNode::send_to_elders(context, NodeMsg::HandoverVotes(vec![signed_vote]))
     }
 
     /// Broadcast the decision of the terminated handover consensus by proposing the HandoverCompleted SAP(s)

--- a/sn_node/src/node/messaging/join_section.rs
+++ b/sn_node/src/node/messaging/join_section.rs
@@ -19,7 +19,7 @@ impl MyNode {
         if context.network_knowledge.is_section_member(&context.name) {
             None
         } else {
-            Some(MyNode::send_msg_to_our_elders_await_responses(
+            Some(MyNode::send_to_elders_await_responses(
                 context,
                 NodeMsg::TryJoin(relocation),
             ))
@@ -40,7 +40,7 @@ mod tests {
         MIN_ADULT_AGE,
     };
 
-    use sn_comms::MsgFromPeer;
+    use sn_comms::CommEvent;
     use sn_interface::{
         elder_count, init_logger,
         messaging::system::{JoinRejectReason, JoinResponse},
@@ -413,7 +413,7 @@ mod tests {
         (network_knowledge, section)
     }
 
-    async fn connect_flows(node: MyNode, incoming_msg_receiver: Receiver<MsgFromPeer>) -> TestNode {
+    async fn connect_flows(node: MyNode, incoming_msg_receiver: Receiver<CommEvent>) -> TestNode {
         let node = Arc::new(RwLock::new(node));
         let (dispatcher, data_replication_receiver) = Dispatcher::new(node.clone());
         let cmd_ctrl = CmdCtrl::new(dispatcher);

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -44,7 +44,7 @@ impl MyNode {
                     return None;
                 }
             };
-            Some(MyNode::send_msg_to_our_elders(
+            Some(MyNode::send_to_elders(
                 context,
                 NodeMsg::MembershipVotes(vec![membership_vote]),
             ))
@@ -64,8 +64,7 @@ impl MyNode {
         if let Some(membership) = membership_context {
             trace!("{}", LogMarker::GossippingMembershipVotes);
             if let Ok(ae_votes) = membership.anti_entropy(membership.generation()) {
-                let cmd =
-                    MyNode::send_msg_to_our_elders(context, NodeMsg::MembershipVotes(ae_votes));
+                let cmd = MyNode::send_to_elders(context, NodeMsg::MembershipVotes(ae_votes));
                 return Some(cmd);
             }
         }
@@ -131,7 +130,7 @@ impl MyNode {
             };
 
             if let Some(vote_msg) = vote_broadcast {
-                cmds.push(MyNode::send_msg_to_our_elders(context, vote_msg));
+                cmds.push(MyNode::send_to_elders(context, vote_msg));
             }
         }
 

--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -442,7 +442,7 @@ mod tests {
                 // Allow the node to receive msgs from others
                 tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
-                while let Some(msg) = get_next_msg(comm_rx) {
+                while let Some(msg) = get_next_msg(comm_rx).await {
                     let cmds = dispatcher
                         .test_handle_msg_from_peer(msg, msg_counter, Some(name))
                         .await;

--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -132,7 +132,7 @@ mod tests {
             network_builder::TestNetworkBuilder,
         },
     };
-    use sn_comms::MsgFromPeer;
+    use sn_comms::CommEvent;
     use sn_interface::{
         init_logger,
         messaging::system::{
@@ -410,7 +410,7 @@ mod tests {
     /// Main loop that sends and processes Cmds
     async fn relocation_loop(
         node_instances: &BTreeMap<(Prefix, XorName), Arc<Dispatcher>>,
-        comm_receivers: &mut BTreeMap<(Prefix, XorName), Receiver<MsgFromPeer>>,
+        comm_receivers: &mut BTreeMap<(Prefix, XorName), Receiver<CommEvent>>,
         from_section_n_elders: usize,
         msg_counter: &mut TestMsgCounter,
     ) -> Result<()> {

--- a/sn_node/src/node/messaging/streams.rs
+++ b/sn_node/src/node/messaging/streams.rs
@@ -96,9 +96,9 @@ impl MyNode {
         .await
     }
 
-    /// Sends a msg via comms, and listens for any response
+    /// Sends a msg, and listens for any response
     /// The response is returned to be handled via the dispatcher (though a response is not necessarily expected)
-    pub(crate) fn send_msg_with_bi_response(
+    pub(crate) fn send_and_enqueue_any_response(
         msg: NodeMsg,
         msg_id: MsgId,
         context: NodeContext,
@@ -122,14 +122,14 @@ impl MyNode {
             let bytes_to_node = wire_msg.serialize_with_new_dst(&dst)?;
             let comm = context.comm.clone();
             info!("About to send {msg_id:?} to holder node: {target:?}");
-            comm.send_with_bi_response(target, msg_id, bytes_to_node);
+            comm.send_and_return_response(target, msg_id, bytes_to_node);
         }
 
         Ok(())
     }
 
     /// Send out msg and await response to forward on to client
-    pub(crate) fn send_msg_await_response_and_send_to_client(
+    pub(crate) fn send_and_forward_response_to_client(
         wire_msg: WireMsg,
         context: NodeContext,
         targets: BTreeSet<Peer>,

--- a/sn_node/src/node/messaging/streams.rs
+++ b/sn_node/src/node/messaging/streams.rs
@@ -8,8 +8,6 @@
 
 use crate::node::{core::NodeContext, Cmd, Error, MyNode, Result};
 
-use sn_comms::Error as CommsError;
-use sn_fault_detection::IssueType;
 use sn_interface::{
     messaging::{data::ClientDataResponse, system::NodeMsg, Dst, MsgId, MsgKind, WireMsg},
     types::Peer,
@@ -19,10 +17,9 @@ use qp2p::SendStream;
 use xor_name::XorName;
 
 use bytes::Bytes;
-use futures::FutureExt;
 use lazy_static::lazy_static;
 use std::{collections::BTreeSet, env::var, str::FromStr};
-use tokio::time::{error::Elapsed, timeout, Duration};
+use tokio::time::Duration;
 
 /// Environment variable to set timeout value (in seconds) for data queries
 /// forwarded to Adults. Default value (`NODE_RESPONSE_DEFAULT_TIMEOUT`) is otherwise used.
@@ -60,12 +57,11 @@ impl MyNode {
         recipient: Peer,
         context: NodeContext,
         send_stream: SendStream,
-    ) -> Result<Vec<Cmd>> {
+    ) -> Result<Option<Cmd>> {
         let stream_id = send_stream.id();
         info!("Sending response msg {msg_id:?} over {stream_id}");
         let (kind, payload) = MyNode::serialize_node_msg(context.name, &msg)?;
-
-        match send_msg_on_stream(
+        send_msg_on_stream(
             context.network_knowledge.section_key(),
             payload,
             kind,
@@ -74,23 +70,6 @@ impl MyNode {
             msg_id,
         )
         .await
-        {
-            Ok(()) => Ok(vec![]),
-            Err(err) => {
-                error!(
-                    "Could not send response msg {msg_id:?} \
-                    to {recipient:?} over {stream_id}: {err:?}"
-                );
-                if let Error::Comms(_) = err {
-                    Ok(vec![Cmd::HandleFailedSendToNode {
-                        peer: recipient,
-                        msg_id,
-                    }])
-                } else {
-                    Ok(vec![])
-                }
-            }
-        }
     }
 
     pub(crate) async fn send_client_response(
@@ -99,7 +78,7 @@ impl MyNode {
         send_stream: SendStream,
         context: NodeContext,
         source_client: Peer,
-    ) -> Result<()> {
+    ) -> Result<Option<Cmd>> {
         info!("Sending client response msg for {correlation_id:?}");
         let (kind, payload) = MyNode::serialize_client_msg_response(context.name, &msg)?;
         send_msg_on_stream(
@@ -115,214 +94,88 @@ impl MyNode {
 
     /// Sends a msg via comms, and listens for any response
     /// The response is returned to be handled via the dispatcher (though a response is not necessarily expected)
-    pub(crate) async fn send_msg_enqueue_any_response(
+    pub(crate) fn send_msg_with_bi_response(
         msg: NodeMsg,
         msg_id: MsgId,
         context: NodeContext,
         recipients: BTreeSet<Peer>,
-    ) -> Result<Vec<Cmd>> {
+    ) -> Result<()> {
         let targets_len = recipients.len();
         trace!("Sending out + awaiting response of {msg_id:?} to {targets_len} holder node/s {recipients:?}");
 
-        // TODO: Should we change this func to just return the futures and handlers can decide to wait on all
-        // or process as they come in
-        let results =
-            send_to_target_peers_and_await_responses(msg_id, &msg, recipients, &context).await?;
+        let (kind, payload) = MyNode::serialize_node_msg(context.name, &msg)?;
 
-        let mut output_cmds = vec![];
-        results.into_iter().for_each(|(peer, result)| match result {
-            Err(_elapsed) => {
-                error!(
-                    "{msg_id:?}: No response from {peer:?} after {:?} timeout.",
-                    *NODE_RESPONSE_TIMEOUT
-                );
-            }
-            Ok(Ok(wire_msg)) => {
-                debug!("A response came in from {peer:?} for {msg_id:?}: {wire_msg:?}");
+        // We create a Dst with random dst name, but we'll update it accordingly for each target
+        let mut dst = Dst {
+            name: XorName::default(),
+            section_key: context.network_knowledge.section_key(),
+        };
+        let mut wire_msg = WireMsg::new_msg(msg_id, payload, kind, dst);
+        let _bytes = wire_msg.serialize_and_cache_bytes()?;
 
-                output_cmds.push(Cmd::HandleMsg { origin: peer, wire_msg, send_stream: None });
-            }
-            Ok(Err(comms_err)) => {
-                error!("{msg_id:?} Error when sending request to node {peer:?}, tracking node as fault: {comms_err:?}");
-                output_cmds.push(Cmd::TrackNodeIssue {
-                    name: peer.name(),
-                    issue: IssueType::Communication,
-                });
-            }
-        });
+        for target in recipients {
+            dst.name = target.name();
+            let bytes_to_node = wire_msg.serialize_with_new_dst(&dst)?;
+            let comm = context.comm.clone();
+            info!("About to send {msg_id:?} to holder node: {target:?}");
+            comm.send_with_bi_response(target, msg_id, bytes_to_node);
+        }
 
-        Ok(output_cmds)
+        Ok(())
     }
 
     /// Send out msg and await response to forward on to client
-    pub(crate) async fn send_msg_await_response_and_send_to_client(
+    pub(crate) fn send_msg_await_response_and_send_to_client(
         wire_msg: WireMsg,
         context: NodeContext,
         targets: BTreeSet<Peer>,
         client_stream: SendStream,
         source_client: Peer,
-    ) -> Result<Vec<Cmd>> {
+    ) -> Result<()> {
         let msg_id = wire_msg.msg_id();
         let targets_len = targets.len();
 
         debug!("Sending out {msg_id:?} to {targets_len} holder node/s {targets:?}");
-        let results = send_wiremsg_to_target_peers_and_await_responses(
-            msg_id,
-            wire_msg.clone(),
-            targets,
-            &context,
-        )
-        .await?;
 
-        let mut output_cmds = vec![];
-        let mut success_count = 0;
-        let mut last_success_response = None;
-        let mut last_error = None;
-        results.into_iter().for_each(|(peer, result)| match result {
-            Err(_elapsed) => {
-                error!(
-                    "{msg_id:?}: No response from {peer:?} after {:?} timeout. Tracking node fault",
-                    *NODE_RESPONSE_TIMEOUT
-                );
-                output_cmds.push(Cmd::TrackNodeIssue {
-                    name: peer.name(),
-                    issue: IssueType::Communication,
-                });
-                // TODO: report timeout error to client?
-            }
-            Ok(Ok(response)) => {
-                debug!("Expected response in from {peer:?} for {msg_id:?}: {response:?}");
-                success_count += 1;
-                last_success_response = Some(response);
-            }
-            Ok(Err(comms_err)) => {
-                error!("{msg_id:?} Error when sending request to holder node {peer:?}, tracking node as fault: {comms_err:?}");
-                if let CommsError::FailedSend(peer) = comms_err {
-                    output_cmds.push(Cmd::TrackNodeIssue {
-                        name: peer.name(),
-                        issue: IssueType::Communication,
-                    });
-                } else {
-                    output_cmds.push(Cmd::TrackNodeIssue {
-                        name: peer.name(),
-                        issue: IssueType::RequestOperation,
-                    });
-                }
+        let mut dst = *wire_msg.dst();
 
-                last_error = Some(Error::Comms(comms_err));
-            }
-        });
+        let node_bytes = targets
+            .into_iter()
+            .filter_map(|target| {
+                dst.name = target.name();
+                wire_msg
+                    .serialize_with_new_dst(&dst)
+                    .ok()
+                    .map(|bytes_to_node| (target, bytes_to_node))
+            })
+            .collect();
 
-        if success_count == targets_len {
-            if let Some(response) = last_success_response {
-                let response_kind = response.kind().clone();
-                // TODO: Keep this as cmd
-                send_msg_on_stream(
-                    context.network_knowledge.section_key(),
-                    response.payload,
-                    response_kind,
-                    client_stream,
-                    source_client,
-                    msg_id,
-                )
-                .await?;
-            }
-        } else {
-            error!("Request to holder node/s was not completely successful for {msg_id:?}");
-            if let Some(error) = last_error {
-                debug!("Error error being returned to client {source_client:?}: {error:?}");
-                let msg = ClientDataResponse::NetworkIssue(
-                    sn_interface::types::DataError::CouldNotContactAllStorageNodes(msg_id),
-                );
-                output_cmds.push(Cmd::SendClientResponse {
-                    msg,
-                    correlation_id: msg_id,
-                    send_stream: client_stream,
-                    context,
-                    source_client,
-                })
-            }
-        }
+        use sn_interface::messaging::system::NodeMsgType::*;
+        let msg_type = match wire_msg.kind() {
+            MsgKind::Client {
+                query_index: Some(_),
+                ..
+            } => DataQuery,
+            MsgKind::Client {
+                query_index: None, ..
+            } => StoreData,
+            _ => return Err(Error::InvalidMessage),
+        };
 
-        Ok(output_cmds)
-    }
-}
-
-// Send a msg to each of the targets, and await for the responses from all of them
-async fn send_wiremsg_to_target_peers_and_await_responses(
-    msg_id: MsgId,
-    wire_msg: WireMsg,
-    targets: BTreeSet<Peer>,
-    context: &NodeContext,
-) -> Result<Vec<(Peer, Result<Result<WireMsg, CommsError>, Elapsed>)>> {
-    // We create a Dst with random dst name, but we'll update it accordingly for each target
-    let mut dst = *wire_msg.dst();
-
-    let mut send_tasks = vec![];
-    for target in targets {
-        dst.name = target.name();
-        let bytes_to_node = wire_msg.serialize_with_new_dst(&dst)?;
-
-        let comm = context.comm.clone();
-        debug!("About to send {msg_id:?} to holder node: {target:?}");
-
-        send_tasks.push(
-            async move {
-                let outcome = timeout(*NODE_RESPONSE_TIMEOUT, async {
-                    comm.send_out_bytes_to_peer_and_return_response(target, msg_id, bytes_to_node)
-                        .await
-                })
-                .await;
-
-                (target, outcome)
-            }
-            .boxed(),
+        let dst_stream = (
+            Dst {
+                name: source_client.name(),
+                section_key: context.network_knowledge.section_key(),
+            },
+            client_stream,
         );
+
+        context
+            .comm
+            .send_and_respond_on_stream(msg_id, msg_type, node_bytes, dst_stream);
+
+        Ok(())
     }
-
-    Ok(futures::future::join_all(send_tasks).await)
-}
-
-// Send a msg to each of the targets, and await for the responses from all of them
-async fn send_to_target_peers_and_await_responses(
-    msg_id: MsgId,
-    msg: &NodeMsg,
-    targets: BTreeSet<Peer>,
-    context: &NodeContext,
-) -> Result<Vec<(Peer, Result<Result<WireMsg, CommsError>, Elapsed>)>> {
-    let (kind, payload) = MyNode::serialize_node_msg(context.name, msg)?;
-
-    // We create a Dst with random dst name, but we'll update it accordingly for each target
-    let mut dst = Dst {
-        name: XorName::default(),
-        section_key: context.network_knowledge.section_key(),
-    };
-    let mut wire_msg = WireMsg::new_msg(msg_id, payload, kind, dst);
-    let _bytes = wire_msg.serialize_and_cache_bytes()?;
-
-    let mut send_tasks = vec![];
-    for target in targets {
-        dst.name = target.name();
-        let bytes_to_node = wire_msg.serialize_with_new_dst(&dst)?;
-
-        let comm = context.comm.clone();
-        info!("About to send {msg_id:?} to holder node: {target:?}");
-
-        send_tasks.push(
-            async move {
-                let outcome = timeout(*NODE_RESPONSE_TIMEOUT, async {
-                    comm.send_out_bytes_to_peer_and_return_response(target, msg_id, bytes_to_node)
-                        .await
-                })
-                .await;
-
-                (target, outcome)
-            }
-            .boxed(),
-        );
-    }
-
-    Ok(futures::future::join_all(send_tasks).await)
 }
 
 // Send a msg on a given stream
@@ -333,7 +186,7 @@ async fn send_msg_on_stream(
     mut send_stream: SendStream,
     target_peer: Peer,
     correlation_id: MsgId,
-) -> Result<()> {
+) -> Result<Option<Cmd>> {
     let dst = Dst {
         name: target_peer.name(),
         section_key,
@@ -353,7 +206,10 @@ async fn send_msg_on_stream(
             "Could not send response {correlation_id:?} to peer {target_peer:?} \
             over response {stream_id}: {error:?}"
         );
-        return Err(error.into());
+        return Ok(Some(Cmd::HandleCommsError {
+            peer: target_peer,
+            error: sn_comms::Error::from(error),
+        }));
     }
 
     trace!("Msg away for {correlation_id:?} to {target_peer:?}, over {stream_id}");
@@ -369,5 +225,5 @@ async fn send_msg_on_stream(
 
     trace!("Sent the msg {correlation_id:?} to {target_peer:?} over {stream_id}");
 
-    Ok(())
+    Ok(None)
 }

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -142,11 +142,10 @@ async fn bootstrap_node(
     CmdChannel,
     mpsc::Receiver<RejoinReason>,
 )> {
-    let (incoming_msg_pipe, incoming_msg_receiver) = mpsc::channel(STANDARD_CHANNEL_SIZE);
     let (fault_cmds_sender, fault_cmds_receiver) =
         mpsc::channel::<FaultsCmd>(STANDARD_CHANNEL_SIZE);
 
-    let comm = Comm::new(config.local_addr(), incoming_msg_pipe)?;
+    let (comm, incoming_msg_receiver) = Comm::new(config.local_addr())?;
 
     let node = if config.is_first() {
         start_genesis_node(


### PR DESCRIPTION
This removes dashmap use for sessions in comms.

It also makes comms error handling and issue reporting focused to one place.

Additional thing to note is that Elders now relay responses back to client as soon as they are received.
The way the requests are designed now, that would only be more than one response when storing data,
since queries from a Client, only go out to one data holder from the Elders.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
