### PR TITLE
fix: extend cleanup to registers

### DIFF
--- a/sn_node/src/storage/register_store.rs
+++ b/sn_node/src/storage/register_store.rs
@@ -91,7 +91,7 @@ impl RegisterStore {
             }
         }
 
-        trace!("Listening all register addrs done");
+        trace!("Listing all register addrs done.");
         addrs.into_values().collect()
     }
 


### PR DESCRIPTION
As nodes fill up they check if there's any data they are no longer responsible for, and clean it up.

It was missing the removal of registers.

NB: This can be made more granular, by looking at close nodes instead of prefix.