### PR TITLE
Fix Misc User Experience Issues

### DIFF
--- a/sn_cli/src/operations/helpers.rs
+++ b/sn_cli/src/operations/helpers.rs
@@ -164,11 +164,12 @@ fn set_exec_perms(file_path: PathBuf) -> Result<()> {
 
 /// Gets the version number from the full version number string.
 ///
-/// The `release_version` input is in the form "0.1.0-0.1.1-0.62.0-0.51.6-0.46.2-0.39.1", which is the
-/// `sn_fault_detection`, `sn_interface`, `sn_client`, `sn_node`, `sn_api`, `sn_cli` versions, respectively. This
-/// function will return the `safe_network` part.
+/// The `release_version` input is in the form "0.17.1-0.15.3-0.2.1-0.78.2-0.73.3-0.76.1-0.69.0",
+/// which is the `sn_interface`, `sn_fault_detection`, `sn_comms`, `sn_client`, `sn_node`,
+/// `sn_api`, `sn_cli` respectively. This function will return the `safe_network` part.
 fn get_version_from_release_version(release_version: &str) -> Result<String> {
     let mut parts = release_version.split('-');
+    parts.next();
     parts.next();
     parts.next();
     parts.next();

--- a/sn_node/src/bin/sn_node/log/mod.rs
+++ b/sn_node/src/bin/sn_node/log/mod.rs
@@ -125,7 +125,16 @@ pub fn init_node_logging(config: &Config) -> Result<Option<WorkerGuard>> {
     layers.fmt_layer(config);
 
     #[cfg(feature = "otlp")]
-    layers.otlp_layer()?;
+    {
+        use tracing::info;
+        match std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+            Ok(_) => layers.otlp_layer()?,
+            Err(_) => info!(
+                "The OTLP feature is enabled but the OTEL_EXPORTER_OTLP_ENDPOINT variable is not \
+                set, so traces will not be submitted."
+            ),
+        }
+    }
 
     #[cfg(feature = "tokio-console")]
     layers.layers.push(console_subscriber::spawn().boxed());


### PR DESCRIPTION
- 1c83fd880 **fix: pull the correct version of sn_node**

  We added a new crate but forgot to account for the new version in the `node install` command, so it
  was using sn_client's version number.

- 41fc52222 **feat: only submit traces if environment var is set**

  We will only configure the tracing infrastructure if the `otlp` feature is enabled *and* the
  `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is set.

