### PR TITLE
chore: remove redundant enum variant

### DIFF
--- a/sn_client/src/sessions/listeners.rs
+++ b/sn_client/src/sessions/listeners.rs
@@ -97,8 +97,7 @@ impl Session {
                 };
 
             match resp_msg {
-                ClientDataResponse::CommunicationIssues(err)
-                | ClientDataResponse::NetworkIssue(err) => {
+                ClientDataResponse::NetworkIssue(err) => {
                     break MsgResponse::Failure(
                         peer.addr(),
                         Error::CmdError {

--- a/sn_interface/src/messaging/data/errors.rs
+++ b/sn_interface/src/messaging/data/errors.rs
@@ -26,7 +26,7 @@ pub type Result<T, E = Error> = result::Result<T, E>;
 #[derive(Error, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Error {
-    /// Failture to contact one or more storage nodes
+    /// Failure to contact one or more storage nodes (send or receipt of msg).
     #[error("Msg: {0:?} failed as contact to one or more storage nodes failed.")]
     CouldNotContactAllStorageNodes(MsgId),
     /// Access denied for user

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -76,8 +76,6 @@ impl Display for ClientMsg {
 #[allow(clippy::large_enum_variant)]
 #[derive(Eq, PartialEq, Clone, Serialize, Deserialize, custom_debug::Debug)]
 pub enum ClientDataResponse {
-    /// There was an error in send or receipt of message to storage nodes
-    CommunicationIssues(Error),
     /// Network Issue
     NetworkIssue(Error),
     /// The response to a query, containing the query result.
@@ -123,9 +121,6 @@ impl Display for ClientDataResponse {
             }
             Self::AntiEntropy { .. } => {
                 write!(f, "ClientDataResponse::AntiEntropy")
-            }
-            Self::CommunicationIssues(error) => {
-                write!(f, "ClientDataResponse::CommunicationIssues({error:?})")
             }
             Self::NetworkIssue(error) => {
                 write!(f, "ClientDataResponse::NetworkIssue({error:?})")

--- a/sn_node/src/node/messaging/streams.rs
+++ b/sn_node/src/node/messaging/streams.rs
@@ -231,7 +231,7 @@ impl MyNode {
             error!("Request to holder node/s was not completely successful for {msg_id:?}");
             if let Some(error) = last_error {
                 debug!("Error error being returned to client {source_client:?}: {error:?}");
-                let msg = ClientDataResponse::CommunicationIssues(
+                let msg = ClientDataResponse::NetworkIssue(
                     sn_interface::types::DataError::CouldNotContactAllStorageNodes(msg_id),
                 );
                 output_cmds.push(Cmd::SendClientResponse {


### PR DESCRIPTION
- `ClientDataResponse` variant `CommunicationIssues` was not differentiated on client, and was carrying the exact same error enum as the variant `NetworkIssue`.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
