### PR TITLE
feat(client)!: include msg-id in sn_client::Error::CmdAckValidationTimeout

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -269,8 +269,6 @@ jobs:
 
       - name: Run client tests
         env:
-          SN_CMD_TIMEOUT: 90
-          SN_QUERY_TIMEOUT: 90
           RUST_LOG: "sn_client=trace,qp2p=debug"
         run: cd sn_client && cargo test --release --features check-replicas
         timeout-minutes: 10
@@ -399,10 +397,8 @@ jobs:
 
       - name: Run client tests
         env:
-          SN_CMD_TIMEOUT: 90
-          SN_QUERY_TIMEOUT: 90
           RUST_LOG: "sn_client=trace,qp2p=debug"
-        run: cd sn_client && cargo test --release --features msg-happy-path -- --test-threads=1
+        run: cd sn_client && cargo test --release --features msg-happy-path
         timeout-minutes: 10
 
       - name: Run example app for file API against local network
@@ -636,7 +632,7 @@ jobs:
   #     - name: Run client tests
   #       env:
   #         RUST_LOG: "sn_client=trace,qp2p=debug"
-  #       run: cargo test --release -p sn_client -- --test-threads=1
+  #       run: cargo test --release -p sn_client
   #       timeout-minutes: 25
 
   #     - name: Run example app for file API against local network

--- a/sn_client/src/api/cmds.rs
+++ b/sn_client/src/api/cmds.rs
@@ -12,7 +12,7 @@ use crate::{Error, Result};
 use sn_interface::{
     messaging::{
         data::{ClientMsg, DataCmd},
-        ClientAuth, WireMsg,
+        ClientAuth, MsgId, WireMsg,
     },
     types::{PublicKey, Signature},
 };
@@ -42,13 +42,15 @@ impl Client {
             signature,
         };
 
+        let msg_id = MsgId::new();
         tokio::time::timeout(self.cmd_timeout, async {
             self.session
-                .send_cmd(dst_address, auth, serialised_cmd, is_spend_cmd)
+                .send_cmd(dst_address, auth, serialised_cmd, is_spend_cmd, msg_id)
                 .await
         })
         .await
         .map_err(|_| Error::CmdAckValidationTimeout {
+            msg_id,
             elapsed: self.cmd_timeout,
             dst_address,
         })?

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -166,8 +166,10 @@ pub enum Error {
         peers: Vec<Peer>,
     },
     /// Timeout when awaiting command ACK from Elders.
-    #[error("Timeout after {elapsed:?} when awaiting command ACK from Elders for data address {dst_address}")]
+    #[error("Timeout after {elapsed:?} when awaiting command ACK from Elders for {msg_id:?}, data address {dst_address}")]
     CmdAckValidationTimeout {
+        /// MsgId of the msg sent
+        msg_id: MsgId,
         /// Time elapsed before timing out
         elapsed: Duration,
         /// Address name of the data the ACK was expected for

--- a/sn_client/src/sessions/messaging.rs
+++ b/sn_client/src/sessions/messaging.rs
@@ -75,13 +75,13 @@ impl Session {
         auth: ClientAuth,
         payload: Bytes,
         is_spend: bool,
+        msg_id: MsgId,
     ) -> Result<()> {
         let endpoint = self.endpoint.clone();
         // TODO: Consider other approach: Keep a session per section!
         let (section_pk, elders) = self.get_cmd_elders(dst_address).await?;
 
         let elders_len = elders.len();
-        let msg_id = MsgId::new();
         debug!(
             "Sending cmd with {msg_id:?}, dst: {dst_address:?}, from {}, \
             to {elders_len} Elders: {elders:?}",

--- a/sn_node/src/node/messaging/streams.rs
+++ b/sn_node/src/node/messaging/streams.rs
@@ -105,7 +105,10 @@ impl MyNode {
         let msg_id = wire_msg.msg_id();
         let targets_len = targets.len();
 
-        debug!("Sending out {msg_id:?} to {targets_len} holder node/s {targets:?}");
+        debug!(
+            "Sending out {msg_id:?}, coming from {}, to {targets_len} holder node/s {targets:?}",
+            source_client.addr()
+        );
 
         let node_bytes: BTreeMap<_, _> = targets
             .into_par_iter()


### PR DESCRIPTION
Running all sn-client tests multi-threaded in CI/Bors.
