### PR TITLE
fix(node): node to update its own members list upon being relocated

### DIFF
--- a/sn_interface/src/network_knowledge/node_state/relocation.rs
+++ b/sn_interface/src/network_knowledge/node_state/relocation.rs
@@ -157,8 +157,12 @@ impl RelocationProof {
         self.info.signed_relocation.age()
     }
 
+    pub fn signed_relocation(&self) -> &SectionSigned<NodeState> {
+        &self.info.signed_relocation
+    }
+
     // ed25519_dalek::Signature has overly verbose debug output, so we provide our own
-    pub fn fmt_ed25519(sig: &Signature, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt_ed25519(sig: &Signature, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Signature({:0.10})", HexFmt(sig))
     }
 
@@ -172,6 +176,8 @@ impl RelocationProof {
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum RelocationState {
+    /// The node is not peforming a relocation
+    NoRelocation,
     /// A relocation dst is sent from a section to one of its members, based upon
     /// the node matching the trigger.
     /// This is the elders asking the node to start polling
@@ -179,4 +185,13 @@ pub enum RelocationState {
     PreparingToRelocate(RelocationTrigger),
     /// When the node has a `RelocationProof` it can join the dst section with the provided proof.
     ReadyToJoinNewSection(RelocationProof),
+}
+
+impl RelocationState {
+    pub fn proof(&self) -> Option<&RelocationProof> {
+        match self {
+            Self::ReadyToJoinNewSection(proof) => Some(proof),
+            _ => None,
+        }
+    }
 }

--- a/sn_node/src/node/context.rs
+++ b/sn_node/src/node/context.rs
@@ -40,7 +40,7 @@ pub struct NodeContext {
     pub(crate) joins_allowed_until_split: bool,
     #[debug(skip)]
     pub(crate) fault_cmds_sender: Sender<FaultsCmd>,
-    pub(crate) relocation_state: Option<RelocationState>,
+    pub(crate) relocation_state: RelocationState,
 }
 
 impl NodeContext {

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -117,7 +117,7 @@ impl FlowCtrl {
         // check if we can request for relocation
         // The relocation_state will be changed into `JoinAsRelocated` once the request has been
         // approved by the section
-        if let Some(RelocationState::PreparingToRelocate(trigger)) = &context.relocation_state {
+        if let RelocationState::PreparingToRelocate(trigger) = &context.relocation_state {
             if self.timestamps.request_to_relocate_check.elapsed() > REQUEST_TO_RELOCATE_TIMEOUT_SEC
             {
                 info!(
@@ -134,7 +134,7 @@ impl FlowCtrl {
         }
 
         // check if we can join the dst section
-        if let Some(RelocationState::ReadyToJoinNewSection(proof)) = &context.relocation_state {
+        if let RelocationState::ReadyToJoinNewSection(proof) = &context.relocation_state {
             let prev_name = proof.previous_name();
             let new_name = proof.new_name();
             if self.timestamps.join_as_relocated_check.elapsed() > JOIN_AS_RELOCATED_TIMEOUT_SEC {
@@ -159,7 +159,7 @@ impl FlowCtrl {
                         context.info.age()
                     );
                     info!("We've joined a section, dropping the relocation proof.");
-                    node.relocation_state = None;
+                    node.relocation_state = RelocationState::NoRelocation;
                 }
             }
         }

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -172,7 +172,6 @@ impl MyNode {
                 trace!("Handling ProceedRelocation msg from {node_id}: {msg_id:?}");
                 Ok(node.proceed_relocation(node_id.name(), dst)?)
             }
-
             NodeMsg::CompleteRelocation(signed_relocation) => {
                 trace!("Handling CompleteRelocation msg from {node_id}: {msg_id:?}");
                 Ok(node.relocate(signed_relocation)?.into_iter().collect())
@@ -214,6 +213,11 @@ impl MyNode {
                             "=========>> This node ({:?} @ {:?}) has been approved to join the section at {:?}!", context.name, context.info.addr,
                             target_sap.prefix(),
                         );
+
+                        // If we were relocating finalise it
+                        if let Some(proof) = context.relocation_state.proof() {
+                            node.finalise_relocation(&context, proof.signed_relocation().clone());
+                        }
 
                         Ok(vec![])
                     }

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -105,7 +105,7 @@ pub(crate) struct MyNode {
     pub(crate) elder_promotion_aggregator: SignatureAggregator,
     pub(crate) pending_split_sections:
         BTreeMap<Generation, BTreeSet<SectionSigned<SectionAuthorityProvider>>>,
-    pub(crate) relocation_state: Option<RelocationState>,
+    pub(crate) relocation_state: RelocationState,
     // ======================== Elder only ========================
     pub(crate) membership: Option<Membership>,
     // Section handover consensus state (Some for Elders, None for others)
@@ -206,7 +206,7 @@ impl MyNode {
             section_keys_provider,
             dkg_sessions_info: HashMap::default(),
             pending_split_sections: Default::default(),
-            relocation_state: None,
+            relocation_state: RelocationState::NoRelocation,
             dkg_start_aggregator: SignatureAggregator::default(),
             dkg_voter: DkgVoter::default(),
             handover_voting: handover,


### PR DESCRIPTION
This also adds an improvement to the relocation process where we try to finalise an ongoing relocation both when we receive the join approval, or with our periodic checks. 
This prevents from having unnecessary delays in updating the node's internal state, i.e. if the join approval is received we update our state and members right away, without having to wait till the periodic check's timer goes off. If, on the contrary, we missed the join approval msg but we've got an AE msg where we learned we've been approved, then we'll perform the node's internal state update with the periodic check as usual.