### PR TITLE
Restore Updating Mechanisms for `safe` and `sn_node` Binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,13 @@ jobs:
           ./resources/scripts/output_versioning_info.sh
       - name: cargo login
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+      - name: publish sn_updater
+        run: |
+          commit_message="${{ github.event.head_commit.message }}"
+          if [[ $commit_message == *"sn_updater"* ]]; then
+            # The sn_updater crate doesn't have any dependencies so we can go ahead and publish.
+            cd sn_updater && cargo publish --allow-dirty
+          fi
       - name: publish sn_interface
         run: |
           commit_message="${{ github.event.head_commit.message }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3991,6 +3991,7 @@ dependencies = [
  "sn_cmd_test_utilities",
  "sn_dbc",
  "sn_launch_tool",
+ "sn_updater",
  "tempfile",
  "tokio",
  "tracing",
@@ -4255,6 +4256,7 @@ dependencies = [
  "sn_fault_detection",
  "sn_interface",
  "sn_sdkg",
+ "sn_updater",
  "strum",
  "strum_macros",
  "sysinfo",
@@ -4288,6 +4290,15 @@ dependencies = [
  "serde",
  "thiserror",
  "tiny-keccak",
+]
+
+[[package]]
+name = "sn_updater"
+version = "0.1.0"
+dependencies = [
+ "self_update",
+ "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "sn_api",
     "sn_client",
     "sn_cli",
+    "sn_updater",
     "sn_comms",
     "sn_fault_detection",
     "sn_cmd_test_utilities",

--- a/resources/scripts/get_release_description.sh
+++ b/resources/scripts/get_release_description.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+sn_updater_version=$( \
+  grep "^version" < sn_updater/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
 sn_fault_detection_version=$( \
   grep "^version" < sn_fault_detection/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
 sn_interface_version=$( \
@@ -15,6 +17,7 @@ sn_cli_version=$(grep "^version" < sn_cli/Cargo.toml | head -n 1 | awk '{ print 
 # The single quotes around EOF is to stop attempted variable and backtick expansion.
 read -r -d '' release_description << 'EOF'
 This release of Safe Network consists of:
+* Safe Updater v__SN_UPDATER_VERSION__
 * Safe Node Fault Detection v__SN_FAULT_DETECTION_VERSION__
 * Safe Network Interface v__SN_INTERFACE_VERSION__
 * Safe Node Comms v__SN_COMMS_VERSION__
@@ -22,6 +25,10 @@ This release of Safe Network consists of:
 * Safe Node v__SN_NODE_VERSION__
 * Safe API v__SN_API_VERSION__
 * Safe CLI v__SN_CLI_VERSION__
+
+## Safe Updater Changelog
+
+__SN_UPDATER_CHANGELOG_TEXT__
 
 ## Safe Network Interface Changelog
 
@@ -180,6 +187,7 @@ sn_cli_tar_aarch64_checksum=$(sha256sum \
     "./deploy/prod/safe/sn_cli-$sn_cli_version-aarch64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 
+release_description=$(sed "s/__SN_UPDATER_VERSION__/$sn_updater_version/g" <<< "$release_description")
 release_description=$(sed "s/__SN_FAULT_DETECTION_VERSION__/$sn_fault_detection_version/g" <<< "$release_description")
 release_description=$(sed "s/__SN_INTERFACE_VERSION__/$sn_interface_version/g" <<< "$release_description")
 release_description=$(sed "s/__SN_COMMS_VERSION__/$sn_comms_version/g" <<< "$release_description")

--- a/resources/scripts/insert_changelog_entry.py
+++ b/resources/scripts/insert_changelog_entry.py
@@ -6,9 +6,11 @@
 
 import toml
 
+
 def get_crate_version(crate_name):
     manifest = toml.load(f"{crate_name}/Cargo.toml")
     return manifest["package"]["version"]
+
 
 def get_changelog_entry(changelog_path, version):
     sn_changelog_content = ""
@@ -17,6 +19,7 @@ def get_changelog_entry(changelog_path, version):
     start = sn_changelog_content.find("## v{version}".format(version=version))
     end = sn_changelog_content.find("## v", start + 10)
     return sn_changelog_content[start:end].strip()
+
 
 def insert_changelog_entry(entry, pattern):
     if not entry.strip():
@@ -28,37 +31,55 @@ def insert_changelog_entry(entry, pattern):
     with open("release_description.md", "w") as file:
         file.write(release_description)
 
+
 def main(
-        sn_interface_version,
-        sn_fault_detection_version,
-        sn_comms_version,
-        sn_client_version,
-        sn_node_version,
-        sn_api_version,
-        sn_cli_version):
+    sn_updater_version,
+    sn_interface_version,
+    sn_fault_detection_version,
+    sn_comms_version,
+    sn_client_version,
+    sn_node_version,
+    sn_api_version,
+    sn_cli_version,
+):
+    if sn_updater_version:
+        changelog_entry = get_changelog_entry(
+            "sn_updater/CHANGELOG.md", sn_updater_version
+        )
+        insert_changelog_entry(changelog_entry, "__SN_UPDATER_CHANGELOG_TEXT__")
     if sn_interface_version:
-        sn_node_changelog_entry = get_changelog_entry("sn_interface/CHANGELOG.md", sn_interface_version)
-        insert_changelog_entry(sn_node_changelog_entry, "__SN_INTERFACE_CHANGELOG_TEXT__")
+        changelog_entry = get_changelog_entry(
+            "sn_interface/CHANGELOG.md", sn_interface_version
+        )
+        insert_changelog_entry(changelog_entry, "__SN_INTERFACE_CHANGELOG_TEXT__")
     if sn_comms_version:
-        sn_node_changelog_entry = get_changelog_entry("sn_comms/CHANGELOG.md", sn_comms_version)
-        insert_changelog_entry(sn_node_changelog_entry, "__SN_COMMS_CHANGELOG_TEXT__")
+        changelog_entry = get_changelog_entry("sn_comms/CHANGELOG.md", sn_comms_version)
+        insert_changelog_entry(changelog_entry, "__SN_COMMS_CHANGELOG_TEXT__")
     if sn_fault_detection_version:
-        sn_node_changelog_entry = get_changelog_entry("sn_fault_detection/CHANGELOG.md", sn_fault_detection_version)
-        insert_changelog_entry(sn_node_changelog_entry, "__SN_FAULT_DETECTION_CHANGELOG_TEXT__")
+        changelog_entry = get_changelog_entry(
+            "sn_fault_detection/CHANGELOG.md", sn_fault_detection_version
+        )
+        insert_changelog_entry(changelog_entry, "__SN_FAULT_DETECTION_CHANGELOG_TEXT__")
     if sn_client_version:
-        sn_client_changelog_entry = get_changelog_entry("sn_client/CHANGELOG.md", sn_client_version)
-        insert_changelog_entry(sn_client_changelog_entry, "__SN_CLIENT_CHANGELOG_TEXT__")
+        changelog_entry = get_changelog_entry(
+            "sn_client/CHANGELOG.md", sn_client_version
+        )
+        insert_changelog_entry(changelog_entry, "__SN_CLIENT_CHANGELOG_TEXT__")
     if sn_node_version:
-        sn_node_changelog_entry = get_changelog_entry("sn_node/CHANGELOG.md", sn_node_version)
-        insert_changelog_entry(sn_node_changelog_entry, "__SN_NODE_CHANGELOG_TEXT__")
+        changelog_entry = get_changelog_entry("sn_node/CHANGELOG.md", sn_node_version)
+        insert_changelog_entry(changelog_entry, "__SN_NODE_CHANGELOG_TEXT__")
     if sn_api_version:
-        sn_api_changelog_entry = get_changelog_entry("sn_api/CHANGELOG.md", sn_api_version)
-        insert_changelog_entry(sn_api_changelog_entry, "__SN_API_CHANGELOG_TEXT__")
+        changelog_entry = get_changelog_entry("sn_api/CHANGELOG.md", sn_api_version)
+        insert_changelog_entry(changelog_entry, "__SN_API_CHANGELOG_TEXT__")
     if sn_cli_version:
-        sn_cli_changelog_entry = get_changelog_entry("sn_cli/CHANGELOG.md", sn_cli_version)
+        sn_cli_changelog_entry = get_changelog_entry(
+            "sn_cli/CHANGELOG.md", sn_cli_version
+        )
         insert_changelog_entry(sn_cli_changelog_entry, "__SN_CLI_CHANGELOG_TEXT__")
 
+
 if __name__ == "__main__":
+    sn_updater_version = get_crate_version("sn_updater")
     sn_interface_version = get_crate_version("sn_interface")
     sn_fault_detection_version = get_crate_version("sn_fault_detection")
     sn_comms_version = get_crate_version("sn_comms")
@@ -67,10 +88,12 @@ if __name__ == "__main__":
     sn_api_version = get_crate_version("sn_api")
     sn_cli_version = get_crate_version("sn_client")
     main(
+        sn_updater_version,
         sn_interface_version,
         sn_fault_detection_version,
         sn_comms_version,
         sn_client_version,
         sn_node_version,
         sn_api_version,
-        sn_cli_version)
+        sn_cli_version,
+    )

--- a/resources/scripts/output_versioning_info.sh
+++ b/resources/scripts/output_versioning_info.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+sn_updater_version=""
 sn_fault_detection_version=""
 sn_interface_version=""
 sn_comms_version=""
@@ -9,6 +10,8 @@ sn_api_version=""
 sn_cli_version=""
 
 function get_crate_versions() {
+  sn_updater_version=$( \
+    grep "^version" < sn_updater/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
   sn_fault_detection_version=$( \
     grep "^version" < sn_fault_detection/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
   sn_interface_version=$( \
@@ -23,7 +26,8 @@ function get_crate_versions() {
 }
 
 function build_release_name() {
-  gh_release_name="Safe Network v$sn_fault_detection_version/"
+  gh_release_name="Safe Network v$sn_updater_version/"
+  gh_release_name="${gh_release_name}v$sn_fault_detection_version/"
   gh_release_name="${gh_release_name}v$sn_interface_version/"
   gh_release_name="${gh_release_name}v$sn_comms_version/"
   gh_release_name="${gh_release_name}v$sn_client_version/"
@@ -33,7 +37,8 @@ function build_release_name() {
 }
 
 function build_release_tag_name() {
-  gh_release_tag_name="$sn_interface_version-"
+  gh_release_tag_name="$sn_updater_version-"
+  gh_release_tag_name="${gh_release_tag_name}$sn_interface_version-"
   gh_release_tag_name="${gh_release_tag_name}$sn_fault_detection_version-"
   gh_release_tag_name="${gh_release_tag_name}$sn_comms_version-"
   gh_release_tag_name="${gh_release_tag_name}$sn_client_version-"
@@ -43,6 +48,7 @@ function build_release_tag_name() {
 }
 
 function output_version_info() {
+  echo "sn_updater_version=$sn_updater_version" >> $GITHUB_OUTPUT
   echo "sn_fault_detection_version=$sn_fault_detection_version" >> $GITHUB_OUTPUT
   echo "sn_interface_version=$sn_interface_version" >> $GITHUB_OUTPUT
   echo "sn_comms_version=$sn_comms_version" >> $GITHUB_OUTPUT

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -36,6 +36,7 @@ rcgen = "~0.9"
 relative-path = "1.3.2"
 reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls"] }
 rmp-serde = "1.0.0"
+sn_updater = { path = "../sn_updater", version = "^0.1.0" }
 sn_api = { path = "../sn_api", version = "^0.77.0", default-features = false, features = ["app"] }
 sn_dbc = { version = "8.3.0", features = ["serdes"] }
 sn_launch_tool = "0.13.1"
@@ -63,14 +64,13 @@ features = [
 ]
 
 [features]
-default = [ "self-update", "limit-client-upload-size" ]
+default = [ "limit-client-upload-size" ]
 check-replicas = [ "sn_api/check-replicas" ]
 cmd-happy-path = [ "sn_api/cmd-happy-path" ]
 data-network = []
 query-happy-path = [ "sn_api/query-happy-path" ]
 msg-happy-path = [ "sn_api/msg-happy-path" ]
 limit-client-upload-size = ["sn_api/limit-client-upload-size"]
-self-update = []
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/sn_cli/src/cli.rs
+++ b/sn_cli/src/cli.rs
@@ -122,10 +122,7 @@ async fn process_commands(mut safe: &mut Safe, args: CmdArgs, config: &mut Confi
             // the self_update crate as it seems to be creating its own runtime.
             // The use of the move keyword is required for the closure to take ownership of
             // the no_confirm flag.
-            let handler = std::thread::spawn(move || {
-                update_commander(no_confirm)
-                    .map_err(|err| eyre!("Error performing update: {}", err))
-            });
+            let handler = std::thread::spawn(move || update_commander(no_confirm));
             handler
                 .join()
                 .map_err(|err| eyre!("Failed to run self update: {:?}", err))?

--- a/sn_cli/src/operations/mod.rs
+++ b/sn_cli/src/operations/mod.rs
@@ -9,5 +9,5 @@
 pub mod auth_and_connect;
 // pub mod auth_daemon;
 pub mod config;
-mod helpers;
+pub mod helpers;
 pub mod node;

--- a/sn_cli/src/operations/node.rs
+++ b/sn_cli/src/operations/node.rs
@@ -54,8 +54,7 @@ pub fn node_version(node_path: Option<PathBuf>) -> Result<()> {
 }
 
 pub fn node_install(target_dir_path: PathBuf, version: Option<String>) -> Result<()> {
-    let _ =
-        download_and_install_node(target_dir_path, SN_NODE_EXECUTABLE, "safe_network", version)?;
+    download_and_install_node(target_dir_path, SN_NODE_EXECUTABLE, "safe_network", version)?;
     Ok(())
 }
 

--- a/sn_cli/src/subcommands/mod.rs
+++ b/sn_cli/src/subcommands/mod.rs
@@ -118,7 +118,7 @@ pub enum SubCommands {
     #[clap(name = "update", global_settings(&[AppSettings::DisableVersion]))]
     /// Update the application to the latest available version
     Update {
-        /// Remove prompt to confirm the update.
+        /// Do not prompt to confirm the update
         #[clap(short = 'y', long = "no-confirm")]
         no_confirm: bool,
     },

--- a/sn_cli/src/subcommands/update.rs
+++ b/sn_cli/src/subcommands/update.rs
@@ -6,51 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::error::Error;
-#[cfg(feature = "self-update")]
-use tracing::debug;
+use color_eyre::{eyre::eyre, Result};
+use sn_updater::{update_binary, UpdateType};
 
-#[cfg(feature = "self-update")]
-const REPO_NAME: &str = "sn_cli";
-
-#[cfg(not(feature = "self-update"))]
-pub fn update_commander(_no_confirm: bool) -> Result<(), Box<dyn Error>> {
-    println!("Self updates are disabled.");
-    Ok(())
-}
-
-#[cfg(feature = "self-update")]
-pub fn update_commander(no_confirm: bool) -> Result<(), Box<dyn Error>> {
-    let target = self_update::get_target();
-    let releases = self_update::backends::github::ReleaseList::configure()
-        .repo_owner("maidsafe")
-        .repo_name(REPO_NAME)
-        .with_target(target)
-        .build()?
-        .fetch()?;
-
-    if releases.is_empty() {
-        println!("Current version is {}", env!("CARGO_PKG_VERSION"));
-        println!("No releases are available on GitHub to perform an update");
-    } else {
-        debug!("Found releases: {:#?}\n", releases);
-        let bin_name = if target.contains("pc-windows") {
-            "safe.exe"
-        } else {
-            "safe"
-        };
-        let status = self_update::backends::github::Update::configure()
-            .repo_owner("maidsafe")
-            .repo_name(REPO_NAME)
-            .target(target)
-            .bin_name(bin_name)
-            .no_confirm(no_confirm)
-            .show_download_progress(true)
-            .current_version(env!("CARGO_PKG_VERSION"))
-            .build()?
-            .update()?;
-        println!("Update status: `{}`!", status.version());
-    }
-
-    Ok(())
+pub fn update_commander(no_confirm: bool) -> Result<()> {
+    let current_version = env!("CARGO_PKG_VERSION");
+    update_binary(UpdateType::Safe, current_version, !no_confirm)
+        .map_err(|e| eyre!(format!("Failed to update safe: {e}")))
 }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -56,6 +56,7 @@ rayon = "1.5.1"
 rmp-serde = "1.0.0"
 self_encryption = "~0.27.5"
 sn_consensus = "3.2.1"
+sn_updater = { path = "../sn_updater", version = "^0.1.0" }
 sn_comms = { path = "../sn_comms", version = "^0.3.5" }
 sn_dbc = { version = "8.3.0", features = ["serdes"] }
 sn_fault_detection = { path = "../sn_fault_detection", version = "^0.15.4" }

--- a/sn_node/examples/config_handling.rs
+++ b/sn_node/examples/config_handling.rs
@@ -73,8 +73,8 @@ async fn main() -> Result<()> {
         file_config.update || command_line_args.update
     );
     assert_eq!(
-        config.update_only,
-        file_config.update_only || command_line_args.update_only
+        config.no_confirm,
+        file_config.no_confirm || command_line_args.no_confirm
     );
     assert_eq!(
         config.clear_data,

--- a/sn_node/src/node/cfg/config_handler.rs
+++ b/sn_node/src/node/cfg/config_handler.rs
@@ -118,7 +118,7 @@ impl Config {
     /// Validate configuration that came from the cmd line.
     ///
     /// `StructOpt` doesn't support validation that crosses multiple field values.
-    fn validate(&self) -> Result<(), Error> {
+    pub fn validate(&self) -> Result<(), Error> {
         if !(self.first.is_some() ^ self.network_contacts_file.is_some()) {
             return Err(Error::Configuration(
                 "Either the --first or --network-contacts-file argument is required, and they \
@@ -162,7 +162,7 @@ impl Config {
         self.logs_uncompressed = config.logs_uncompressed();
 
         self.update = config.update || self.update;
-        self.update_only = config.update_only || self.update_only;
+        self.no_confirm = config.no_confirm || self.no_confirm;
         self.clear_data = config.clear_data || self.clear_data;
         if config.first.is_some() {
             self.first = config.first;

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -45,7 +45,7 @@ impl Dispatcher {
     /// Handles a single cmd.
     pub(crate) async fn process_cmd(&self, cmd: Cmd) -> Result<Vec<Cmd>> {
         let start = Instant::now();
-        let cmd_string = format!("{}", cmd);
+        let cmd_string = format!("{cmd}");
         let result = match cmd {
             Cmd::TryJoinNetwork => {
                 info!("[NODE READ]: getting lock for try_join_section");

--- a/sn_updater/CHANGELOG.md
+++ b/sn_updater/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## v0.1.0 (2023-02-22)
+
+First manual entry for this new crate.

--- a/sn_updater/Cargo.toml
+++ b/sn_updater/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+authors = ["MaidSafe Developers <dev@maidsafe.net>"]
+description = "Provides utilities for updating Safe-related command line interfaces."
+documentation = "https://docs.rs/sn_node"
+edition = "2021"
+homepage = "https://maidsafe.net"
+license = "GPL-3.0"
+name = "sn_updater"
+readme = "README.md"
+repository = "https://github.com/maidsafe/safe_network"
+version = "0.1.0"
+
+[dependencies]
+thiserror = "1.0.23"
+url = "2.2.2"
+
+[dependencies.self_update]
+version = "0.32"
+default-features = false
+features = [
+    "rustls",
+    "archive-tar",
+    "compression-flate2",
+]

--- a/sn_updater/README.md
+++ b/sn_updater/README.md
@@ -1,0 +1,3 @@
+# Safe Updater
+
+Provides utilities for updating Safe-related command line interfaces.

--- a/sn_updater/src/errors.rs
+++ b/sn_updater/src/errors.rs
@@ -1,0 +1,29 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use thiserror::Error;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error("Invalid download URL: {0}")]
+    InvalidDownloadUrl(String),
+    #[error("Invalid target path: {0}")]
+    InvalidTargetPath(String),
+    #[error("Could not parse version number from release version '{0}'")]
+    InvalidReleaseVersionFormat(String),
+    #[error(transparent)]
+    SelfUpdate(#[from] self_update::errors::Error),
+    #[error("Failed to update binary: {0}")]
+    UpdateFailed(String),
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+}

--- a/sn_updater/src/lib.rs
+++ b/sn_updater/src/lib.rs
@@ -1,0 +1,237 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+pub mod errors;
+
+use crate::errors::{Error, Result};
+use self_update::version::bump_is_greater;
+use std::path::PathBuf;
+
+const ORG_NAME: &str = "maidsafe";
+const REPO_NAME: &str = "safe_network";
+
+pub enum UpdateType {
+    Safe,
+    Node,
+}
+
+/// Updates the binary to the latest available version.
+///
+/// This function queries the target platform then uses the self_update library to check for a
+/// newer release on GitHub. If a newer release is found, the existing binary is replaced with the
+/// new one.
+///
+/// # Arguments
+///
+/// * `update_type` - The type of binary to update (Safe or Node).
+/// * `current_version` - The current version of the binary.
+/// * `confirm_update` - A flag indicating if the update should be confirmed by the user.
+///
+/// # Errors
+///
+/// An error is returned if:
+///
+/// * Getting the target platform or binary name fails.
+/// * Configuring the self_update library fails.
+/// * Getting the latest release from GitHub fails.
+/// * Determining the latest version from the latest release fails.
+/// * Downloading or installing the new binary fails.
+///
+/// # Examples
+///
+/// ```
+/// use sn_updater::{UpdateType, update_binary};
+///
+/// let current_version = env!("CARGO_PKG_VERSION");
+/// update_binary(UpdateType::Safe, current_version, false);
+/// ```
+pub fn update_binary(
+    update_type: UpdateType,
+    current_version: &str,
+    confirm_update: bool,
+) -> Result<()> {
+    let target_platform = get_target_platform();
+    let bin_name = get_bin_name(&update_type, &target_platform);
+    println!("Current version is: {current_version}");
+    let latest_release = self_update::backends::github::Update::configure()
+        .repo_owner(ORG_NAME)
+        .repo_name(REPO_NAME)
+        .target(&target_platform)
+        .bin_name(&bin_name)
+        .current_version(current_version)
+        .build()?
+        .get_latest_release()?;
+    let latest_version = get_version_from_release_version(&update_type, &latest_release.version)?;
+    if bump_is_greater(current_version, &latest_version)? {
+        println!("Newer version is available: {latest_version}");
+        println!("The existing binary will be replaced.");
+        if confirm_update {
+            println!("Proceed with the update? [y/n]");
+            if !proceed()? {
+                return Ok(());
+            }
+        }
+        let url = get_download_url(&update_type, &latest_version, &target_platform)?;
+        download_and_install_bin(&url, std::env::current_exe()?)?;
+    } else {
+        println!("Newer version is not available at this time.");
+        println!("Everything is up to date.");
+    }
+    Ok(())
+}
+
+fn get_download_url(
+    update_type: &UpdateType,
+    version: &str,
+    target_platform: &str,
+) -> Result<String> {
+    match update_type {
+        UpdateType::Safe => Ok(format!(
+            "https://sn-cli.s3.eu-west-2.amazonaws.com/sn_cli-{version}-{target_platform}.tar.gz"
+        )),
+        UpdateType::Node => Ok(format!(
+            "https://sn-node.s3.eu-west-2.amazonaws.com/sn_node-{version}-{target_platform}.tar.gz"
+        )),
+    }
+}
+
+fn get_bin_name(update_type: &UpdateType, target_platform: &str) -> String {
+    match update_type {
+        UpdateType::Safe => {
+            if target_platform.contains("pc-windows") {
+                "safe.exe".to_string()
+            } else {
+                "safe".to_string()
+            }
+        }
+        UpdateType::Node => {
+            if target_platform.contains("pc-windows") {
+                "sn_node.exe".to_string()
+            } else {
+                "sn_node".to_string()
+            }
+        }
+    }
+}
+
+fn get_target_platform() -> String {
+    let target = self_update::get_target();
+    if target.contains("linux") {
+        // For now, all of our Linux builds are using musl, so we can make this
+        // assumption. We would need to update this code if we changed that.
+        target.replace("gnu", "musl")
+    } else {
+        target.to_string()
+    }
+}
+
+/// Gets the version number from the full version number string.
+///
+/// The `release_version` input is in the form "0.17.1-0.15.3-0.2.1-0.78.2-0.73.3-0.76.1-0.69.0",
+/// which is the `sn_interface`, `sn_fault_detection`, `sn_comms`, `sn_client`, `sn_node`,
+/// `sn_api`, `sn_cli` respectively.
+///
+/// Returns either the `sn_node` or `sn_cli` part.
+fn get_version_from_release_version(source: &UpdateType, release_version: &str) -> Result<String> {
+    let mut parts = release_version.split('-');
+    let version = match source {
+        UpdateType::Safe => parts
+            .last()
+            .ok_or_else(|| Error::InvalidReleaseVersionFormat(release_version.to_string()))?
+            .to_string(),
+        UpdateType::Node => {
+            parts.next();
+            parts.next();
+            parts.next();
+            parts.next();
+            parts
+                .next()
+                .ok_or_else(|| Error::InvalidReleaseVersionFormat(release_version.to_string()))?
+                .to_string()
+        }
+    };
+    Ok(version)
+}
+
+fn proceed() -> Result<bool> {
+    let mut s = String::new();
+    std::io::stdin().read_line(&mut s)?;
+    let s = s.trim().to_lowercase();
+    if !s.is_empty() && s != "y" {
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+fn download_and_install_bin(url: &str, target_file_path: PathBuf) -> Result<()> {
+    println!("Downloading release from: {url}");
+    let url = url::Url::parse(url)?;
+    let archive_file_name = match url.path_segments() {
+        Some(mut segments) => match segments.next_back() {
+            Some(file_name) => file_name,
+            None => {
+                return Err(Error::InvalidDownloadUrl("No filename in URL".to_string()));
+            }
+        },
+        None => {
+            return Err(Error::InvalidDownloadUrl("No path in URL".to_string()));
+        }
+    };
+
+    let tmp_dir = std::env::temp_dir();
+    let tmp_tarball_path = tmp_dir.join(archive_file_name);
+    let tmp_tarball = std::fs::File::create(&tmp_tarball_path)?;
+
+    self_update::Download::from_url(url.as_ref())
+        .show_progress(true)
+        .download_to(&tmp_tarball)?;
+
+    let target_dir_path = target_file_path.parent().ok_or_else(|| {
+        Error::InvalidTargetPath("Could not obtain parent from target path".to_string())
+    })?;
+    if !target_dir_path.exists() {
+        println!("Creating parent directory at {}", target_dir_path.display());
+        std::fs::create_dir_all(target_dir_path)?;
+    }
+
+    let bin_name = target_file_path
+        .file_name()
+        .ok_or_else(|| {
+            Error::InvalidTargetPath("Could not obtain file name from target file path".to_string())
+        })?
+        .to_str()
+        .ok_or_else(|| Error::InvalidTargetPath("Could not obtain str from OsStr".to_string()))?;
+    println!(
+        "Extracting {} binary to {}...",
+        bin_name,
+        target_file_path.display()
+    );
+    self_update::Extract::from_source(&tmp_tarball_path).extract_file(target_dir_path, bin_name)?;
+    set_exec_perms(target_file_path)?;
+    println!("Done!");
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+#[allow(clippy::unnecessary_wraps)]
+#[inline]
+fn set_exec_perms(_file_path: PathBuf) -> Result<()> {
+    // no need to set execution permissions on Windows
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(not(target_os = "windows"))]
+#[inline]
+fn set_exec_perms(bin_path: PathBuf) -> Result<()> {
+    let file = std::fs::File::open(bin_path)?;
+    let mut perms = file.metadata()?.permissions();
+    perms.set_mode(0o755);
+    file.set_permissions(perms)?;
+    Ok(())
+}


### PR DESCRIPTION
- 00c77f428 **chore: introduce sn_updater library crate**

  This library crate provides utility code to be shared between the `safe` and `sn_node` binaries so
  they can update themselves to the latest version.

  We can no longer use the `self_update` crate to do this with a single statement because
  `self_update` is designed for use with single-crate repositories, though we do still make use of
  utility code it happens to make public.

  The crate makes an `update_binary` function available. The doc comments in the diff provide details
  of how it works, so I won't repeat that here.

- 7d6b2c5ff **fix: restore sn_node update command**

  The updating mechanisms for the `safe` and `sn_node` binaries stopped working when we switched to
  using a workspace repository.

  We now make use of the newly introduced `sn_updater` crate to provide a working solution.

  The start up behaviour of the node changes slightly here. The code that validated the arguments was
  moved to occur after the updating process because that validation doesn't apply when you're just
  performing a simple update, which will terminate the node process after it's done. In addition, the
  `--update-only` argument was removed, because you always need to restart the node after it has been
  updated. I didn't see much purpose in this argument and also though it could potentially cause
  confusion.

- 877ec2ae3 **fix: restore safe update command**

  The `safe` binary also makes use of the newly introduced `sn_updater` crate to provide a working
  update mechanism.

  Important note: there is code in the `node update` command that could be replaced with `sn_updater`,
  but the whole `node` command is due to be removed anyway, which is what I will be working on next.

  Also fixes up a few things after a rebase from main.

- 98bb986d0 **ci: add new sn_updater crate to release process**

  This small crate has no dependencies on the other crates in the workspace so it can be published
  first.
  
  Also fix reference to modified node arguments in one of the examples.