### PR TITLE
refactor(node): pass public addr in --first

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4186,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c4e0297134de4c10e3be4a7305619a5948cc4751fdbfd70e3ee58e4455c8dc"
+checksum = "672f61dc617431dac0125777c988d29e0b7f03044d229db7cdebf761db680101"
 dependencies = [
  "clap",
  "color-eyre",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls
 rmp-serde = "1.0.0"
 sn_api = { path = "../sn_api", version = "^0.77.0", default-features = false, features = ["app"] }
 sn_dbc = { version = "8.3.0", features = ["serdes"] }
-sn_launch_tool = "~0.13.0"
+sn_launch_tool = "0.13.1"
 serde = "1.0.123"
 serde_json = "1.0.62"
 serde_yaml = "~0.8"

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -96,7 +96,7 @@ eyre = "~0.6.5"
 grep="~0.2.8"
 proptest = "1.0.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
-sn_launch_tool = "~0.13.0"
+sn_launch_tool = "0.13.1"
 termcolor="1.1.2"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 walkdir = "2"

--- a/sn_node/README.md
+++ b/sn_node/README.md
@@ -14,7 +14,7 @@ By specifying the `otlp` feature for the `sn_node` binary, logs will be sent to 
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" # Already the default
 export RUST_LOG=sn_node=info # This filters the output for stdout/files, not OTLP
 export RUST_LOG_OTLP=sn_node=trace # This filters what is sent to OTLP endpoint 
-cargo run --release --bin sn_node --features otlp -- --first --local-addr=127.0.0.1:0
+cargo run --release --bin sn_node --features otlp -- --first 127.0.0.1:0 --local-addr=127.0.0.1:0
 ```
 
 Before running the node, an OTLP endpoint should be available. An example of an OTLP-supporting endpoint is Jaeger, which can be launched with Docker like this (see [documentation](https://www.jaegertracing.io/docs/1.42/getting-started/#all-in-one)):

--- a/sn_node/examples/config_handling.rs
+++ b/sn_node/examples/config_handling.rs
@@ -87,8 +87,8 @@ async fn main() -> Result<()> {
         assert_eq!(file_config.local_addr, config.local_addr);
     }
 
-    if command_line_args.first {
-        assert!(config.first);
+    if command_line_args.first.is_some() {
+        assert!(config.first.is_some());
     }
 
     clear_disk_config().await?;

--- a/sn_node/src/bin/sn_node/main.rs
+++ b/sn_node/src/bin/sn_node/main.rs
@@ -137,7 +137,7 @@ fn create_runtime_and_node(config: &Config) -> Result<()> {
                         let mut rng = rand::thread_rng();
                         let x: f64 = rng.gen_range(0.0..1.0);
 
-                        if !config.is_first() && x > 0.6 {
+                        if config.first().is_none() && x > 0.6 {
                             println!(
                                "\n =========== [Chaos] (PID: {our_pid}): Startup chaos crash w/ x of: {x}. ============== \n",
                            );

--- a/sn_node/src/node/flow_ctrl/tests/network_builder.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_builder.rs
@@ -143,7 +143,7 @@ impl<R: RngCore> TestNetworkBuilder<R> {
             };
 
             let socket_addr: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
-            let (comm, rx) = Comm::new(socket_addr).expect("failed to create Comm");
+            let (comm, rx) = Comm::new(socket_addr, None).expect("failed to create Comm");
             let mut node = node.clone();
             node.addr = comm.socket_addr();
 
@@ -795,7 +795,7 @@ impl TestNetwork {
         let handle = Handle::current();
         let _ = handle.enter();
         let socket_addr: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
-        let (comm, rx) = Comm::new(socket_addr).expect("failed  to create comm");
+        let (comm, rx) = Comm::new(socket_addr, None).expect("failed  to create comm");
         let info = MyNodeInfo::new(
             gen_keypair(&prefix.unwrap_or_default().range_inclusive(), age),
             comm.socket_addr(),

--- a/sn_node/src/node/node_starter.rs
+++ b/sn_node/src/node/node_starter.rs
@@ -145,9 +145,9 @@ async fn bootstrap_node(
     let (fault_cmds_sender, fault_cmds_receiver) =
         mpsc::channel::<FaultsCmd>(STANDARD_CHANNEL_SIZE);
 
-    let (comm, incoming_msg_receiver) = Comm::new(config.local_addr())?;
+    let (comm, incoming_msg_receiver) = Comm::new(config.local_addr(), config.first())?;
 
-    let node = if config.is_first() {
+    let node = if config.first().is_some() {
         start_genesis_node(
             comm,
             used_space,

--- a/testnet/Cargo.toml
+++ b/testnet/Cargo.toml
@@ -28,7 +28,7 @@ color-eyre = "~0.6.0"
 eyre = "~0.6.5"
 clap = { version = "3.0.0", features = ["derive", "env"]}
 dirs-next = "2.0.0"
-sn_launch_tool = "~0.13.0"
+sn_launch_tool = "0.13.1"
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
 tracing-subscriber = { version = "~0.3.1", features = ["env-filter", "json"] }


### PR DESCRIPTION
The genesis node will output a network contact file which contains its own address. This public address was specified by a separate flag but was removed, making the genesis incapable of producing a proper contacts file. This changes the `--first` flag to be used to pass in that public address, which should be done for all genesis nodes, so the proper external address can be advertised.


See https://github.com/maidsafe/sn_launch_tool/pull/136 for relevant changes in the sn_launch_tool after which this PR can be turned into review mode.
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
