### PR TITLE
refactor: moves serialize call to where needed

### DIFF
--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -86,7 +86,7 @@ impl MyNode {
                 MyNode::check_for_entropy(&wire_msg, &context.network_knowledge, &origin)?;
             if let Some((update, ae_kind)) = entropy {
                 debug!("bailing early, AE found for {msg_id:?}");
-                return MyNode::perform_any_anti_entropy_cmds(
+                return MyNode::generate_anti_entropy_cmds(
                     &context,
                     &wire_msg,
                     origin,


### PR DESCRIPTION
- We were serializing before hitting the branch where it was needed.
- Also aligns fn name withy doc. The cases when no cmd is generated are the unreachable and invalid msg cases.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
