### PR TITLE
Refactor comms, evaluate acks on client

### DIFF
--- a/sn_api/src/app/test_helpers.rs
+++ b/sn_api/src/app/test_helpers.rs
@@ -222,3 +222,23 @@ pub fn random_nrs_name() -> String {
         .map(char::from)
         .collect()
 }
+
+pub fn extract_error_string(
+    received_errors: Vec<(sn_interface::types::Peer, Vec<sn_client::ErrorMsg>)>,
+) -> anyhow::Result<String> {
+    match received_errors
+        .into_iter()
+        .flat_map(|(_, errors)| errors)
+        .filter_map(|err| {
+            if let sn_client::ErrorMsg::InvalidOperation(error_string) = err {
+                Some(error_string)
+            } else {
+                None
+            }
+        })
+        .last()
+    {
+        Some(error_string) => Ok(error_string),
+        None => anyhow::bail!("We expected an error to be returned"),
+    }
+}

--- a/sn_api/src/app/wallet.rs
+++ b/sn_api/src/app/wallet.rs
@@ -566,11 +566,11 @@ fn verify_spent_proof_shares_for_tx<'a>(
 mod tests {
     use super::*;
     use crate::app::test_helpers::{
-        get_next_bearer_dbc, new_read_only_safe_instance, new_safe_instance,
+        extract_error_string, get_next_bearer_dbc, new_read_only_safe_instance, new_safe_instance,
         new_safe_instance_with_dbc, new_safe_instance_with_dbc_owner, GENESIS_DBC,
     };
     use anyhow::{anyhow, Result};
-    use sn_client::{Error as ClientError, ErrorMsg};
+    use sn_client::Error as ClientError;
     use sn_dbc::{Error as DbcError, Owner};
 
     #[tokio::test]
@@ -1202,9 +1202,9 @@ mod tests {
         // It shall detect no spent proofs for this TX, thus fail to reissue
         match safe.wallet_reissue(&wallet_xorurl, "0.1", None).await {
             Err(Error::ClientError(ClientError::CmdError {
-                source: ErrorMsg::InvalidOperation(msg),
-                ..
+                received_errors, ..
             })) => {
+                let msg = extract_error_string(received_errors)?;
                 assert_eq!(
                     msg,
                     format!(

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -127,9 +127,9 @@ impl Client {
         }
 
         let query = DataQueryVariant::GetChunk(ChunkAddress(*name));
-        let res = self.send_query(query.clone()).await?;
+        let response = self.send_query(query.clone()).await?;
 
-        let chunk: Chunk = match res.response {
+        let chunk: Chunk = match response {
             QueryResponse::GetChunk(result) => {
                 result.map_err(|err| Error::ErrorMsg { source: err })
             }
@@ -375,7 +375,7 @@ impl Client {
         let query = DataQueryVariant::GetChunk(ChunkAddress(name));
         let results = self.send_query_to_replicas(query.clone(), replicas).await?;
         for (replica_index, res) in results {
-            let outcome = res.map(|query_result| match query_result.response {
+            let outcome = res.map(|response| match response {
                 QueryResponse::GetChunk(Ok(chunk)) => {
                     found_chunk = Some(chunk);
                     Ok(())

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -219,7 +219,7 @@ impl Client {
         for next_batch in all_chunks.chunks(CHUNKS_BATCH_MAX_SIZE) {
             // Connect to all relevant elders before we fire off all msgs...
             self.session
-                .setup_connections_to_relevant_nodes(next_batch.iter().map(|c| *c.name()).collect())
+                .prepare_connections(next_batch.iter().map(|c| *c.name()).collect(), false)
                 .await?;
 
             let tasks = next_batch.iter().cloned().map(|chunk| {

--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -89,7 +89,7 @@ impl Client {
         loop {
             // Send the dummy message to probe the network for it's infrastructure details.
             match self.send_query_without_retry(query.clone()).await {
-                Ok(result) if result.response.is_data_not_found() => {
+                Ok(response) if response.is_data_not_found() => {
                     // A data-not-found response means it comes from the right set of Elders,
                     // any AE retries should have taken place as well.
                     let network_knowledge = self.session.network.read().await;

--- a/sn_client/src/api/register_apis.rs
+++ b/sn_client/src/api/register_apis.rs
@@ -133,10 +133,10 @@ impl Client {
     pub async fn get_register(&self, address: Address) -> Result<Register> {
         // Let's fetch the Register from the network
         let query = DataQueryVariant::Register(RegisterQuery::Get(address));
-        let query_result = self.send_query(query.clone()).await?;
+        let response = self.send_query(query.clone()).await?;
 
-        debug!("get_register result is; {query_result:?}");
-        match query_result.response {
+        debug!("get_register response is; {response:?}");
+        match response {
             QueryResponse::GetRegister(res) => res.map_err(|err| Error::ErrorMsg { source: err }),
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -149,8 +149,8 @@ impl Client {
     #[instrument(skip(self), level = "debug")]
     pub async fn read_register(&self, address: Address) -> Result<BTreeSet<(EntryHash, Entry)>> {
         let query = DataQueryVariant::Register(RegisterQuery::Read(address));
-        let query_result = self.send_query(query.clone()).await?;
-        match query_result.response {
+        let response = self.send_query(query.clone()).await?;
+        match response {
             QueryResponse::ReadRegister(res) => res.map_err(|err| Error::ErrorMsg { source: err }),
             other => Err(Error::UnexpectedQueryResponse {
                 query,
@@ -163,8 +163,8 @@ impl Client {
     #[instrument(skip(self), level = "debug")]
     pub async fn get_register_entry(&self, address: Address, hash: EntryHash) -> Result<Entry> {
         let query = DataQueryVariant::Register(RegisterQuery::GetEntry { address, hash });
-        let query_result = self.send_query(query.clone()).await?;
-        match query_result.response {
+        let response = self.send_query(query.clone()).await?;
+        match response {
             QueryResponse::GetRegisterEntry(res) => {
                 res.map_err(|err| Error::ErrorMsg { source: err })
             }
@@ -183,8 +183,8 @@ impl Client {
     #[instrument(skip(self), level = "debug")]
     pub async fn get_register_owner(&self, address: Address) -> Result<User> {
         let query = DataQueryVariant::Register(RegisterQuery::GetOwner(address));
-        let query_result = self.send_query(query.clone()).await?;
-        match query_result.response {
+        let response = self.send_query(query.clone()).await?;
+        match response {
             QueryResponse::GetRegisterOwner(res) => {
                 res.map_err(|err| Error::ErrorMsg { source: err })
             }
@@ -207,8 +207,8 @@ impl Client {
         user: User,
     ) -> Result<Permissions> {
         let query = DataQueryVariant::Register(RegisterQuery::GetUserPermissions { address, user });
-        let query_result = self.send_query(query.clone()).await?;
-        match query_result.response {
+        let response = self.send_query(query.clone()).await?;
+        match response {
             QueryResponse::GetRegisterUserPermissions(res) => {
                 res.map_err(|err| Error::ErrorMsg { source: err })
             }
@@ -223,8 +223,8 @@ impl Client {
     #[instrument(skip(self), level = "debug")]
     pub async fn get_register_policy(&self, address: Address) -> Result<Policy> {
         let query = DataQueryVariant::Register(RegisterQuery::GetPolicy(address));
-        let query_result = self.send_query(query.clone()).await?;
-        match query_result.response {
+        let response = self.send_query(query.clone()).await?;
+        match response {
             QueryResponse::GetRegisterPolicy(res) => {
                 res.map_err(|err| Error::ErrorMsg { source: err })
             }

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -109,8 +109,8 @@ impl Client {
     pub async fn spent_proof_shares(&self, key_image: KeyImage) -> Result<Vec<SpentProofShare>> {
         let address = SpentbookAddress::new(XorName::from_content(&key_image.to_bytes()));
         let query = DataQueryVariant::Spentbook(SpentbookQuery::SpentProofShares(address));
-        let query_result = self.send_query(query.clone()).await?;
-        match query_result.response {
+        let response = self.send_query(query.clone()).await?;
+        match response {
             QueryResponse::SpentProofShares(res) => {
                 res.map_err(|err| Error::ErrorMsg { source: err })
             }

--- a/sn_client/src/bin/query-adult/main.rs
+++ b/sn_client/src/bin/query-adult/main.rs
@@ -142,8 +142,7 @@ async fn send_query(client: &Client, query: DataQuery) -> Result<QueryResponse> 
             serialised_query.clone(),
             signature.clone(),
         )
-        .await?
-        .response)
+        .await?)
 }
 
 /// Parse arguments and setup file/bytes to use

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -331,6 +331,6 @@ pub enum DataReplicasCheckError {
         /// Query sent to data replicas
         query: DataQueryVariant,
         /// List of responses received with their corresponding replica/Adult index
-        responses: Vec<(crate::sessions::QueryResult, usize)>,
+        responses: Vec<(QueryResponse, usize)>,
     },
 }

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -211,12 +211,12 @@ pub enum Error {
         source: ErrorMsg,
     },
     /// Error response received for a client cmd sent to the network
-    #[error("Error received from the network: {source:?} for cmd: {msg_id:?}")]
+    #[error("Errors received from the network: {received_errors:?} for cmd: {msg_id:?}")]
     CmdError {
-        /// The source of an error msg
-        source: ErrorMsg,
         /// MsgId of the cmd sent
         msg_id: MsgId,
+        /// The errors returned from remote nodes (via Elders).
+        received_errors: Vec<(Peer, Vec<ErrorMsg>)>,
     },
     /// Errors occurred when serialising or deserialising msgs
     #[error(transparent)]

--- a/sn_client/src/sessions/messaging.rs
+++ b/sn_client/src/sessions/messaging.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{MsgResponse, QueryResult, Session};
+use super::{MsgResponse, Session};
 use crate::{Error, Result};
 
 use sn_interface::{
@@ -323,7 +323,7 @@ impl Session {
         auth: ClientAuth,
         payload: Bytes,
         dst_section_info: Option<(bls::PublicKey, Vec<Peer>)>,
-    ) -> Result<QueryResult> {
+    ) -> Result<QueryResponse> {
         let endpoint = self.endpoint.clone();
 
         let chunk_addr = if let DataQueryVariant::GetChunk(address) = query.variant {
@@ -378,7 +378,7 @@ impl Session {
         elders: Vec<Peer>,
         chunk_addr: Option<ChunkAddress>,
         mut send_query_tasks: JoinSet<MsgResponse>,
-    ) -> Result<QueryResult> {
+    ) -> Result<QueryResponse> {
         let mut discarded_responses: usize = 0;
         let mut error_response = None;
         let mut valid_response = None;
@@ -485,12 +485,12 @@ impl Session {
         // if any are valid, lets return it
         if let Some(response) = valid_response {
             debug!("Valid response in!!!: {response:?}");
-            return Ok(QueryResult { response });
+            return Ok(response);
             // otherwise, if we've got an error in
             // we can return that too
         } else if let Some(response) = error_response {
             if discarded_responses > elders_len / 2 {
-                return Ok(QueryResult { response });
+                return Ok(response);
             }
         }
 

--- a/sn_client/src/sessions/mod.rs
+++ b/sn_client/src/sessions/mod.rs
@@ -29,22 +29,6 @@ pub(super) enum MsgResponse {
     Failure(SocketAddr, Error),
 }
 
-#[derive(Debug)]
-pub struct QueryResult {
-    pub response: QueryResponse,
-}
-
-impl QueryResult {
-    /// Returns true if the QueryResponse is DataNotFound
-    pub(crate) fn data_was_found(&self) -> bool {
-        let found = !self.response.is_data_not_found();
-
-        debug!("was the data found??? {found:?}, {self:?}");
-
-        found
-    }
-}
-
 #[derive(Clone, Debug)]
 pub(super) struct Session {
     // Session endpoint.

--- a/sn_client/src/sessions/mod.rs
+++ b/sn_client/src/sessions/mod.rs
@@ -7,7 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 mod listeners;
-mod messaging;
+mod send_cmd;
+mod send_query;
 
 use crate::{connections::PeerLinks, Error, Result};
 

--- a/sn_client/src/sessions/send_cmd.rs
+++ b/sn_client/src/sessions/send_cmd.rs
@@ -10,64 +10,18 @@ use super::{MsgResponse, Session};
 use crate::{Error, Result};
 
 use sn_interface::{
-    messaging::{
-        data::{DataQuery, DataQueryVariant, QueryResponse},
-        ClientAuth, Dst, MsgId, MsgKind, WireMsg,
-    },
+    messaging::{ClientAuth, Dst, MsgId, MsgKind, WireMsg},
     network_knowledge::supermajority,
-    types::{ChunkAddress, Peer},
+    types::Peer,
 };
 
 use bytes::Bytes;
-use rand::{rngs::OsRng, seq::SliceRandom};
 use std::collections::BTreeSet;
 use tokio::task::JoinSet;
 use tracing::{debug, error, trace, warn};
 use xor_name::XorName;
 
-// Number of Elders subset to send queries to
-#[cfg(not(feature = "query-happy-path"))]
-pub(crate) const NUM_OF_ELDERS_SUBSET_FOR_QUERIES: usize = 3;
-#[cfg(feature = "query-happy-path")]
-pub(crate) const NUM_OF_ELDERS_SUBSET_FOR_QUERIES: usize = 1;
-
 impl Session {
-    #[instrument(skip(self), level = "debug", name = "session setup conns")]
-    /// Make a best effort to pre connect to only relevant nodes for a set of dst addresses
-    /// This should reduce the number of connections attempts to the same elder set
-    pub(crate) async fn setup_connections_to_relevant_nodes(
-        &self,
-        dst_addresses: Vec<XorName>,
-    ) -> Result<()> {
-        let mut relevant_elders = BTreeSet::new();
-        // TODO: get relevant nodes
-        for address in dst_addresses {
-            let (_, elders) = self.get_cmd_elders(address).await?;
-            for elder in elders {
-                let _existed = relevant_elders.insert(elder);
-            }
-        }
-
-        let mut tasks = vec![];
-        for peer in relevant_elders {
-            let session = self.clone();
-
-            let task = async move {
-                let connect_now = true;
-                // We don't retry here.. if we fail it will be retried on a per message basis
-                let _ = session
-                    .peer_links
-                    .get_or_create_link(&peer, connect_now, None)
-                    .await;
-            };
-            tasks.push(task);
-        }
-
-        let _ = futures::future::join_all(tasks).await;
-
-        Ok(())
-    }
-
     #[instrument(skip(self, auth, payload), level = "debug", name = "session send cmd")]
     pub(crate) async fn send_cmd(
         &self,
@@ -122,13 +76,49 @@ impl Session {
         }
     }
 
+    #[instrument(skip(self), level = "debug", name = "session setup conns")]
+    /// Make a best effort to pre connect to only relevant nodes for a set of dst addresses
+    /// This should reduce the number of connections attempts to the same elder set
+    pub(crate) async fn setup_connections_to_relevant_nodes(
+        &self,
+        dst_addresses: Vec<XorName>,
+    ) -> Result<()> {
+        let mut relevant_elders = BTreeSet::new();
+        // TODO: get relevant nodes
+        for address in dst_addresses {
+            let (_, elders) = self.get_cmd_elders(address).await?;
+            for elder in elders {
+                let _existed = relevant_elders.insert(elder);
+            }
+        }
+
+        let mut tasks = vec![];
+        for peer in relevant_elders {
+            let session = self.clone();
+
+            let task = async move {
+                let connect_now = true;
+                // We don't retry here.. if we fail it will be retried on a per message basis
+                let _ = session
+                    .peer_links
+                    .get_or_create_link(&peer, connect_now, None)
+                    .await;
+            };
+            tasks.push(task);
+        }
+
+        let _ = futures::future::join_all(tasks).await;
+
+        Ok(())
+    }
+
     async fn send_msg_and_check_acks(
         &self,
         msg_id: MsgId,
         elders: Vec<Peer>,
         wire_msg: WireMsg,
     ) -> Result<()> {
-        let send_cmd_tasks = self.send_msg(elders.clone(), wire_msg).await?;
+        let send_cmd_tasks = self.send_cmd_msg(elders.clone(), wire_msg).await?;
         trace!("Cmd msg {msg_id:?} sent");
         // On non-happy-path, we currently expect all elders to ack.
         let expected_acks = elders.len();
@@ -179,7 +169,7 @@ impl Session {
                 .await;
 
             trace!("Sending cmd {msg_id:?}, skipping {skip}, sending to {take} elders..");
-            let send_cmd_tasks = self.send_msg(elders.clone(), wire_msg.clone()).await?;
+            let send_cmd_tasks = self.send_cmd_msg(elders.clone(), wire_msg.clone()).await?;
 
             // We only require one ack, we wait it to get received.
             // Any AE message is handled by the tasks, hence no extra wait is required.
@@ -310,228 +300,6 @@ impl Session {
         })
     }
 
-    #[instrument(
-        skip(self, auth, payload),
-        level = "debug",
-        name = "session send query"
-    )]
-    #[allow(clippy::too_many_arguments)]
-    /// Send a `ClientMsg` to the network awaiting for the response.
-    pub(crate) async fn send_query(
-        &self,
-        query: DataQuery,
-        auth: ClientAuth,
-        payload: Bytes,
-        dst_section_info: Option<(bls::PublicKey, Vec<Peer>)>,
-    ) -> Result<QueryResponse> {
-        let endpoint = self.endpoint.clone();
-
-        let chunk_addr = if let DataQueryVariant::GetChunk(address) = query.variant {
-            Some(address)
-        } else {
-            None
-        };
-
-        let dst = query.variant.dst_name();
-
-        let (section_pk, elders) = if let Some(section_info) = dst_section_info {
-            section_info
-        } else {
-            self.get_query_elders(dst).await?
-        };
-
-        let elders_len = elders.len();
-        let msg_id = MsgId::new();
-
-        debug!(
-            "Sending query message {msg_id:?}, from {}, {query:?} to \
-            the {elders_len} Elders closest to data name: {elders:?}",
-            endpoint.local_addr(),
-        );
-
-        let dst = Dst {
-            name: dst,
-            section_key: section_pk,
-        };
-        let kind = MsgKind::Client(auth);
-        let wire_msg = WireMsg::new_msg(msg_id, payload, kind, dst);
-
-        let send_query_tasks = self.send_msg(elders.clone(), wire_msg).await?;
-
-        // TODO:
-        // We are now simply accepting the very first valid response we receive,
-        // but we may want to revisit this to compare multiple responses and validate them,
-        // similar to what we used to do up to the following commit:
-        // https://github.com/maidsafe/sn_client/blob/9091a4f1f20565f25d3a8b00571cc80751918928/src/connection_manager.rs#L328
-        //
-        // For Chunk responses we already validate its hash matches the xorname requested from,
-        // so we don't need more than one valid response to prevent from accepting invalid responses
-        // from byzantine nodes, however for mutable data (non-Chunk responses) we will
-        // have to review the approach.
-        self.check_query_responses(msg_id, elders.clone(), chunk_addr, send_query_tasks)
-            .await
-    }
-
-    async fn check_query_responses(
-        &self,
-        msg_id: MsgId,
-        elders: Vec<Peer>,
-        chunk_addr: Option<ChunkAddress>,
-        mut send_query_tasks: JoinSet<MsgResponse>,
-    ) -> Result<QueryResponse> {
-        let mut discarded_responses: usize = 0;
-        let mut error_response = None;
-        let mut valid_response = None;
-        let elders_len = elders.len();
-
-        while let Some(msg_resp) = send_query_tasks.join_next().await {
-            let (peer_address, response) = match msg_resp {
-                Ok(MsgResponse::QueryResponse(src, resp)) => (src, resp),
-                Ok(MsgResponse::CmdResponse(src, resp)) => {
-                    debug!("Unexpected cmd response received from {src:?} for {msg_id:?} when awaiting a QueryResponse: {resp:?}");
-                    discarded_responses += 1;
-                    continue;
-                }
-                Ok(MsgResponse::Failure(src, error)) => {
-                    debug!("Failure occurred with msg {msg_id:?} from {src:?}: {error:?}");
-                    discarded_responses += 1;
-                    continue;
-                }
-                Err(join_err) => {
-                    warn!("Join failure occurred with msg {msg_id:?}: {join_err:?}");
-                    continue;
-                }
-            };
-
-            // let's see if we have a positive response...
-            debug!("Response to {msg_id:?}: {response:?}");
-
-            match *response {
-                QueryResponse::GetChunk(Ok(chunk)) => {
-                    if let Some(chunk_addr) = chunk_addr {
-                        // We are dealing with Chunk query responses, thus we validate its hash
-                        // matches its xorname, if so, we don't need to await for more responses
-                        debug!("Chunk QueryResponse received is: {chunk:#?}");
-
-                        if chunk_addr.name() == chunk.name() {
-                            trace!("Valid Chunk received for {msg_id:?}");
-                            valid_response = Some(QueryResponse::GetChunk(Ok(chunk)));
-                            break;
-                        } else {
-                            // the Chunk content doesn't match its XorName,
-                            // this is suspicious and it could be a byzantine node
-                            warn!("We received an invalid Chunk response from one of the nodes for {msg_id:?}");
-                            discarded_responses += 1;
-                        }
-                    }
-                }
-                QueryResponse::GetRegister(Err(_))
-                | QueryResponse::ReadRegister(Err(_))
-                | QueryResponse::GetRegisterPolicy(Err(_))
-                | QueryResponse::GetRegisterOwner(Err(_))
-                | QueryResponse::GetRegisterUserPermissions(Err(_))
-                | QueryResponse::GetChunk(Err(_)) => {
-                    debug!(
-                        "QueryResponse error #{discarded_responses} for {msg_id:?} received \
-                        from {peer_address:?} (but may be overridden by a non-error response \
-                        from another elder): {:#?}",
-                        &response
-                    );
-                    error_response = Some(*response);
-                    discarded_responses += 1;
-                }
-                QueryResponse::GetRegister(Ok(ref register)) => {
-                    debug!("okay got register from {peer_address:?}");
-                    // TODO: properly merge all registers
-                    if let Some(QueryResponse::GetRegister(Ok(prior_response))) = &valid_response {
-                        if register.size() > prior_response.size() {
-                            debug!("longer register");
-                            // keep this new register
-                            valid_response = Some(*response);
-                        }
-                    } else {
-                        valid_response = Some(*response);
-                    }
-                }
-                QueryResponse::ReadRegister(Ok(_)) => {
-                    debug!("okay _read_ register from {peer_address:?}");
-                    if valid_response.is_none() {
-                        valid_response = Some(*response);
-                    }
-                }
-                QueryResponse::SpentProofShares(Ok(ref spentproof_set)) => {
-                    debug!("okay _read_ spentproofs from {peer_address:?}");
-                    // TODO: properly merge all registers
-                    if let Some(QueryResponse::SpentProofShares(Ok(prior_response))) =
-                        &valid_response
-                    {
-                        if spentproof_set.len() > prior_response.len() {
-                            debug!("longer spentproof response retrieved");
-                            // keep this new register
-                            valid_response = Some(*response);
-                        }
-                    } else {
-                        valid_response = Some(*response);
-                    }
-                }
-                response => {
-                    // we got a valid response
-                    valid_response = Some(response)
-                }
-            }
-        }
-
-        // we've looped over all responses...
-        // if any are valid, lets return it
-        if let Some(response) = valid_response {
-            debug!("Valid response in!!!: {response:?}");
-            return Ok(response);
-            // otherwise, if we've got an error in
-            // we can return that too
-        } else if let Some(response) = error_response {
-            if discarded_responses > elders_len / 2 {
-                return Ok(response);
-            }
-        }
-
-        Err(Error::NoResponse {
-            msg_id,
-            peers: elders,
-        })
-    }
-
-    /// Get DataSection elders details. Resort to own section if DataSection is not available.
-    /// Takes a random subset (NUM_OF_ELDERS_SUBSET_FOR_QUERIES) of the avialable elders as targets
-    pub(crate) async fn get_query_elders(
-        &self,
-        dst: XorName,
-    ) -> Result<(bls::PublicKey, Vec<Peer>)> {
-        let sap = self.network.read().await.closest(&dst, None).cloned();
-        let (section_pk, mut elders) = if let Some(sap) = &sap {
-            (sap.section_key(), sap.elders_vec())
-        } else {
-            return Err(Error::NoNetworkKnowledge(dst));
-        };
-
-        elders.shuffle(&mut OsRng);
-
-        // We select the NUM_OF_ELDERS_SUBSET_FOR_QUERIES closest Elders we are querying
-        let elders: Vec<_> = elders
-            .into_iter()
-            .take(NUM_OF_ELDERS_SUBSET_FOR_QUERIES)
-            .collect();
-
-        let elders_len = elders.len();
-        if elders_len < NUM_OF_ELDERS_SUBSET_FOR_QUERIES && elders_len > 1 {
-            return Err(Error::InsufficientElderConnections {
-                connections: elders_len,
-                required: NUM_OF_ELDERS_SUBSET_FOR_QUERIES,
-            });
-        }
-
-        Ok((section_pk, elders))
-    }
-
     async fn get_cmd_elders(&self, dst_address: XorName) -> Result<(bls::PublicKey, Vec<Peer>)> {
         let a_close_sap = self
             .network
@@ -546,7 +314,7 @@ impl Session {
             let section_pk = sap.section_key();
             trace!("SAP elders found {sap_elders:?}");
 
-            // Supermajority of elders is expected.
+            // Supermajority of elders is expected. (NB: This can - for data - be `at_least_one_correct` = 3 out of 7).
             let targets_count = supermajority(sap_elders.len());
 
             // any SAP that does not hold elders_count() is indicative of a broken network (after genesis)
@@ -570,7 +338,7 @@ impl Session {
     }
 
     #[instrument(skip_all, level = "trace")]
-    pub(super) async fn send_msg(
+    async fn send_cmd_msg(
         &self,
         nodes: Vec<Peer>,
         wire_msg: WireMsg,

--- a/sn_client/src/sessions/send_cmd.rs
+++ b/sn_client/src/sessions/send_cmd.rs
@@ -9,14 +9,16 @@
 use super::{MsgResponse, Session};
 use crate::{Error, Result};
 
+use qp2p::UsrMsgBytes;
 use sn_interface::{
+    at_least_one_correct_elder, data_copy_count,
     messaging::{ClientAuth, Dst, MsgId, MsgKind, WireMsg},
     network_knowledge::supermajority,
-    types::Peer,
+    types::{DataError, Peer},
 };
 
 use bytes::Bytes;
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, net::SocketAddr};
 use tokio::task::JoinSet;
 use tracing::{debug, error, trace, warn};
 use xor_name::XorName;
@@ -32,7 +34,9 @@ impl Session {
     ) -> Result<()> {
         let endpoint = self.endpoint.clone();
         // TODO: Consider other approach: Keep a session per section!
-        let (section_pk, elders) = self.get_cmd_elders(dst_address).await?;
+        let (section_pk, elders) = self
+            .get_cmd_elders(dst_address, needs_super_majority)
+            .await?;
 
         let elders_len = elders.len();
         let msg_id = MsgId::new();
@@ -58,8 +62,7 @@ impl Session {
 
         if needs_super_majority {
             log_line(format!("{elders_len}"));
-            self.send_msg_and_check_acks(msg_id, elders.clone(), wire_msg)
-                .await
+            self.send_cmd_msg(elders.clone(), wire_msg).await
         } else {
             #[cfg(feature = "cmd-happy-path")]
             {
@@ -70,8 +73,7 @@ impl Session {
             #[cfg(not(feature = "cmd-happy-path"))]
             {
                 log_line(format!("{elders_len}"));
-                self.send_msg_and_check_acks(msg_id, elders.clone(), wire_msg)
-                    .await
+                self.send_cmd_msg(elders.clone(), wire_msg).await
             }
         }
     }
@@ -79,14 +81,14 @@ impl Session {
     #[instrument(skip(self), level = "debug", name = "session setup conns")]
     /// Make a best effort to pre connect to only relevant nodes for a set of dst addresses
     /// This should reduce the number of connections attempts to the same elder set
-    pub(crate) async fn setup_connections_to_relevant_nodes(
+    pub(crate) async fn prepare_connections(
         &self,
         dst_addresses: Vec<XorName>,
+        needs_super_majority: bool,
     ) -> Result<()> {
         let mut relevant_elders = BTreeSet::new();
-        // TODO: get relevant nodes
         for address in dst_addresses {
-            let (_, elders) = self.get_cmd_elders(address).await?;
+            let (_, elders) = self.get_cmd_elders(address, needs_super_majority).await?;
             for elder in elders {
                 let _existed = relevant_elders.insert(elder);
             }
@@ -112,30 +114,6 @@ impl Session {
         Ok(())
     }
 
-    async fn send_msg_and_check_acks(
-        &self,
-        msg_id: MsgId,
-        elders: Vec<Peer>,
-        wire_msg: WireMsg,
-    ) -> Result<()> {
-        let send_cmd_tasks = self.send_cmd_msg(elders.clone(), wire_msg).await?;
-        trace!("Cmd msg {msg_id:?} sent");
-        // On non-happy-path, we currently expect all elders to ack.
-        let expected_acks = elders.len();
-        // We wait for ALL the expected acks get received.
-        // The AE messages are handled by the tasks, hence no extra wait is required.
-        match self
-            .we_have_sufficient_acks_for_cmd(msg_id, elders, expected_acks, send_cmd_tasks)
-            .await
-        {
-            Ok(()) => {
-                trace!("Acks of Cmd {:?} received", msg_id);
-                Ok(())
-            }
-            error => error,
-        }
-    }
-
     /// This function will try a happy path,
     /// successively expanding to all the other elders in case of failure.
     ///
@@ -152,29 +130,24 @@ impl Session {
     ) -> Result<()> {
         let msg_id = wire_msg.msg_id();
         // On happy path, we only require 1 ack.
-        let expected_acks = 1;
+        // NB: we are for now expecting as many acks as we are calling Elders. To be fixed.
+        let _expected_acks = 1;
 
-        // this will do at most 4 attempts, eventually calling all 7 elders
+        // This will do at most 4 attempts, to: 1, 1, 2, and finally 3 elders,
+        // thus eventually calling all 7 elders.
         for skip in 0..3 {
-            let take = if skip == 0 {
-                1
-            } else if skip == 3 {
-                4
-            } else {
-                skip
-            };
+            let take = if skip == 0 { 1 } else { skip };
 
             let elders = self
                 .pick_elders(target, all_elders.clone(), skip, take)
                 .await;
 
             trace!("Sending cmd {msg_id:?}, skipping {skip}, sending to {take} elders..");
-            let send_cmd_tasks = self.send_cmd_msg(elders.clone(), wire_msg.clone()).await?;
 
-            // We only require one ack, we wait it to get received.
+            // We only require one ack, we wait for it to get received.
             // Any AE message is handled by the tasks, hence no extra wait is required.
             if self
-                .we_have_sufficient_acks_for_cmd(msg_id, elders, expected_acks, send_cmd_tasks)
+                .send_cmd_msg(elders.clone(), wire_msg.clone())
                 .await
                 .is_ok()
             {
@@ -210,97 +183,103 @@ impl Session {
 
     /// Checks for acks for a given msg.
     /// Returns Ok if we've sufficient to call this cmd a success
+    ///
+    /// We send the cmd to each Elder, who then relays the cmd to the data holders.
+    /// We will get back the cmd responses from each data holder, for each Elder.
+    /// With sending to at least one correct Elder (3) who each sends to 4 data holders, that
+    /// gives a total of 12 acks that we expect. With super majority (5) we get a total of 20 acks.
     async fn we_have_sufficient_acks_for_cmd(
         &self,
         msg_id: MsgId,
         elders: Vec<Peer>,
-        expected_acks: usize,
-        mut send_cmd_tasks: JoinSet<MsgResponse>,
+        mut send_cmd_tasks: JoinSet<(Peer, Vec<MsgResponse>)>,
     ) -> Result<()> {
-        debug!("----> Init of check for acks for {msg_id:?}");
-        let mut received_acks = BTreeSet::default();
-        let mut received_errors = BTreeSet::default();
-        let mut failures = BTreeSet::default();
+        // We don't yet have a way to differentiate the data holder responses
+        // we get from each Elder. We need to have the data holders sign their response (the serialized payload)
+        // then the Elder receiving it needs to verify the sig before sending it on to the client. (The Elders
+        // do not need to deserialize the payload.) The client can then see by the different sigs that they are from different
+        // data holders. If a deserialized payload turns out to be something unexpected, such as a wrong type or data not found,
+        // then the client can send that in, with the sig, to the Elders. Their incentive to do this is to ensure that the
+        // data they paid for, is actually being stored in the network. This way, we have the clients doing the work of checking the adults,
+        // while still shielding the adults from the clients.
 
+        debug!("----> Init of check for acks for {msg_id:?}");
+
+        let mut reports = vec![];
+
+        // here we expect `elders.len()` x `data_copy_count()` acks
         while let Some(msg_resp) = send_cmd_tasks.join_next().await {
             debug!("Handling msg_resp sent to ack wait channel: {msg_resp:?}");
-            let (src, result) = match msg_resp {
-                Ok(MsgResponse::CmdResponse(src, response)) => (src, response.result().clone()),
-                Ok(MsgResponse::QueryResponse(src, resp)) => {
-                    debug!("Unexpected query response received from {src:?} for {msg_id:?} when awaiting a CmdAck: {resp:?}");
-                    let _ = received_errors.insert(src);
-                    continue;
-                }
-                Ok(MsgResponse::Failure(src, error)) => {
-                    debug!("Failure occurred with msg {msg_id:?} from {src:?}: {error:?}");
-                    let _ = failures.insert(src);
-                    continue;
-                }
-                Err(join_err) => {
-                    warn!("Join failure occurred with msg {msg_id:?}: {join_err:?}");
+            match msg_resp {
+                Ok(responses) => reports.push(categorize(msg_id, responses)),
+                Err(task_join_err) => {
+                    warn!("Task join failure occurred with msg {msg_id:?}: {task_join_err:?}");
+                    warn!("An elder will be considered unresponsive due to this, it might or might not be warranted.");
                     continue;
                 }
             };
-
-            match result {
-                Ok(()) => {
-                    let preexisting = !received_acks.insert(src) || received_errors.contains(&src);
-                    if preexisting {
-                        warn!("ACK from {src:?} for {msg_id:?} was received more than once");
-                    }
-
-                    if received_acks.len() >= expected_acks {
-                        trace!("{msg_id:?} Good! We're at or above {expected_acks} expected_acks");
-                        return Ok(());
-                    }
-                }
-                Err(error) => {
-                    let _ = received_errors.insert(src);
-                    error!(
-                        "Received error {error:?} of cmd {msg_id:?} from {src:?}, so far {} respones and {} of them are errors",
-                        received_acks.len() + received_errors.len(), received_errors.len()
-                    );
-
-                    // exit if too many errors:
-                    if failures.len() + received_errors.len() >= expected_acks {
-                        error!("Received majority of error response for cmd {msg_id:?}: {error:?}");
-                        return Err(Error::CmdError {
-                            source: error,
-                            msg_id,
-                        });
-                    }
-                }
-            }
         }
 
-        debug!("ACKs for {msg_id:?} received from: {received_acks:?}");
-        debug!("CmdErrors for {msg_id:?} received from: {received_errors:?}");
-        debug!("Failures for {msg_id:?} with: {failures:?}");
+        // For now, we require `data_copy_count()` acks from _each_ Elder!
+        // (Below line would instead allow us to deduplicate.)
+        // let expected_unique_acks = data_copy_count();
+        let data_copy_count = data_copy_count();
+        let expected_acks = elders.len() * data_copy_count;
 
-        let missing_responses: Vec<Peer> = elders
+        let (succeeded, failed): (Vec<_>, Vec<_>) =
+            reports.iter().partition(|r| r.has_enough_acks());
+
+        if succeeded.len() >= elders.len() {
+            trace!(
+                "{msg_id:?} Good! We've got the expected_acks from {} elders, /
+                ({} from each, for a total of {expected_acks}).",
+                elders.len(),
+                data_copy_count
+            );
+            return Ok(());
+        }
+
+        let received_errors: Vec<_> = failed
             .iter()
-            .cloned()
-            .filter(|p| {
-                let addr = &p.addr();
-                !received_acks.contains(addr)
-                    && !received_errors.contains(addr)
-                    && !failures.contains(addr)
-            })
+            .map(|r| (r.elder, r.received_errors.clone()))
+            .collect();
+
+        if received_errors.len() > data_copy_count / 2 {
+            error!("Received majority of error response for cmd {msg_id:?}: {received_errors:?}");
+            return Err(Error::CmdError {
+                received_errors,
+                msg_id,
+            });
+        }
+
+        let received_acks = succeeded.len() * data_copy_count;
+
+        let incomplete_acks: Vec<_> = failed.iter().map(|r| r.elder).collect();
+
+        let unresponsive: Vec<_> = elders
+            .iter()
+            .filter(|peer| !reports.iter().any(|r| &r.elder == peer))
             .collect();
 
         debug!(
-            "Insufficient CmdAcks returned for {msg_id:?}: {}/{expected_acks}. \
-            Missing Responses from: {missing_responses:?}",
-            received_acks.len()
+            "Insufficient CmdAcks returned for {msg_id:?}: {received_acks}/{expected_acks}. \
+            Unresponsive elders: {unresponsive:?}  \
+            Incomplete acks from: {incomplete_acks:?}",
         );
+
         Err(Error::InsufficientAcksReceived {
             msg_id,
             expected: expected_acks,
-            received: received_acks.len(),
+            received: received_acks,
         })
     }
 
-    async fn get_cmd_elders(&self, dst_address: XorName) -> Result<(bls::PublicKey, Vec<Peer>)> {
+    /// Returns either `supermajority=5` or `at_least_one_correct=3` Elders.
+    async fn get_cmd_elders(
+        &self,
+        dst_address: XorName,
+        needs_super_majority: bool,
+    ) -> Result<(bls::PublicKey, Vec<Peer>)> {
         let a_close_sap = self
             .network
             .read()
@@ -314,8 +293,13 @@ impl Session {
             let section_pk = sap.section_key();
             trace!("SAP elders found {sap_elders:?}");
 
-            // Supermajority of elders is expected. (NB: This can - for data - be `at_least_one_correct` = 3 out of 7).
-            let targets_count = supermajority(sap_elders.len());
+            let targets_count = if needs_super_majority {
+                // Supermajority of elders is expected for payment-cmds.
+                supermajority(sap_elders.len())
+            } else {
+                // Three out of seven is enough for data cmds.
+                at_least_one_correct_elder()
+            };
 
             // any SAP that does not hold elders_count() is indicative of a broken network (after genesis)
             if sap_elders.len() < targets_count {
@@ -338,70 +322,172 @@ impl Session {
     }
 
     #[instrument(skip_all, level = "trace")]
-    async fn send_cmd_msg(
-        &self,
-        nodes: Vec<Peer>,
-        wire_msg: WireMsg,
-    ) -> Result<JoinSet<MsgResponse>> {
+    async fn send_cmd_msg(&self, elders: Vec<Peer>, wire_msg: WireMsg) -> Result<()> {
         let msg_id = wire_msg.msg_id();
-        debug!("---> Send msg {msg_id:?} going out.");
+        debug!(
+            "---> Send msg {msg_id:?} going out to {} elders.",
+            elders.len()
+        );
         let bytes = wire_msg.serialize()?;
 
         let mut tasks = JoinSet::new();
 
-        for (peer_index, peer) in nodes.into_iter().enumerate() {
+        for (peer_index, peer) in elders.iter().enumerate() {
             let session = self.clone();
             let bytes = bytes.clone();
+            let _abort_handle = tasks.spawn(send_to_one(msg_id, *peer, peer_index, session, bytes));
+        }
 
-            let _abort_handle = tasks.spawn(async move {
-                let mut connect_now = false;
-                debug!("Trying to send msg {msg_id:?} to {peer:?}");
-                loop {
-                    let link = session
-                        .peer_links
-                        .get_or_create_link(&peer, connect_now, Some(msg_id))
-                        .await;
-                    match link.send_bi(bytes.clone(), msg_id).await {
-                        Ok(recv_stream) => {
-                            debug!(
-                                "That's {msg_id:?} sent to {peer:?}... starting receive listener"
-                            );
-                            // let's listen for responses on the bi-stream
-                            break session
-                                .recv_stream_listener(msg_id, peer, peer_index, recv_stream)
-                                .await;
+        trace!("Cmd msg {msg_id:?} sent");
+
+        // We wait for ALL the expected acks get received.
+        // The AE messages are handled by the tasks, hence no extra wait is required.
+        match self
+            .we_have_sufficient_acks_for_cmd(msg_id, elders, tasks)
+            .await
+        {
+            Ok(()) => {
+                trace!("Acks of Cmd {:?} received", msg_id);
+                Ok(())
+            }
+            error => error,
+        }
+    }
+}
+
+async fn send_to_one(
+    msg_id: MsgId,
+    peer: Peer,
+    peer_index: usize,
+    session: Session,
+    bytes: UsrMsgBytes,
+) -> (Peer, Vec<MsgResponse>) {
+    let mut connect_now = false;
+    debug!("Trying to send msg {msg_id:?} to {peer:?}");
+    loop {
+        let link = session
+            .peer_links
+            .get_or_create_link(&peer, connect_now, Some(msg_id))
+            .await;
+        match link.send_bi(bytes.clone(), msg_id).await {
+            Ok(recv_stream) => {
+                debug!("That's {msg_id:?} sent to {peer:?}... starting receive listener");
+                // Listen for responses on the bi-stream.
+                let responses = session
+                    .receive_cmd_responses(msg_id, peer, peer_index, data_copy_count(), recv_stream)
+                    .await;
+                break (peer, responses);
+            }
+            Err(error) if !connect_now => {
+                // Retry (only once) to reconnect to this peer and send the msg.
+                error!(
+                    "Failed to send {msg_id:?} to {peer:?} on a new \
+                    bi-stream: {error:?}. Creating a new connection to retry once ..."
+                );
+                session.peer_links.remove_link_from_peer_links(&peer).await;
+                connect_now = true;
+                continue;
+            }
+            Err(error) => {
+                error!("Error sending {msg_id:?} bidi to {peer:?}: {error:?}");
+                session.peer_links.remove_link_from_peer_links(&peer).await;
+                break (
+                    peer,
+                    vec![MsgResponse::Failure(
+                        peer.addr(),
+                        Error::FailedToInitateBiDiStream { msg_id, error },
+                    )],
+                );
+            }
+        }
+    }
+}
+
+/// This is the collection of
+/// received responses and failures while
+/// trying to read a response, from a specific Elder,
+/// from which we expect `data_copy_count()` responses.
+struct ResponseReport {
+    elder: Peer,
+    expected_acks: usize,
+    received_acks: BTreeSet<SocketAddr>,
+    received_errors: Vec<DataError>,
+    invalid_responses: BTreeSet<SocketAddr>,
+    failures: BTreeSet<SocketAddr>,
+}
+
+impl ResponseReport {
+    fn new(elder: Peer) -> Self {
+        Self {
+            elder,
+            expected_acks: data_copy_count(),
+            received_acks: BTreeSet::new(),
+            received_errors: vec![],
+            invalid_responses: BTreeSet::new(),
+            failures: BTreeSet::new(),
+        }
+    }
+
+    /// Will require `data_copy_count()` acks.
+    /// (Would normally count unique responses, and require a certain number of successes.)
+    fn has_enough_acks(&self) -> bool {
+        self.received_acks.len() > self.expected_acks
+        // let bad_requests =
+        //     self.received_errors.len() + self.invalid_responses.len() + self.failures.len();
+
+        // self.received_acks.len() > bad_requests
+    }
+}
+
+fn categorize(msg_id: MsgId, peer_responses: (Peer, Vec<MsgResponse>)) -> ResponseReport {
+    let (peer, responses) = peer_responses;
+    let mut report = ResponseReport::new(peer);
+
+    for response in responses {
+        match response {
+            MsgResponse::CmdResponse(src, response) => {
+                match response.result() {
+                    Ok(()) => {
+                        if src == report.elder.addr() {
+                            let _ = report.received_acks.insert(src);
                         }
-                        Err(error) if !connect_now => {
-                            // Let's retry (only once) to reconnect to this peer and send the msg.
-                            error!(
-                                "Failed to send {msg_id:?} to {peer:?} on a new \
-                                bi-stream: {error:?}. Creating a new connection to retry once ..."
-                            );
-                            session.peer_links.remove_link_from_peer_links(&peer).await;
-                            connect_now = true;
-                            continue;
-                        }
-                        Err(error) => {
-                            error!("Error sending {msg_id:?} bidi to {peer:?}: {error:?}");
-                            session.peer_links.remove_link_from_peer_links(&peer).await;
-                            break MsgResponse::Failure(
-                                peer.addr(),
-                                Error::FailedToInitateBiDiStream { msg_id, error },
-                            );
+                    }
+                    Err(error) => {
+                        if src == report.elder.addr() {
+                            report.received_errors.push(error.clone());
+                            debug!("Cmd response error from {} in response to msg {msg_id:?}: {error:?}", report.elder);
                         }
                     }
                 }
-            });
-        }
-
-        Ok(tasks)
+            }
+            MsgResponse::Failure(src, error) => {
+                if src == report.elder.addr() {
+                    debug!(
+                        "Failure returned from {} in response to msg {msg_id:?}: {error:?}",
+                        report.elder
+                    );
+                    let _ = report.failures.insert(src);
+                }
+                continue;
+            }
+            MsgResponse::QueryResponse(src, resp) => {
+                if src == report.elder.addr() {
+                    debug!("Unexpected query response received from {} for {msg_id:?} when awaiting a CmdAck: {resp:?}", report.elder);
+                    let _ = report.invalid_responses.insert(src);
+                }
+                continue;
+            }
+        };
     }
+
+    report
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use sn_interface::{
+        elder_count,
         network_knowledge::SectionTree,
         test_utils::{prefix, TestKeys, TestSapBuilder},
     };
@@ -423,7 +509,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn cmd_sent_to_all_elders() -> Result<()> {
-        let elders_len = 5;
+        let elders_len = supermajority(elder_count());
+        let needs_super_majority = true;
 
         let prefix = prefix("0");
         let (sap, secret_key_set, ..) = TestSapBuilder::new(prefix).elder_count(elders_len).build();
@@ -437,7 +524,9 @@ mod tests {
         )?;
 
         let mut rng = rand::thread_rng();
-        let result = session.get_cmd_elders(XorName::random(&mut rng)).await?;
+        let result = session
+            .get_cmd_elders(XorName::random(&mut rng), needs_super_majority)
+            .await?;
         assert_eq!(result.0, secret_key_set.public_keys().public_key());
         assert_eq!(result.1.len(), elders_len);
 

--- a/sn_client/src/sessions/send_query.rs
+++ b/sn_client/src/sessions/send_query.rs
@@ -283,7 +283,7 @@ impl Session {
                             );
                             // let's listen for responses on the bi-stream
                             break session
-                                .recv_stream_listener(msg_id, peer, peer_index, recv_stream)
+                                .receive_query_response(msg_id, peer, peer_index, recv_stream)
                                 .await;
                         }
                         Err(error) if !connect_now => {

--- a/sn_client/src/sessions/send_query.rs
+++ b/sn_client/src/sessions/send_query.rs
@@ -1,0 +1,314 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{MsgResponse, Session};
+use crate::{Error, Result};
+
+use sn_interface::{
+    messaging::{
+        data::{DataQuery, DataQueryVariant, QueryResponse},
+        ClientAuth, Dst, MsgId, MsgKind, WireMsg,
+    },
+    types::{ChunkAddress, Peer},
+};
+
+use bytes::Bytes;
+use rand::{rngs::OsRng, seq::SliceRandom};
+use tokio::task::JoinSet;
+use tracing::{debug, trace, warn};
+use xor_name::XorName;
+
+// Number of Elders subset to send queries to
+#[cfg(not(feature = "query-happy-path"))]
+pub(crate) const NUM_OF_ELDERS_SUBSET_FOR_QUERIES: usize = 3;
+#[cfg(feature = "query-happy-path")]
+pub(crate) const NUM_OF_ELDERS_SUBSET_FOR_QUERIES: usize = 1;
+
+impl Session {
+    /// Get DataSection elders details. Resort to own section if DataSection is not available.
+    /// Takes a random subset (NUM_OF_ELDERS_SUBSET_FOR_QUERIES) of the avialable elders as targets
+    pub(crate) async fn get_query_elders(
+        &self,
+        dst: XorName,
+    ) -> Result<(bls::PublicKey, Vec<Peer>)> {
+        let sap = self.network.read().await.closest(&dst, None).cloned();
+        let (section_pk, mut elders) = if let Some(sap) = &sap {
+            (sap.section_key(), sap.elders_vec())
+        } else {
+            return Err(Error::NoNetworkKnowledge(dst));
+        };
+
+        elders.shuffle(&mut OsRng);
+
+        // We select the NUM_OF_ELDERS_SUBSET_FOR_QUERIES closest Elders we are querying
+        let elders: Vec<_> = elders
+            .into_iter()
+            .take(NUM_OF_ELDERS_SUBSET_FOR_QUERIES)
+            .collect();
+
+        let elders_len = elders.len();
+        if elders_len < NUM_OF_ELDERS_SUBSET_FOR_QUERIES && elders_len > 1 {
+            return Err(Error::InsufficientElderConnections {
+                connections: elders_len,
+                required: NUM_OF_ELDERS_SUBSET_FOR_QUERIES,
+            });
+        }
+
+        Ok((section_pk, elders))
+    }
+
+    #[instrument(
+        skip(self, auth, payload),
+        level = "debug",
+        name = "session send query"
+    )]
+    #[allow(clippy::too_many_arguments)]
+    /// Send a `ClientMsg` to the network awaiting for the response.
+    pub(crate) async fn send_query(
+        &self,
+        query: DataQuery,
+        auth: ClientAuth,
+        payload: Bytes,
+        dst_section_info: Option<(bls::PublicKey, Vec<Peer>)>,
+    ) -> Result<QueryResponse> {
+        let endpoint = self.endpoint.clone();
+
+        let chunk_addr = if let DataQueryVariant::GetChunk(address) = query.variant {
+            Some(address)
+        } else {
+            None
+        };
+
+        let dst = query.variant.dst_name();
+
+        let (section_pk, elders) = if let Some(section_info) = dst_section_info {
+            section_info
+        } else {
+            self.get_query_elders(dst).await?
+        };
+
+        let elders_len = elders.len();
+        let msg_id = MsgId::new();
+
+        debug!(
+            "Sending query message {msg_id:?}, from {}, {query:?} to \
+            the {elders_len} Elders closest to data name: {elders:?}",
+            endpoint.local_addr(),
+        );
+
+        let dst = Dst {
+            name: dst,
+            section_key: section_pk,
+        };
+        let kind = MsgKind::Client(auth);
+        let wire_msg = WireMsg::new_msg(msg_id, payload, kind, dst);
+
+        let send_query_tasks = self.send_query_msg(elders.clone(), wire_msg).await?;
+
+        // TODO:
+        // We are now simply accepting the very first valid response we receive,
+        // but we may want to revisit this to compare multiple responses and validate them,
+        // similar to what we used to do up to the following commit:
+        // https://github.com/maidsafe/sn_client/blob/9091a4f1f20565f25d3a8b00571cc80751918928/src/connection_manager.rs#L328
+        //
+        // For Chunk responses we already validate its hash matches the xorname requested from,
+        // so we don't need more than one valid response to prevent from accepting invalid responses
+        // from byzantine nodes, however for mutable data (non-Chunk responses) we will
+        // have to review the approach.
+        self.check_query_responses(msg_id, elders.clone(), chunk_addr, send_query_tasks)
+            .await
+    }
+
+    async fn check_query_responses(
+        &self,
+        msg_id: MsgId,
+        elders: Vec<Peer>,
+        chunk_addr: Option<ChunkAddress>,
+        mut send_query_tasks: JoinSet<MsgResponse>,
+    ) -> Result<QueryResponse> {
+        let mut discarded_responses: usize = 0;
+        let mut error_response = None;
+        let mut valid_response = None;
+        let elders_len = elders.len();
+
+        while let Some(msg_resp) = send_query_tasks.join_next().await {
+            let (peer_address, response) = match msg_resp {
+                Ok(MsgResponse::QueryResponse(src, resp)) => (src, resp),
+                Ok(MsgResponse::CmdResponse(src, resp)) => {
+                    debug!("Unexpected cmd response received from {src:?} for {msg_id:?} when awaiting a QueryResponse: {resp:?}");
+                    discarded_responses += 1;
+                    continue;
+                }
+                Ok(MsgResponse::Failure(src, error)) => {
+                    debug!("Failure occurred with msg {msg_id:?} from {src:?}: {error:?}");
+                    discarded_responses += 1;
+                    continue;
+                }
+                Err(join_err) => {
+                    warn!("Join failure occurred with msg {msg_id:?}: {join_err:?}");
+                    continue;
+                }
+            };
+
+            // let's see if we have a positive response...
+            debug!("Response to {msg_id:?}: {response:?}");
+
+            match *response {
+                QueryResponse::GetChunk(Ok(chunk)) => {
+                    if let Some(chunk_addr) = chunk_addr {
+                        // We are dealing with Chunk query responses, thus we validate its hash
+                        // matches its xorname, if so, we don't need to await for more responses
+                        debug!("Chunk QueryResponse received is: {chunk:#?}");
+
+                        if chunk_addr.name() == chunk.name() {
+                            trace!("Valid Chunk received for {msg_id:?}");
+                            valid_response = Some(QueryResponse::GetChunk(Ok(chunk)));
+                            break;
+                        } else {
+                            // the Chunk content doesn't match its XorName,
+                            // this is suspicious and it could be a byzantine node
+                            warn!("We received an invalid Chunk response from one of the nodes for {msg_id:?}");
+                            discarded_responses += 1;
+                        }
+                    }
+                }
+                QueryResponse::GetRegister(Err(_))
+                | QueryResponse::ReadRegister(Err(_))
+                | QueryResponse::GetRegisterPolicy(Err(_))
+                | QueryResponse::GetRegisterOwner(Err(_))
+                | QueryResponse::GetRegisterUserPermissions(Err(_))
+                | QueryResponse::GetChunk(Err(_)) => {
+                    debug!(
+                        "QueryResponse error #{discarded_responses} for {msg_id:?} received \
+                        from {peer_address:?} (but may be overridden by a non-error response \
+                        from another elder): {:#?}",
+                        &response
+                    );
+                    error_response = Some(*response);
+                    discarded_responses += 1;
+                }
+                QueryResponse::GetRegister(Ok(ref register)) => {
+                    debug!("okay got register from {peer_address:?}");
+                    // TODO: properly merge all registers
+                    if let Some(QueryResponse::GetRegister(Ok(prior_response))) = &valid_response {
+                        if register.size() > prior_response.size() {
+                            debug!("longer register");
+                            // keep this new register
+                            valid_response = Some(*response);
+                        }
+                    } else {
+                        valid_response = Some(*response);
+                    }
+                }
+                QueryResponse::ReadRegister(Ok(_)) => {
+                    debug!("okay _read_ register from {peer_address:?}");
+                    if valid_response.is_none() {
+                        valid_response = Some(*response);
+                    }
+                }
+                QueryResponse::SpentProofShares(Ok(ref spentproof_set)) => {
+                    debug!("okay _read_ spentproofs from {peer_address:?}");
+                    // TODO: properly merge all registers
+                    if let Some(QueryResponse::SpentProofShares(Ok(prior_response))) =
+                        &valid_response
+                    {
+                        if spentproof_set.len() > prior_response.len() {
+                            debug!("longer spentproof response retrieved");
+                            // keep this new register
+                            valid_response = Some(*response);
+                        }
+                    } else {
+                        valid_response = Some(*response);
+                    }
+                }
+                response => {
+                    // we got a valid response
+                    valid_response = Some(response)
+                }
+            }
+        }
+
+        // we've looped over all responses...
+        // if any are valid, lets return it
+        if let Some(response) = valid_response {
+            debug!("Valid response in!!!: {response:?}");
+            return Ok(response);
+            // otherwise, if we've got an error in
+            // we can return that too
+        } else if let Some(response) = error_response {
+            if discarded_responses > elders_len / 2 {
+                return Ok(response);
+            }
+        }
+
+        Err(Error::NoResponse {
+            msg_id,
+            peers: elders,
+        })
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    async fn send_query_msg(
+        &self,
+        nodes: Vec<Peer>,
+        wire_msg: WireMsg,
+    ) -> Result<JoinSet<MsgResponse>> {
+        let msg_id = wire_msg.msg_id();
+        debug!("---> Send msg {msg_id:?} going out.");
+        let bytes = wire_msg.serialize()?;
+
+        let mut tasks = JoinSet::new();
+
+        for (peer_index, peer) in nodes.into_iter().enumerate() {
+            let session = self.clone();
+            let bytes = bytes.clone();
+
+            let _abort_handle = tasks.spawn(async move {
+                let mut connect_now = false;
+                debug!("Trying to send msg {msg_id:?} to {peer:?}");
+                loop {
+                    let link = session
+                        .peer_links
+                        .get_or_create_link(&peer, connect_now, Some(msg_id))
+                        .await;
+                    match link.send_bi(bytes.clone(), msg_id).await {
+                        Ok(recv_stream) => {
+                            debug!(
+                                "That's {msg_id:?} sent to {peer:?}... starting receive listener"
+                            );
+                            // let's listen for responses on the bi-stream
+                            break session
+                                .recv_stream_listener(msg_id, peer, peer_index, recv_stream)
+                                .await;
+                        }
+                        Err(error) if !connect_now => {
+                            // Let's retry (only once) to reconnect to this peer and send the msg.
+                            error!(
+                                "Failed to send {msg_id:?} to {peer:?} on a new \
+                                bi-stream: {error:?}. Creating a new connection to retry once ..."
+                            );
+                            session.peer_links.remove_link_from_peer_links(&peer).await;
+                            connect_now = true;
+                            continue;
+                        }
+                        Err(error) => {
+                            error!("Error sending {msg_id:?} bidi to {peer:?}: {error:?}");
+                            session.peer_links.remove_link_from_peer_links(&peer).await;
+                            break MsgResponse::Failure(
+                                peer.addr(),
+                                Error::FailedToInitateBiDiStream { msg_id, error },
+                            );
+                        }
+                    }
+                }
+            });
+        }
+
+        Ok(tasks)
+    }
+}

--- a/sn_client/src/utils/test_utils/mod.rs
+++ b/sn_client/src/utils/test_utils/mod.rs
@@ -21,3 +21,29 @@ pub use test_client::read_genesis_dbc_from_first_node;
 
 #[cfg(test)]
 pub use sn_interface::init_logger;
+
+#[cfg(test)]
+use eyre::{bail, Result};
+#[cfg(test)]
+use sn_interface::messaging::data::Error as ErrorMsg;
+
+#[cfg(test)]
+pub fn extract_error_string(
+    received_errors: Vec<(sn_interface::types::Peer, Vec<ErrorMsg>)>,
+) -> Result<String> {
+    match received_errors
+        .into_iter()
+        .flat_map(|(_, errors)| errors)
+        .filter_map(|err| {
+            if let ErrorMsg::InvalidOperation(error_string) = err {
+                Some(error_string)
+            } else {
+                None
+            }
+        })
+        .last()
+    {
+        Some(error_string) => Ok(error_string),
+        None => bail!("We expected an error to be returned"),
+    }
+}

--- a/sn_comms/src/error.rs
+++ b/sn_comms/src/error.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use sn_interface::types::Peer;
+use sn_interface::messaging::MsgId;
 use thiserror::Error;
 
 /// The type returned by the `sn_routing` message handling methods.
@@ -17,16 +17,16 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[allow(missing_docs)]
 pub enum Error {
     /// Any unknown node comms should be bidi, initiated by the other side
-    #[error("Attempted to create a connection to an unknown node: {0:?}")]
-    CreatingConnectionToUnknownNode(Peer),
+    #[error("Attempted to create a connection for msg {0:?} to unknown node.")]
+    ConnectingToUnknownNode(MsgId),
     #[error("Cannot connect to the endpoint: {0}")]
     CannotConnectEndpoint(#[from] qp2p::EndpointError),
     #[error("Address not reachable: {0}")]
     AddressNotReachable(#[from] qp2p::RpcError),
-    #[error("Content of a received message is inconsistent.")]
-    InvalidMessage,
-    #[error("Failed to send a message to {0}")]
-    FailedSend(Peer),
+    #[error("Content of received msg {0:?} is invalid.")]
+    InvalidMsgReceived(MsgId),
+    #[error("Failed to send msg {0:?}")]
+    FailedSend(MsgId),
 }
 
 impl From<qp2p::SendError> for Error {

--- a/sn_comms/src/lib.rs
+++ b/sn_comms/src/lib.rs
@@ -92,31 +92,6 @@ pub enum CommEvent {
     },
 }
 
-/// Internal comm cmds.
-#[derive(custom_debug::Debug)]
-enum CommCmd {
-    Send {
-        msg_id: MsgId,
-        peer: Peer,
-        #[debug(skip)]
-        bytes: UsrMsgBytes,
-    },
-    SetTargets(BTreeSet<Peer>),
-    SendWithBiResponse {
-        peer: Peer,
-        msg_id: MsgId,
-        bytes: UsrMsgBytes,
-    },
-    SendAndRespondOnStream {
-        msg_id: MsgId,
-        msg_type: NodeMsgType,
-        peer: Peer,
-        #[debug(skip)]
-        bytes: UsrMsgBytes,
-        dst_stream: (Dst, Arc<RwLock<SendStream>>),
-    },
-}
-
 /// A msg received on the wire.
 #[derive(Debug)]
 pub struct MsgFromPeer {
@@ -150,7 +125,7 @@ impl Comm {
             .server()?;
 
         trace!("Creating comms..");
-        // comm_events_receiver will be used by upper layer to receive all msgs comming in from the network
+        // comm_events_receiver will be used by upper layer to receive all msgs coming in from the network
         let (comm_events_sender, comm_events_receiver) = mpsc::channel(STANDARD_CHANNEL_SIZE);
         let (cmd_sender, cmd_receiver) = mpsc::channel(STANDARD_CHANNEL_SIZE);
 
@@ -183,42 +158,31 @@ impl Comm {
         // We only remove sessions by calling this function,
         // No removals are made even if we failed to send using all peer session's connections,
         // as it's our source of truth for known and connectable peers.
-        let sender = self.cmd_sender.clone();
-        let _handle = task::spawn(async move { sender.send(CommCmd::SetTargets(targets)).await });
+        self.send_cmd(CommCmd::SetTargets(targets))
     }
 
     /// Sends the payload on a new or existing connection.
     #[tracing::instrument(skip(self, bytes))]
     pub fn send_out_bytes(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) {
-        let sender = self.cmd_sender.clone();
-        let _handle = task::spawn(async move {
-            sender
-                .send(CommCmd::Send {
-                    msg_id,
-                    peer,
-                    bytes,
-                })
-                .await
-        });
+        self.send_cmd(CommCmd::Send {
+            msg_id,
+            peer,
+            bytes,
+        })
     }
 
     /// Sends the payload on a new bidi-stream and pushes the response onto the comm event channel.
     #[tracing::instrument(skip(self, bytes))]
-    pub fn send_with_bi_response(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) {
-        let sender = self.cmd_sender.clone();
-        let _handle = task::spawn(async move {
-            sender
-                .send(CommCmd::SendWithBiResponse {
-                    msg_id,
-                    peer,
-                    bytes,
-                })
-                .await
-        });
+    pub fn send_and_return_response(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) {
+        self.send_cmd(CommCmd::SendAndReturnResponse {
+            msg_id,
+            peer,
+            bytes,
+        })
     }
 
-    /// Sends the payload on new bidi-streams and sends the responses on the dst stream.
-    #[tracing::instrument(skip(bytes))]
+    /// Sends the payload on new bidi-stream to noe and sends the response on the dst stream.
+    #[tracing::instrument(skip(self, bytes))]
     pub fn send_and_respond_on_stream(
         &self,
         msg_id: MsgId,
@@ -227,34 +191,65 @@ impl Comm {
         bytes: UsrMsgBytes,
         dst_stream: (Dst, Arc<RwLock<SendStream>>),
     ) {
+        self.send_cmd(CommCmd::SendAndRespondOnStream {
+            msg_id,
+            msg_type,
+            peer,
+            bytes,
+            dst_stream,
+        })
+    }
+
+    fn send_cmd(&self, cmd: CommCmd) {
         let sender = self.cmd_sender.clone();
         let _handle = task::spawn(async move {
-            sender
-                .send(CommCmd::SendAndRespondOnStream {
-                    msg_id,
-                    msg_type,
-                    peer,
-                    bytes,
-                    dst_stream,
-                })
-                .await
+            let error_msg = format!("Failed to send {cmd:?} on comm cmd channel ");
+            if let Err(error) = sender.send(cmd).await {
+                error!("{error_msg} due to {error}.");
+            }
         });
     }
 }
 
+/// Internal comm cmds.
+#[derive(custom_debug::Debug)]
+enum CommCmd {
+    Send {
+        msg_id: MsgId,
+        peer: Peer,
+        #[debug(skip)]
+        bytes: UsrMsgBytes,
+    },
+    SetTargets(BTreeSet<Peer>),
+    SendAndReturnResponse {
+        peer: Peer,
+        msg_id: MsgId,
+        #[debug(skip)]
+        bytes: UsrMsgBytes,
+    },
+    SendAndRespondOnStream {
+        msg_id: MsgId,
+        msg_type: NodeMsgType,
+        peer: Peer,
+        #[debug(skip)]
+        bytes: UsrMsgBytes,
+        dst_stream: (Dst, Arc<RwLock<SendStream>>),
+    },
+}
+
 fn process_cmds(
     our_endpoint: Endpoint,
-    mut update_receiver: Receiver<CommCmd>,
+    mut cmd_receiver: Receiver<CommCmd>,
     comm_events: Sender<CommEvent>,
 ) {
     let _handle = task::spawn(async move {
         let mut sessions = BTreeMap::<Peer, PeerSession>::new();
-        while let Some(cmd) = update_receiver.recv().await {
+        while let Some(cmd) = cmd_receiver.recv().await {
             trace!("Comms cmd handling: {cmd:?}");
             match cmd {
                 // This is the only place that mutates `sessions`.
                 CommCmd::SetTargets(targets) => {
-                    // Drops sessions that not among the targets.
+                    // Drops sessions that are not among the targets.
                     sessions.retain(|p, _| targets.contains(p));
                     // Adds new sessions for each new target.
                     targets.iter().for_each(|peer| {
@@ -269,42 +264,20 @@ fn process_cmds(
                     peer,
                     bytes,
                 } => {
-                    let session = match sessions.get(&peer) {
-                        Some(session) => session.clone(),
-                        None => {
-                            error!(
-                                "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
-                            );
-                            send_error(
-                                peer,
-                                Error::ConnectingToUnknownNode(msg_id),
-                                comm_events.clone(),
-                            );
-                            continue;
-                        }
-                    };
-                    send(msg_id, session, bytes, comm_events.clone());
+                    if let Some(session) = get_session(msg_id, peer, &sessions, comm_events.clone())
+                    {
+                        send(msg_id, session, bytes, comm_events.clone())
+                    }
                 }
-                CommCmd::SendWithBiResponse {
+                CommCmd::SendAndReturnResponse {
                     peer,
                     msg_id,
                     bytes,
                 } => {
-                    let session = match sessions.get(&peer) {
-                        Some(session) => session.clone(),
-                        None => {
-                            error!(
-                                "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
-                            );
-                            send_error(
-                                peer,
-                                Error::ConnectingToUnknownNode(msg_id),
-                                comm_events.clone(),
-                            );
-                            continue;
-                        }
-                    };
-                    send_with_bi_response(msg_id, session, bytes, comm_events.clone());
+                    if let Some(session) = get_session(msg_id, peer, &sessions, comm_events.clone())
+                    {
+                        send_and_return_response(msg_id, session, bytes, comm_events.clone())
+                    }
                 }
                 CommCmd::SendAndRespondOnStream {
                     msg_id,
@@ -313,35 +286,41 @@ fn process_cmds(
                     bytes,
                     dst_stream,
                 } => {
-                    debug!("Trying to get {peer:?} session in order to send: {msg_id:?}",);
-                    let session = match sessions.get(&peer) {
-                        Some(session) => session.clone(),
-                        None => {
-                            error!(
-                                "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
-                            );
-                            send_error(
-                                peer,
-                                Error::ConnectingToUnknownNode(msg_id),
-                                comm_events.clone(),
-                            );
-                            continue;
-                        }
-                    };
-                    send_and_respond_on_stream(
-                        msg_id,
-                        msg_type,
-                        session,
-                        bytes,
-                        dst_stream,
-                        comm_events.clone(),
-                    );
+                    if let Some(session) = get_session(msg_id, peer, &sessions, comm_events.clone())
+                    {
+                        send_and_respond_on_stream(
+                            msg_id,
+                            msg_type,
+                            session,
+                            bytes,
+                            dst_stream,
+                            comm_events.clone(),
+                        )
+                    }
                 }
             }
         }
     });
 }
 
+fn get_session(
+    msg_id: MsgId,
+    peer: Peer,
+    sessions: &BTreeMap<Peer, PeerSession>,
+    comm_events: Sender<CommEvent>,
+) -> Option<PeerSession> {
+    debug!("Trying to get {peer:?} session in order to send: {msg_id:?}");
+    match sessions.get(&peer) {
+        Some(session) => Some(session.clone()),
+        None => {
+            error!("Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node.");
+            send_error(peer, Error::ConnectingToUnknownNode(msg_id), comm_events);
+            None
+        }
+    }
+}
+
+#[tracing::instrument(skip_all)]
 fn send(msg_id: MsgId, session: PeerSession, bytes: UsrMsgBytes, comm_events: Sender<CommEvent>) {
     let _handle = task::spawn(async move {
         let (h, d, p) = &bytes;
@@ -360,7 +339,8 @@ fn send(msg_id: MsgId, session: PeerSession, bytes: UsrMsgBytes, comm_events: Se
     });
 }
 
-fn send_with_bi_response(
+#[tracing::instrument(skip_all)]
+fn send_and_return_response(
     msg_id: MsgId,
     session: PeerSession,
     bytes: UsrMsgBytes,
@@ -395,6 +375,7 @@ fn send_with_bi_response(
     });
 }
 
+#[tracing::instrument(skip_all)]
 fn send_and_respond_on_stream(
     msg_id: MsgId,
     msg_type: NodeMsgType,
@@ -453,6 +434,7 @@ fn send_and_respond_on_stream(
 
 /// Verify what kind of response was received, and if that's the expected type based on
 /// the type of msg sent to the nodes, then return the corresponding response to the client.
+#[tracing::instrument(skip_all)]
 fn map_to_client_response(
     sent: NodeMsgType,
     correlation_id: MsgId,
@@ -513,9 +495,8 @@ fn send_error(peer: Peer, error: Error, comm_events: Sender<CommEvent>) {
     let _handle = task::spawn(async move {
         let error_msg =
             format!("Failed to send error {error} of peer {peer} on comm event channel ");
-        match comm_events.send(CommEvent::Error { peer, error }).await {
-            Ok(()) => (),
-            Err(err) => error!("{error_msg} due to {err}."),
+        if let Err(err) = comm_events.send(CommEvent::Error { peer, error }).await {
+            error!("{error_msg} due to {err}.")
         }
     });
 }

--- a/sn_comms/src/lib.rs
+++ b/sn_comms/src/lib.rs
@@ -49,21 +49,68 @@ mod peer_session;
 
 pub use self::error::{Error, Result};
 
-use self::{listener::MsgListener, peer_session::PeerSession};
+use self::peer_session::PeerSession;
 
 use sn_interface::{
-    messaging::{MsgId, WireMsg},
+    messaging::{
+        data::ClientDataResponse as ClientResponse,
+        system::{NodeDataResponse as NodeResponse, NodeMsgType},
+        Dst, MsgId, MsgKind, MsgType, WireMsg,
+    },
     types::Peer,
 };
 
 use qp2p::{Endpoint, SendStream, UsrMsgBytes};
 
-use dashmap::DashMap;
-use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
-use tokio::sync::mpsc::Sender;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::SocketAddr,
+};
+use tokio::{
+    sync::mpsc::{self, Receiver, Sender},
+    task,
+};
 
 /// Standard channel size, to allow for large swings in throughput
 static STANDARD_CHANNEL_SIZE: usize = 100_000;
+
+/// Events from the comm module.
+#[derive(Debug)]
+pub enum CommEvent {
+    /// A msg was received.
+    Msg(MsgFromPeer),
+    /// A send error occurred.
+    Error {
+        /// The sender/recipient that failed.
+        peer: Peer,
+        /// The failure type.
+        error: Error,
+    },
+}
+
+/// Internal comm cmds.
+#[derive(custom_debug::Debug)]
+enum CommCmd {
+    Send {
+        msg_id: MsgId,
+        peer: Peer,
+        #[debug(skip)]
+        bytes: UsrMsgBytes,
+    },
+    SetTargets(BTreeSet<Peer>),
+    SendWithBiResponse {
+        peer: Peer,
+        msg_id: MsgId,
+        bytes: UsrMsgBytes,
+    },
+    SendAndRespondOnStream {
+        msg_id: MsgId,
+        msg_type: NodeMsgType,
+        #[debug(skip)]
+        node_bytes: BTreeMap<Peer, UsrMsgBytes>,
+        dst_stream: (Dst, SendStream),
+    },
+}
 
 /// A msg received on the wire.
 #[derive(Debug)]
@@ -78,33 +125,42 @@ pub struct MsgFromPeer {
 }
 
 /// Communication component of the node to interact with other nodes.
-#[allow(missing_debug_implementations)]
-#[derive(Clone)]
+///
+/// Any failed sends are tracked via `CommEvent::Error`, which will track issues for any peers
+/// in the section (otherwise ignoring failed send to out of section nodes or clients).
+#[derive(Clone, Debug)]
 pub struct Comm {
     our_endpoint: Endpoint,
-    sessions: Arc<DashMap<Peer, PeerSession>>,
+    cmd_sender: Sender<CommCmd>,
 }
 
 impl Comm {
     /// Creates a new instance of Comm with an endpoint
     /// and starts listening to the incoming messages from other nodes.
-    #[tracing::instrument(skip_all)]
-    pub async fn new(
-        local_addr: SocketAddr,
-        incoming_msg_pipe: Sender<MsgFromPeer>,
-    ) -> Result<Self> {
+    pub async fn new(local_addr: SocketAddr) -> Result<(Self, Receiver<CommEvent>)> {
+        // creates an endpoint to listen to the incoming messages from other nodes
         let (our_endpoint, incoming_connections) = Endpoint::builder()
             .addr(local_addr)
             .idle_timeout(70_000)
             .server()?;
 
-        let msg_listener = MsgListener::new(incoming_msg_pipe);
-        msg_listener.listen_for_incoming_msgs(incoming_connections);
+        trace!("Creating comms..");
+        // comm_events_receiver will be used by upper layer to receive all msgs comming in from the network
+        let (comm_events_sender, comm_events_receiver) = mpsc::channel(STANDARD_CHANNEL_SIZE);
+        let (cmd_sender, cmd_receiver) = mpsc::channel(STANDARD_CHANNEL_SIZE);
 
-        Ok(Self {
-            our_endpoint,
-            sessions: Arc::new(DashMap::new()),
-        })
+        // listen for msgs/connections to our endpoint
+        listener::listen_for_connections(comm_events_sender.clone(), incoming_connections);
+
+        process_cmds(our_endpoint.clone(), cmd_receiver, comm_events_sender);
+
+        Ok((
+            Self {
+                our_endpoint,
+                cmd_sender,
+            },
+            comm_events_receiver,
+        ))
     }
 
     /// The socket address of our endpoint.
@@ -122,85 +178,372 @@ impl Comm {
         // We only remove sessions by calling this function,
         // No removals are made even if we failed to send using all peer session's connections,
         // as it's our source of truth for known and connectable peers.
-
-        // Drops sessions that not among the targets.
-        self.sessions.retain(|p, _| targets.contains(p));
-
-        // Adds new sessions for each new target.
-        targets.iter().for_each(|peer| {
-            if self.sessions.get(peer).is_none() {
-                let session = PeerSession::new(*peer, self.our_endpoint.clone());
-                let _ = self.sessions.insert(*peer, session);
-            }
-        });
+        let sender = self.cmd_sender.clone();
+        let _handle = task::spawn(async move { sender.send(CommCmd::SetTargets(targets)).await });
     }
 
     /// Sends the payload on a new or existing connection.
     #[tracing::instrument(skip(self, bytes))]
-    pub async fn send_out_bytes(
-        &self,
-        peer: Peer,
-        msg_id: MsgId,
-        bytes: UsrMsgBytes,
-    ) -> Result<()> {
-        let (h, d, p) = &bytes;
-        let bytes_len = h.len() + d.len() + p.len();
-        trace!("Sending message bytes ({bytes_len} bytes) w/ {msg_id:?} to {peer:?}");
-
-        let peer_session = self.get_session(&peer).await?;
-        debug!("Peer session retrieved: {peer:?}");
-
-        let sessions = self.sessions.clone();
-        trace!("Sessions known of: {:?}", sessions.len());
-
-        match peer_session.send(msg_id, bytes).await {
-            Ok(()) => {
-                trace!("Msg {msg_id:?} sent to {peer:?}");
-                Ok(())
-            }
-            Err(error) => {
-                error!("Sending message (msg_id: {msg_id:?}) to {peer:?} failed: {error}");
-                Err(Error::FailedSend(peer))
-            }
-        }
+    pub fn send_out_bytes(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) {
+        let sender = self.cmd_sender.clone();
+        let _handle = task::spawn(async move {
+            sender
+                .send(CommCmd::Send {
+                    msg_id,
+                    peer,
+                    bytes,
+                })
+                .await
+        });
     }
 
     /// Sends the payload on a new bidi-stream and returns the response.
     #[tracing::instrument(skip(self, bytes))]
-    pub async fn send_out_bytes_to_peer_and_return_response(
+    pub fn send_with_bi_response(&self, peer: Peer, msg_id: MsgId, bytes: UsrMsgBytes) {
+        let sender = self.cmd_sender.clone();
+        let _handle = task::spawn(async move {
+            sender
+                .send(CommCmd::SendWithBiResponse {
+                    msg_id,
+                    peer,
+                    bytes,
+                })
+                .await
+        });
+    }
+
+    /// Sends the payload on a new bidi-stream and returns the response.
+    #[tracing::instrument(skip(node_bytes))]
+    pub fn send_and_respond_on_stream(
         &self,
-        peer: Peer,
         msg_id: MsgId,
-        bytes: UsrMsgBytes,
-    ) -> Result<WireMsg> {
-        // TODO: tweak messaging to just allow passthrough
-        debug!("Trying to get {peer:?} session in order to send: {msg_id:?}");
-
-        let mut session = self.get_session(&peer).await?;
-        debug!("Session of {peer:?} retrieved for {msg_id:?}");
-        let adult_response_bytes = session
-            .send_with_bi_return_response(bytes, msg_id)
-            .await
-            .map_err(|err| {
-                error!("Failed sending {msg_id:?} to {peer:?}: {err:?}");
-                Error::FailedSend(peer)
-            })?;
-        debug!("Peer response from {peer:?} is in for {msg_id:?}");
-        WireMsg::from(adult_response_bytes).map_err(|_| Error::InvalidMessage)
+        msg_type: NodeMsgType,
+        node_bytes: BTreeMap<Peer, UsrMsgBytes>,
+        dst_stream: (Dst, SendStream),
+    ) {
+        let sender = self.cmd_sender.clone();
+        let _handle = task::spawn(async move {
+            sender
+                .send(CommCmd::SendAndRespondOnStream {
+                    msg_id,
+                    msg_type,
+                    node_bytes,
+                    dst_stream,
+                })
+                .await
+        });
     }
 
-    /// Get a PeerSession
-    #[instrument(skip(self))]
-    async fn get_session(&self, peer: &Peer) -> Result<PeerSession> {
-        debug!("Attempting to get or create peer session to member: {peer:?}");
-        if let Some(entry) = self.sessions.get(peer) {
-            debug!("Session to {peer:?} exists");
-            Ok(entry.value().clone())
-        } else {
-            debug!("Did not attempt to connect to external peer: {peer:?}");
-            Err(Error::CreatingConnectionToUnknownNode(*peer))
+    // /// Sends the payload on a new bidi-stream and returns the response.
+    // #[tracing::instrument(skip(bytes))]
+    // pub async fn send_out_bytes_to_peer_and_return_response(
+    //     &self,
+    //     peer: Peer,
+    //     msg_id: MsgId,
+    //     bytes: UsrMsgBytes,
+    // ) -> Result<WireMsg> {
+    //     let sender = self.cmd_sender.clone();
+    //     let _ = task::spawn(async move {
+    //         sender
+    //             .send(CommCmd::SendAndRespondOnStream {
+    //                 msg_id,
+    //                 node_bytes: BTreeMap::from([(peer, bytes)]),
+    //                 client_stream,
+    //                 dst,
+    //             })
+    //             .await
+    //     });
+
+    //     unimplemented!();
+    // }
+}
+
+fn process_cmds(
+    our_endpoint: Endpoint,
+    mut update_receiver: Receiver<CommCmd>,
+    comm_events: Sender<CommEvent>,
+) {
+    let _handle = task::spawn(async move {
+        let mut sessions = BTreeMap::<Peer, PeerSession>::new();
+        // let sessions = Arc::new(DashMap::<Peer, PeerSession>::new());
+        while let Some(cmd) = update_receiver.recv().await {
+            trace!("Comms cmd handling: {cmd:?}");
+            match cmd {
+                // This is the only place that mutates `sessions`.
+                CommCmd::SetTargets(targets) => {
+                    // Drops sessions that not among the targets.
+                    sessions.retain(|p, _| targets.contains(p));
+                    // Adds new sessions for each new target.
+                    targets.iter().for_each(|peer| {
+                        if sessions.get(peer).is_none() {
+                            let session = PeerSession::new(*peer, our_endpoint.clone());
+                            let _ = sessions.insert(*peer, session);
+                        }
+                    });
+                }
+                CommCmd::Send {
+                    msg_id,
+                    peer,
+                    bytes,
+                } => {
+                    let session = match sessions.get(&peer) {
+                        Some(session) => session.clone(),
+                        None => {
+                            error!(
+                                "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
+                            );
+                            send_error(
+                                peer,
+                                Error::ConnectingToUnknownNode(msg_id),
+                                comm_events.clone(),
+                            );
+                            continue;
+                        }
+                    };
+                    send(msg_id, session, bytes, comm_events.clone());
+                }
+                CommCmd::SendWithBiResponse {
+                    peer,
+                    msg_id,
+                    bytes,
+                } => {
+                    // TODO: use `NODE_RESPONSE_TIMEOUT`
+                    let session = match sessions.get(&peer) {
+                        Some(session) => session.clone(),
+                        None => {
+                            error!(
+                                "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
+                            );
+                            send_error(
+                                peer,
+                                Error::ConnectingToUnknownNode(msg_id),
+                                comm_events.clone(),
+                            );
+                            continue;
+                        }
+                    };
+                    send_with_bi_response(msg_id, session, bytes, comm_events.clone());
+                }
+                CommCmd::SendAndRespondOnStream {
+                    msg_id,
+                    msg_type,
+                    node_bytes,
+                    dst_stream,
+                } => {
+                    let node_bytes = node_bytes
+                        .into_iter()
+                        .filter_map(|(peer, bytes)| {
+                            debug!("Trying to get {peer:?} session in order to send: {msg_id:?}", );
+                            match sessions.get(&peer) {
+                                Some(session) => Some((session.clone(), bytes)),
+                                None => {
+                                    error!(
+                                        "Sending message (msg_id: {msg_id:?}) to {peer:?} failed: unknown node."
+                                    );
+                                    send_error(peer, Error::ConnectingToUnknownNode(msg_id), comm_events.clone());
+                                    None
+                                }
+                            }
+                        }).collect();
+                    send_and_respond_on_stream(
+                        msg_id,
+                        msg_type,
+                        node_bytes,
+                        dst_stream,
+                        comm_events.clone(),
+                    );
+                }
+            }
         }
-    }
+    });
+}
+
+fn send(msg_id: MsgId, session: PeerSession, bytes: UsrMsgBytes, comm_events: Sender<CommEvent>) {
+    let _handle = task::spawn(async move {
+        let (h, d, p) = &bytes;
+        let bytes_len = h.len() + d.len() + p.len();
+        let peer = session.peer();
+        trace!("Sending message bytes ({bytes_len} bytes) w/ {msg_id:?} to {peer:?}");
+        match session.send(msg_id, bytes).await {
+            Ok(()) => {
+                trace!("Msg {msg_id:?} sent to {peer:?}");
+            }
+            Err(error) => {
+                error!("Sending message (msg_id: {msg_id:?}) to {peer:?} failed: {error}");
+                send_error(peer, Error::FailedSend(msg_id), comm_events.clone());
+            }
+        }
+    });
+}
+
+fn send_with_bi_response(
+    msg_id: MsgId,
+    session: PeerSession,
+    bytes: UsrMsgBytes,
+    comm_events: Sender<CommEvent>,
+) {
+    let _handle = task::spawn(async move {
+        let (h, d, p) = &bytes;
+        let bytes_len = h.len() + d.len() + p.len();
+        let peer = session.peer();
+        trace!("Sending message bytes ({bytes_len} bytes) w/ {msg_id:?} to {peer:?}");
+        let node_response_bytes = match session.send_with_bi_return_response(bytes, msg_id).await {
+            Ok(response_bytes) => {
+                debug!("Peer response from {peer:?} is in for {msg_id:?}");
+                response_bytes
+            }
+            Err(error) => {
+                error!("Sending message (msg_id: {msg_id:?}) to {peer:?} failed: {error}");
+                send_error(peer, Error::FailedSend(msg_id), comm_events.clone());
+                return;
+            }
+        };
+        match WireMsg::from(node_response_bytes) {
+            Ok(wire_msg) => {
+                listener::msg_received(wire_msg, peer, None, comm_events.clone());
+            }
+            Err(error) => {
+                error!("Failed sending {msg_id:?} to {peer:?}: {error:?}");
+                send_error(peer, Error::InvalidMsgReceived(msg_id), comm_events.clone());
+            }
+        };
+    });
+}
+
+fn send_and_respond_on_stream(
+    msg_id: MsgId,
+    msg_type: NodeMsgType,
+    node_bytes: Vec<(PeerSession, UsrMsgBytes)>,
+    dst_stream: (Dst, SendStream),
+    comm_events: Sender<CommEvent>,
+) {
+    let _handle = task::spawn(async move {
+        // responses from those we send to
+        let mut all_received = vec![];
+
+        for (session, bytes) in node_bytes {
+            let peer = session.peer();
+            let node_response_bytes =
+                match session.send_with_bi_return_response(bytes, msg_id).await {
+                    Ok(response_bytes) => response_bytes,
+                    Err(error) => {
+                        error!("Failed sending {msg_id:?} to {peer:?}: {error:?}");
+                        send_error(peer, Error::FailedSend(msg_id), comm_events.clone());
+                        // continue with next node
+                        continue;
+                    }
+                };
+
+            debug!("Response from node {peer:?} is in for {msg_id:?}");
+
+            match WireMsg::from(node_response_bytes) {
+                Ok(received) => {
+                    match received.into_msg() {
+                        Ok(msg) => all_received.push((msg, peer)),
+                        Err(_error) => {
+                            send_error(
+                                peer,
+                                Error::InvalidMsgReceived(msg_id),
+                                comm_events.clone(),
+                            );
+                            // continue with next received msg
+                        }
+                    };
+                }
+                Err(error) => {
+                    error!("Failed sending {msg_id:?} to {peer:?}: {error:?}");
+                    send_error(peer, Error::InvalidMsgReceived(msg_id), comm_events.clone());
+                    // continue with next received msg
+                }
+            };
+        }
+
+        let (dst, mut stream) = dst_stream;
+        for (received, peer) in all_received {
+            match map_to_client_response(msg_type, msg_id, received, dst) {
+                Some(bytes) => match stream.send_user_msg(bytes).await {
+                    Ok(()) => (),
+                    Err(error) => {
+                        send_error(peer, Error::from(error), comm_events.clone());
+                        // continue with next received msg
+                    }
+                },
+                None => {
+                    send_error(peer, Error::InvalidMsgReceived(msg_id), comm_events.clone());
+                    // continue with next received msg
+                }
+            }
+        }
+    });
+}
+
+/// Verify what kind of response was received, and if that's the expected type based on
+/// the type of msg sent to the nodes, then return the corresponding response to the client.
+fn map_to_client_response(
+    sent: NodeMsgType,
+    correlation_id: MsgId,
+    received: MsgType,
+    dst: Dst,
+) -> Option<UsrMsgBytes> {
+    let response = match sent {
+        NodeMsgType::DataQuery => {
+            match received {
+                MsgType::NodeDataResponse {
+                    msg: NodeResponse::QueryResponse { response, .. },
+                    ..
+                } => {
+                    // We sent a data query and we received a query response,
+                    // so let's forward it to the client
+                    debug!("{correlation_id:?} sending query response back to client");
+                    ClientResponse::QueryResponse {
+                        response,
+                        correlation_id,
+                    }
+                }
+                other_resp => {
+                    error!("Unexpected response to query from node for {correlation_id:?}: {other_resp:?}");
+                    return None;
+                }
+            }
+        }
+        NodeMsgType::StoreData => {
+            match received {
+                MsgType::NodeDataResponse {
+                    msg: NodeResponse::CmdResponse { response, .. },
+                    ..
+                } => {
+                    // We sent a data cmd to store client data and we received a
+                    // cmd response, so let's forward it to the client
+                    debug!("{correlation_id:?} sending cmd response ACK back to client");
+                    ClientResponse::CmdResponse {
+                        response,
+                        correlation_id,
+                    }
+                }
+                other_resp => {
+                    error!("Unexpected response to cmd from node for {correlation_id:?}: {other_resp:?}");
+                    return None;
+                }
+            }
+        }
+    };
+
+    let kind = MsgKind::ClientDataResponse(dst.name);
+    let payload = WireMsg::serialize_msg_payload(&response).ok()?;
+    let wire_msg = WireMsg::new_msg(correlation_id, payload, kind, dst);
+
+    wire_msg.serialize().ok()
+}
+
+fn send_error(peer: Peer, error: Error, comm_events: Sender<CommEvent>) {
+    let _handle = task::spawn(async move {
+        let error_msg =
+            format!("Failed to send error {error} of peer {peer} on comm event channel ");
+        match comm_events.send(CommEvent::Error { peer, error }).await {
+            Ok(()) => (),
+            Err(err) => error!("{error_msg} due to {err}."),
+        }
+    });
 }
 
 #[cfg(test)]
@@ -229,8 +572,7 @@ mod tests {
 
     #[tokio::test]
     async fn successful_send() -> Result<()> {
-        let (tx, _rx) = mpsc::channel(1);
-        let comm = Comm::new(local_addr(), tx).await?;
+        let (comm, _rx) = Comm::new(local_addr()).await?;
 
         let (peer0, mut rx0) = new_peer().await?;
         let (peer1, mut rx1) = new_peer().await?;
@@ -241,10 +583,8 @@ mod tests {
         let peer0_msg = new_test_msg(dst(peer0))?;
         let peer1_msg = new_test_msg(dst(peer1))?;
 
-        comm.send_out_bytes(peer0, peer0_msg.msg_id(), peer0_msg.serialize()?)
-            .await?;
-        comm.send_out_bytes(peer1, peer1_msg.msg_id(), peer1_msg.serialize()?)
-            .await?;
+        comm.send_out_bytes(peer0, peer0_msg.msg_id(), peer0_msg.serialize()?);
+        comm.send_out_bytes(peer1, peer1_msg.msg_id(), peer1_msg.serialize()?);
 
         if let Some(bytes) = rx0.recv().await {
             assert_eq!(WireMsg::from(bytes)?, peer0_msg);
@@ -259,34 +599,35 @@ mod tests {
 
     #[tokio::test]
     async fn failed_send() -> Result<()> {
-        let (tx, _rx) = mpsc::channel(1);
-        let comm = Comm::new(local_addr(), tx).await?;
+        let (comm, mut rx) = Comm::new(local_addr()).await?;
 
         let invalid_peer = get_invalid_peer().await?;
         let invalid_addr = invalid_peer.addr();
         let msg = new_test_msg(dst(invalid_peer))?;
-        let result = comm
-            .send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?)
-            .await;
+        comm.send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?);
 
-        // the peer is still not set as a known member thus it should have failed
-        assert_matches!(result, Err(Error::CreatingConnectionToUnknownNode(peer)) => assert_eq!(peer.addr(), invalid_addr));
+        if let Some(CommEvent::Error { peer, error }) = rx.recv().await {
+            // the peer is still not set as a known member thus it should have failed
+            assert_matches!(error, Error::ConnectingToUnknownNode(_));
+            assert_eq!(peer.addr(), invalid_addr);
+        }
 
         // let's add the peer as a known member and check again
         comm.set_comm_targets([invalid_peer].into());
 
-        let result = comm
-            .send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?)
-            .await;
-        assert_matches!(result, Err(Error::FailedSend(peer)) => assert_eq!(peer.addr(), invalid_addr));
+        comm.send_out_bytes(invalid_peer, msg.msg_id(), msg.serialize()?);
+
+        if let Some(CommEvent::Error { peer, error }) = rx.recv().await {
+            assert_matches!(error, Error::FailedSend(_));
+            assert_eq!(peer.addr(), invalid_addr);
+        }
 
         Ok(())
     }
 
     #[tokio::test]
     async fn send_after_reconnect() -> Result<()> {
-        let (tx, _rx) = mpsc::channel(1);
-        let send_comm = Comm::new(local_addr(), tx).await?;
+        let (send_comm, _rx) = Comm::new(local_addr()).await?;
 
         let (recv_endpoint, mut incoming_connections) = Endpoint::builder()
             .addr(local_addr())
@@ -300,9 +641,7 @@ mod tests {
         // add peer as a known member
         send_comm.set_comm_targets([peer].into());
 
-        send_comm
-            .send_out_bytes(peer, msg0.msg_id(), msg0.serialize()?)
-            .await?;
+        send_comm.send_out_bytes(peer, msg0.msg_id(), msg0.serialize()?);
 
         let mut msg0_received = false;
 
@@ -319,9 +658,7 @@ mod tests {
         }
 
         let msg1 = new_test_msg(dst(peer))?;
-        send_comm
-            .send_out_bytes(peer, msg1.msg_id(), msg1.serialize()?)
-            .await?;
+        send_comm.send_out_bytes(peer, msg1.msg_id(), msg1.serialize()?);
 
         let mut msg1_received = false;
 
@@ -339,11 +676,10 @@ mod tests {
 
     #[tokio::test]
     async fn incoming_connection_lost() -> Result<()> {
-        let (tx, mut rx0) = mpsc::channel(1);
-        let comm0 = Comm::new(local_addr(), tx.clone()).await?;
+        let (comm0, mut rx0) = Comm::new(local_addr()).await?;
         let addr0 = comm0.socket_addr();
 
-        let comm1 = Comm::new(local_addr(), tx).await?;
+        let (comm1, _rx1) = Comm::new(local_addr()).await?;
 
         let peer = Peer::new(xor_name::rand::random(), addr0);
         let msg = new_test_msg(dst(peer))?;
@@ -352,11 +688,9 @@ mod tests {
         comm1.set_comm_targets([peer].into());
 
         // Send a message to establish the connection
-        comm1
-            .send_out_bytes(peer, msg.msg_id(), msg.serialize()?)
-            .await?;
+        comm1.send_out_bytes(peer, msg.msg_id(), msg.serialize()?);
 
-        assert_matches!(rx0.recv().await, Some(MsgFromPeer { .. }));
+        assert_matches!(rx0.recv().await, Some(CommEvent::Msg(MsgFromPeer { .. })));
 
         // Drop `comm1` to cause connection lost.
         drop(comm1);

--- a/sn_comms/src/listener.rs
+++ b/sn_comms/src/listener.rs
@@ -6,105 +6,109 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::MsgFromPeer;
+use super::{CommEvent, MsgFromPeer};
 
 use sn_interface::{
     messaging::{MsgKind, WireMsg},
     types::{log_markers::LogMarker, Peer},
 };
 
-use qp2p::{ConnectionIncoming, IncomingConnections};
-use tokio::{sync::mpsc, task};
-use tracing::Instrument;
+use qp2p::{Connection, ConnectionIncoming, IncomingConnections};
+use tokio::{sync::mpsc::Sender, task};
 
-#[derive(Clone)]
-pub(crate) struct MsgListener {
-    receive_msg: mpsc::Sender<MsgFromPeer>,
+#[tracing::instrument(skip_all)]
+pub(crate) fn listen_for_connections(
+    comm_events_sender: Sender<CommEvent>,
+    mut incoming_connections: IncomingConnections,
+) {
+    let _handle = task::spawn(async move {
+        while let Some((connection, incoming_msgs)) = incoming_connections.next().await {
+            trace!(
+                "{}: from {:?} with connection_id {}",
+                LogMarker::IncomingConnection,
+                connection.remote_address(),
+                connection.id()
+            );
+
+            let _handle = task::spawn(listen_for_msgs(
+                comm_events_sender.clone(),
+                connection,
+                incoming_msgs,
+            ));
+        }
+    });
 }
 
-impl MsgListener {
-    pub(crate) fn new(receive_msg: mpsc::Sender<MsgFromPeer>) -> Self {
-        Self { receive_msg }
-    }
+#[tracing::instrument(skip_all)]
+pub(crate) async fn listen_for_msgs(
+    comm_events: Sender<CommEvent>,
+    conn: Connection,
+    mut incoming_msgs: ConnectionIncoming,
+) {
+    let conn_id = conn.id();
+    let remote_address = conn.remote_address();
 
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn listen_for_incoming_msgs(self, mut incoming_connections: IncomingConnections) {
-        let _handle = task::spawn(async move {
-            while let Some((connection, incoming_msgs)) = incoming_connections.next().await {
-                trace!(
-                    "{}: from {:?} with connection_id {}",
-                    LogMarker::IncomingConnection,
-                    connection.remote_address(),
-                    connection.id()
+    while let Some(result) = incoming_msgs.next_with_stream().await.transpose() {
+        match result {
+            Ok((msg_bytes, send_stream)) => {
+                let stream_info = if let Some(stream) = &send_stream {
+                    format!(" on {}", stream.id())
+                } else {
+                    "".to_string()
+                };
+                debug!(
+                    "New msg arrived over conn_id={conn_id} from {remote_address:?}{stream_info}"
                 );
 
-                let clone = self.clone();
-                let _handle =
-                    task::spawn(clone.listen(connection, incoming_msgs).in_current_span());
+                let wire_msg = match WireMsg::from(msg_bytes.0) {
+                    Ok(wire_msg) => wire_msg,
+                    Err(error) => {
+                        // TODO: should perhaps rather drop this connection.. as it is a spam vector
+                        debug!("Failed to deserialize message received from {remote_address:?}{stream_info}: {error:?}");
+                        continue;
+                    }
+                };
+                let src_name = match wire_msg.kind() {
+                    MsgKind::Client(auth) => auth.public_key.into(),
+                    MsgKind::Node { name, .. }
+                    | MsgKind::ClientDataResponse(name)
+                    | MsgKind::NodeDataResponse(name) => *name,
+                };
+
+                let peer = Peer::new(src_name, remote_address);
+                let msg_id = wire_msg.msg_id();
+                debug!(
+                    "Msg {msg_id:?} received, over conn_id={conn_id}, from: {peer:?}{stream_info} was: {wire_msg:?}"
+                );
+
+                msg_received(wire_msg, peer, send_stream, comm_events.clone());
             }
-        });
-    }
-
-    #[tracing::instrument(skip_all)]
-    async fn listen(self, conn: qp2p::Connection, mut incoming_msgs: ConnectionIncoming) {
-        let conn_id = conn.id();
-        let remote_address = conn.remote_address();
-
-        while let Some(result) = incoming_msgs.next_with_stream().await.transpose() {
-            match result {
-                Ok((msg_bytes, send_stream)) => {
-                    let stream_info = if let Some(stream) = &send_stream {
-                        format!(" on {}", stream.id())
-                    } else {
-                        "".to_string()
-                    };
-                    debug!(
-                        "New msg arrived over conn_id={conn_id} from {remote_address:?}{stream_info}"
-                    );
-
-                    let wire_msg = match WireMsg::from(msg_bytes.0) {
-                        Ok(wire_msg) => wire_msg,
-                        Err(error) => {
-                            // TODO: should perhaps rather drop this connection.. as it is a spam vector
-                            debug!("Failed to deserialize message received from {remote_address:?}{stream_info}: {error:?}");
-                            continue;
-                        }
-                    };
-
-                    let src_name = match wire_msg.kind() {
-                        MsgKind::Client(auth) => auth.public_key.into(),
-                        MsgKind::Node { name, .. }
-                        | MsgKind::ClientDataResponse(name)
-                        | MsgKind::NodeDataResponse(name) => *name,
-                    };
-
-                    let peer = Peer::new(src_name, remote_address);
-
-                    let msg_id = wire_msg.msg_id();
-                    debug!(
-                        "Msg {msg_id:?} received, over conn_id={conn_id}, from: {peer:?}{stream_info} was: {wire_msg:?}"
-                    );
-
-                    let msg_sender = self.receive_msg.clone();
-                    let msg = MsgFromPeer {
-                        sender: peer,
-                        wire_msg,
-                        send_stream,
-                    };
-                    // move this channel sending off thread so we don't hold up incoming msgs at all.
-                    let _handle = tokio::spawn(async move {
-                        // handle the message first
-                        if let Err(error) = msg_sender.send(msg).await {
-                            error!("Error pushing msg {msg_id:?} onto internal msg handling channel: {error:?}");
-                        }
-                    });
-                }
-                Err(error) => {
-                    warn!("Error on connection {conn_id} with {remote_address}: {error:?}");
-                }
+            Err(error) => {
+                warn!("Error on connection {conn_id} with {remote_address}: {error:?}");
             }
         }
-
-        trace!(%conn_id, %remote_address, "{}", LogMarker::ConnectionClosed);
     }
+
+    trace!(%conn_id, %remote_address, "{}", LogMarker::ConnectionClosed);
+}
+
+pub(crate) fn msg_received(
+    wire_msg: WireMsg,
+    peer: Peer,
+    send_stream: Option<qp2p::SendStream>,
+    comm_events: Sender<CommEvent>,
+) {
+    let msg_id = wire_msg.msg_id();
+    let msg_event = CommEvent::Msg(MsgFromPeer {
+        sender: peer,
+        wire_msg,
+        send_stream,
+    });
+    // move this channel sending off thread so we don't hold up incoming msgs at all.
+    let _handle = tokio::spawn(async move {
+        // handle the message first
+        if let Err(error) = comm_events.send(msg_event).await {
+            error!("Error pushing msg {msg_id:?} onto internal msg handling channel: {error:?}");
+        }
+    });
 }

--- a/sn_comms/src/peer_session.rs
+++ b/sn_comms/src/peer_session.rs
@@ -67,6 +67,10 @@ impl PeerSession {
         }
     }
 
+    pub(crate) fn peer(&self) -> Peer {
+        self.peer
+    }
+
     /// Sends out a UsrMsg on a bidi connection and awaits response bytes.
     /// As such this may be long running if response is returned slowly.
     /// When sending a msg to a peer, if it fails with an existing
@@ -75,7 +79,7 @@ impl PeerSession {
     /// b. or it cleaned them all up from the cache creating a new connection
     ///    to the peer as last attempt.
     pub(crate) async fn send_with_bi_return_response(
-        &mut self,
+        &self,
         bytes: UsrMsgBytes,
         msg_id: MsgId,
     ) -> Result<UsrMsgBytes, PeerSessionError> {

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -69,6 +69,12 @@ pub enum SectionStateVote {
     JoinsAllowed(bool),
 }
 
+#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
+pub enum NodeMsgType {
+    DataQuery,
+    StoreData,
+}
+
 #[derive(Clone, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 #[allow(clippy::large_enum_variant, clippy::derive_partial_eq_without_eq)]
 /// Message sent over the among nodes

--- a/sn_interface/src/types/log_markers.rs
+++ b/sn_interface/src/types/log_markers.rs
@@ -37,6 +37,7 @@ pub enum LogMarker {
     IgnoredNodeAsOffline,
     VotedOffline,
     // Messaging
+    MsgReceived,
     ClientMsgToBeHandled,
     NodeMsgToBeHandled,
     // Membership
@@ -63,7 +64,6 @@ pub enum LogMarker {
     RegisterQueryReceivedAtElder,
     RegisterQueryReceivedAtAdult,
     // Routing cmds
-    DispatchHandleMsgCmd,
     CmdHandlingSpawned,
     CmdProcessStart,
     CmdProcessEnd,

--- a/sn_node/src/node/connectivity.rs
+++ b/sn_node/src/node/connectivity.rs
@@ -7,22 +7,41 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{flow_ctrl::cmds::Cmd, MyNode, Result, SectionStateVote};
+
 use sn_fault_detection::IssueType;
-use std::{collections::BTreeSet, net::SocketAddr};
+use sn_interface::types::Peer;
+
+use std::collections::BTreeSet;
 use xor_name::XorName;
 
 impl MyNode {
-    /// Track comms issue if this is a peer we know and care about
-    pub(crate) fn handle_failed_send(&self, addr: &SocketAddr) {
-        let name = if let Some(peer) = self.network_knowledge.find_member_by_addr(addr) {
-            debug!("Lost known peer {}", peer);
-            peer.name()
-        } else {
-            trace!("Lost unknown peer {}", addr);
-            return;
-        };
-
-        self.track_node_issue(name, IssueType::Communication);
+    /// Handle error in communication with peer.
+    pub(crate) fn handle_comms_error(&self, peer: Peer, error: sn_comms::Error) {
+        use sn_comms::Error::*;
+        match error {
+            ConnectingToUnknownNode(msg_id) => {
+                trace!(
+                    "Tried to send msg {msg_id:?} to unknown peer {}. No connection made.",
+                    peer
+                );
+            }
+            CannotConnectEndpoint(_err) => {
+                debug!("Cannot connect to endpoint: {}", peer);
+            }
+            AddressNotReachable(_err) => {
+                debug!("Address not reachable: {}", peer);
+            }
+            FailedSend(msg_id) => {
+                debug!("Could not send {msg_id:?}, lost known peer: {}", peer);
+            }
+            InvalidMsgReceived(msg_id) => {
+                debug!("Invalid msg {msg_id:?} received from {}.", peer);
+            }
+        }
+        // Track comms issue if this is a peer we know and care about
+        if self.network_knowledge.is_section_member(&peer.name()) {
+            self.track_node_issue(peer.name(), IssueType::Communication);
+        }
     }
 
     pub(crate) fn cast_offline_proposals(&mut self, names: &BTreeSet<XorName>) -> Result<Vec<Cmd>> {

--- a/sn_node/src/node/connectivity.rs
+++ b/sn_node/src/node/connectivity.rs
@@ -26,16 +26,16 @@ impl MyNode {
                 );
             }
             CannotConnectEndpoint(_err) => {
-                debug!("Cannot connect to endpoint: {}", peer);
+                trace!("Cannot connect to endpoint: {}", peer);
             }
             AddressNotReachable(_err) => {
-                debug!("Address not reachable: {}", peer);
+                trace!("Address not reachable: {}", peer);
             }
             FailedSend(msg_id) => {
-                debug!("Could not send {msg_id:?}, lost known peer: {}", peer);
+                trace!("Could not send {msg_id:?}, lost known peer: {}", peer);
             }
             InvalidMsgReceived(msg_id) => {
-                debug!("Invalid msg {msg_id:?} received from {}.", peer);
+                trace!("Invalid msg {msg_id:?} received from {}.", peer);
             }
         }
         // Track comms issue if this is a peer we know and care about

--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -127,7 +127,7 @@ pub(crate) enum Cmd {
     },
     /// Performs serialisation and signing and sends the msg over a bidi connection
     /// and then enqueues any response returned.
-    SendMsgWithBiResponse {
+    SendAndEnqueueAnyResponse {
         msg: NodeMsg,
         msg_id: MsgId,
         recipients: BTreeSet<Peer>,
@@ -164,7 +164,7 @@ pub(crate) enum Cmd {
     },
     /// Performs serialisation and sends the msg to the peer node over a new bi-stream,
     /// awaiting for a response which is forwarded to the client.
-    SendMsgAwaitResponseAndRespondToClient {
+    SendAndForwardResponseToClient {
         msg_id: MsgId,
         msg: NodeMsg,
         #[debug(skip)]
@@ -193,11 +193,11 @@ impl Cmd {
         use sn_interface::statemap::State;
         match self {
             Cmd::SendMsg { .. }
-            | Cmd::SendMsgWithBiResponse { .. }
+            | Cmd::SendAndEnqueueAnyResponse { .. }
             | Cmd::SendNodeMsgResponse { .. }
             | Cmd::SendClientResponse { .. }
             | Cmd::SendNodeDataResponse { .. }
-            | Cmd::SendMsgAwaitResponseAndRespondToClient { .. } => State::Comms,
+            | Cmd::SendAndForwardResponseToClient { .. } => State::Comms,
             Cmd::HandleCommsError { .. } => State::Comms,
             Cmd::HandleMsg { .. } => State::HandleMsg,
             Cmd::UpdateNetworkAndHandleValidClientMsg { .. } => State::ClientMsg,
@@ -236,12 +236,12 @@ impl fmt::Display for Cmd {
             Cmd::HandleMembershipDecision(_) => write!(f, "HandleMembershipDecision"),
             Cmd::HandleDkgOutcome { .. } => write!(f, "HandleDkgOutcome"),
             Cmd::SendMsg { .. } => write!(f, "SendMsg"),
-            Cmd::SendMsgWithBiResponse { .. } => write!(f, "SendMsgWithBiResponse"),
+            Cmd::SendAndEnqueueAnyResponse { .. } => write!(f, "SendAndEnqueueAnyResponse"),
             Cmd::SendNodeMsgResponse { .. } => write!(f, "SendNodeMsgResponse"),
             Cmd::SendClientResponse { .. } => write!(f, "SendClientResponse"),
             Cmd::SendNodeDataResponse { .. } => write!(f, "SendNodeDataResponse"),
-            Cmd::SendMsgAwaitResponseAndRespondToClient { .. } => {
-                write!(f, "SendMsgAwaitResponseAndRespondToClient")
+            Cmd::SendAndForwardResponseToClient { .. } => {
+                write!(f, "SendAndForwardResponseToClient")
             }
             Cmd::EnqueueDataForReplication { .. } => write!(f, "EnqueueDataForReplication"),
             Cmd::TrackNodeIssue { name, issue } => {

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -57,13 +57,19 @@ impl Dispatcher {
                 msg_id,
                 recipients,
                 context,
-            } => MyNode::send_msg(msg, msg_id, recipients, context).await,
-            Cmd::SendMsgEnqueueAnyResponse {
+            } => {
+                MyNode::send_msg(msg, msg_id, recipients, context)?;
+                Ok(vec![])
+            }
+            Cmd::SendMsgWithBiResponse {
                 msg,
                 msg_id,
                 recipients,
                 context,
-            } => MyNode::send_msg_enqueue_any_response(msg, msg_id, context, recipients).await,
+            } => {
+                MyNode::send_msg_with_bi_response(msg, msg_id, context, recipients)?;
+                Ok(vec![])
+            }
             Cmd::SendMsgAwaitResponseAndRespondToClient {
                 msg_id,
                 msg,
@@ -79,8 +85,8 @@ impl Dispatcher {
                     targets,
                     client_stream,
                     source_client,
-                )
-                .await
+                )?;
+                Ok(vec![])
             }
             Cmd::SendNodeMsgResponse {
                 msg,
@@ -88,41 +94,44 @@ impl Dispatcher {
                 recipient,
                 send_stream,
                 context,
-            } => MyNode::send_node_msg_response(msg, msg_id, recipient, context, send_stream).await,
+            } => Ok(
+                MyNode::send_node_msg_response(msg, msg_id, recipient, context, send_stream)
+                    .await?
+                    .into_iter()
+                    .collect(),
+            ),
             Cmd::SendClientResponse {
                 msg,
                 correlation_id,
                 send_stream,
                 context,
                 source_client,
-            } => {
-                MyNode::send_client_response(
-                    msg,
-                    correlation_id,
-                    send_stream,
-                    context,
-                    source_client,
-                )
-                .await?;
-                Ok(vec![])
-            }
+            } => Ok(MyNode::send_client_response(
+                msg,
+                correlation_id,
+                send_stream,
+                context,
+                source_client,
+            )
+            .await?
+            .into_iter()
+            .collect()),
             Cmd::SendNodeDataResponse {
                 msg,
                 correlation_id,
                 send_stream,
                 context,
                 requesting_peer,
-            } => {
-                MyNode::send_node_data_response(
-                    msg,
-                    correlation_id,
-                    send_stream,
-                    context,
-                    requesting_peer,
-                )
-                .await?;
-                Ok(vec![])
-            }
+            } => Ok(MyNode::send_node_data_response(
+                msg,
+                correlation_id,
+                send_stream,
+                context,
+                requesting_peer,
+            )
+            .await?
+            .into_iter()
+            .collect()),
             Cmd::TrackNodeIssue { name, issue } => {
                 let node = self.node.read().await;
                 debug!("[NODE READ]: fault tracking read got");
@@ -191,11 +200,11 @@ impl Dispatcher {
                 node.handle_new_sections_agreement(sap1, sig1, sap2, sig2)
                     .await
             }
-            Cmd::HandleFailedSendToNode { peer, msg_id } => {
-                warn!("Message sending failed to {peer}, for {msg_id:?}");
+            Cmd::HandleCommsError { peer, error } => {
+                trace!("Comms error {error}");
                 let node = self.node.read().await;
-                debug!("[NODE READ]: HandleFailedSendToNode agreements read got...");
-                node.handle_failed_send(&peer.addr());
+                debug!("[NODE READ]: HandleCommsError read got...");
+                node.handle_comms_error(peer, error);
                 Ok(vec![])
             }
             Cmd::HandleDkgOutcome {

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -61,16 +61,16 @@ impl Dispatcher {
                 MyNode::send_msg(msg, msg_id, recipients, context)?;
                 Ok(vec![])
             }
-            Cmd::SendMsgWithBiResponse {
+            Cmd::SendAndEnqueueAnyResponse {
                 msg,
                 msg_id,
                 recipients,
                 context,
             } => {
-                MyNode::send_msg_with_bi_response(msg, msg_id, context, recipients)?;
+                MyNode::send_and_enqueue_any_response(msg, msg_id, context, recipients)?;
                 Ok(vec![])
             }
-            Cmd::SendMsgAwaitResponseAndRespondToClient {
+            Cmd::SendAndForwardResponseToClient {
                 msg_id,
                 msg,
                 context,
@@ -78,7 +78,7 @@ impl Dispatcher {
                 client_stream,
                 source_client,
             } => {
-                MyNode::send_msg_await_response_and_send_to_client(
+                MyNode::send_and_forward_response_to_client(
                     msg_id,
                     msg,
                     context,

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -241,7 +241,7 @@ impl FlowCtrl {
                             );
                         } else {
                             trace!(
-                                "{:?} from {sender:?}, unknown length due to serialization issued.",
+                                "{:?} from {sender:?}, unknown length due to serialization issues.",
                                 LogMarker::MsgReceived,
                             );
                         }

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -25,10 +25,10 @@ use crate::node::{
         fault_detection::{FaultChannels, FaultsCmd},
     },
     messaging::Peers,
-    MyNode, Result, STANDARD_CHANNEL_SIZE,
+    MyNode, STANDARD_CHANNEL_SIZE,
 };
 
-use sn_comms::MsgFromPeer;
+use sn_comms::{CommEvent, MsgFromPeer};
 use sn_fault_detection::FaultDetection;
 use sn_interface::{
     messaging::system::{JoinRejectReason, NodeDataCmd, NodeMsg},
@@ -36,7 +36,10 @@ use sn_interface::{
 };
 
 use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{
+    mpsc::{self, Receiver, Sender},
+    RwLock,
+};
 use xor_name::XorName;
 
 /// Sent via the rejoin_network_tx to restart the join process.
@@ -66,7 +69,7 @@ impl RejoinReason {
 /// Periodically triggers other Cmd Processes (eg health checks, fault detection etc)
 pub(crate) struct FlowCtrl {
     node: Arc<RwLock<MyNode>>,
-    cmd_sender_channel: mpsc::Sender<(Cmd, Vec<usize>)>,
+    cmd_sender_channel: Sender<(Cmd, Vec<usize>)>,
     fault_channels: FaultChannels,
     timestamps: PeriodicChecksTimestamps,
 }
@@ -76,13 +79,10 @@ impl FlowCtrl {
     /// returning the channel where it can receive commands on
     pub(crate) async fn start(
         cmd_ctrl: CmdCtrl,
-        mut incoming_msg_events: mpsc::Receiver<MsgFromPeer>,
-        data_replication_receiver: mpsc::Receiver<(Vec<DataAddress>, Peer)>,
-        fault_cmds_channels: (mpsc::Sender<FaultsCmd>, mpsc::Receiver<FaultsCmd>),
-    ) -> (
-        mpsc::Sender<(Cmd, Vec<usize>)>,
-        mpsc::Receiver<RejoinReason>,
-    ) {
+        incoming_msg_events: Receiver<CommEvent>,
+        data_replication_receiver: Receiver<(Vec<DataAddress>, Peer)>,
+        fault_cmds_channels: (Sender<FaultsCmd>, Receiver<FaultsCmd>),
+    ) -> (Sender<(Cmd, Vec<usize>)>, Receiver<RejoinReason>) {
         debug!("[NODE READ]: flowctrl node context lock got");
         let node_context = cmd_ctrl.node().read().await.context();
         let (cmd_sender_channel, mut incoming_cmds_from_apis) =
@@ -151,22 +151,7 @@ impl FlowCtrl {
         )
         .await;
 
-        // start a new thread to convert msgs to Cmds
-        let _handle = tokio::task::spawn(async move {
-            while let Some(peer_msg) = incoming_msg_events.recv().await {
-                let cmd = match Self::handle_new_msg_event(peer_msg).await {
-                    Ok(cmd) => cmd,
-                    Err(error) => {
-                        error!("Could not handle incoming msg event: {error:?}");
-                        continue;
-                    }
-                };
-
-                if let Err(error) = cmd_channel_for_msgs.send((cmd, vec![])).await {
-                    error!("Error sending msg onto cmd channel {error:?}");
-                }
-            }
-        });
+        Self::listen_for_comm_events(incoming_msg_events, cmd_channel_for_msgs);
 
         (cmd_sender_channel, rejoin_network_rx)
     }
@@ -175,8 +160,8 @@ impl FlowCtrl {
     async fn send_out_data_for_replication(
         node_arc: Arc<RwLock<MyNode>>,
         node_data_storage: DataStorage,
-        mut data_replication_receiver: mpsc::Receiver<(Vec<DataAddress>, Peer)>,
-        cmd_channel: mpsc::Sender<(Cmd, Vec<usize>)>,
+        mut data_replication_receiver: Receiver<(Vec<DataAddress>, Peer)>,
+        cmd_channel: Sender<(Cmd, Vec<usize>)>,
     ) {
         // start a new thread to kick off data replication
         let _handle = tokio::task::spawn(async move {
@@ -231,29 +216,48 @@ impl FlowCtrl {
         }
     }
 
-    // Listen for a new incoming connection event and handle it.
-    async fn handle_new_msg_event(msg: MsgFromPeer) -> Result<Cmd> {
-        let MsgFromPeer {
-            sender,
-            wire_msg,
-            send_stream,
-        } = msg;
+    // starts a new thread to convert comm event to cmds
+    fn listen_for_comm_events(
+        mut incoming_msg_events: Receiver<CommEvent>,
+        cmd_channel_for_msgs: Sender<(Cmd, Vec<usize>)>,
+    ) {
+        let _handle = tokio::task::spawn(async move {
+            while let Some(event) = incoming_msg_events.recv().await {
+                let cmd = match event {
+                    CommEvent::Error { peer, error } => Cmd::HandleCommsError { peer, error },
+                    CommEvent::Msg(MsgFromPeer {
+                        sender,
+                        wire_msg,
+                        send_stream,
+                    }) => {
+                        if let Ok((header, dst, payload)) = wire_msg.serialize() {
+                            let original_bytes_len = header.len() + dst.len() + payload.len();
+                            let span =
+                                trace_span!("handle_message", ?sender, msg_id = ?wire_msg.msg_id());
+                            let _span_guard = span.enter();
+                            trace!(
+                                "{:?} from {sender:?} length {original_bytes_len}",
+                                LogMarker::MsgReceived,
+                            );
+                        } else {
+                            trace!(
+                                "{:?} from {sender:?}, unknown length due to serialization issued.",
+                                LogMarker::MsgReceived,
+                            );
+                        }
 
-        let (header, dst, payload) = wire_msg.serialize()?;
-        let original_bytes_len = header.len() + dst.len() + payload.len();
+                        Cmd::HandleMsg {
+                            origin: sender,
+                            wire_msg,
+                            send_stream,
+                        }
+                    }
+                };
 
-        let span = trace_span!("handle_message", ?sender, msg_id = ?wire_msg.msg_id());
-        let _span_guard = span.enter();
-
-        trace!(
-            "{:?} from {sender:?} length {original_bytes_len}",
-            LogMarker::DispatchHandleMsgCmd,
-        );
-
-        Ok(Cmd::HandleMsg {
-            origin: sender,
-            wire_msg,
-            send_stream,
-        })
+                if let Err(error) = cmd_channel_for_msgs.send((cmd, vec![])).await {
+                    error!("Error sending msg onto cmd channel {error:?}");
+                }
+            }
+        });
     }
 }

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -240,6 +240,7 @@ impl FlowCtrl {
                                 LogMarker::MsgReceived,
                             );
                         } else {
+                            // this should be unreachable
                             trace!(
                                 "{:?} from {sender:?}, unknown length due to serialization issues.",
                                 LogMarker::MsgReceived,

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -172,7 +172,7 @@ impl FlowCtrl {
             if !context.network_knowledge.is_section_member(&context.name) {
                 if self.timestamps.last_relocation_retry_check.elapsed() > RELOCATION_TIMEOUT_SECS {
                     self.timestamps.last_relocation_retry_check = Instant::now();
-                    cmds.push(MyNode::send_msg_to_our_elders_await_responses(
+                    cmds.push(MyNode::send_to_elders_await_responses(
                         context.clone(),
                         NodeMsg::TryJoin(Some(proof.clone())),
                     ));
@@ -303,7 +303,7 @@ impl FlowCtrl {
                     }
                     // we may also be behind, so lets request AE incase that is the case!
                     let msg = NodeMsg::MembershipAE(membership.generation());
-                    cmds.push(MyNode::send_msg_to_our_elders(context, msg));
+                    cmds.push(MyNode::send_to_elders(context, msg));
                 }
             }
         }

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -258,7 +258,8 @@ impl Dispatcher {
 }
 
 // Receive the next `MsgFromPeer` if the buffer is not empty. Returns None if the buffer is currently empty
-pub(crate) fn get_next_msg(comm_rx: &mut Receiver<CommEvent>) -> Option<MsgFromPeer> {
+pub(crate) async fn get_next_msg(comm_rx: &mut Receiver<CommEvent>) -> Option<MsgFromPeer> {
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     match comm_rx.try_recv() {
         Ok(CommEvent::Msg(msg)) => Some(msg),
         Ok(_) => None,

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -166,7 +166,7 @@ impl<'a> ProcessAndInspectCmds<'a> {
             if !matches!(
                 cmd,
                 Cmd::SendMsg { .. }
-                    | Cmd::SendMsgAwaitResponseAndRespondToClient { .. }
+                    | Cmd::SendAndForwardResponseToClient { .. }
                     | Cmd::SendClientResponse { .. }
                     | Cmd::SendNodeDataResponse { .. }
                     | Cmd::SendNodeMsgResponse { .. }

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -21,7 +21,7 @@ use crate::node::{
 };
 use cmd_utils::{handle_online_cmd, ProcessAndInspectCmds};
 
-use sn_comms::MsgFromPeer;
+use sn_comms::{CommEvent, MsgFromPeer};
 use sn_consensus::Decision;
 use sn_dbc::Hash;
 use sn_interface::{
@@ -606,7 +606,7 @@ async fn msg_to_self() -> Result<()> {
 
     assert!(cmds.is_empty());
 
-    let msg_type = assert_matches!(comm_rx.recv().await, Some(MsgFromPeer { sender, wire_msg, .. }) => {
+    let msg_type = assert_matches!(comm_rx.recv().await, Some(CommEvent::Msg(MsgFromPeer { sender, wire_msg, .. })) => {
         assert_eq!(sender.addr(), info.addr);
         assert_matches!(wire_msg.into_msg(), Ok(msg_type) => msg_type)
     });

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -868,7 +868,7 @@ async fn spentbook_spend_client_message_should_replicate_to_adults_and_send_ack(
     .await?;
 
     while let Some(cmd) = cmds.next().await? {
-        if let Cmd::SendMsgAwaitResponseAndRespondToClient {
+        if let Cmd::SendAndForwardResponseToClient {
             msg: NodeMsg::NodeDataCmd(NodeDataCmd::StoreData(data)),
             targets,
             ..

--- a/sn_node/src/node/messaging/data.rs
+++ b/sn_node/src/node/messaging/data.rs
@@ -243,7 +243,7 @@ impl MyNode {
                     });
                     is_full = true;
 
-                    cmds.push(MyNode::send_msg_to_our_elders(context, msg))
+                    cmds.push(MyNode::send_to_elders(context, msg))
                 }
                 Err(error) => {
                     // the rest seem to be non-problematic errors.. (?)

--- a/sn_node/src/node/messaging/data.rs
+++ b/sn_node/src/node/messaging/data.rs
@@ -72,7 +72,7 @@ impl MyNode {
         // Atm that's perhaps more bother than its worth..
         let msg = NodeMsg::NodeDataCmd(NodeDataCmd::StoreData(data));
 
-        let cmd = Cmd::SendMsgAwaitResponseAndRespondToClient {
+        let cmd = Cmd::SendAndForwardResponseToClient {
             msg_id,
             msg,
             context,
@@ -139,7 +139,7 @@ impl MyNode {
             operation_id,
         });
 
-        let cmd = Cmd::SendMsgAwaitResponseAndRespondToClient {
+        let cmd = Cmd::SendAndForwardResponseToClient {
             msg_id,
             msg,
             context,

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -861,7 +861,7 @@ mod tests {
                 // used to check if the buffer is empty during the first iteration of the buffer.
                 // If all the node buffers are empty during the first try, break out of main loop
                 let mut empty_at_first_try = true;
-                while let Some(msg) = get_next_msg(comm_rx) {
+                while let Some(msg) = get_next_msg(comm_rx).await {
                     if empty_at_first_try {
                         empty_at_first_try = false;
                     }
@@ -925,7 +925,7 @@ mod tests {
                 // used to check if the buffer is empty during the first iteration of the buffer.
                 // If all the node buffers are empty during the first try, break out of main loop
                 let mut empty_at_first_try = true;
-                while let Some(msg) = get_next_msg(comm_rx) {
+                while let Some(msg) = get_next_msg(comm_rx).await {
                     if empty_at_first_try {
                         empty_at_first_try = false;
                     }
@@ -1076,7 +1076,7 @@ mod tests {
                 // used to check if the buffer is empty during the first iteration of the buffer.
                 // If all the node buffers are empty during the first try, break out of main loop
                 let mut empty_at_first_try = true;
-                while let Some(msg) = get_next_msg(comm_rx) {
+                while let Some(msg) = get_next_msg(comm_rx).await {
                     if empty_at_first_try {
                         empty_at_first_try = false;
                     }
@@ -1129,7 +1129,7 @@ mod tests {
                 // used to check if the buffer is empty during the first iteration of the buffer.
                 // If all the node buffers are empty during the first try, break out of main loop
                 let mut empty_at_first_try = true;
-                while let Some(msg) = get_next_msg(comm_rx) {
+                while let Some(msg) = get_next_msg(comm_rx).await {
                     if empty_at_first_try {
                         empty_at_first_try = false;
                     }

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -809,7 +809,7 @@ mod tests {
         tests::{cmd_utils::get_next_msg, network_builder::TestNetworkBuilder},
     };
 
-    use sn_comms::MsgFromPeer;
+    use sn_comms::{CommEvent, MsgFromPeer};
     use sn_interface::{
         init_logger,
         messaging::{
@@ -1220,7 +1220,7 @@ mod tests {
         rng: impl RngCore,
     ) -> (
         BTreeMap<XorName, Dispatcher>,
-        BTreeMap<XorName, mpsc::Receiver<MsgFromPeer>>,
+        BTreeMap<XorName, mpsc::Receiver<CommEvent>>,
         SecretKeySet,
     ) {
         let mut env = TestNetworkBuilder::new(rng)

--- a/sn_node/src/node/messaging/handover.rs
+++ b/sn_node/src/node/messaging/handover.rs
@@ -185,7 +185,7 @@ impl MyNode {
         // Deliver each SignedVote to all current Elders
         trace!("Broadcasting Vote msg: {:?}", signed_vote);
 
-        MyNode::send_msg_to_our_elders(context, NodeMsg::HandoverVotes(vec![signed_vote]))
+        MyNode::send_to_elders(context, NodeMsg::HandoverVotes(vec![signed_vote]))
     }
 
     /// Broadcast the decision of the terminated handover consensus by proposing the HandoverCompleted SAP(s)

--- a/sn_node/src/node/messaging/join_section.rs
+++ b/sn_node/src/node/messaging/join_section.rs
@@ -19,7 +19,7 @@ impl MyNode {
         if context.network_knowledge.is_section_member(&context.name) {
             None
         } else {
-            Some(MyNode::send_msg_to_our_elders_await_responses(
+            Some(MyNode::send_to_elders_await_responses(
                 context,
                 NodeMsg::TryJoin(relocation),
             ))
@@ -40,7 +40,7 @@ mod tests {
         MIN_ADULT_AGE,
     };
 
-    use sn_comms::MsgFromPeer;
+    use sn_comms::CommEvent;
     use sn_interface::{
         elder_count, init_logger,
         messaging::system::{JoinRejectReason, JoinResponse},
@@ -403,7 +403,7 @@ mod tests {
         (network_knowledge, section)
     }
 
-    async fn connect_flows(node: MyNode, incoming_msg_receiver: Receiver<MsgFromPeer>) -> TestNode {
+    async fn connect_flows(node: MyNode, incoming_msg_receiver: Receiver<CommEvent>) -> TestNode {
         let node = Arc::new(RwLock::new(node));
         let (dispatcher, data_replication_receiver) = Dispatcher::new(node.clone());
         let cmd_ctrl = CmdCtrl::new(dispatcher);

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -44,7 +44,7 @@ impl MyNode {
                     return None;
                 }
             };
-            Some(MyNode::send_msg_to_our_elders(
+            Some(MyNode::send_to_elders(
                 context,
                 NodeMsg::MembershipVotes(vec![membership_vote]),
             ))
@@ -64,8 +64,7 @@ impl MyNode {
         if let Some(membership) = membership_context {
             trace!("{}", LogMarker::GossippingMembershipVotes);
             if let Ok(ae_votes) = membership.anti_entropy(membership.generation()) {
-                let cmd =
-                    MyNode::send_msg_to_our_elders(context, NodeMsg::MembershipVotes(ae_votes));
+                let cmd = MyNode::send_to_elders(context, NodeMsg::MembershipVotes(ae_votes));
                 return Some(cmd);
             }
         }
@@ -131,7 +130,7 @@ impl MyNode {
             };
 
             if let Some(vote_msg) = vote_broadcast {
-                cmds.push(MyNode::send_msg_to_our_elders(context, vote_msg));
+                cmds.push(MyNode::send_to_elders(context, vote_msg));
             }
         }
 

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -13,7 +13,7 @@ use crate::{
     storage::{Error as StorageError, StorageLevel},
 };
 
-use sn_comms::Error as CommsError;
+use sn_fault_detection::IssueType;
 use sn_interface::{
     messaging::{
         data::CmdResponse,
@@ -25,21 +25,18 @@ use sn_interface::{
 };
 
 use qp2p::{SendStream, UsrMsgBytes};
-use sn_fault_detection::IssueType;
-use xor_name::XorName;
-
-use std::collections::BTreeSet;
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 use tokio::sync::RwLock;
+use xor_name::XorName;
 
 impl MyNode {
     /// Send a (`NodeMsg`) message to peers
-    pub(crate) async fn send_msg(
+    pub(crate) fn send_msg(
         msg: NodeMsg,
         msg_id: MsgId,
         recipients: Peers,
         context: NodeContext,
-    ) -> Result<Vec<Cmd>> {
+    ) -> Result<()> {
         trace!("Sending msg: {msg_id:?}");
         let peer_msgs = into_msg_bytes(
             &context.network_knowledge,
@@ -49,50 +46,25 @@ impl MyNode {
             recipients,
         )?;
 
-        let comm = context.comm.clone();
-        let tasks = peer_msgs
+        peer_msgs
             .into_iter()
-            .map(|(peer, msg)| comm.send_out_bytes(peer, msg_id, msg));
-        let results = futures::future::join_all(tasks).await;
+            .for_each(|(peer, msg)| context.comm.send_out_bytes(peer, msg_id, msg));
 
-        // Any failed sends are tracked via Cmd::HandlePeerFailedSend, which will track issues for any peers
-        // in the section (otherwise ignoring failed send to out of section nodes or clients)
-        let cmds = results
-            .into_iter()
-            .filter_map(|result| match result {
-                Err(CommsError::FailedSend(peer)) => {
-                    Some(Cmd::HandleFailedSendToNode { peer, msg_id })
-                }
-                Err(error) => {
-                    error!("Error in comms for {msg_id:?}: {error:?}");
-                    None
-                }
-                Ok(_) => {
-                    // nothing need be done
-                    None
-                }
-            })
-            .collect();
-
-        Ok(cmds)
+        Ok(())
     }
 
     /// Send a (`NodeMsg`) message to all Elders in our section
-    pub(crate) fn send_msg_to_our_elders(context: &NodeContext, msg: NodeMsg) -> Cmd {
+    pub(crate) fn send_to_elders(context: &NodeContext, msg: NodeMsg) -> Cmd {
         let sap = context.network_knowledge.section_auth();
         let recipients = sap.elders_set();
         Cmd::send_msg(msg, Peers::Multiple(recipients), context.clone())
     }
 
     /// Send a (`NodeMsg`) message to all Elders in our section, await all responses & enqueue
-    pub(crate) fn send_msg_to_our_elders_await_responses(
-        context: NodeContext,
-        msg: NodeMsg,
-    ) -> Cmd {
+    pub(crate) fn send_to_elders_await_responses(context: NodeContext, msg: NodeMsg) -> Cmd {
         let sap = context.network_knowledge.section_auth();
         let recipients = sap.elders_set();
-
-        Cmd::SendMsgEnqueueAnyResponse {
+        Cmd::SendMsgWithBiResponse {
             msg,
             msg_id: MsgId::new(),
             recipients,
@@ -148,7 +120,7 @@ impl MyNode {
                     cmds.push(Cmd::SetJoinsAllowedUntilSplit(true));
                 }
 
-                cmds.push(MyNode::send_msg_to_our_elders(context, msg));
+                cmds.push(MyNode::send_to_elders(context, msg));
                 CmdResponse::err(data, StorageError::NotEnoughSpace.into())?
             }
             Err(error) => {
@@ -439,7 +411,6 @@ impl MyNode {
             }
             NodeMsg::NodeDataCmd(NodeDataCmd::StoreData(data)) => {
                 debug!("Attempting to store data locally: {:?}", data.address());
-
                 // store data and respond w/ack on the response stream
                 MyNode::store_data_and_respond(&context, data, send_stream, sender, msg_id).await
             }

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -64,7 +64,7 @@ impl MyNode {
     pub(crate) fn send_to_elders_await_responses(context: NodeContext, msg: NodeMsg) -> Cmd {
         let sap = context.network_knowledge.section_auth();
         let recipients = sap.elders_set();
-        Cmd::SendMsgWithBiResponse {
+        Cmd::SendAndEnqueueAnyResponse {
             msg,
             msg_id: MsgId::new(),
             recipients,

--- a/sn_node/src/node/messaging/streams.rs
+++ b/sn_node/src/node/messaging/streams.rs
@@ -116,9 +116,9 @@ impl MyNode {
         .await
     }
 
-    /// Sends a msg via comms, and listens for any response
+    /// Sends a msg, and listens for any response
     /// The response is returned to be handled via the dispatcher (though a response is not necessarily expected)
-    pub(crate) fn send_msg_with_bi_response(
+    pub(crate) fn send_and_enqueue_any_response(
         msg: NodeMsg,
         msg_id: MsgId,
         context: NodeContext,
@@ -142,13 +142,13 @@ impl MyNode {
             let bytes_to_node = wire_msg.serialize_with_new_dst(&dst)?;
             let comm = context.comm.clone();
             info!("About to send {msg_id:?} to holder node: {target:?}");
-            comm.send_with_bi_response(target, msg_id, bytes_to_node);
+            comm.send_and_return_response(target, msg_id, bytes_to_node);
         }
 
         Ok(())
     }
 
-    pub(crate) fn send_msg_await_response_and_send_to_client(
+    pub(crate) fn send_and_forward_response_to_client(
         msg_id: MsgId,
         msg: NodeMsg,
         context: NodeContext,

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -139,11 +139,10 @@ async fn bootstrap_node(
     CmdChannel,
     mpsc::Receiver<RejoinReason>,
 )> {
-    let (incoming_msg_pipe, incoming_msg_receiver) = mpsc::channel(STANDARD_CHANNEL_SIZE);
     let (fault_cmds_sender, fault_cmds_receiver) =
         mpsc::channel::<FaultsCmd>(STANDARD_CHANNEL_SIZE);
 
-    let comm = Comm::new(config.local_addr(), incoming_msg_pipe).await?;
+    let (comm, incoming_msg_receiver) = Comm::new(config.local_addr()).await?;
 
     let node = if config.is_first() {
         start_genesis_node(


### PR DESCRIPTION
NB: On top of #2058 and #2059.
Supersedes #2043.
***

This removes dashmap use for sessions in comms.

It also makes comms error handling and issue reporting focused to one place.

Additional thing to note is that Elders now relay responses back to client as soon as they are received.
The way the requests are designed now, that would only be more than one response when storing data,
since queries from a Client, only go out to one data holder from the Elders.

***

Client is refactored to evaluate all acks received from each Elder called when storing data.