### PR TITLE
Remove DKG sessions with absent members on membership update

### DIFF
--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -188,6 +188,10 @@ impl MyNode {
                     .network_knowledge
                     .update_section_member_knowledge(members)?;
 
+                if updated_members {
+                    write_locked_node.remove_dkg_sessions_with_missing_members();
+                }
+
                 if updated_knowledge {
                     debug!("net knowledge updated");
                     cmds.extend(

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -551,7 +551,7 @@ mod core {
             let missing_members_hashes = Vec::from_iter(
                 self.dkg_sessions_info
                     .iter()
-                    .filter(|(_, info)| info.session_id.elders.keys().all(is_member))
+                    .filter(|(_, info)| !info.session_id.elders.keys().all(is_member))
                     .map(|(hash, _)| *hash),
             );
             for hash in missing_members_hashes {

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -540,6 +540,31 @@ mod core {
             }
         }
 
+        pub(crate) fn remove_dkg_sessions_with_missing_members(&mut self) {
+            let current_section_members: BTreeSet<_> = self
+                .network_knowledge
+                .members()
+                .iter()
+                .map(|m| m.name())
+                .collect();
+            let is_member = |m: &XorName| current_section_members.contains(m);
+            let missing_members_hashes = Vec::from_iter(
+                self.dkg_sessions_info
+                    .iter()
+                    .filter(|(_, info)| info.session_id.elders.keys().all(is_member))
+                    .map(|(hash, _)| *hash),
+            );
+            for hash in missing_members_hashes {
+                if let Some(info) = self.dkg_sessions_info.remove(&hash) {
+                    debug!(
+                        "Removed old DKG s{} containing members that are not in our section anymore.",
+                        info.session_id.sh(),
+                    );
+                }
+                self.dkg_voter.remove(&hash);
+            }
+        }
+
         /// Updates various state if elders SAP changed.
         pub(crate) async fn update_on_sap_change(&mut self, old: &NodeContext) -> Result<Vec<Cmd>> {
             let new = self.context();


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->

When membership is updated by an AE message, we check if our ongoing DKGs contain any non-member candidates as to avoid wasting energy on messages for nodes that are not in our section anymore. 
This fixes some DKG gossip loops we've been seeing, with nodes ignoring DKG gossip because they where relocated and the others gossiping forever in the hopes of seeing them back! 