### PR TITLE
refactor(comms): add debug skip to struct field

### DIFF
--- a/sn_comms/src/peer_session.rs
+++ b/sn_comms/src/peer_session.rs
@@ -424,6 +424,7 @@ pub(crate) struct SendJob {
     #[debug(skip)]
     bytes: UsrMsgBytes,
     connection_retries: usize, // TAI: Do we need this if we are using QP2P's retry
+    #[debug(skip)]
     reporter: mpsc::Sender<Result<(), PeerSessionError>>,
 }
 


### PR DESCRIPTION
Skip a field when printing Debug information for the `SendJob` struct.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
