### PR TITLE
tests(node): fix using the response stream

### DIFF
--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -523,7 +523,9 @@ mod tests {
                             ..
                         } = &cmd
                         {
-                            // skip
+                            msg_counter.track(&cmd);
+                            // Send out the `UnderConsideration` as stream response.
+                            let _ = dispatcher.process_cmd(cmd).await?;
                         } else {
                             panic!("got a different cmd {cmd:?}");
                         }


### PR DESCRIPTION
The other side expects us to send the UnderConsideration message,
otherwise it will get unexpected errors because the stream is not
responded to

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
