### PR TITLE
feat(client): do not re-attempt connect

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -493,6 +493,10 @@ jobs:
           cache-on-failure: true
           sharedKey: ${{github.run_id}}
 
+      - name: Build network churn data integrity test
+        shell: bash
+        run: cargo build --release --example churn
+
       # This starts a NODE_COUNT node network, and then adds 12 more nodes. We should kill before moving on to split checks
       - name: Run network churn data integrity test
         timeout-minutes: 55 # made 55 for now due to slow network startup


### PR DESCRIPTION
Currently, the E2E churn test fails once in a while. This is mostly due to the client not connecting properly while nodes are added to the network.

This PR introduces the client not retrying connecting by default. This will be the responsibility of the API user. In the case of the client churn example, it will be retried up to 5 times with a delay of 1.5s.

Also, the CI will build the churn example in a separate step so we more tightly see how long the example runs for.