### PR TITLE
fix(ci): set different name for node logs on `e2e-msg-happy-path` action run

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -460,7 +460,7 @@ jobs:
       - name: Upload Node Logs
         uses: actions/upload-artifact@main
         with:
-          name: sn_node_logs_e2e_${{matrix.os}}
+          name: sn_node_logs_e2e_msg_happy_path${{matrix.os}}
           path: log_files.tar.gz
         if: failure()
         continue-on-error: true


### PR DESCRIPTION
When `e2e-msg-happy-path` tests fails, the uploaded log filename clashes with the one uploaded by a failed `e2e` action loosing them.