### PR TITLE
feat(sn_node): refactor SectionPeers to use Decision

### DIFF
--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
-sn_consensus = "3.1"
+sn_consensus = "3.2.1"
 sn_dbc = { version = "8.3.0", features = ["serdes"] }
 sn_sdkg = "3.1.2"
 strum = "0.24"

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -20,7 +20,7 @@ pub use join::{JoinRejectReason, JoinRequest, JoinResponse};
 pub use node_msgs::{NodeDataCmd, NodeEvent, NodeQueryResponse};
 pub use section_sig::{SectionSig, SectionSigShare, SectionSigned};
 
-use sn_consensus::{Generation, SignedVote};
+use sn_consensus::{Decision, Generation, SignedVote};
 use sn_sdkg::DkgSignedVote;
 
 use bls::PublicKey as BlsPublicKey;
@@ -33,7 +33,7 @@ use std::{
 use xor_name::XorName;
 
 /// List of peers of a section
-pub type SectionPeers = BTreeSet<SectionSigned<NodeState>>;
+pub type SectionPeers = BTreeSet<Decision<NodeState>>;
 
 /// A vote about the state of the section
 /// This can be a result of seeing a node go offline or deciding wether we want to accept new nodes

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -55,7 +55,7 @@ rand-07 = { package = "rand", version = "~0.7.3" }
 rayon = "1.5.1"
 rmp-serde = "1.0.0"
 self_encryption = "~0.27.5"
-sn_consensus = "3.1.2"
+sn_consensus = "3.2.1"
 sn_comms = { path = "../sn_comms", version = "^0.3.5" }
 sn_dbc = { version = "8.3.0", features = ["serdes"] }
 sn_fault_detection = { path = "../sn_fault_detection", version = "^0.15.4" }

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -69,7 +69,7 @@ impl MyNode {
         recipients: Peers,
         section_pk: BlsPublicKey,
     ) -> Cmd {
-        let members = context.network_knowledge.section_signed_members();
+        let members = context.network_knowledge.section_members_with_decision();
 
         let ae_msg = NetworkMsg::AntiEntropy(AntiEntropyMsg::AntiEntropy {
             section_tree_update: MyNode::generate_ae_section_tree_update(context, Some(section_pk)),

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -226,12 +226,7 @@ mod core {
                 let n_elders = network_knowledge.signed_sap().elder_count();
 
                 // TODO: the bootstrap members should come from handover
-                let bootstrap_members = BTreeSet::from_iter(
-                    network_knowledge
-                        .section_signed_members()
-                        .into_iter()
-                        .map(|section_auth| section_auth.value),
-                );
+                let bootstrap_members = network_knowledge.section_members();
 
                 Some(Membership::from(
                     (key.index as u8, key.secret_key_share),
@@ -810,11 +805,12 @@ mod core {
         pub(crate) fn update_comm_target_list(context: &NodeContext) {
             let relocated_members = context
                 .network_knowledge
-                .section_signed_archived_members()
+                .archived_members()
                 .into_iter()
                 .filter_map(|state| {
+                    // TODO: figure out hot to retain the section sign key info within Decsion
                     if state.is_relocated()
-                        && state.sig.public_key == context.network_knowledge.section_key()
+                    // && state.sig.public_key == context.network_knowledge.section_key()
                     {
                         Some(*state.peer())
                     } else {


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

Being the first step as described within the issue https://github.com/maidsafe/safe_network/issues/2081 , the work of this PR relies on couple of TODO points that shall get addressed in the following PRs :
1, the util function of `section_signed_to_decision` shall get removed once complete the full transition
2, Decision requires the PublicKeySet to validate, however NetworkKnowledge only retains the PublicKey info currently. Need to re-enable the validation in the following PR
3, The current `update`, `merge_members` procedure is based on `node_state` as atomic. However `Decision` may contain multipe of `node_state` within one. Need to double check this won't incur any trouble.
4, The current `members` function return list of `Decision`, which may contain `Join` and `Left` in one Decision, or multiple Joins. This need to be double checked in the following PRs.
5,  
