### PR TITLE
refactor(node): send response to joiner

### DIFF
--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -37,6 +37,8 @@ pub enum JoinResponse {
     Approved(Decision<NodeState>),
     /// Join was rejected
     Rejected(JoinRejectReason),
+    /// Join is being considered
+    UnderConsideration,
 }
 
 /// Reason of a join request being rejected

--- a/sn_node/src/node/messaging/join_section.rs
+++ b/sn_node/src/node/messaging/join_section.rs
@@ -98,10 +98,13 @@ mod tests {
         let elder = Arc::new(RwLock::new(elder));
 
         let joiner_peer = joining_node.info().peer();
-        let some_cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None)
+        let some_cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None, None)
             .await
             .expect("An error was not expected.");
 
+        let some_cmd = some_cmd
+            .iter()
+            .find(|cmd| matches!(cmd, Cmd::SendMsg { .. }));
         assert_matches!(some_cmd, Some(Cmd::SendMsg {
             msg,
             recipients,
@@ -158,10 +161,11 @@ mod tests {
         let adult = Arc::new(RwLock::new(adult));
 
         let joiner_peer = joining_node.info().peer();
-        let cmd = MyNode::handle_join(adult, &adult_context, joiner_peer, None)
+        let cmd = MyNode::handle_join(adult, &adult_context, joiner_peer, None, None)
             .await
             .expect("An error was not expected.");
 
+        let cmd = cmd.iter().find(|cmd| matches!(cmd, Cmd::SendMsg { .. }));
         assert_matches!(cmd, None);
 
         Ok(())
@@ -194,10 +198,11 @@ mod tests {
         let elder = Arc::new(RwLock::new(elder));
 
         let joiner_peer = joining_node.info().peer();
-        let cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None)
+        let cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None, None)
             .await
             .expect("An error was not expected.");
 
+        let cmd = cmd.iter().find(|cmd| matches!(cmd, Cmd::SendMsg { .. }));
         assert_matches!(cmd, None);
 
         Ok(())
@@ -228,10 +233,11 @@ mod tests {
         let elder = Arc::new(RwLock::new(elder));
 
         let joiner_peer = joining_node.info().peer();
-        let cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None)
+        let cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None, None)
             .await
             .expect("An error was not expected.");
 
+        let cmd = cmd.iter().find(|cmd| matches!(cmd, Cmd::SendMsg { .. }));
         assert_matches!(cmd, None);
 
         Ok(())
@@ -265,9 +271,13 @@ mod tests {
         let elder = Arc::new(RwLock::new(elder));
 
         let joiner_peer = joining_node.info().peer();
-        let some_cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None)
+        let some_cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None, None)
             .await
             .expect("An error was not expected.");
+
+        let some_cmd = some_cmd
+            .iter()
+            .find(|cmd| matches!(cmd, Cmd::SendMsg { .. }));
 
         assert_matches!(some_cmd, Some(Cmd::SendMsg {
             msg,

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -189,7 +189,7 @@ impl MyNode {
         match msg {
             NodeMsg::TryJoin(relocation) => {
                 trace!("Handling msg {:?}: TryJoin from {}", msg_id, sender);
-                MyNode::handle_join(node, &context, sender, relocation)
+                MyNode::handle_join(node, &context, sender, relocation, send_stream)
                     .await
                     .map(|c| c.into_iter().collect())
             }
@@ -275,6 +275,10 @@ impl MyNode {
                             info!("{}", LogMarker::RelocateEnd);
                         }
 
+                        Ok(vec![])
+                    }
+                    JoinResponse::UnderConsideration => {
+                        info!("Our join request is being considered by the network");
                         Ok(vec![])
                     }
                 }

--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -518,6 +518,12 @@ mod tests {
                             });
                         } else if let Cmd::TrackNodeIssue { .. } = &cmd {
                             // skip
+                        } else if let Cmd::SendNodeMsgResponse {
+                            msg: NodeMsg::JoinResponse(JoinResponse::UnderConsideration),
+                            ..
+                        } = &cmd
+                        {
+                            // skip
                         } else {
                             panic!("got a different cmd {cmd:?}");
                         }


### PR DESCRIPTION
TryJoin wasn't previously answered over the bi-stream. This adds a
'Considering' response that is sent back over the same stream.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
