### PR TITLE
refactor: `Cmd` + test utils

### DIFF
--- a/sn_node/src/node/flow_ctrl/cmds.rs
+++ b/sn_node/src/node/flow_ctrl/cmds.rs
@@ -137,6 +137,7 @@ pub(crate) enum Cmd {
     SendNodeMsgResponse {
         msg: NodeMsg,
         msg_id: MsgId,
+        correlation_id: MsgId,
         recipient: Peer,
         send_stream: SendStream,
         #[debug(skip)]
@@ -145,6 +146,7 @@ pub(crate) enum Cmd {
     /// Performs serialisation and sends the msg to the client over the given stream.
     SendClientResponse {
         msg: ClientDataResponse,
+        msg_id: MsgId,
         correlation_id: MsgId,
         send_stream: SendStream,
         #[debug(skip)]
@@ -173,6 +175,42 @@ impl Cmd {
             msg,
             msg_id,
             recipients,
+            context,
+        }
+    }
+
+    pub(crate) fn send_node_response(
+        msg: NodeMsg,
+        correlation_id: MsgId,
+        recipient: Peer,
+        send_stream: SendStream,
+        context: NodeContext,
+    ) -> Self {
+        let msg_id = MsgId::new();
+        Cmd::SendNodeMsgResponse {
+            msg,
+            msg_id,
+            correlation_id,
+            recipient,
+            send_stream,
+            context,
+        }
+    }
+
+    pub(crate) fn send_client_response(
+        msg: ClientDataResponse,
+        correlation_id: MsgId,
+        source_client: Peer,
+        send_stream: SendStream,
+        context: NodeContext,
+    ) -> Self {
+        let msg_id = MsgId::new();
+        Cmd::SendClientResponse {
+            msg,
+            msg_id,
+            correlation_id,
+            source_client,
+            send_stream,
             context,
         }
     }

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -89,23 +89,31 @@ impl Dispatcher {
             Cmd::SendNodeMsgResponse {
                 msg,
                 msg_id,
+                correlation_id,
                 recipient,
                 send_stream,
                 context,
-            } => Ok(
-                MyNode::send_node_msg_response(msg, msg_id, recipient, context, send_stream)
-                    .await?
-                    .into_iter()
-                    .collect(),
-            ),
+            } => Ok(MyNode::send_node_msg_response(
+                msg,
+                msg_id,
+                correlation_id,
+                recipient,
+                context,
+                send_stream,
+            )
+            .await?
+            .into_iter()
+            .collect()),
             Cmd::SendClientResponse {
                 msg,
+                msg_id,
                 correlation_id,
                 send_stream,
                 context,
                 source_client,
             } => Ok(MyNode::send_client_response(
                 msg,
+                msg_id,
                 correlation_id,
                 send_stream,
                 context,

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -332,16 +332,16 @@ impl MyNode {
                     trace!("Sending AE response over send_stream for {msg_id:?}");
                     Ok(vec![
                         track_node_cmd,
-                        Cmd::SendNodeMsgResponse {
-                            msg: NodeMsg::AntiEntropy {
+                        Cmd::send_node_response(
+                            NodeMsg::AntiEntropy {
                                 section_tree_update,
                                 kind,
                             },
                             msg_id,
-                            send_stream: stream,
-                            recipient: origin,
-                            context: context.clone(),
-                        },
+                            origin,
+                            stream,
+                            context.clone(),
+                        ),
                     ])
                 } else {
                     trace!("Attempting to send AE response over fresh conn for {msg_id:?}");
@@ -454,16 +454,16 @@ impl MyNode {
             LogMarker::AeSendRetryAsOutdated
         );
 
-        Cmd::SendClientResponse {
-            msg: ClientDataResponse::AntiEntropy {
+        Cmd::send_client_response(
+            ClientDataResponse::AntiEntropy {
                 section_tree_update,
                 bounced_msg,
             },
             correlation_id,
-            send_stream: response_stream,
-            context,
             source_client,
-        }
+            response_stream,
+            context,
+        )
     }
 }
 

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -43,13 +43,7 @@ impl MyNode {
         source_client: Peer,
     ) -> Cmd {
         debug!("{correlation_id:?} sending cmd response error back to client");
-        Cmd::SendClientResponse {
-            msg,
-            correlation_id,
-            send_stream,
-            context,
-            source_client,
-        }
+        Cmd::send_client_response(msg, correlation_id, source_client, send_stream, context)
     }
 
     /// Handle data query
@@ -73,13 +67,13 @@ impl MyNode {
             correlation_id: msg_id,
         };
 
-        vec![Cmd::SendClientResponse {
+        vec![Cmd::send_client_response(
             msg,
-            correlation_id: msg_id,
+            msg_id,
+            source_client,
             send_stream,
             context,
-            source_client,
-        }]
+        )]
     }
 
     /// Handle incoming client msgs.

--- a/sn_node/src/node/messaging/join_section.rs
+++ b/sn_node/src/node/messaging/join_section.rs
@@ -43,7 +43,10 @@ mod tests {
     use sn_comms::CommEvent;
     use sn_interface::{
         elder_count, init_logger,
-        messaging::system::{JoinRejectReason, JoinResponse},
+        messaging::{
+            system::{JoinRejectReason, JoinResponse},
+            MsgId,
+        },
         network_knowledge::{MembershipState, NetworkKnowledge},
     };
 
@@ -98,9 +101,10 @@ mod tests {
         let elder = Arc::new(RwLock::new(elder));
 
         let joiner_peer = joining_node.info().peer();
-        let some_cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None, None)
-            .await
-            .expect("An error was not expected.");
+        let some_cmd =
+            MyNode::handle_join(elder, &elder_context, joiner_peer, MsgId::new(), None, None)
+                .await
+                .expect("An error was not expected.");
 
         let some_cmd = some_cmd
             .iter()
@@ -161,7 +165,7 @@ mod tests {
         let adult = Arc::new(RwLock::new(adult));
 
         let joiner_peer = joining_node.info().peer();
-        let cmd = MyNode::handle_join(adult, &adult_context, joiner_peer, None, None)
+        let cmd = MyNode::handle_join(adult, &adult_context, joiner_peer, MsgId::new(), None, None)
             .await
             .expect("An error was not expected.");
 
@@ -198,7 +202,7 @@ mod tests {
         let elder = Arc::new(RwLock::new(elder));
 
         let joiner_peer = joining_node.info().peer();
-        let cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None, None)
+        let cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, MsgId::new(), None, None)
             .await
             .expect("An error was not expected.");
 
@@ -233,7 +237,7 @@ mod tests {
         let elder = Arc::new(RwLock::new(elder));
 
         let joiner_peer = joining_node.info().peer();
-        let cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None, None)
+        let cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, MsgId::new(), None, None)
             .await
             .expect("An error was not expected.");
 
@@ -271,9 +275,10 @@ mod tests {
         let elder = Arc::new(RwLock::new(elder));
 
         let joiner_peer = joining_node.info().peer();
-        let some_cmd = MyNode::handle_join(elder, &elder_context, joiner_peer, None, None)
-            .await
-            .expect("An error was not expected.");
+        let some_cmd =
+            MyNode::handle_join(elder, &elder_context, joiner_peer, MsgId::new(), None, None)
+                .await
+                .expect("An error was not expected.");
 
         let some_cmd = some_cmd
             .iter()

--- a/sn_node/src/node/messaging/joining_nodes.rs
+++ b/sn_node/src/node/messaging/joining_nodes.rs
@@ -29,6 +29,7 @@ impl MyNode {
         node: Arc<RwLock<MyNode>>,
         context: &NodeContext,
         peer: Peer,
+        correlation_id: MsgId,
         relocation: Option<RelocationProof>,
         send_stream: Option<SendStream>,
     ) -> Result<Vec<Cmd>> {
@@ -87,13 +88,13 @@ impl MyNode {
 
                 // Send it over response stream if we have one
                 if let Some(stream) = send_stream {
-                    return Ok(vec![Cmd::SendNodeMsgResponse {
+                    return Ok(vec![Cmd::send_node_response(
                         msg,
-                        msg_id: MsgId::new(),
-                        send_stream: stream,
-                        recipient: peer,
-                        context: context.clone(),
-                    }]);
+                        correlation_id,
+                        peer,
+                        stream,
+                        context.clone(),
+                    )]);
                 }
 
                 return Ok(vec![Cmd::send_msg(
@@ -110,13 +111,13 @@ impl MyNode {
 
         // Let the joiner know we are considering.
         if let Some(send_stream) = send_stream {
-            cmds.push(Cmd::SendNodeMsgResponse {
-                msg: NodeMsg::JoinResponse(JoinResponse::UnderConsideration),
-                msg_id: MsgId::new(),
+            cmds.push(Cmd::send_node_response(
+                NodeMsg::JoinResponse(JoinResponse::UnderConsideration),
+                correlation_id,
+                peer,
                 send_stream,
-                recipient: peer,
-                context: context.clone(),
-            });
+                context.clone(),
+            ));
         }
 
         // We propose membership

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -135,13 +135,13 @@ impl MyNode {
             response,
             correlation_id,
         };
-        cmds.push(Cmd::SendClientResponse {
+        cmds.push(Cmd::send_client_response(
             msg,
             correlation_id,
-            send_stream,
-            context: context.clone(),
             source_client,
-        });
+            send_stream,
+            context.clone(),
+        ));
 
         Ok(cmds)
     }
@@ -161,7 +161,7 @@ impl MyNode {
         match msg {
             NodeMsg::TryJoin(relocation) => {
                 trace!("Handling msg {:?}: TryJoin from {}", msg_id, sender);
-                MyNode::handle_join(node, &context, sender, relocation, send_stream)
+                MyNode::handle_join(node, &context, sender, msg_id, relocation, send_stream)
                     .await
                     .map(|c| c.into_iter().collect())
             }

--- a/sn_node/src/node/messaging/relocation.rs
+++ b/sn_node/src/node/messaging/relocation.rs
@@ -431,7 +431,7 @@ mod tests {
                         let (_, handle) = join_handle_for_relocating_node
                             .take()
                             .expect("join_handle is present");
-                        let _issue_tracker = handle.await??;
+                        assert!(handle.await??.is_empty());
                     }
                 }
 
@@ -511,7 +511,7 @@ mod tests {
                             ..
                         } = &cmd
                         {
-                            // skip
+                            assert!(dispatcher.process_cmd(cmd).await?.is_empty());
                         } else {
                             panic!("got a different cmd {cmd:?}");
                         }

--- a/sn_node/src/node/messaging/streams.rs
+++ b/sn_node/src/node/messaging/streams.rs
@@ -24,6 +24,7 @@ impl MyNode {
     pub(crate) async fn send_node_msg_response(
         msg: NodeMsg,
         msg_id: MsgId,
+        correlation_id: MsgId,
         recipient: Peer,
         context: NodeContext,
         send_stream: SendStream,
@@ -38,12 +39,14 @@ impl MyNode {
             send_stream,
             recipient,
             msg_id,
+            correlation_id,
         )
         .await
     }
 
     pub(crate) async fn send_client_response(
         msg: ClientDataResponse,
+        msg_id: MsgId,
         correlation_id: MsgId,
         send_stream: SendStream,
         context: NodeContext,
@@ -57,6 +60,7 @@ impl MyNode {
             kind,
             send_stream,
             source_client,
+            msg_id,
             correlation_id,
         )
         .await
@@ -147,13 +151,13 @@ async fn send_msg_on_stream(
     kind: MsgKind,
     mut send_stream: SendStream,
     target_peer: Peer,
+    msg_id: MsgId,
     correlation_id: MsgId,
 ) -> Result<Option<Cmd>> {
     let dst = Dst {
         name: target_peer.name(),
         section_key,
     };
-    let msg_id = MsgId::new();
     let wire_msg = WireMsg::new_msg(msg_id, payload, kind, dst);
     let bytes = wire_msg.serialize().map_err(|_| Error::InvalidMessage)?;
 


### PR DESCRIPTION
- refactor(test_utils): bundle `TestMsgTracker` along with `Dispatcher`
  - This removes a lot of boilerplate code from the tests, eliminating potential sources for bugs.
- refactor(cmd): include `MsgId` with the stream response Cmd
  - The `SendNodeMsgResponse` and the `SendClientResponse` now contain both the `msg_id` and the `correlation_id`
- fix(test): send the stream response
  - Sends back a response through the bidi-stream eliminating the error msgs that were popping up.