### PR TITLE
Remove unused pub interface

### DIFF
--- a/sn_cli/src/subcommands/files_get.rs
+++ b/sn_cli/src/subcommands/files_get.rs
@@ -74,8 +74,9 @@ impl std::str::FromStr for FileExistsAction {
 }
 
 // What type of Progress Indicator to display.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum ProgressIndicator {
+    #[default]
     Text,
     None,
 }
@@ -91,12 +92,6 @@ impl std::str::FromStr for ProgressIndicator {
                 "'{other}' not supported. Supported values are bars, text, and none",
             )),
         }
-    }
-}
-
-impl Default for ProgressIndicator {
-    fn default() -> Self {
-        ProgressIndicator::Text
     }
 }
 

--- a/sn_fault_detection/src/lib.rs
+++ b/sn_fault_detection/src/lib.rs
@@ -103,12 +103,6 @@ impl FaultDetection {
         }
     }
 
-    /// Set to track provided elders
-    pub fn update_elders(&mut self, elders: BTreeSet<NodeIdentifier>) {
-        info!("Setting elder nodes:{elders:?} in FaultDetection tracker");
-        self.elders = elders
-    }
-
     /// Adds an issue to the fault tracker.
     ///
     /// The `op_id` only applies when adding an operational issue.

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -55,18 +55,6 @@ pub fn max_num_faulty_elders() -> usize {
     elder_count() / 3
 }
 
-/// Max number of faulty Elders is assumed to be less than 1/3.
-/// So it's no more than 2 with 7 Elders.
-pub fn max_num_faulty_elders_for_sap(sap: SectionAuthorityProvider) -> usize {
-    sap.elder_count() / 3
-}
-
-/// The least number of Elders to select, to be "guaranteed" one correctly functioning Elder.
-/// This number will be 3 with 7 Elders.
-pub fn at_least_one_correct_elder() -> usize {
-    max_num_faulty_elders() + 1
-}
-
 /// Get the expected chunk copy count for our network.
 /// Defaults to `DEFAULT_DATA_COPY_COUNT`, but can be overridden by the env var `SN_DATA_COPY_COUNT`.
 pub fn data_copy_count() -> usize {

--- a/sn_interface/src/messaging/authority.rs
+++ b/sn_interface/src/messaging/authority.rs
@@ -10,10 +10,7 @@ pub use super::system::{SectionSig, SectionSigShare};
 use super::{Error, Result};
 use crate::types::{PublicKey, Signature};
 use bls::PublicKey as BlsPublicKey;
-use ed25519_dalek::{
-    Keypair as EdKeypair, PublicKey as EdPublicKey, Signature as EdSignature, Signer as _,
-    Verifier as _,
-};
+use ed25519_dalek::{PublicKey as EdPublicKey, Signature as EdSignature, Verifier as _};
 use serde::{Deserialize, Serialize};
 
 /// Authority of a network peer.

--- a/sn_interface/src/messaging/authority.rs
+++ b/sn_interface/src/messaging/authority.rs
@@ -39,21 +39,6 @@ pub struct NodeSig {
     pub signature: EdSignature,
 }
 
-impl NodeSig {
-    /// Construct verified node authority by signing a payload.
-    pub fn authorize(
-        section_pk: BlsPublicKey,
-        keypair: &EdKeypair,
-        payload: impl AsRef<[u8]>,
-    ) -> AuthorityProof<Self> {
-        AuthorityProof(Self {
-            section_pk,
-            node_ed_pk: keypair.public,
-            signature: keypair.sign(payload.as_ref()),
-        })
-    }
-}
-
 /// Verified authority.
 ///
 /// Values of this type constitute a proof that the signature is valid for a particular payload.

--- a/sn_interface/src/messaging/data/cmd.rs
+++ b/sn_interface/src/messaging/data/cmd.rs
@@ -35,15 +35,6 @@ pub enum DataCmd {
 }
 
 impl DataCmd {
-    /// Returns the address of the corresponding variant.
-    pub fn address(&self) -> DataAddress {
-        match self {
-            Self::StoreChunk(chunk) => DataAddress::Bytes(*chunk.address()),
-            Self::Register(register_cmd) => DataAddress::Register(register_cmd.dst_address()),
-            Self::Spentbook(spentbook_cmd) => DataAddress::Spentbook(spentbook_cmd.dst_address()),
-        }
-    }
-
     /// Returns the xorname of the data for this cmd.
     pub fn dst_name(&self) -> XorName {
         use DataCmd::*;

--- a/sn_interface/src/messaging/data/cmd.rs
+++ b/sn_interface/src/messaging/data/cmd.rs
@@ -7,10 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Error, RegisterCmd, SpentbookCmd};
-use crate::{
-    messaging::data::CmdResponse,
-    types::{Chunk, DataAddress},
-};
+use crate::{messaging::data::CmdResponse, types::Chunk};
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -145,22 +145,6 @@ pub enum QueryResponse {
 }
 
 impl QueryResponse {
-    /// Returns true if the result returned is a success or not
-    pub fn is_success(&self) -> bool {
-        use QueryResponse::*;
-        matches!(
-            self,
-            GetChunk(Ok(_))
-                | GetRegister(Ok(_))
-                | GetRegisterEntry(Ok(_))
-                | GetRegisterOwner(Ok(_))
-                | ReadRegister(Ok(_))
-                | GetRegisterPolicy(Ok(_))
-                | GetRegisterUserPermissions(Ok(_))
-                | SpentProofShares(Ok(_))
-        )
-    }
-
     /// Returns true if the result returned is DataNotFound
     pub fn is_data_not_found(&self) -> bool {
         use QueryResponse::*;
@@ -237,11 +221,6 @@ impl CmdResponse {
             ReplicatedData::SpentbookLog(_) => return Err(Error::NoCorrespondingCmdError), // this should be unreachable, since `SpentbookLog` is not resulting from a cmd.
         };
         Ok(res)
-    }
-
-    /// Returns true if the result returned is a success or not
-    pub fn is_success(&self) -> bool {
-        self.result().is_ok()
     }
 
     /// Returns the result

--- a/sn_interface/src/messaging/data/query.rs
+++ b/sn_interface/src/messaging/data/query.rs
@@ -36,33 +36,12 @@ pub enum DataQuery {
 }
 
 impl DataQuery {
-    /// Creates a Response containing an error, with the Response variant corresponding to the
-    /// Request.
-    pub fn to_error_response(&self, error: Error) -> QueryResponse {
-        match self {
-            Self::GetChunk(_) => QueryResponse::GetChunk(Err(error)),
-            Self::Register(q) => q.to_error_response(error),
-            Self::Spentbook(q) => q.to_error_response(error),
-        }
-    }
-
     /// Returns the xorname of the data destination for `request`.
     pub fn dst_name(&self) -> XorName {
         match self {
             Self::GetChunk(address) => *address.name(),
             Self::Register(q) => q.dst_name(),
             Self::Spentbook(q) => q.dst_name(),
-        }
-    }
-
-    /// Returns the address of the data
-    pub fn address(&self) -> DataAddress {
-        match self {
-            Self::GetChunk(address) => DataAddress::Bytes(*address),
-            Self::Register(read) => DataAddress::Register(read.dst_address()),
-            Self::Spentbook(read) => {
-                DataAddress::Spentbook(SpentbookAddress::new(*read.dst_address().name()))
-            }
         }
     }
 }

--- a/sn_interface/src/messaging/data/query.rs
+++ b/sn_interface/src/messaging/data/query.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{register::RegisterQuery, spentbook::SpentbookQuery, Error, QueryResponse};
-use crate::types::{ChunkAddress, DataAddress, SpentbookAddress};
+use super::{register::RegisterQuery, spentbook::SpentbookQuery};
+use crate::types::ChunkAddress;
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
@@ -25,7 +25,7 @@ pub enum DataQuery {
     /// This should eventually lead to a [`GetChunk`] response.
     ///
     /// [`Chunk`]:  crate::types::Chunk
-    /// [`GetChunk`]: QueryResponse::GetChunk
+    /// [`GetChunk`]: super::QueryResponse::GetChunk
     GetChunk(ChunkAddress),
     /// [`Register`] read operation.
     ///

--- a/sn_interface/src/messaging/data/register.rs
+++ b/sn_interface/src/messaging/data/register.rs
@@ -224,15 +224,4 @@ impl RegisterCmd {
             Self::Edit(cmd) => cmd.dst_address(),
         }
     }
-
-    /// Owner of the Register
-    pub fn owner(&self) -> Option<User> {
-        match self {
-            Self::Create {
-                cmd: SignedRegisterCreate { op, .. },
-                ..
-            } => Some(op.owner()),
-            _ => None,
-        }
-    }
 }

--- a/sn_interface/src/messaging/msg_kind.rs
+++ b/sn_interface/src/messaging/msg_kind.rs
@@ -47,13 +47,6 @@ impl MsgKind {
             _ => false,
         }
     }
-    /// is a client query msg
-    pub fn is_client_query(&self) -> bool {
-        match self {
-            Self::Client { query_index, .. } => query_index.is_some(),
-            _ => false,
-        }
-    }
     /// return query index
     pub fn query_index(&self) -> &Option<usize> {
         match self {

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -18,7 +18,6 @@ use bytes::{BufMut, Bytes, BytesMut};
 use custom_debug::Debug;
 use qp2p::UsrMsgBytes;
 use serde::Serialize;
-use xor_name::XorName;
 
 /// In order to send a message over the wire, it needs to be serialized
 /// along with a header (`WireMsgHeader`) which contains the information needed

--- a/sn_interface/src/messaging/serialisation/wire_msg.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg.rs
@@ -79,24 +79,6 @@ impl WireMsg {
         Self::serialize_dst_payload(&self.dst)
     }
 
-    /// Serialize into a WireMsg for Node Join
-    pub fn single_src_node(name: XorName, dst: Dst, msg: NodeMsg) -> Result<WireMsg> {
-        let msg_payload = WireMsg::serialize_msg_payload(&msg)
-            .map_err(|_| Error::Serialisation("Could not serialise node msg".to_string()))?;
-
-        let wire_msg = WireMsg::new_msg(
-            MsgId::new(),
-            msg_payload,
-            MsgKind::Node {
-                name,
-                is_join: msg.is_join(),
-            },
-            dst,
-        );
-
-        Ok(wire_msg)
-    }
-
     /// Creates a new `WireMsg` with the provided serialized payload and `MsgKind`.
     pub fn new_msg(msg_id: MsgId, payload: Bytes, kind: MsgKind, dst: Dst) -> Self {
         Self {
@@ -232,11 +214,6 @@ impl WireMsg {
         &self.header.msg_envelope.kind
     }
 
-    /// Return the destination section `PublicKey` for this message
-    pub fn dst_section_key(&self) -> bls::PublicKey {
-        self.dst.section_key
-    }
-
     /// Return the dst of this msg
     pub fn dst(&self) -> &Dst {
         &self.dst
@@ -288,7 +265,7 @@ mod tests {
         assert_eq!(deserialized, wire_msg);
         assert_eq!(deserialized.msg_id(), wire_msg.msg_id());
         assert_eq!(deserialized.dst(), &dst);
-        assert_eq!(deserialized.dst_section_key(), dst.section_key);
+        assert_eq!(deserialized.dst().section_key, dst.section_key);
 
         // test deserialisation of payload
         assert_eq!(deserialized.into_msg()?, NetworkMsg::Node(msg),);
@@ -330,7 +307,7 @@ mod tests {
         assert_eq!(deserialized, wire_msg);
         assert_eq!(deserialized.msg_id(), wire_msg.msg_id());
         assert_eq!(deserialized.dst(), &dst);
-        assert_eq!(deserialized.dst_section_key(), dst.section_key);
+        assert_eq!(deserialized.dst().section_key, dst.section_key);
 
         // test deserialisation of payload
         assert_eq!(

--- a/sn_interface/src/messaging/serialisation/wire_msg_header.rs
+++ b/sn_interface/src/messaging/serialisation/wire_msg_header.rs
@@ -154,11 +154,4 @@ impl WireMsgHeader {
 
         Ok(buffer_writer.into_inner().freeze())
     }
-
-    // Message Pack uses type tags, but also variable length encoding, so we expect that serialized
-    // `MsgEnvelope`s size will typically be ≤ their in-memory size. This should only be relied on
-    // as a 'ballpark' estimate.
-    pub fn max_size() -> u16 {
-        (HeaderMeta::SIZE + size_of::<MsgEnvelope>()) as u16
-    }
 }

--- a/sn_interface/src/messaging/system/dkg.rs
+++ b/sn_interface/src/messaging/system/dkg.rs
@@ -34,27 +34,6 @@ pub struct DkgSessionId {
     pub membership_gen: Generation,
 }
 impl DkgSessionId {
-    pub fn new(
-        prefix: Prefix,
-        elders: BTreeMap<XorName, SocketAddr>,
-        section_chain_len: u64,
-        bootstrap_members: BTreeSet<NodeState>,
-        membership_gen: Generation,
-    ) -> Self {
-        assert!(elders
-            .keys()
-            .all(|e| bootstrap_members.iter().any(|m| &m.name() == e)));
-
-        // Calculate the hash without involving serialization to avoid having to return `Result`.
-        Self {
-            prefix,
-            elders,
-            section_chain_len,
-            bootstrap_members,
-            membership_gen,
-        }
-    }
-
     pub fn hash(&self) -> Digest256 {
         let mut hasher = Sha3::v256();
         self.hash_update(&mut hasher);
@@ -95,9 +74,5 @@ impl DkgSessionId {
 
     pub fn elder_index(&self, elder: XorName) -> Option<usize> {
         self.elder_names().sorted().position(|p| p == elder)
-    }
-
-    pub fn contains_elder(&self, elder: XorName) -> bool {
-        self.elder_names().any(|e| e == elder)
     }
 }

--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -18,16 +18,6 @@ pub struct JoinRequest {
     pub section_key: bls::PublicKey,
 }
 
-impl JoinRequest {
-    pub fn section_key(&self) -> bls::PublicKey {
-        self.section_key
-    }
-
-    pub fn set_section_key(&mut self, section_key: bls::PublicKey) {
-        self.section_key = section_key;
-    }
-}
-
 /// Response to a request to join a section
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum JoinResponse {

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -134,33 +134,6 @@ impl NodeMsg {
     }
 }
 
-impl NodeMsg {
-    pub fn statemap_states(&self) -> crate::statemap::State {
-        use crate::statemap::State;
-        match self {
-            Self::Relocate(_) => State::Relocate,
-            Self::BeginRelocating(_) => State::Relocate,
-            Self::RelocationRequest { .. } => State::Relocate,
-            Self::MembershipAE(_) => State::Membership,
-            Self::MembershipVotes(_) => State::Membership,
-            Self::TryJoin(_) => State::Join,
-            Self::JoinResponse(_) => State::Join,
-            Self::DkgStart { .. } => State::Dkg,
-            Self::DkgEphemeralPubKey { .. } => State::Dkg,
-            Self::DkgVotes { .. } => State::Dkg,
-            Self::DkgAE { .. } => State::Dkg,
-            Self::RequestHandover { .. } => State::Dkg,
-            Self::HandoverVotes(_) => State::Handover,
-            Self::HandoverAE(_) => State::Handover,
-            Self::SectionHandoverPromotion { .. } => State::Handover,
-            Self::SectionSplitPromotion { .. } => State::Handover,
-            Self::ProposeNodeOff { .. } => State::Propose,
-            Self::NodeEvent(_) => State::Node,
-            Self::NodeDataCmd(_) => State::Node,
-        }
-    }
-}
-
 impl Display for NodeMsg {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -48,7 +48,6 @@ use sn_consensus::Decision;
 use std::{
     collections::{BTreeMap, BTreeSet},
     iter,
-    net::SocketAddr,
 };
 use xor_name::{Prefix, XorName};
 

--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -422,11 +422,6 @@ impl NetworkKnowledge {
         self.section_tree.get_sections_dag().has_key(section_key)
     }
 
-    /// Return the set of known keys
-    pub fn known_keys(&self) -> BTreeSet<bls::PublicKey> {
-        self.section_tree.get_sections_dag().keys().collect()
-    }
-
     /// Try to merge this `NetworkKnowledge` members with `peers`.
     /// Checks if we're already up to date before attempting to verify and merge members
     pub fn merge_members(&mut self, peers: BTreeSet<Decision<NodeState>>) -> Result<bool> {
@@ -530,33 +525,14 @@ impl NetworkKnowledge {
         self.section_peers.archived_members()
     }
 
-    /// Returns current section size, i.e. number of peers in the section.
-    pub fn section_size(&self) -> usize {
-        self.section_peers.num_of_members()
-    }
-
     /// Get info for the member with the given name.
     pub fn get_section_member(&self, name: &XorName) -> Option<NodeState> {
         self.section_peers.get(name)
     }
 
-    /// Get info for the member with the given name either from current members list,
-    /// or from the archive of left/relocated members
-    pub fn is_either_member_or_archived(&self, name: &XorName) -> Option<NodeState> {
-        self.section_peers.is_either_member_or_archived(name)
-    }
-
     /// Get info for the member with the given name.
     pub fn is_section_member(&self, name: &XorName) -> bool {
         self.section_peers.is_member(name)
-    }
-
-    pub fn find_member_by_addr(&self, addr: &SocketAddr) -> Option<Peer> {
-        self.section_peers
-            .members()
-            .into_iter()
-            .find(|info| info.addr() == *addr)
-            .map(|info| *info.peer())
     }
 
     pub fn anti_entropy_probe(&self) -> NetworkMsg {

--- a/sn_interface/src/network_knowledge/section_peers.rs
+++ b/sn_interface/src/network_knowledge/section_peers.rs
@@ -63,11 +63,6 @@ impl SectionPeers {
         node_state_list
     }
 
-    /// Returns the number of current members.
-    pub(super) fn num_of_members(&self) -> usize {
-        self.members().len()
-    }
-
     /// Get the `NodeState` for the member with the given name.
     pub(super) fn get(&self, name: &XorName) -> Option<NodeState> {
         self.members()
@@ -79,18 +74,6 @@ impl SectionPeers {
     /// Returns whether the given peer is currently a member of our section.
     pub(super) fn is_member(&self, name: &XorName) -> bool {
         self.get(name).is_some()
-    }
-
-    /// Get section signed `NodeState` for the member with the given name.
-    pub(super) fn is_either_member_or_archived(&self, name: &XorName) -> Option<NodeState> {
-        if let Some(member) = self.get(name) {
-            Some(member)
-        } else {
-            self.archived_members()
-                .iter()
-                .find(|node_state| node_state.name() == *name)
-                .cloned()
-        }
     }
 
     /// Update a member of our section.

--- a/sn_interface/src/network_knowledge/section_tree/mod.rs
+++ b/sn_interface/src/network_knowledge/section_tree/mod.rs
@@ -507,23 +507,6 @@ pub mod test_utils {
                 .expect("Failed to insert into proof_chain");
             SectionTreeUpdate::new(sap.clone(), proof_chain)
         }
-
-        /// Generate a proof chain from the provided `genesis_key` followed by all keys provided in `other_keys`
-        pub fn gen_proof_chain(
-            genesis_key: &bls::SecretKey,
-            other_keys: &Vec<bls::SecretKey>,
-        ) -> SectionsDAG {
-            let mut proof_chain = SectionsDAG::new(genesis_key.public_key());
-            let mut parent = genesis_key.clone();
-            for key in other_keys {
-                let sig = parent.sign(key.public_key().to_bytes());
-                proof_chain
-                    .verify_and_insert(&parent.public_key(), key.public_key(), sig)
-                    .expect("Failed to insert into proof_chain");
-                parent = key.clone();
-            }
-            proof_chain
-        }
     }
 }
 

--- a/sn_interface/src/types/address/mod.rs
+++ b/sn_interface/src/types/address/mod.rs
@@ -48,16 +48,6 @@ impl DataAddress {
     pub fn bytes(name: XorName) -> Self {
         Self::Bytes(ChunkAddress(name))
     }
-
-    ///
-    pub fn safe_key(name: XorName) -> Self {
-        Self::SafeKey(name)
-    }
-
-    ///
-    pub fn spentbook(name: XorName) -> Self {
-        Self::Spentbook(SpentbookAddress::new(name))
-    }
 }
 
 /// Address of a Chunk.

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -47,8 +47,6 @@ use xor_name::XorName;
 // still not implemented, it uses a Public Register for now.
 pub const SPENTBOOK_TYPE_TAG: u64 = 0;
 
-const REGISTER_CMD_SIZE: usize = 300;
-
 /// Register data exchange.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReplicatedRegisterLog {

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -23,7 +23,6 @@ mod chunk;
 mod errors;
 mod peer;
 
-use crate::messaging::data::CmdResponse;
 pub use crate::messaging::{
     data::{Error as DataError, RegisterCmd},
     SectionSig,

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -98,30 +98,4 @@ impl ReplicatedData {
             }
         }
     }
-
-    pub fn size(&self) -> u64 {
-        let length = match self {
-            Self::Chunk(chunk) => chunk.payload_size(),
-            Self::RegisterWrite(_) | Self::SpentbookWrite(_) => REGISTER_CMD_SIZE,
-            Self::RegisterLog(log) | Self::SpentbookLog(log) => {
-                REGISTER_CMD_SIZE * log.op_log.len()
-            }
-        };
-        length as u64
-    }
-
-    pub fn error_response(&self, error: DataError) -> Result<CmdResponse> {
-        match self {
-            Self::Chunk(_) => Ok(CmdResponse::StoreChunk(Err(error))),
-            Self::RegisterWrite(RegisterCmd::Create { .. }) => {
-                Ok(CmdResponse::CreateRegister(Err(error)))
-            }
-            Self::RegisterWrite(RegisterCmd::Edit { .. }) => {
-                Ok(CmdResponse::EditRegister(Err(error)))
-            }
-            Self::SpentbookWrite(_) => Ok(CmdResponse::SpendKey(Err(error))),
-            Self::SpentbookLog(_) => Err(Error::NoCmdResponseForTheVariant), // should be unreachable, since `SpentbookLog` is not resulting from a cmd.
-            Self::RegisterLog(_) => Err(Error::NoCmdResponseForTheVariant), // should be unreachable, since `RegisterLog` is not resulting from a cmd.,
-        }
-    }
 }

--- a/sn_interface/src/types/peer.rs
+++ b/sn_interface/src/types/peer.rs
@@ -41,10 +41,6 @@ impl Peer {
         calc_age(&self.name)
     }
 
-    pub fn id(&self) -> (XorName, SocketAddr) {
-        (self.name, self.addr)
-    }
-
     pub fn from(addr: SocketAddr, public_key: ed25519_dalek::PublicKey) -> Peer {
         Peer {
             addr,

--- a/sn_interface/src/types/register/mod.rs
+++ b/sn_interface/src/types/register/mod.rs
@@ -96,11 +96,6 @@ impl Register {
         self.crdt.size()
     }
 
-    /// Return true if the register is empty.
-    pub fn is_empty(&self) -> bool {
-        self.size() == 0
-    }
-
     /// Return a value corresponding to the provided 'hash', if present.
     pub fn get(&self, hash: EntryHash) -> Result<&Entry> {
         self.crdt.get(hash).ok_or(Error::NoSuchEntry(hash))

--- a/sn_interface/src/types/register/policy.rs
+++ b/sn_interface/src/types/register/policy.rs
@@ -28,11 +28,6 @@ impl Permissions {
         }
     }
 
-    /// Sets permissions.
-    pub fn set_perms(&mut self, write: impl Into<Option<bool>>) {
-        self.write = write.into();
-    }
-
     /// Returns `Some(true)` if `action` is allowed and `Some(false)` if it's not permitted.
     /// `None` means that default permissions should be applied.
     pub fn is_allowed(self, action: Action) -> Option<bool> {

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -9,7 +9,7 @@
 use crate::{
     node::{
         flow_ctrl::{cmds::Cmd, fault_detection::FaultsCmd},
-        Error, MyNode, Result,
+        MyNode, Result,
     },
     UsedSpace,
 };
@@ -18,7 +18,7 @@ use sn_comms::Comm;
 use sn_interface::{
     dbcs::gen_genesis_dbc,
     messaging::system::SectionSigned,
-    network_knowledge::{NetworkKnowledge, SectionKeyShare, SectionsDAG, GENESIS_DBC_SK},
+    network_knowledge::{NetworkKnowledge, SectionsDAG, GENESIS_DBC_SK},
     types::{log_markers::LogMarker, Peer},
     SectionAuthorityProvider,
 };
@@ -84,20 +84,6 @@ impl MyNode {
 
     pub(crate) fn is_not_elder(&self) -> bool {
         !self.is_elder()
-    }
-
-    /// Returns the current BLS public key set
-    pub(crate) fn public_key_set(&self) -> Result<bls::PublicKeySet> {
-        Ok(self.key_share()?.public_key_set)
-    }
-
-    /// Returns our key share in the current BLS group if this node is a member of one, or
-    /// `Error::MissingSecretKeyShare` otherwise.
-    pub(crate) fn key_share(&self) -> Result<SectionKeyShare> {
-        let section_key = self.network_knowledge.section_key();
-        self.section_keys_provider
-            .key_share(&section_key)
-            .map_err(Error::from)
     }
 
     // ----------------------------------------------------------------------------------------

--- a/sn_node/src/node/cfg/config_handler.rs
+++ b/sn_node/src/node/cfg/config_handler.rs
@@ -18,7 +18,7 @@ use tokio::{
     fs::{self, File},
     io::AsyncWriteExt,
 };
-use tracing::{debug, error, warn, Level};
+use tracing::{error, Level};
 
 pub(crate) const DEFAULT_MIN_CAPACITY: usize = 1024 * 1024 * 1024; // 1gb
 pub(crate) const DEFAULT_MAX_CAPACITY: usize = 2 * DEFAULT_MIN_CAPACITY;

--- a/sn_node/src/node/cfg/config_handler.rs
+++ b/sn_node/src/node/cfg/config_handler.rs
@@ -212,16 +212,6 @@ impl Config {
         })
     }
 
-    /// Set the root directory for dbs and cached state.
-    pub fn set_root_dir<P: Into<PathBuf>>(&mut self, path: P) {
-        self.root_dir = Some(path.into())
-    }
-
-    /// Set the directory to write the logs.
-    pub fn set_log_dir<P: Into<PathBuf>>(&mut self, path: P) {
-        self.log_dir = Some(path.into())
-    }
-
     /// Get the log level.
     pub fn verbose(&self) -> Level {
         match self.verbose {
@@ -292,34 +282,6 @@ impl Config {
         }
 
         Ok(())
-    }
-
-    /// Reads the default node config file.
-    #[allow(unused)]
-    async fn read_from_file() -> Result<Option<Config>> {
-        let path = project_dirs()?.join(CONFIG_FILE);
-
-        match fs::read(path.clone()).await {
-            Ok(content) => {
-                debug!("Reading settings from {}", path.display());
-
-                serde_json::from_slice(&content).map_err(|err| {
-                    warn!(
-                        "Could not parse content of config file '{:?}': {:?}",
-                        path, err
-                    );
-                    err.into()
-                })
-            }
-            Err(error) => {
-                if error.kind() == std::io::ErrorKind::NotFound {
-                    warn!("No config file available at {:?}", path);
-                    Ok(None)
-                } else {
-                    Err(error.into())
-                }
-            }
-        }
     }
 
     /// Writes the config file to disk

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -123,7 +123,7 @@ mod core {
     }
 
     #[derive(custom_debug::Debug, Clone)]
-    pub struct NodeContext {
+    pub(crate) struct NodeContext {
         pub(crate) root_storage_dir: PathBuf,
         pub(crate) is_elder: bool,
         pub(crate) data_storage: DataStorage,

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -53,7 +53,7 @@ mod core {
             handover::Handover,
             membership::{elder_candidates, try_split_dkg, Membership},
             messaging::Peers,
-            DataStorage, Error, Result, XorName,
+            DataStorage, Result, XorName,
         },
         UsedSpace,
     };
@@ -142,16 +142,6 @@ mod core {
     }
 
     impl NodeContext {
-        /// Returns the SAP of the section matching the name.
-        pub(crate) fn section_sap_matching_name(
-            &self,
-            name: &XorName,
-        ) -> Result<SectionAuthorityProvider> {
-            self.network_knowledge
-                .section_auth_by_name(name)
-                .map_err(Error::from)
-        }
-
         /// Log an issue in dysfunction
         /// Spawns a process to send this incase the channel may be full, we don't hold up
         /// processing around this (as this can be called during dkg eg)

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -6,12 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::{CmdChannel, Error, MyNode, Result};
+use crate::node::{CmdChannel, MyNode};
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
-
-use super::flow_ctrl::cmds::Cmd;
 
 /// Test interface for sending and receiving messages to and from other nodes.
 ///
@@ -19,24 +17,10 @@ use super::flow_ctrl::cmds::Cmd;
 /// location. Its methods can be used to send requests and responses as either an individual
 /// `Node` or as a part of a section or group location.
 #[allow(missing_debug_implementations)]
-pub struct NodeTestApi {
-    node: Arc<RwLock<MyNode>>,
-    cmd_channel: CmdChannel,
-}
+pub struct NodeTestApi {}
 
 impl NodeTestApi {
-    pub(crate) fn new(node: Arc<RwLock<MyNode>>, cmd_channel: CmdChannel) -> Self {
-        Self { node, cmd_channel }
-    }
-
-    /// Send a message.
-    /// Messages sent here, either section to section or node to node.
-    async fn send_cmd(&self, cmd: Cmd) -> Result<()> {
-        self.cmd_channel
-            .send((cmd, vec![]))
-            .await
-            .map_err(|_| Error::CmdChannelSendError)?;
-
-        Ok(())
+    pub(crate) fn new(_node: Arc<RwLock<MyNode>>, _cmd_channel: CmdChannel) -> Self {
+        Self {}
     }
 }

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -36,73 +36,6 @@ impl NodeTestApi {
         Self { node, cmd_channel }
     }
 
-    /// Returns the current age of this node.
-    pub async fn age(&self) -> u8 {
-        self.node.read().await.info().age()
-    }
-
-    /// Returns the current NodeContext
-    pub async fn context(&self) -> NodeContext {
-        self.node.read().await.context()
-    }
-
-    /// Returns the ed25519 public key of this node.
-    pub async fn public_key(&self) -> PublicKey {
-        self.node.read().await.keypair.public
-    }
-
-    /// The name of this node.
-    pub async fn name(&self) -> XorName {
-        self.node.read().await.info().name()
-    }
-
-    /// Returns connection info of this node.
-    pub async fn our_connection_info(&self) -> SocketAddr {
-        self.node.read().await.info().addr
-    }
-
-    /// Returns the Section Signed Chain
-    pub async fn section_chain(&self) -> SectionsDAG {
-        self.node.read().await.section_chain()
-    }
-
-    /// Returns the Section Chain's genesis key
-    pub async fn genesis_key(&self) -> bls::PublicKey {
-        *self.node.read().await.network_knowledge().genesis_key()
-    }
-
-    /// Prefix of our section
-    pub async fn our_prefix(&self) -> Prefix {
-        self.node.read().await.network_knowledge().prefix()
-    }
-
-    /// Returns whether the node is Elder.
-    pub async fn is_elder(&self) -> bool {
-        self.node.read().await.is_elder()
-    }
-
-    /// Returns the information of all the current section elders.
-    pub async fn our_elders(&self) -> BTreeSet<Peer> {
-        self.node.read().await.network_knowledge().elders()
-    }
-
-    /// Returns the information of all the current section adults.
-    pub async fn our_adults(&self) -> BTreeSet<Peer> {
-        self.node.read().await.network_knowledge().adults()
-    }
-
-    /// Returns the info about the section matching the name.
-    pub async fn matching_section(&self, name: &XorName) -> Result<SectionAuthorityProvider> {
-        let context = &self.node.read().await.context();
-        context.section_sap_matching_name(name)
-    }
-
-    /// Send a system msg.
-    pub async fn send(&self, msg: NodeMsg, recipients: BTreeSet<Peer>) -> Result<()> {
-        let cmd = Cmd::send_msg(msg, Peers::Multiple(recipients), self.context().await);
-        self.send_cmd(cmd).await
-    }
-
     /// Send a message.
     /// Messages sent here, either section to section or node to node.
     async fn send_cmd(&self, cmd: Cmd) -> Result<()> {
@@ -112,11 +45,5 @@ impl NodeTestApi {
             .map_err(|_| Error::CmdChannelSendError)?;
 
         Ok(())
-    }
-
-    /// Returns the current BLS public key set if this node has one, or
-    /// `Error::MissingSecretKeyShare` otherwise.
-    pub async fn public_key_set(&self) -> Result<bls::PublicKeySet> {
-        self.node.read().await.public_key_set()
     }
 }

--- a/sn_node/src/node/node_test_api.rs
+++ b/sn_node/src/node/node_test_api.rs
@@ -6,19 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::{core::NodeContext, CmdChannel, Error, MyNode, Peer, Result};
+use crate::node::{CmdChannel, Error, MyNode, Result};
 
-use sn_interface::{
-    messaging::system::NodeMsg,
-    network_knowledge::{SectionAuthorityProvider, SectionsDAG},
-};
-
-use ed25519_dalek::PublicKey;
-use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::RwLock;
-use xor_name::{Prefix, XorName};
 
-use super::{flow_ctrl::cmds::Cmd, messaging::Peers};
+use super::flow_ctrl::cmds::Cmd;
 
 /// Test interface for sending and receiving messages to and from other nodes.
 ///


### PR DESCRIPTION
This PR was produced with the help of [warnalyzer](https://github.com/est31/warnalyzer), which attempts to analyze a workspace like `safe_network` and spot APIs that are not used within the project. This is not picked up by default tools, as these are marked with `pub`.

Interesting to see if this might have an impact on build times.


- refactor: remove unused pub fn/methods
- refactor: fix clippy lints; fmt
- refactor: remove more unused pub

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
