### PR TITLE
chore: clarify relocation flow

### DIFF
--- a/sn_interface/src/network_knowledge/mod.rs
+++ b/sn_interface/src/network_knowledge/mod.rs
@@ -24,8 +24,7 @@ pub use self::{
     errors::{Error, Result},
     node_info::MyNodeInfo,
     node_state::{
-        MembershipState, NodeState, RelocationDst, RelocationInfo, RelocationProof,
-        RelocationState, RelocationTrigger,
+        MembershipState, NodeState, RelocationDst, RelocationInfo, RelocationProof, RelocationState,
     },
     section_authority_provider::{SapCandidate, SectionAuthUtils, SectionAuthorityProvider},
     section_keys::{SectionKeyShare, SectionKeysProvider},

--- a/sn_interface/src/network_knowledge/node_state/mod.rs
+++ b/sn_interface/src/network_knowledge/node_state/mod.rs
@@ -8,9 +8,7 @@
 
 mod relocation;
 
-pub use relocation::{
-    RelocationDst, RelocationInfo, RelocationProof, RelocationState, RelocationTrigger,
-};
+pub use relocation::{RelocationDst, RelocationInfo, RelocationProof, RelocationState};
 
 use crate::network_knowledge::{section_has_room_for_node, Error, Result};
 use crate::types::Peer;

--- a/sn_interface/src/network_knowledge/section_peers.rs
+++ b/sn_interface/src/network_knowledge/section_peers.rs
@@ -334,9 +334,7 @@ mod tests {
             let node_state = match membership_state {
                 MembershipState::Joined => NodeState::joined(peer, None),
                 MembershipState::Left => NodeState::left(peer, None),
-                MembershipState::Relocated(ref dst) => {
-                    NodeState::relocated(peer, None, (*dst).clone())
-                }
+                MembershipState::Relocated(ref dst) => NodeState::relocated(peer, None, *dst),
             };
             let sectioin_signed_node_state = TestKeys::get_section_signed(secret_key, node_state);
             decisions.push(section_signed_to_decision(sectioin_signed_node_state));

--- a/sn_node/src/node/messaging/membership.rs
+++ b/sn_node/src/node/messaging/membership.rs
@@ -355,7 +355,7 @@ impl MyNode {
         if node_state.is_relocated() {
             let peer = *node_state.peer();
             info!("Notify relocation to node {:?}", peer);
-            let msg = NodeMsg::Relocate(node_state);
+            let msg = NodeMsg::CompleteRelocation(node_state);
             Some(Cmd::send_msg(msg, Peers::Single(peer), self.context()))
         } else {
             None

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -165,26 +165,23 @@ impl MyNode {
                     .await
                     .map(|c| c.into_iter().collect())
             }
-            NodeMsg::BeginRelocating(relocation_trigger) => {
+            NodeMsg::PrepareToRelocate(relocation_trigger) => {
                 let mut node = node.write().await;
-                trace!("[NODE WRITE]: BeginRelocating write gottt...");
-                trace!("Handling BeginRelocating msg from {sender}: {msg_id:?}");
-                Ok(node.handle_begin_relocating(relocation_trigger))
+                trace!("[NODE WRITE]: PrepareToRelocate write gottt...");
+                trace!("Handling PrepareToRelocate msg from {sender}: {msg_id:?}");
+                Ok(node.prepare_to_relocate(relocation_trigger))
             }
-            NodeMsg::RelocationRequest {
-                relocation_node,
-                relocation_trigger,
-            } => {
+            NodeMsg::ProceedRelocation(dst) => {
                 let mut node = node.write().await;
-                trace!("[NODE WRITE]: RelocationRequest write gottt...");
-                trace!("Handling RelocationRequest msg from {sender}: {msg_id:?}");
-                Ok(node.handle_relocation_request(relocation_node, relocation_trigger)?)
+                trace!("[NODE WRITE]: ProceedRelocation write gottt...");
+                trace!("Handling ProceedRelocation msg from {sender}: {msg_id:?}");
+                Ok(node.proceed_relocation(sender.name(), dst)?)
             }
 
-            NodeMsg::Relocate(signed_relocation) => {
+            NodeMsg::CompleteRelocation(signed_relocation) => {
                 let mut node = node.write().await;
-                trace!("[NODE WRITE]: Relocated write gottt...");
-                trace!("Handling Relocate msg from {sender}: {msg_id:?}");
+                trace!("[NODE WRITE]: CompleteRelocation write gottt...");
+                trace!("Handling CompleteRelocation msg from {sender}: {msg_id:?}");
                 Ok(node.relocate(signed_relocation)?.into_iter().collect())
             }
             // The approval or rejection of a join (approval both for new network joiner as well as


### PR DESCRIPTION
This is intended to make it a little bit easier to get an intuition for what the back-and-forward process here is about.

The reason this was implemented in the first place is that due to membership changes being limited to one at a time, we needed the node to drive the process and keep polling the elders to get it to proceed, so that it in the end could be completed even in the presence of concurrent membership changes.

| 1. Elders->Node  | 2. Node->Elders (polling) | 3. Elders->Node |
| ------------- | ------------- | ------------- |
| PrepareToRelocate | ProceedRelocation | CompleteRelocation |
