### PR TITLE
fix: ae updates and affects split into sap and member updates

### DIFF
--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -234,10 +234,9 @@ impl NetworkKnowledge {
     }
 
     /// Update our network knowledge with the provided `SectionTreeUpdate`
-    pub fn update_knowledge_if_valid(
+    pub fn update_sap_knowledge_if_valid(
         &mut self,
         section_tree_update: SectionTreeUpdate,
-        updated_members: Option<SectionPeersMsg>,
         our_name: &XorName,
     ) -> Result<bool> {
         trace!("Attempting to update network knoweldge");
@@ -283,6 +282,17 @@ impl NetworkKnowledge {
                 return Err(err);
             }
         }
+
+        Ok(there_was_an_update)
+    }
+
+    /// Update our network knowledge with the provided `SectionTreeUpdate`
+    pub fn update_section_member_knowledge(
+        &mut self,
+        updated_members: Option<SectionPeersMsg>,
+    ) -> Result<bool> {
+        trace!("Attempting to update section member's knowledge");
+        let mut there_was_an_update = false;
 
         // Update members if changes were provided
         if let Some(members) = updated_members {
@@ -626,11 +636,8 @@ mod tests {
         let proof_chain = knowledge.section_chain();
         let section_tree_update =
             TestSectionTree::get_section_tree_update(&sap1, &proof_chain, &sk_gen.secret_key());
-        assert!(knowledge.update_knowledge_if_valid(
-            section_tree_update,
-            None,
-            &our_node_name_prefix_1
-        )?);
+        assert!(knowledge
+            .update_sap_knowledge_if_valid(section_tree_update, &our_node_name_prefix_1)?);
         assert_eq!(knowledge.signed_sap, sap1);
 
         // section with different prefix (0) and our node name doesn't match
@@ -639,11 +646,8 @@ mod tests {
         let section_tree_update =
             TestSectionTree::get_section_tree_update(&sap0, &proof_chain, &sk_gen.secret_key());
         // our node is still in prefix1
-        assert!(knowledge.update_knowledge_if_valid(
-            section_tree_update,
-            None,
-            &our_node_name_prefix_1
-        )?);
+        assert!(knowledge
+            .update_sap_knowledge_if_valid(section_tree_update, &our_node_name_prefix_1)?);
         // sap should not be updated
         assert_eq!(knowledge.signed_sap, sap1);
 

--- a/sn_node/src/node/flow_ctrl/dispatcher.rs
+++ b/sn_node/src/node/flow_ctrl/dispatcher.rs
@@ -189,9 +189,8 @@ impl Dispatcher {
                     let mut node = node.write().await;
                     let name = node.name();
                     trace!("[NODE WRITE]: update client write got");
-                    node.network_knowledge.update_knowledge_if_valid(
+                    node.network_knowledge.update_sap_knowledge_if_valid(
                         SectionTreeUpdate::new(signed_sap, proof_chain),
-                        None,
                         &name,
                     )?
                 };

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -167,7 +167,7 @@ impl<'a> ProcessAndInspectCmds<'a> {
     }
 
     pub(crate) async fn next(&mut self) -> crate::node::error::Result<Option<&Cmd>> {
-        let mut next_index = self.index_inspected + 1;
+        let mut next_index = self.index_inspected.wrapping_add(1);
         if next_index < self.pending_cmds.len() {
             let cmd = self.pending_cmds.get(next_index);
             assert!(cmd.is_some());

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -614,7 +614,7 @@ async fn handle_elders_update() -> Result<()> {
         // Merging the section contained in the message with the original section succeeds.
         assert!(section0
             .clone()
-            .update_knowledge_if_valid(section_tree_update, None, &info.name())
+            .update_sap_knowledge_if_valid(section_tree_update, &info.name())
             .is_ok());
 
         update_actual_recipients.extend(recipients);

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -133,11 +133,11 @@ impl MyNode {
                         to update the node network knowledge before processing the spend."
                     );
                     let name = context.name;
-                    let there_was_an_update = context.network_knowledge.update_knowledge_if_valid(
-                        SectionTreeUpdate::new(signed_sap.clone(), proof_chain.clone()),
-                        None,
-                        &name,
-                    )?;
+                    let there_was_an_update =
+                        context.network_knowledge.update_sap_knowledge_if_valid(
+                            SectionTreeUpdate::new(signed_sap.clone(), proof_chain.clone()),
+                            &name,
+                        )?;
 
                     if there_was_an_update {
                         // To avoid a loop, recompose the message without the updated proof_chain.

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -821,7 +821,7 @@ impl MyNode {
         // it to sign any msg that needs section agreement.
         self.section_keys_provider.insert(key_share.clone());
 
-        let mut cmds = self.update_on_section_change(&self.context()).await?;
+        let mut cmds = self.update_on_sap_change(&self.context()).await?;
 
         if !self.network_knowledge.has_chain_key(&sap.section_key()) {
             // This request is sent to the current set of elders to be aggregated

--- a/sn_node/src/node/messaging/promotion.rs
+++ b/sn_node/src/node/messaging/promotion.rs
@@ -188,11 +188,9 @@ impl MyNode {
         )?;
         let their_prefix = their_sap.prefix();
         let section_tree_update = SectionTreeUpdate::new(their_sap, parent_section_chain);
-        let updated = self.network_knowledge.update_knowledge_if_valid(
-            section_tree_update,
-            None,
-            &self.name(),
-        )?;
+        let updated = self
+            .network_knowledge
+            .update_sap_knowledge_if_valid(section_tree_update, &self.name())?;
         if updated {
             let context = self.context();
             info!("Updated our network knowledge for {:?}", their_prefix);
@@ -231,10 +229,10 @@ impl MyNode {
         let name = old_context.name;
         let updated = self
             .network_knowledge
-            .update_knowledge_if_valid(update, None, &name)?;
+            .update_sap_knowledge_if_valid(update, &name)?;
 
         if updated {
-            let cmds = self.update_on_section_change(&old_context).await;
+            let cmds = self.update_on_sap_change(&old_context).await;
 
             let latest_context = self.context();
             info!("Updated our network knowledge for {:?}", prefix);

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -540,11 +540,8 @@ mod core {
             }
         }
 
-        /// Updates various state if elders changed.
-        pub(crate) async fn update_on_section_change(
-            &mut self,
-            old: &NodeContext,
-        ) -> Result<Vec<Cmd>> {
+        /// Updates various state if elders SAP changed.
+        pub(crate) async fn update_on_sap_change(&mut self, old: &NodeContext) -> Result<Vec<Cmd>> {
             let new = self.context();
             let new_section_key = new.network_knowledge.section_key();
             let new_prefix = new.network_knowledge.prefix();


### PR DESCRIPTION
We were only updating members if the SAP changed. We were attempting to terminate DKG runs if members changed.

Now those two flows are distinct

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
