### PR TITLE
chore: feat gate data

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -196,12 +196,12 @@ jobs:
         run: cd sn_node && cargo test --release
 
       - name: Build sn_cli tests before running
-        run: cd sn_cli && cargo test --no-run --release
+        run: cd sn_cli && cargo test --no-run --release --features data-network
         timeout-minutes: 50
 
       - name: Run sn_cli tests
         timeout-minutes: 25
-        run: cd sn_cli && cargo test --release --bin safe
+        run: cd sn_cli && cargo test --release --bin safe --features data-network
 
   e2e:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
@@ -883,11 +883,11 @@ jobs:
         run: cargo run --package sn_cli --release -- keys create --for-cli
 
       - name: Build all tests before running
-        run: cd sn_cli && cargo test --no-run --release --features check-replicas
+        run: cd sn_cli && cargo test --no-run --release --features check-replicas,data-network
         timeout-minutes: 50
 
       - name: Run CLI tests
-        run: cd sn_cli && cargo test --release --features check-replicas -- --test-threads=1
+        run: cd sn_cli && cargo test --release --features check-replicas,data-network -- --test-threads=1
         timeout-minutes: 7
 
       - name: Are nodes still running...?

--- a/.github/workflows/run_pr_checks.yml
+++ b/.github/workflows/run_pr_checks.yml
@@ -134,12 +134,12 @@ jobs:
         run: cd sn_node && cargo test --release
 
       - name: Build sn_cli tests before running
-        run: cd sn_cli && cargo test --no-run --release
+        run: cd sn_cli && cargo test --no-run --release --features data-network
         timeout-minutes: 50
 
       - name: Run sn_cli tests
         timeout-minutes: 25
-        run: cd sn_cli && cargo test --release --bin safe
+        run: cd sn_cli && cargo test --release --bin safe --features data-network
 
   build:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
@@ -623,7 +623,7 @@ jobs:
         run: cargo run --release --bin safe keys create --for-cli
 
       - name: Run CLI tests
-        run: cargo test --release --features check-replicas --package sn_cli
+        run: cargo test --release --features check-replicas,data-network --package sn_cli
         timeout-minutes: 50
 
       - name: Are nodes still running...?

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -66,6 +66,7 @@ features = [
 default = [ "self-update", "limit-client-upload-size" ]
 check-replicas = [ "sn_api/check-replicas" ]
 cmd-happy-path = [ "sn_api/cmd-happy-path" ]
+data-network = []
 query-happy-path = [ "sn_api/query-happy-path" ]
 msg-happy-path = [ "sn_api/msg-happy-path" ]
 limit-client-upload-size = ["sn_api/limit-client-upload-size"]
@@ -95,3 +96,6 @@ harness = false
 [[bench]]
 name = "keys"
 harness = false
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["ansi_term", "pretty-hex"]  # these are used under feature flag, which `cargo-udeps` cannot check.

--- a/sn_cli/src/subcommands/dog.rs
+++ b/sn_cli/src/subcommands/dog.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#![cfg(feature = "data-network")]
+
 use super::{
     helpers::{
         get_from_arg_or_stdin, get_target_url, print_nrs_map, serialise_output, xorname_to_hex,

--- a/sn_cli/src/subcommands/files.rs
+++ b/sn_cli/src/subcommands/files.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#![cfg(feature = "data-network")]
+
 use super::{
     files_get::{process_get_command, FileExistsAction, ProgressIndicator},
     helpers::{

--- a/sn_cli/src/subcommands/files_get.rs
+++ b/sn_cli/src/subcommands/files_get.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#![cfg(feature = "data-network")]
+
 use super::{
     helpers::{div_or, pluralize, processed_files_err_report, prompt_user},
     OutputFmt,

--- a/sn_cli/src/subcommands/helpers.rs
+++ b/sn_cli/src/subcommands/helpers.rs
@@ -7,22 +7,28 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::OutputFmt;
-use ansi_term::Style;
-use color_eyre::{eyre::bail, eyre::eyre, eyre::WrapErr, Result};
-use comfy_table::{Cell, CellAlignment, Table};
-use num_traits::Float;
-use serde::ser::Serialize;
+
+#[cfg(feature = "data-network")]
+use sn_api::nrs::NrsMap;
 use sn_api::{
     files::{FilesMapChange, ProcessedFiles},
     multimap::Multimap,
-    nrs::NrsMap,
     wallet::Dbc,
     Safe, SafeUrl,
 };
+
+#[cfg(feature = "data-network")]
+use ansi_term::Style;
+use color_eyre::{eyre::bail, eyre::eyre, eyre::WrapErr, Result};
+use comfy_table::{Cell, CellAlignment, Table};
+#[cfg(feature = "data-network")]
+use num_traits::Float;
+use serde::ser::Serialize;
 use std::io::{stdin, stdout, Read, Write};
 use tracing::{debug, warn};
 use xor_name::XorName;
 
+#[cfg(feature = "data-network")]
 // Warn the user about a dry-run being performed
 pub fn notice_dry_run() {
     println!("NOTE the operation is being performed in dry-run mode, therefore no changes are committed to the network.");
@@ -199,6 +205,7 @@ pub async fn gen_wallet_table(safe: &Safe, multimap: &Multimap) -> Result<Table>
     Ok(table)
 }
 
+#[cfg(feature = "data-network")]
 // converts "-" to "", both of which mean to read from stdin.
 pub fn parse_stdin_arg(src: &str) -> String {
     if src.is_empty() || src == "-" {
@@ -227,6 +234,7 @@ where
     }
 }
 
+#[cfg(feature = "data-network")]
 pub fn print_nrs_map(nrs_map: &NrsMap) {
     println!("Listing NRS map contents:");
     let summary = nrs_map.get_map_summary();
@@ -235,6 +243,7 @@ pub fn print_nrs_map(nrs_map: &NrsMap) {
     }
 }
 
+#[cfg(feature = "data-network")]
 // returns singular or plural version of string, based on count.
 pub fn pluralize<'a>(singular: &'a str, plural: &'a str, count: u64) -> &'a str {
     if count == 1 {
@@ -244,6 +253,7 @@ pub fn pluralize<'a>(singular: &'a str, plural: &'a str, count: u64) -> &'a str 
     }
 }
 
+#[cfg(feature = "data-network")]
 // if stdout is a TTY, then it returns a string with ansi codes according to
 // style.  Otherwise, it returns the original string.
 pub fn if_tty(s: &str, style: Style) -> String {
@@ -254,6 +264,7 @@ pub fn if_tty(s: &str, style: Style) -> String {
     }
 }
 
+#[cfg(feature = "data-network")]
 pub fn div_or<X: Float>(num: X, den: X, default: X) -> X {
     if (!num.is_normal() && !num.is_zero()) || !den.is_normal() {
         default

--- a/sn_cli/src/subcommands/mod.rs
+++ b/sn_cli/src/subcommands/mod.rs
@@ -12,8 +12,6 @@ pub mod cat;
 pub mod config;
 pub mod dog;
 pub mod files;
-mod files_get;
-mod helpers;
 pub mod keys;
 pub mod networks;
 pub mod node;
@@ -23,6 +21,9 @@ pub mod setup;
 pub mod update;
 pub mod wallet;
 pub mod xorurl;
+
+mod files_get;
+mod helpers;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum OutputFmt {
@@ -76,18 +77,21 @@ pub enum SubCommands {
     )]
     /// Read data on the SAFE Network
     Cat(cat::CatCommands),
+    #[cfg(feature = "data-network")]
     #[clap(
         name = "dog",
         global_settings(&[AppSettings::DisableVersion]),
     )]
     /// Inspect data on the SAFE Network providing only metadata information about the content
     Dog(dog::DogCommands),
+    #[cfg(feature = "data-network")]
     #[clap(name = "files", subcommand, global_settings(&[AppSettings::DisableVersion]))]
     /// Manage files on the SAFE Network
     Files(files::FilesSubCommands),
     #[clap(name = "setup", subcommand, global_settings(&[AppSettings::DisableVersion]))]
     /// Perform setup tasks
     Setup(setup::SetupSubCommands),
+    #[cfg(feature = "data-network")]
     #[clap(name = "nrs", subcommand, global_settings(&[AppSettings::DisableVersion]))]
     /// Manage public names on the SAFE Network
     Nrs(nrs::NrsSubCommands),

--- a/sn_cli/src/subcommands/nrs.rs
+++ b/sn_cli/src/subcommands/nrs.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#![cfg(feature = "data-network")]
+
 use std::fmt::Write as _;
 
 use super::{


### PR DESCRIPTION
This gives a first simple version of a `payment-network`.
Storing data needs enabling of the `data-network` feature.

NB: This does not gate it in `sn_node`, thus with a custom client, data operations could still be available.
As the current wallet impl is dependent on the data storage, we cannot gate data without updating the wallet to work without it. That is a larger change suitable for a follow up PR.