### PR TITLE
feat(client): sn_client to not have any default cmd/query timeout value set

### DIFF
--- a/sn_client/src/api/client_builder.rs
+++ b/sn_client/src/api/client_builder.rs
@@ -36,8 +36,6 @@ pub const ENV_CMD_TIMEOUT: &str = "SN_CMD_TIMEOUT";
 
 /// Bind by default to all network interfaces on a OS assigned port
 pub const DEFAULT_LOCAL_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
-/// Default timeout to use before timing out queries and commands
-pub const DEFAULT_QUERY_CMD_TIMEOUT: Duration = Duration::from_secs(90);
 /// Max amount of time for an operation backoff (time between attempts). In Seconds.
 pub const DEFAULT_MAX_QUERY_CMD_BACKOFF_INTERVAL: Duration = Duration::from_secs(3);
 
@@ -126,15 +124,14 @@ impl ClientBuilder {
     ///
     /// In case parameters have not been passed to this builder, defaults will be used:
     /// - `[Self::keypair]` and `[Self::dbc_owner]` are randomly generated
-    /// - `[Self::query_timeout`] and `[Self::cmd_timeout]` default to [`DEFAULT_QUERY_CMD_TIMEOUT`]
     /// - `[Self::max_backoff_interval`] defaults to [`DEFAULT_MAX_QUERY_CMD_BACKOFF_INTERVAL`]
     /// - Network contacts file will be read from a standard location
     pub async fn build(self) -> Result<Client, Error> {
         let max_backoff_interval = self
             .max_backoff_interval
             .unwrap_or(DEFAULT_MAX_QUERY_CMD_BACKOFF_INTERVAL);
-        let query_timeout = self.query_timeout.unwrap_or(DEFAULT_QUERY_CMD_TIMEOUT);
-        let cmd_timeout = self.cmd_timeout.unwrap_or(DEFAULT_QUERY_CMD_TIMEOUT);
+        let query_timeout = self.query_timeout;
+        let cmd_timeout = self.cmd_timeout;
 
         let network_contacts = match self.network_contacts {
             Some(pm) => pm,

--- a/sn_client/src/api/file_apis.rs
+++ b/sn_client/src/api/file_apis.rs
@@ -266,27 +266,30 @@ impl Client {
 
     // Verify a chunk is stored at provided address
     async fn verify_chunk_is_stored(&self, address: XorName) -> Result<()> {
-        // `read_bytes` could return earlier than query_timeout
-        // with `DataNotFound` eg, but this could just mean that the data has not yet
-        // reached adults...and so, we retry once but within the timeout limit set
-        let _chunk = tokio::time::timeout(self.query_timeout, async {
-            let mut response = self.get_chunk(&address).await;
-            if response.is_err() {
-                error!(
-                    "Error when attempting to verify chunk was stored at {:?}: {:?}",
-                    address, response
-                );
+        if let Some(query_timeout) = self.query_timeout {
+            // `query_chunk` could return earlier than query_timeout
+            // with `DataNotFound` eg, but this could just mean that the data has not yet
+            // reached adults...and so, we retry once but within the timeout limit set
+            tokio::time::timeout(query_timeout, self.query_chunk_and_retry_once(address))
+                .await
+                .map_err(|_| Error::ChunkUploadValidationTimeout {
+                    elapsed: query_timeout,
+                    address,
+                })??
+        } else {
+            self.query_chunk_and_retry_once(address).await?
+        };
 
-                sleep(self.max_backoff_interval).await;
-                response = self.get_chunk(&address).await;
-            }
-            response
-        })
-        .await
-        .map_err(|_| Error::ChunkUploadValidationTimeout {
-            elapsed: self.query_timeout,
-            address,
-        })??;
+        Ok(())
+    }
+
+    // Attempt to get chunk, otherwise retry (once) after a backoff interval
+    async fn query_chunk_and_retry_once(&self, address: XorName) -> Result<()> {
+        if let Err(err) = self.get_chunk(&address).await {
+            error!("Error when attempting to verify chunk was stored at {address:?}: {err:?}",);
+            sleep(self.max_backoff_interval).await;
+            let _ = self.get_chunk(&address).await?;
+        }
 
         Ok(())
     }

--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -57,9 +57,9 @@ pub struct Client {
     keypair: Keypair,
     dbc_owner: Owner,
     session: Session,
-    pub(crate) query_timeout: Duration,
+    pub(crate) query_timeout: Option<Duration>,
     pub(crate) max_backoff_interval: Duration,
-    pub(crate) cmd_timeout: Duration,
+    pub(crate) cmd_timeout: Option<Duration>,
     chunks_cache: Arc<RwLock<ChunksCache>>,
 }
 

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -62,7 +62,7 @@ impl Client {
         let mut backoff = ExponentialBackoff {
             initial_interval: max_interval / 2,
             max_interval,
-            max_elapsed_time: Some(self.query_timeout),
+            max_elapsed_time: self.query_timeout,
             randomization_factor: 1.5,
             ..Default::default()
         };


### PR DESCRIPTION
sn_client is now set to send msgs to the network without any default timeout values, the user of the lib can still set them with SN_CMD_TIMEOUT and SN_QUERY_TIMEOUT env vars according to its own requirements.