### PR TITLE
fix(ci): adapt script to check joined nodes to log msgs changes

### DIFF
--- a/.github/workflows/benchmark_prs.yml
+++ b/.github/workflows/benchmark_prs.yml
@@ -9,7 +9,7 @@ concurrency:
 env:
   CARGO_INCREMENTAL: '0'
   RUST_BACKTRACE: 1
-  NODE_COUNT: 15
+  NODE_COUNT: 14
 
 jobs:
   benchmarks:

--- a/.github/workflows/benchmarks_pages.yml
+++ b/.github/workflows/benchmarks_pages.yml
@@ -15,7 +15,7 @@ permissions:
 env:
   CARGO_INCREMENTAL: '0'
   RUST_BACKTRACE: 1
-  NODE_COUNT: 15
+  NODE_COUNT: 14
 
 jobs:
   benchmark:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   CARGO_INCREMENTAL: 0 # bookkeeping for incremental builds has overhead, not useful in CI.
-  NODE_COUNT: 15
+  NODE_COUNT: 14
 
 jobs:
   cargo-udeps:
@@ -162,7 +162,7 @@ jobs:
         timeout-minutes: 50
 
       - name: Run sn_fault_detection tests
-        timeout-minutes: 15
+        timeout-minutes: 14
         env:
           RUST_LOG: sn_fault_detection
         run: cd sn_fault_detection && cargo test --release
@@ -542,7 +542,7 @@ jobs:
   #   name: E2E tests w/ full network
   #   runs-on: self-hosted-ubuntu
   #   env:
-  #     NODE_COUNT: 15
+  #     NODE_COUNT: 14
   #   steps:
   #     - uses: actions/checkout@v2
 
@@ -602,7 +602,7 @@ jobs:
   #     #     sleep 10
   #     #     rm -rf ~/.safe
 
-  #     # # This starts a NODE_COUNT node network, and then adds 15 _more_ nodes
+  #     # # This starts a NODE_COUNT node network, and then adds 14 _more_ nodes
   #     # - name: Run network split data integrity test
   #     #   timeout-minutes: 35 # made 35 for now due to client slowdown. TODO: fix that!
   #     #   shell: bash

--- a/resources/scripts/all_nodes_joined.sh
+++ b/resources/scripts/all_nodes_joined.sh
@@ -12,30 +12,33 @@ DEFAULT_LOG_DIR="$HOME/.safe/node/local-test-network"
 NODE_COUNT="${NODE_COUNT:-$DEFAULT_NODE_COUNT}"
 
 log_dir="${LOG_DIR:-$DEFAULT_LOG_DIR}"
+echo
 echo "Checking nodes log files to verify all nodes have joined. Logs path: $log_dir"
 
 # -u needed here to search log dirs
-nodes_ips=$(rg "connection info:.*" "$log_dir" -g "*.log*" -u | rg "(127.0.0.1:\d{5})" -or '$1' | sort)
+nodes=$(rg ".*connection info:.*" "$log_dir" -g "*.log*" -u | rg "(sn-node-.*).sn_node.log.*(.{6}\(\d{8}\)).*(127.0.0.1:\d{5})" -or '$2->$3 $1' --sort path)
+nodes_ips=$(rg "connection info:.*" "$log_dir" -g "*.log*" -u | rg "(.{6}\(\d{8}\)).*(127.0.0.1:\d{5})" -or '$1->$2' | sort)
 nodes_ips_count=$(echo "$nodes_ips" | wc -l)
 
+echo
 echo "Number of nodes: $nodes_ips_count"
 
 if [[ $nodes_ips_count -ne $NODE_COUNT ]]
     then
         echo "Unexpected number of joined nodes. Expected $NODE_COUNT, we have $nodes_ips_count:"
-        echo "$nodes_ips"
+        echo "$nodes"
         exit 100
     else
-        echo "All nodes have joined. Nodes IPs:"
-        echo "$nodes_ips"
+        echo "All nodes have joined. Nodes names and IPs:"
+        echo "$nodes"
 fi
 
 # We'll use the logs from the nodes that joined, to obtain the
 # list of members in the network knowledge they share with AE messages.
-members=$(rg ".* msg: AntiEntropy \{.* kind: Update \{ members: \{(SectionSigned \{.*\})+ \}.*" -or '$1' "$log_dir" -g "*.log*" | rg "(127.0.0.1:\d{5})" -or '$1' | sort -u)
+members=$(rg ".* msg: AntiEntropy\(AntiEntropy \{.* kind: Update \{ members: \{(.*)\} \}\)" -or '$1' "$log_dir" -g "*.log*" | rg "(?:NodeState\((.{6}\(\d{8}\)).., (127.0.0.1:\d{5}), Joined)+" -or '$1->$2' | sort -u)
 members_count=$(echo "$members" | wc -l)
 
-echo ""
+echo
 if [[ $members_count -ne $NODE_COUNT ]]
 then
   echo "Unexpected number of nodes in network knowledge. Expected $NODE_COUNT, we have $members_count:"
@@ -44,8 +47,8 @@ else
   echo "Number of nodes found in network knowledge: $members_count"
 fi
 
-echo ""
-echo "Checking which nodes in network knowledge match the list of nodes IPs..."
+echo
+echo "Checking which nodes in network knowledge match the list of joined nodes..."
 
 invalid_member_found=false
 for m in $members
@@ -54,16 +57,22 @@ do
     then
       echo "Node $m is a valid member"
     else
-      echo "Node $m in network knowledge was not found in the list of nodes IPs"
+      echo "Node $m in network knowledge was not found in the list of joined nodes"
       invalid_member_found=true
     fi
 done
 
-echo ""
+echo
 if $invalid_member_found
 then
   echo "At least one member in the network knowledge was found invalid"
   exit 100
 else
-  echo "All good, members in the network knowledge found in the list of nodes IPs!"
+  if [[ $members_count -lt $NODE_COUNT ]]
+  then
+    echo "Some joined nodes ($NODE_COUNT) not found in the network knowledge ($members_count)"
+    exit 100
+  else
+    echo "All good!, members in the network knowledge match the list of joined nodes!"
+  fi
 fi


### PR DESCRIPTION
- This is also changing the script to not only compare the nodes' IPs but also their names.
- Changing CI to use 14 nodes for testnets launched.

Example output of a detection reported by updated script:
```
Checking nodes log files to verify all nodes have joined. Logs path: /home/runner/.safe/node/local-test-network

Number of nodes: 14
All nodes have joined. Nodes names and IPs:
bfdafe(10111111)->127.0.0.1:34480 sn-node-12
1e8e67(00011110)->127.0.0.1:60079 sn-node-genesis
28f7dd(00101000)->127.0.0.1:55884 sn-node-7
8c89de(10001100)->127.0.0.1:57425 sn-node-2
777f6a(01110111)->127.0.0.1:46141 sn-node-8
29c050(00101001)->127.0.0.1:55646 sn-node-10
58c1b4(01011000)->127.0.0.1:49787 sn-node-9
6a21d7(01101010)->127.0.0.1:55231 sn-node-3
67bcd1(01100111)->127.0.0.1:34405 sn-node-4
49c06b(01001001)->127.0.0.1:36594 sn-node-5
e8ff38(11101000)->127.0.0.1:52686 sn-node-6
7560c7(01110101)->127.0.0.1:50673 sn-node-11
d91ad6(11011001)->127.0.0.1:55879 sn-node-14
951a50(10010101)->127.0.0.1:38384 sn-node-13

Unexpected number of nodes in network knowledge. Expected 14, we have 15:
1e8e67(00011110)->127.0.0.1:60079
28f7dd(00101000)->127.0.0.1:55884
29c050(00101001)->127.0.0.1:55646
2c1613(00101100)->127.0.0.1:55646
49c06b(01001001)->127.0.0.1:36594
58c1b4(01011000)->127.0.0.1:49787
67bcd1(01100111)->127.0.0.1:34405
6a21d7(01101010)->127.0.0.1:55231
7560c7(01110101)->127.0.0.1:50673
777f6a(01110111)->127.0.0.1:46141
8c89de(10001100)->127.0.0.1:57425
951a50(10010101)->127.0.0.1:38384
bfdafe(10111111)->127.0.0.1:34480
d91ad6(11011001)->127.0.0.1:55879
e8ff38(11101000)->127.0.0.1:52686

Checking which nodes in network knowledge match the list of joined nodes...
Node 1e8e67(00011110)->127.0.0.1:60079 is a valid member
Node 28f7dd(00101000)->127.0.0.1:55884 is a valid member
Node 29c050(00101001)->127.0.0.1:55646 is a valid member
Node 2c1613(00101100)->127.0.0.1:55646 in network knowledge was not found in the list of joined nodes
Node 49c06b(01001001)->127.0.0.1:36594 is a valid member
Node 58c1b4(01011000)->127.0.0.1:49787 is a valid member
Node 67bcd1(01100111)->127.0.0.1:34405 is a valid member
Node 6a21d7(01101010)->127.0.0.1:55231 is a valid member
Node 7560c7(01110101)->127.0.0.1:50673 is a valid member
Node 777f6a(01110111)->127.0.0.1:46141 is a valid member
Node 8c89de(10001100)->127.0.0.1:57425 is a valid member
Node 951a50(10010101)->127.0.0.1:38384 is a valid member
Node bfdafe(10111111)->127.0.0.1:34480 is a valid member
Node d91ad6(11011001)->127.0.0.1:55879 is a valid member
Node e8ff38(11101000)->127.0.0.1:52686 is a valid member

At least one member in the network knowledge was found invalid
```