### PR TITLE
fix(node): send response to the client upon missing response from a peer

### DIFF
--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -19,6 +19,7 @@ use sn_interface::{
 use ed25519::Signature;
 use std::{io, net::SocketAddr};
 use thiserror::Error;
+use tokio::time::Duration;
 use xor_name::XorName;
 
 /// The type returned by the `sn_routing` message handling methods.
@@ -39,6 +40,9 @@ pub enum Error {
     /// This peer has no connections, and none will be created
     #[error("Peer link has no connections ")]
     NoConnectionsForPeer,
+    /// No response received from data holder peer
+    #[error("No response received from data holder peer after {0:?}.")]
+    PeerResponseTimeout(Duration),
     /// This should not be possible as the channel is stored in node, and used to process child commands
     #[error("No more Cmds will be received or processed. CmdChannel senders have been dropped. ")]
     CmdCtrlChannelDropped,

--- a/sn_node/src/node/messaging/streams.rs
+++ b/sn_node/src/node/messaging/streams.rs
@@ -188,7 +188,7 @@ impl MyNode {
                     name: peer.name(),
                     issue: IssueType::Communication,
                 });
-                // TODO: report timeout error to client?
+                last_error = Some(Error::PeerResponseTimeout(*NODE_RESPONSE_TIMEOUT));
             }
             Ok(Ok(response)) => {
                 debug!("Expected response in from {peer:?} for {msg_id:?}: {response:?}");


### PR DESCRIPTION
When an Elder is processing a client request/msg, and it timed out due to not receiving a response from a data holder, a response needs to be sent to the client rather than simply dropping the stream.