### PR TITLE
ci: enable the otlp feature on the release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ gha-build-x86_64-unknown-linux-musl:
 	mkdir artifacts
 	sudo apt update -y && sudo apt install -y musl-tools
 	rustup target add x86_64-unknown-linux-musl
-	cargo build --release --target x86_64-unknown-linux-musl --bin sn_node
+	cargo build --release --target x86_64-unknown-linux-musl --bin sn_node --features otlp
 	cargo build --release --target x86_64-unknown-linux-musl --features limit-client-upload-size --bin safe
 	find target/x86_64-unknown-linux-musl/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 	rm -f artifacts/.cargo-lock
@@ -33,7 +33,7 @@ arm-unknown-linux-musleabi:
 	rm -rf artifacts
 	mkdir artifacts
 	cargo install cross
-	cross build --release --target arm-unknown-linux-musleabi --bin sn_node
+	cross build --release --target arm-unknown-linux-musleabi --bin sn_node --features otlp
 	cross build --release --target arm-unknown-linux-musleabi --features limit-client-upload-size --bin safe
 	find target/arm-unknown-linux-musleabi/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 
@@ -46,7 +46,7 @@ armv7-unknown-linux-musleabihf:
 	rm -rf artifacts
 	mkdir artifacts
 	cargo install cross
-	cross build --release --target armv7-unknown-linux-musleabihf --bin sn_node
+	cross build --release --target armv7-unknown-linux-musleabihf --bin sn_node --features otlp
 	cross build --release --target armv7-unknown-linux-musleabihf --features limit-client-upload-size --bin safe
 	find target/armv7-unknown-linux-musleabihf/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 
@@ -59,14 +59,14 @@ aarch64-unknown-linux-musl:
 	rm -rf artifacts
 	mkdir artifacts
 	cargo install cross
-	cross build --release --target aarch64-unknown-linux-musl --bin sn_node
+	cross build --release --target aarch64-unknown-linux-musl --bin sn_node --features otlp
 	cross build --release --target aarch64-unknown-linux-musl --features limit-client-upload-size --bin safe
 	find target/aarch64-unknown-linux-musl/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 
 release-build:
 	rm -rf artifacts
 	mkdir artifacts
-	cargo build --release --bin sn_node
+	cargo build --release --bin sn_node --features otlp
 	cargo build --release --features limit-client-upload-size --bin safe
 	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 


### PR DESCRIPTION
We're going to do some testnet experimentation with tracing so we want our releases to have the `otlp` feature enabled.
