### PR TITLE
refactor config instantiate

### DIFF
--- a/sn_node/examples/config_handling.rs
+++ b/sn_node/examples/config_handling.rs
@@ -21,7 +21,7 @@ use tokio::{fs::remove_file, io};
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create some config and write it to disk
-    let file_config = Config::new().await?;
+    let file_config = Config::new()?;
 
     // TODO: Uncomment the below lines once we enable reading config from disk
     // file_config.local_addr = Some("127.0.0.1".parse()?);
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     // This should load the config from disk and
     // use the command line arguments to overwrite the config
     // with any provided arguments
-    let config = Config::new().await?;
+    let config = Config::new()?;
 
     let command_line_args = Config::from_args();
 

--- a/sn_node/src/bin/sn_node/main.rs
+++ b/sn_node/src/bin/sn_node/main.rs
@@ -49,7 +49,7 @@ mod log;
 fn main() -> Result<()> {
     color_eyre::install()?;
 
-    let mut config = futures::executor::block_on(Config::new())?;
+    let mut config = Config::new()?;
 
     #[cfg(not(feature = "otlp"))]
     let _log_guard = log::init_node_logging(&config)?;
@@ -96,7 +96,7 @@ fn main() -> Result<()> {
         std::thread::sleep(Duration::from_secs(1));
 
         // pull config again in case it has been updated meanwhile
-        config = futures::executor::block_on(Config::new())?;
+        config = Config::new()?;
     }
 }
 

--- a/sn_node/src/node/cfg/config_handler.rs
+++ b/sn_node/src/node/cfg/config_handler.rs
@@ -43,7 +43,7 @@ pub struct Config {
     #[clap(short, long, parse(from_os_str))]
     pub root_dir: Option<PathBuf>,
     /// Verbose output. `-v` is equivalent to logging with `warn`, `-vv` to `info`, `-vvv` to
-    /// `debug`, `-vvvv` to `trace`. This flag overrides RUST_LOG.
+    /// `debug`, `-vvvv` to `trace`. This is overridden by the `RUST_LOG` environment variable.
     #[clap(short, long, parse(from_occurrences))]
     pub verbose: u8,
     /// dump shell completions for: [bash, fish, zsh, powershell, elvish]

--- a/sn_node/src/node/cfg/config_handler.rs
+++ b/sn_node/src/node/cfg/config_handler.rs
@@ -29,7 +29,6 @@ const DEFAULT_ROOT_DIR_NAME: &str = "root_dir";
 /// Node configuration
 #[derive(Default, Clone, Debug, Serialize, Deserialize, clap::StructOpt)]
 #[clap(rename_all = "kebab-case", bin_name = "sn_node", version)]
-#[clap(global_settings = &[clap::AppSettings::ColoredHelp])]
 pub struct Config {
     /// The address to be credited when this node farms SafeCoin.
     /// A hex formatted BLS public key.


### PR DESCRIPTION
- docs(node): fix documentation about verbose flag
- chore(node): remove deprecated clap setting
- refactor(node): instantiate Config without runtime

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
