### PR TITLE
chore(node): avoid unnecessary relocation candidates look up

### DIFF
--- a/resources/scripts/all_nodes_joined.sh
+++ b/resources/scripts/all_nodes_joined.sh
@@ -16,8 +16,8 @@ echo
 echo "Checking nodes log files to verify all nodes have joined. Logs path: $log_dir"
 
 # -u needed here to search log dirs
-nodes=$(rg ".*connection info:.*" "$log_dir" -g "*.log*" -u | rg "(sn-node-.*).sn_node.log.*(.{6}\(\d{8}\)).*(127.0.0.1:\d{5})" -or '$2->$3 $1' --sort path)
-nodes_ips=$(rg "connection info:.*" "$log_dir" -g "*.log*" -u | rg "(.{6}\(\d{8}\)).*(127.0.0.1:\d{5})" -or '$1->$2' | sort)
+nodes=$(rg ".*connection info:.*" "$log_dir" -g "*.log*" -u | rg "(sn-node-.*).sn_node\.log.*(.{6}\(\d{8}\)).*(127\.0\.0\.1:\d{5})" -or '$2->$3 $1' --sort path)
+nodes_ips=$(rg "connection info:.*" "$log_dir" -g "*.log*" -u | rg "(.{6}\(\d{8}\)).*(127\.0\.0\.1:\d{5})" -or '$1->$2' | sort)
 nodes_ips_count=$(echo "$nodes_ips" | wc -l)
 
 echo
@@ -35,7 +35,7 @@ fi
 
 # We'll use the logs from the nodes that joined, to obtain the
 # list of members in the network knowledge they share with AE messages.
-members=$(rg ".* msg: AntiEntropy\(AntiEntropy \{.* kind: Update \{ members: \{(.*)\} \}\)" -or '$1' "$log_dir" -g "*.log*" | rg "(?:NodeState\((.{6}\(\d{8}\)).., (127.0.0.1:\d{5}), Joined)+" -or '$1->$2' | sort -u)
+members=$(rg ".* msg: AntiEntropy\(AntiEntropy \{.* kind: Update \{ members: \{(.*)\} \}\)" -or '$1' "$log_dir" -g "*.log*" | rg "(?:NodeState\((.{6}\(\d{8}\)).., (127\.0\.0\.1:\d{5}), Joined)+" -or '$1->$2' | sort -u)
 members_count=$(echo "$members" | wc -l)
 
 echo

--- a/sn_node/src/node/relocation.rs
+++ b/sn_node/src/node/relocation.rs
@@ -41,24 +41,24 @@ pub(super) fn find_nodes_to_relocate(
     // Find the peers that pass the relocation check and take only the oldest ones to avoid
     // relocating too many nodes at the same time.
     // Capped by criteria that cannot relocate too many node at once.
-    let section_size = network_knowledge.section_members().len();
+    let section_members = network_knowledge.section_members();
+    let section_size = section_members.len();
+    let recommended_section_size = recommended_section_size();
     info!(
-        "Finding relocation candidates, having {:?} members, recommended section_size {:?}",
-        section_size,
-        recommended_section_size(),
+        "Finding relocation candidates, having {section_size} members, \
+        recommended section_size {recommended_section_size}"
     );
 
     // no relocation if total section size is too small
-    if section_size < recommended_section_size() {
+    if section_size <= recommended_section_size {
         return vec![];
     }
 
     let max_reloctions = elder_count() / 2;
-    let allowed_relocations = min(section_size - recommended_section_size(), max_reloctions);
+    let allowed_relocations = min(section_size - recommended_section_size, max_reloctions);
 
     // Find the peers that pass the relocation check
-    let mut candidates: Vec<_> = network_knowledge
-        .section_members()
+    let mut candidates: Vec<_> = section_members
         .into_iter()
         .filter(|state| network_knowledge.is_adult(&state.name()))
         .filter(|info| check(info.age(), churn_id))


### PR DESCRIPTION
If section size is equal to the recommended section size, we would look up for relocation candidates but we were actually discarding them.