### PR TITLE
fix: verifiable relocation trigger

### DIFF
--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -11,14 +11,14 @@ repository = "https://github.com/maidsafe/safe_network"
 version = "0.19.7"
 
 [features]
-test-utils=["proptest"]
+test-utils = ["proptest"]
 
 [dependencies]
 base64 = "~0.13.0"
 bincode = "1.3.1"
 bls = { package = "blsttc", version = "8.0.1" }
 bytes = { version = "1.0.1", features = ["serde"] }
-crdts = { version = "7.2", default-features=false, features = ["merkle"] }
+crdts = { version = "7.2", default-features = false, features = ["merkle"] }
 custom_debug = "~0.5.0"
 ed25519 = { version = "1.2.0", features = ["serde_bytes"] }
 ed25519-dalek = { version = "1.0.0", features = ["serde"] }
@@ -30,10 +30,10 @@ itertools = "~0.10.0"
 lazy_static = "1"
 multibase = "~0.9.1"
 num_cpus = "1.13.0"
-proptest = { version ="1.0.0", optional =true }
+proptest = { version = "1.0.0", optional = true }
 qp2p = "~0.36.2"
 rand = "~0.8.5"
-rand-07 = { package = "rand", version = "0.7.3" } # required till ed25519-dalek upgrades to rand v0.8
+rand-07 = { package = "rand", version = "0.7.3" }                                    # required till ed25519-dalek upgrades to rand v0.8
 rayon = "1.5.1"
 rmp-serde = "1.0.0"
 self_encryption = "~0.28.0"
@@ -52,7 +52,7 @@ tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
-uluru="3.0.0"
+uluru = "3.0.0"
 xor_name = "~5.0.0"
 
 [dependencies.tokio]
@@ -66,7 +66,7 @@ proptest = { version = "1.0.0" }
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"
-default-features = false # Disable features which are enabled by default
+default-features = false                                           # Disable features which are enabled by default
 features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt"]
 
 [package.metadata.cargo-udeps.ignore]

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -12,7 +12,8 @@ mod node_msgs;
 mod section_sig;
 
 use crate::messaging::AuthorityProof;
-use crate::network_knowledge::{NodeState, RelocationDst, RelocationProof, SapCandidate};
+use crate::network_knowledge::node_state::RelocationTrigger;
+use crate::network_knowledge::{NodeState, RelocationProof, SapCandidate};
 use crate::SectionAuthorityProvider;
 
 pub use dkg::DkgSessionId;
@@ -45,10 +46,10 @@ pub enum NodeMsg {
     /// successfully decided for it to be relocated, at which point the node can start the join
     /// process at the target section, including the necessary proof from src section for it to
     /// be handled as a relocation.
-    PrepareToRelocate(RelocationDst),
+    PrepareToRelocate(RelocationTrigger),
     /// Sent by the relocating node to its section to proceed the relocation process by initiating a
     /// membership change, where the node is considered `Relocated`.
-    ProceedRelocation(RelocationDst),
+    ProceedRelocation(RelocationTrigger),
     /// Sent from the section of a node that is undergoing the relocation process, containing the
     /// signed membership change. This is used by the node to complete the relocation by including
     /// it in a `proof` when joining the new section.

--- a/sn_interface/src/network_knowledge/node_state/mod.rs
+++ b/sn_interface/src/network_knowledge/node_state/mod.rs
@@ -8,12 +8,15 @@
 
 mod relocation;
 
-pub use relocation::{RelocationDst, RelocationInfo, RelocationProof, RelocationState};
+pub use relocation::{
+    ChurnId, RelocationInfo, RelocationProof, RelocationState, RelocationTrigger,
+};
 
 use crate::network_knowledge::{section_has_room_for_node, Error, Result};
 use crate::types::NodeId;
 
 use serde::{Deserialize, Serialize};
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::{self, Debug, Formatter},
@@ -29,7 +32,7 @@ pub enum MembershipState {
     /// Node went offline.
     Left,
     /// Node was relocated to a different section.
-    Relocated(RelocationDst),
+    Relocated(RelocationTrigger),
 }
 
 /// Information about a member of our section.
@@ -84,11 +87,11 @@ impl NodeState {
     pub fn relocated(
         node_id: NodeId,
         previous_name: Option<XorName>,
-        relocation_dst: RelocationDst,
+        relocation_trigger: RelocationTrigger,
     ) -> Self {
         Self {
             node_id,
-            state: MembershipState::Relocated(relocation_dst),
+            state: MembershipState::Relocated(relocation_trigger),
             previous_name,
         }
     }
@@ -186,9 +189,9 @@ impl NodeState {
     }
 
     // Convert this info into one with the state changed to `Relocated`.
-    pub fn relocate(self, relocation_dst: RelocationDst) -> Self {
+    pub fn relocate(self, relocation_trigger: RelocationTrigger) -> Self {
         Self {
-            state: MembershipState::Relocated(relocation_dst),
+            state: MembershipState::Relocated(relocation_trigger),
             ..self
         }
     }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -21,19 +21,24 @@ chaos = []
 unstable-wiremsg-debuginfo = []
 # Needs to be built with RUSTFLAGS="--cfg tokio_unstable"
 tokio-console = ["console-subscriber"]
-otlp = ["opentelemetry", "opentelemetry-otlp", "opentelemetry-semantic-conventions", "tracing-opentelemetry"]
+otlp = [
+    "opentelemetry",
+    "opentelemetry-otlp",
+    "opentelemetry-semantic-conventions",
+    "tracing-opentelemetry",
+]
 statemap = []
 
 [dependencies]
 base64 = "~0.13.0"
 bincode = "1.3.1"
-bls = { package = "blsttc", version = "8.0.1" }
+bls = { package = "blsttc", version = "8.0" }
 bytes = { version = "1.0.1", features = ["serde"] }
 color-eyre = "~0.6.0"
 console-subscriber = { version = "~0.1.0", optional = true }
-crdts = { version = "7.2", default-features=false, features = ["merkle"] }
+crdts = { version = "7.2", default-features = false, features = ["merkle"] }
 custom_debug = "~0.5.0"
-dashmap = {version = "5.1.0", features = [ "serde" ]}
+dashmap = { version = "5.1.0", features = ["serde"] }
 dirs-next = "2.0.0"
 ed25519 = { version = "1.2.0", features = ["serde_bytes"] }
 ed25519-dalek = { version = "1.0.0", features = ["serde"] }
@@ -78,7 +83,7 @@ tracing-core = "0.1"
 tracing-appender = "~0.2.0"
 tracing-opentelemetry = { version = "0.17", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-uluru="3.0.0"
+uluru = "3.0.0"
 url = "2.2.0"
 walkdir = "2"
 xor_name = "~5.0.0"
@@ -87,7 +92,13 @@ parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
 [dependencies.self_update]
 version = "0.32"
 default-features = false
-features = ["archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate", "rustls"]
+features = [
+    "archive-tar",
+    "archive-zip",
+    "compression-flate2",
+    "compression-zip-deflate",
+    "rustls",
+]
 
 [dependencies.tokio]
 version = "1.17.0"
@@ -106,7 +117,7 @@ sn_interface = { path = "../sn_interface", version = "^0.19.7", features= ["test
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"
-default-features = false # Disable features which are enabled by default
+default-features = false                                           # Disable features which are enabled by default
 features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt"]
 
 [package.metadata.cargo-udeps.ignore]

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -118,18 +118,18 @@ impl FlowCtrl {
         // check if we can request for relocation
         // The relocation_state will be changed into `JoinAsRelocated` once the request has been
         // approved by the section
-        if let Some(RelocationState::PreparingToRelocate(dst)) = &context.relocation_state {
+        if let Some(RelocationState::PreparingToRelocate(trigger)) = &context.relocation_state {
             if self.timestamps.request_to_relocate_check.elapsed() > REQUEST_TO_RELOCATE_TIMEOUT_SEC
             {
                 info!(
-                    "Periodic check: sending request to relocate our node to {:?}",
-                    dst
+                    "Periodic check: sending request to relocate our node. churn_id: {}",
+                    trigger.churn_id()
                 );
 
                 self.timestamps.request_to_relocate_check = Instant::now();
                 cmds.push(MyNode::send_to_elders(
                     context,
-                    NodeMsg::ProceedRelocation(*dst),
+                    NodeMsg::ProceedRelocation(trigger.clone()),
                 ));
             }
         }

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -20,6 +20,7 @@ use crate::node::{
 use cmd_utils::{handle_online_cmd, ProcessAndInspectCmds};
 
 use sn_comms::{CommEvent, MsgReceived};
+
 use sn_dbc::Hash;
 use sn_interface::{
     dbcs::gen_genesis_dbc,
@@ -34,8 +35,7 @@ use sn_interface::{
     },
     network_knowledge::{
         section_keys::SectionKeysProvider, Error as NetworkKnowledgeError, MyNodeInfo, NodeState,
-        RelocationDst, RelocationInfo, RelocationProof, SectionTreeUpdate, SectionsDAG,
-        MIN_ADULT_AGE,
+        RelocationInfo, RelocationProof, SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
     },
     test_utils::*,
     types::{keys::ed25519, Participant, PublicKey},
@@ -73,8 +73,8 @@ async fn membership_churn_starts_on_join_request_from_relocated_node() -> Result
         gen_addr(),
     );
 
-    let relocation_dst = RelocationDst::new(xor_name::rand::random());
-    let relocated_state = NodeState::relocated(old_info.id(), Some(old_name), relocation_dst);
+    let (relocation_trigger, _) = create_relocation_trigger(&sk_set, old_info.age() + 1)?;
+    let relocated_state = NodeState::relocated(old_info.id(), Some(old_name), relocation_trigger);
     let section_signed_state = TestKeys::get_section_signed(&sk_set.secret_key(), relocated_state)?;
 
     let info = RelocationInfo::new(section_signed_state, new_info.name());

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -167,7 +167,7 @@ impl MyNode {
             }
             NodeMsg::PrepareToRelocate(relocation_trigger) => {
                 trace!("Handling PrepareToRelocate msg from {node_id}: {msg_id:?}");
-                Ok(node.prepare_to_relocate(relocation_trigger, context.name))
+                Ok(node.prepare_to_relocate(relocation_trigger))
             }
             NodeMsg::ProceedRelocation(dst) => {
                 trace!("Handling ProceedRelocation msg from {node_id}: {msg_id:?}");

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -34,8 +34,6 @@ pub use self::{
 };
 use self::{core::MyNode, flow_ctrl::cmds::Cmd};
 pub use crate::storage::DataStorage;
-#[cfg(test)]
-pub(crate) use relocation::{check as relocation_check, ChurnId};
 
 use sn_interface::messaging::system::NodeMsg;
 pub use sn_interface::network_knowledge::MIN_ADULT_AGE;

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -10,35 +10,21 @@
 
 use sn_interface::{
     elder_count,
-    network_knowledge::{recommended_section_size, NetworkKnowledge, NodeState},
+    network_knowledge::{
+        node_state::RelocationTrigger, recommended_section_size, relocation_check,
+        NetworkKnowledge, NodeState,
+    },
 };
-use std::{
-    cmp::min,
-    collections::BTreeSet,
-    fmt::{self, Display, Formatter},
-};
+use std::{cmp::min, collections::BTreeSet};
 use xor_name::XorName;
-
-// Unique identifier for a churn event, which is used to select nodes to relocate.
-pub(crate) struct ChurnId(pub(crate) [u8; bls::SIG_SIZE]);
-
-impl Display for ChurnId {
-    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        write!(
-            fmt,
-            "Churn-{:02x}{:02x}{:02x}..",
-            self.0[0], self.0[1], self.0[2]
-        )
-    }
-}
 
 /// Find all nodes to relocate after a churn event and generate the relocation details for them.
 pub(super) fn find_nodes_to_relocate(
     network_knowledge: &NetworkKnowledge,
-    churn_id: &ChurnId,
+    relocation_trigger: &RelocationTrigger,
     excluded: BTreeSet<XorName>,
-) -> Vec<(NodeState, XorName)> {
-    // Find the nodes that pass the relocation check and take only the oldest ones to avoid
+) -> Vec<NodeState> {
+    // Find the peers that pass the relocation check and take only the oldest ones to avoid
     // relocating too many nodes at the same time.
     // Capped by criteria that cannot relocate too many node at once.
     let section_members = network_knowledge.section_members();
@@ -54,14 +40,15 @@ pub(super) fn find_nodes_to_relocate(
         return vec![];
     }
 
-    let max_reloctions = elder_count() / 2;
-    let allowed_relocations = min(section_size - recommended_section_size, max_reloctions);
+    let max_relocations = elder_count() / 2;
+    let allowed_relocations = min(section_size - recommended_section_size, max_relocations);
+    let churn_id = relocation_trigger.churn_id();
 
     // Find the nodes that pass the relocation check
     let mut candidates: Vec<_> = section_members
         .into_iter()
         .filter(|state| network_knowledge.is_adult(&state.name()))
-        .filter(|info| check(info.age(), churn_id))
+        .filter(|info| relocation_check(info.age(), &churn_id))
         // the newly joined node shall not be relocated immediately
         .filter(|info| !excluded.contains(&info.name()))
         .collect();
@@ -80,36 +67,8 @@ pub(super) fn find_nodes_to_relocate(
     candidates
         .into_iter()
         .filter(|node| node.age() == max_age)
-        .map(|node| {
-            let dst_section = XorName::from_content_parts(&[&node.name().0, &churn_id.0]);
-            (node, dst_section)
-        })
         .take(allowed_relocations)
         .collect()
-}
-
-// Relocation check - returns whether a member with the given age is a candidate for relocation on
-// a churn event with the given churn id.
-pub(crate) fn check(age: u8, churn_id: &ChurnId) -> bool {
-    // Evaluate the formula: `signature % 2^age == 0` Which is the same as checking the signature
-    // has at least `age` trailing zero bits.
-    trailing_zeros(&churn_id.0) >= age as u32
-}
-
-// Returns the number of trailing zero bits of the bytes slice.
-fn trailing_zeros(bytes: &[u8]) -> u32 {
-    let mut output = 0;
-
-    for &byte in bytes.iter().rev() {
-        if byte == 0 {
-            output += 8;
-        } else {
-            output += byte.trailing_zeros();
-            break;
-        }
-    }
-
-    output
 }
 
 #[cfg(test)]
@@ -119,28 +78,16 @@ mod tests {
     use sn_interface::{
         elder_count,
         network_knowledge::{NodeState, SectionAuthorityProvider, SectionTree, MIN_ADULT_AGE},
-        test_utils::TestKeys,
+        test_utils::{create_relocation_trigger, TestKeys},
         types::NodeId,
     };
 
     use eyre::Result;
     use itertools::Itertools;
     use proptest::{collection::SizeRange, prelude::*};
-    use rand::{rngs::SmallRng, thread_rng, Rng, SeedableRng};
+    use rand::thread_rng;
     use std::net::SocketAddr;
     use xor_name::{Prefix, XOR_NAME_LEN};
-
-    #[test]
-    fn byte_slice_trailing_zeros() {
-        assert_eq!(trailing_zeros(&[0]), 8);
-        assert_eq!(trailing_zeros(&[1]), 0);
-        assert_eq!(trailing_zeros(&[2]), 1);
-        assert_eq!(trailing_zeros(&[4]), 2);
-        assert_eq!(trailing_zeros(&[8]), 3);
-        assert_eq!(trailing_zeros(&[0, 0]), 16);
-        assert_eq!(trailing_zeros(&[1, 0]), 8);
-        assert_eq!(trailing_zeros(&[2, 0]), 9);
-    }
 
     const MAX_AGE: u8 = MIN_ADULT_AGE + 3;
 
@@ -148,7 +95,7 @@ mod tests {
         #[test]
         #[allow(clippy::unwrap_used)]
         fn proptest_actions(
-            nodes in arbitrary_unique_nodes(2..(recommended_section_size() + elder_count()), MIN_ADULT_AGE..MAX_AGE),
+            nodes in arbitrary_unique_peers(2..(recommended_section_size() + elder_count()), MIN_ADULT_AGE..MAX_AGE),
             signature_trailing_zeros in 0..MAX_AGE)
         {
             proptest_actions_impl(nodes, signature_trailing_zeros).unwrap()
@@ -156,8 +103,11 @@ mod tests {
     }
 
     fn proptest_actions_impl(nodes: Vec<NodeId>, signature_trailing_zeros: u8) -> Result<()> {
+        let age = signature_trailing_zeros;
         let sk_set = bls::SecretKeySet::random(0, &mut thread_rng());
         let sk = sk_set.secret_key();
+        let (relocation_trigger, _) = create_relocation_trigger(&sk_set, age)?;
+        let churn_id = relocation_trigger.churn_id();
 
         // Create `Section` with `nodes` as its members and set the `elder_count()` oldest nodes as
         // the elders.
@@ -183,12 +133,8 @@ mod tests {
             assert!(network_knowledge.update_member(info));
         }
 
-        // Simulate a churn event whose signature has the given number of trailing zeros.
-        let churn_id =
-            ChurnId(signature_with_trailing_zeros(signature_trailing_zeros as u32).to_bytes());
-
         let relocations =
-            find_nodes_to_relocate(&network_knowledge, &churn_id, BTreeSet::default());
+            find_nodes_to_relocate(&network_knowledge, &relocation_trigger, BTreeSet::default());
 
         let allowed_relocations = if nodes.len() > recommended_section_size() {
             min(elder_count() / 2, nodes.len() - recommended_section_size())
@@ -221,52 +167,15 @@ mod tests {
         assert_eq!(expected_relocated_nodes.len(), relocations.len());
 
         // NOTE: `zip` works here, as both collections are sorted by the same criteria.
-        for (node_id, (state, dst)) in expected_relocated_nodes.into_iter().zip(relocations) {
-            assert_eq!(node_id.name(), state.node_id().name()); // Note: shouldn't addr also be compared?
-            let dst_section = XorName::from_content_parts(&[&node_id.name().0, &churn_id.0]);
-            assert_eq!(dst_section, dst);
+        for (node_id, state) in expected_relocated_nodes.into_iter().zip(relocations) {
+            assert_eq!(node_id.name(), state.node_id().name());
         }
 
         Ok(())
     }
 
-    // Fetch a `bls::Signature` with the given number of trailing zeros. The signature is generated
-    // from an unspecified random data using an unspecified random `SecretKey`. That is OK because
-    // the relocation algorithm doesn't care about whether the signature is valid. It only
-    // cares about its number of trailing zeros.
-    fn signature_with_trailing_zeros(trailing_zeros_count: u32) -> bls::Signature {
-        use std::{cell::RefCell, collections::HashMap};
-
-        // Cache the signatures to avoid expensive re-computation.
-        thread_local! {
-            static CACHE: RefCell<HashMap<u32, bls::Signature>> = RefCell::new(HashMap::new());
-        }
-
-        CACHE.with(|cache| {
-            cache
-                .borrow_mut()
-                .entry(trailing_zeros_count)
-                .or_insert_with(|| gen_signature_with_trailing_zeros(trailing_zeros_count))
-                .clone()
-        })
-    }
-
-    fn gen_signature_with_trailing_zeros(trailing_zeros_count: u32) -> bls::Signature {
-        let mut rng = SmallRng::seed_from_u64(0);
-        let sk: bls::SecretKey = rng.gen();
-
-        loop {
-            let data: u64 = rng.gen();
-            let signature = sk.sign(data.to_be_bytes());
-
-            if trailing_zeros(&signature.to_bytes()) == trailing_zeros_count {
-                return signature;
-            }
-        }
-    }
-
-    // Generate Vec<NodeId> where no two nodes have the same name.
-    fn arbitrary_unique_nodes(
+    // Generate Vec<Peer> where no two peers have the same name.
+    fn arbitrary_unique_peers(
         count: impl Into<SizeRange>,
         age: impl Strategy<Value = u8>,
     ) -> impl Strategy<Value = Vec<NodeId>> {


### PR DESCRIPTION
## Summary

In this PR:
- `CurhnId` moved to network_knowledge
- `RelocationDst` replaced with `RelocationTrigger` 
- `RelocationTrigger` has decision and therefore it is verifiable
- Test are updated to use trigger (result of decision)

## Issues

It fixes #2011 

## TODO

Perhaps we can mock the decision (consensus) for faster tests. 
