### PR TITLE
refactor: distinguish client and node ids

### DIFF
--- a/sn_cli/src/subcommands/node.rs
+++ b/sn_cli/src/subcommands/node.rs
@@ -69,7 +69,7 @@ pub enum NodeSubCommands {
         local_addr: Option<SocketAddr>,
         /// External address of the node, to use when writing connection info.
         ///
-        /// If unspecified, it will be queried from a peer; if there are no peers, the `local-addr` will
+        /// If unspecified, it will be queried from a node; if there are no nodes, the `local-addr` will
         /// be used, if specified.
         ///
         /// This option can also be used when you're trying to join a remote network, but your join

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -17,7 +17,7 @@ use sn_interface::{
         data::{ClientMsg, DataQuery, QueryResponse},
         ClientAuth, WireMsg,
     },
-    types::{Peer, PublicKey, Signature},
+    types::{NodeId, PublicKey, Signature},
 };
 
 use backoff::{backoff::Backoff, ExponentialBackoff};
@@ -156,7 +156,7 @@ impl Client {
         client_pk: PublicKey,
         serialised_query: Bytes,
         signature: Signature,
-        dst_section_info: Option<(bls::PublicKey, Vec<Peer>)>,
+        dst_section_info: Option<(bls::PublicKey, Vec<NodeId>)>,
     ) -> Result<QueryResponse> {
         let auth = ClientAuth {
             public_key: client_pk,

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -14,7 +14,7 @@ use sn_interface::{
         system::NodeMsg,
         Error as MessagingError, MsgId, NetworkMsg,
     },
-    types::{Error as DtError, Peer},
+    types::{Error as DtError, NodeId},
 };
 
 use bls::PublicKey;
@@ -67,7 +67,7 @@ pub enum Error {
     },
     /// Initial network contact failed
     #[error("Initial network contact probe failed. Attempted contacts: {0:?}")]
-    NetworkContact(Vec<Peer>),
+    NetworkContact(Vec<NodeId>),
     /// Client has not gone through qp2p bootstrap process yet
     #[error(
         "Client has not yet acquired enough/any network knowledge for destination \
@@ -149,21 +149,21 @@ pub enum Error {
         /// Address name of the chunk
         address: XorName,
     },
-    /// Remote peer closed the bi-stream we expected a response on
-    #[error("The bi-stream we expected a msg response on, for {msg_id:?}, was closed by remote peer: {peer:?}")]
+    /// Node closed the bi-stream we expected a response on
+    #[error("The bi-stream we expected a msg response on, for {msg_id:?}, was closed by remote node: {node_id:?}")]
     ResponseStreamClosed {
         /// MsgId of the msg sent
         msg_id: MsgId,
-        /// Peer the msg was sent to
-        peer: Peer,
+        /// Node the msg was sent to
+        node_id: NodeId,
     },
     /// Failed to obtain a response from Elders.
-    #[error("Failed to obtain any response for {msg_id:?} from: {peers:?}")]
+    #[error("Failed to obtain any response for {msg_id:?} from: {nodes:?}")]
     NoResponse {
         /// MsgId of the msg sent
         msg_id: MsgId,
-        /// Peers the msg was sent to
-        peers: Vec<Peer>,
+        /// Nodes the msg was sent to
+        nodes: Vec<NodeId>,
     },
     /// Timeout when awaiting command ACK from Elders.
     #[error("Timeout after {elapsed:?} when awaiting command ACK from Elders for {msg_id:?}, data address {dst_address}")]
@@ -184,22 +184,22 @@ pub enum Error {
         response: QueryResponse,
     },
     /// Unexpected NodeMsg received
-    #[error("Unexpected type of NodeMsg received from {peer} in response to {correlation_id:?}. Received: {msg:?}")]
+    #[error("Unexpected type of NodeMsg received from {node_id} in response to {correlation_id:?}. Received: {msg:?}")]
     UnexpectedNodeMsg {
         /// MsgId of the msg sent
         correlation_id: MsgId,
-        /// Peer the unexpected msg was received from
-        peer: Peer,
+        /// The node that the unexpected msg was received from
+        node_id: NodeId,
         /// Unexpected msg received
         msg: NodeMsg,
     },
     /// Unexpected msg type received
-    #[error("Unexpected type of message received from {peer} in response to {correlation_id:?}. Received: {msg:?}")]
+    #[error("Unexpected type of message received from {node_id} in response to {correlation_id:?}. Received: {msg:?}")]
     UnexpectedNetworkMsg {
         /// MsgId of the msg sent
         correlation_id: MsgId,
-        /// Peer the unexpected msg was received from
-        peer: Peer,
+        /// The node that the unexpected msg was received from
+        node_id: NodeId,
         /// Unexpected msg received
         msg: NetworkMsg,
     },
@@ -236,20 +236,20 @@ pub enum Error {
     #[error(transparent)]
     QuicP2p(#[from] qp2p::RecvError),
     /// QuicP2p Connection error.
-    #[error("Failed to stablish a connection with node {peer:?}: {error}.")]
+    #[error("Failed to stablish a connection with node {node_id:?}: {error}.")]
     QuicP2pConnection {
         /// Node the connection was attempted to be stablished with
-        peer: Peer,
+        node_id: NodeId,
         /// The error encountered when attempting to stablish the connection
         error: qp2p::ConnectionError,
         /// MsgId of the msg that was going to be sent
         msg_id: MsgId,
     },
     /// QuicP2p Send error.
-    #[error("Failed to send a message to node {peer:?}: {error}.")]
+    #[error("Failed to send a message to node {node_id:?}: {error}.")]
     QuicP2pSend {
         /// Node the message was attempted to be sent to
-        peer: Peer,
+        node_id: NodeId,
         /// The error encountered when attempting to send the message
         error: qp2p::SendError,
         /// MsgId of the msg attempted to send

--- a/sn_client/src/sessions/mod.rs
+++ b/sn_client/src/sessions/mod.rs
@@ -9,7 +9,7 @@
 mod listeners;
 mod messaging;
 
-use crate::{connections::PeerLinks, Error, Result};
+use crate::{connections::NodeLinks, Error, Result};
 
 use sn_interface::{
     messaging::data::{CmdResponse, QueryResponse},
@@ -36,7 +36,7 @@ pub(super) struct Session {
     /// All elders we know about from AE messages
     pub(super) network: Arc<RwLock<SectionTree>>,
     /// Links to nodes
-    peer_links: PeerLinks,
+    node_links: NodeLinks,
 }
 
 impl Session {
@@ -47,12 +47,12 @@ impl Session {
             .addr(local_addr)
             .idle_timeout(70_000)
             .client()?;
-        let peer_links = PeerLinks::new(endpoint.clone());
+        let node_links = NodeLinks::new(endpoint.clone());
 
         let session = Self {
             endpoint,
             network: Arc::new(RwLock::new(network_contacts)),
-            peer_links,
+            node_links,
         };
 
         Ok(session)

--- a/sn_interface/src/messaging/anti_entropy.rs
+++ b/sn_interface/src/messaging/anti_entropy.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::system::SectionPeers;
+use super::system::SectionMembers;
 
 use crate::network_knowledge::SectionTreeUpdate;
 
@@ -32,20 +32,20 @@ pub enum AntiEntropyMsg {
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, custom_debug::Debug)]
 pub enum AntiEntropyKind {
-    /// This AE message is sent to a peer when a message with outdated section
+    /// This AE message is sent to a node or client when a message with outdated section
     /// information was received, attaching the bounced message so
-    /// the peer can resend it with up to date destination information.
+    /// the node or client can resend it with up to date destination information.
     Retry {
         #[debug(skip)]
         bounced_msg: UsrMsgBytes,
     },
-    /// This AE message is sent to a peer when a message needs to be sent to a
-    /// different and/or closest section, attaching the bounced message so the peer
+    /// This AE message is sent to a node or client when a message needs to be sent to a
+    /// different and/or closest section, attaching the bounced message so the node or client
     /// can resend it to the correct section with up to date destination information.
     Redirect {
         #[debug(skip)]
         bounced_msg: UsrMsgBytes,
     },
-    /// This AE message is sent to update a peer when we notice they are behind
-    Update { members: SectionPeers },
+    /// This AE message is sent to update a node or client when we notice they are behind
+    Update { members: SectionMembers },
 }

--- a/sn_interface/src/messaging/authority.rs
+++ b/sn_interface/src/messaging/authority.rs
@@ -13,24 +13,24 @@ use bls::PublicKey as BlsPublicKey;
 use ed25519_dalek::{PublicKey as EdPublicKey, Signature as EdSignature, Verifier as _};
 use serde::{Deserialize, Serialize};
 
-/// Authority of a network peer.
+/// Authority of a network client.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ClientAuth {
-    /// Peer's public key.
+    /// Client's public key.
     pub public_key: PublicKey,
-    /// Peer's signature.
+    /// Client's signature.
     pub signature: Signature,
 }
 
-/// Authority of a single peer.
+/// Authority of a node.
 #[derive(Clone, Eq, PartialEq, custom_debug::Debug, serde::Deserialize, serde::Serialize)]
 pub struct NodeSig {
-    /// Section key of the source.
+    /// Section key of the node.
     pub section_pk: BlsPublicKey,
-    /// Public key of the source peer.
+    /// Public key of the node.
     #[debug(with = "PublicKey::fmt_ed25519")]
     pub node_ed_pk: EdPublicKey,
-    /// Ed25519 signature of the message corresponding to the public key of the source peer.
+    /// Ed25519 signature of the message corresponding to the public key of the node.
     #[debug(with = "Signature::fmt_ed25519")]
     #[serde(with = "serde_bytes")]
     pub signature: EdSignature,

--- a/sn_interface/src/messaging/msg_kind.rs
+++ b/sn_interface/src/messaging/msg_kind.rs
@@ -19,7 +19,7 @@ use xor_name::XorName;
 pub enum MsgKind {
     /// An update to our NetworkKnowledge.
     AntiEntropy(XorName),
-    /// A data message, with the requesting peer's authority.
+    /// A data message, with the requesting client's authority.
     /// Authority is needed to access private data, such as reading or writing a private file.
     /// is spend tells us if we're dealing with a spend cmd
     /// query index lets us forward the msg to a given index in xorspace

--- a/sn_interface/src/messaging/system/dkg.rs
+++ b/sn_interface/src/messaging/system/dkg.rs
@@ -7,11 +7,14 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::NodeState;
+
 use crate::types::keys::ed25519::Digest256;
-use crate::types::Peer;
+use crate::types::NodeId;
+
+use sn_consensus::Generation;
+
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use sn_consensus::Generation;
 use std::{
     collections::{BTreeMap, BTreeSet},
     net::SocketAddr,
@@ -66,10 +69,10 @@ impl DkgSessionId {
         self.elders.keys().copied()
     }
 
-    pub fn elder_peers(&self) -> impl Iterator<Item = Peer> + '_ {
+    pub fn elder_ids(&self) -> impl Iterator<Item = NodeId> + '_ {
         self.elders
             .iter()
-            .map(|(name, addr)| Peer::new(*name, *addr))
+            .map(|(name, addr)| NodeId::new(*name, *addr))
     }
 
     pub fn elder_index(&self, elder: XorName) -> Option<usize> {

--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -21,7 +21,7 @@ pub struct JoinRequest {
 /// Response to a request to join a section
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum JoinResponse {
-    /// Message sent to joining peer containing the current node's
+    /// Message sent to joining node containing the current node's
     /// state as a member of the section.
     Approved(Decision<NodeState>),
     /// Join was rejected
@@ -33,7 +33,7 @@ pub enum JoinResponse {
 /// Reason of a join request being rejected
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum JoinRejectReason {
-    /// No new peers are currently accepted for joining
+    /// No new nodes are currently accepted for joining
     /// NB: Relocated nodes that try to join, are accepted even if joins are disallowed.
     JoinsDisallowed,
     /// The requesting node is not externally reachable

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -32,8 +32,8 @@ use std::{
 };
 use xor_name::XorName;
 
-/// List of peers of a section
-pub type SectionPeers = BTreeSet<Decision<NodeState>>;
+/// List of nodes of a section
+pub type SectionMembers = BTreeSet<Decision<NodeState>>;
 
 #[derive(Clone, PartialEq, Serialize, Deserialize, custom_debug::Debug)]
 #[allow(clippy::large_enum_variant, clippy::derive_partial_eq_without_eq)]

--- a/sn_interface/src/network_knowledge/node_info.rs
+++ b/sn_interface/src/network_knowledge/node_info.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::types::{utils::calc_age, Peer, PublicKey};
+use crate::types::{utils::calc_age, NodeId, PublicKey};
 use ed25519_dalek::Keypair;
 use std::{
     fmt::{self, Display, Formatter},
@@ -33,8 +33,8 @@ impl MyNodeInfo {
         }
     }
 
-    pub fn peer(&self) -> Peer {
-        Peer::new(self.name(), self.addr)
+    pub fn id(&self) -> NodeId {
+        NodeId::new(self.name(), self.addr)
     }
 
     pub fn name(&self) -> XorName {

--- a/sn_interface/src/network_knowledge/section_member_history.rs
+++ b/sn_interface/src/network_knowledge/section_member_history.rs
@@ -20,12 +20,12 @@ const ELDER_CHURN_EVENTS_TO_PRUNE_ARCHIVE: usize = 3;
 
 /// Container for storing information about (current and archived) members of our section.
 #[derive(Clone, Default, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub(super) struct SectionPeers {
+pub(super) struct SectionMemberHistory {
     members: BTreeMap<XorName, Decision<NodeState>>,
     archive: BTreeMap<XorName, Decision<NodeState>>,
 }
 
-impl SectionPeers {
+impl SectionMemberHistory {
     /// Returns set of current members, i.e. those with state == `Joined`.
     pub(super) fn members(&self) -> BTreeSet<NodeState> {
         let mut node_state_list = BTreeSet::new();
@@ -71,7 +71,7 @@ impl SectionPeers {
             .cloned()
     }
 
-    /// Returns whether the given peer is currently a member of our section.
+    /// Returns whether the given node is currently a member of our section.
     pub(super) fn is_member(&self, name: &XorName) -> bool {
         self.get(name).is_some()
     }
@@ -148,11 +148,11 @@ impl SectionPeers {
 
 #[cfg(test)]
 mod tests {
-    use super::{SectionPeers, SectionsDAG};
+    use super::{SectionMemberHistory, SectionsDAG};
     use crate::{
         network_knowledge::{MembershipState, NodeState, RelocationDst, SectionSigned},
         test_utils::{assert_lists, gen_addr, TestKeys},
-        types::Peer,
+        types::NodeId,
     };
     use eyre::Result;
     use rand::thread_rng;
@@ -163,18 +163,18 @@ mod tests {
     #[test]
     fn retain_archived_members_of_the_latest_sections_while_pruning() -> Result<()> {
         let mut rng = thread_rng();
-        let mut section_peers = SectionPeers::default();
+        let mut section_members = SectionMemberHistory::default();
 
         // adding node set 1
         let sk_1 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_1 = gen_random_signed_node_states(1, MembershipState::Left, &sk_1)?;
         nodes_1.iter().for_each(|node| {
-            section_peers.update(node.clone());
+            section_members.update(node.clone());
         });
         let mut proof_chain = SectionsDAG::new(sk_1.public_key());
         // 1 should be retained
-        section_peers.prune_members_archive(&proof_chain, &sk_1.public_key())?;
-        assert_lists(section_peers.archive.values(), &nodes_1);
+        section_members.prune_members_archive(&proof_chain, &sk_1.public_key())?;
+        assert_lists(section_members.archive.values(), &nodes_1);
 
         // adding node set 2 as MembershipState::Relocated
         let sk_2 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
@@ -182,14 +182,14 @@ mod tests {
 
         let nodes_2 = gen_random_signed_node_states(1, MembershipState::Relocated(dst), &sk_2)?;
         nodes_2.iter().for_each(|node| {
-            section_peers.update(node.clone());
+            section_members.update(node.clone());
         });
         let sig = TestKeys::sign(&sk_1, &sk_2.public_key())?;
         proof_chain.verify_and_insert(&sk_1.public_key(), sk_2.public_key(), sig)?;
         // 1 -> 2 should be retained
-        section_peers.prune_members_archive(&proof_chain, &sk_2.public_key())?;
+        section_members.prune_members_archive(&proof_chain, &sk_2.public_key())?;
         assert_lists(
-            section_peers.archive.values(),
+            section_members.archive.values(),
             nodes_1.iter().chain(&nodes_2),
         );
 
@@ -197,14 +197,14 @@ mod tests {
         let sk_3 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_3 = gen_random_signed_node_states(1, MembershipState::Left, &sk_3)?;
         nodes_3.iter().for_each(|node| {
-            section_peers.update(node.clone());
+            section_members.update(node.clone());
         });
         let sig = TestKeys::sign(&sk_2, &sk_3.public_key())?;
         proof_chain.verify_and_insert(&sk_2.public_key(), sk_3.public_key(), sig)?;
         // 1 -> 2 -> 3 should be retained
-        section_peers.prune_members_archive(&proof_chain, &sk_3.public_key())?;
+        section_members.prune_members_archive(&proof_chain, &sk_3.public_key())?;
         assert_lists(
-            section_peers.archive.values(),
+            section_members.archive.values(),
             nodes_1.iter().chain(&nodes_2).chain(&nodes_3),
         );
 
@@ -212,14 +212,14 @@ mod tests {
         let sk_4 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_4 = gen_random_signed_node_states(1, MembershipState::Left, &sk_4)?;
         nodes_4.iter().for_each(|node| {
-            section_peers.update(node.clone());
+            section_members.update(node.clone());
         });
         let sig = TestKeys::sign(&sk_3, &sk_4.public_key())?;
         proof_chain.verify_and_insert(&sk_3.public_key(), sk_4.public_key(), sig)?;
         //  2 -> 3 -> 4 should be retained
-        section_peers.prune_members_archive(&proof_chain, &sk_4.public_key())?;
+        section_members.prune_members_archive(&proof_chain, &sk_4.public_key())?;
         assert_lists(
-            section_peers.archive.values(),
+            section_members.archive.values(),
             nodes_2.iter().chain(&nodes_3).chain(&nodes_4),
         );
 
@@ -230,14 +230,14 @@ mod tests {
         let sk_5 = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let nodes_5 = gen_random_signed_node_states(1, MembershipState::Left, &sk_5)?;
         nodes_5.iter().for_each(|node| {
-            section_peers.update(node.clone());
+            section_members.update(node.clone());
         });
         let sig = TestKeys::sign(&sk_3, &sk_5.public_key())?;
         proof_chain.verify_and_insert(&sk_3.public_key(), sk_5.public_key(), sig)?;
         // 2 -> 3 -> 5 should be retained
-        section_peers.prune_members_archive(&proof_chain, &sk_5.public_key())?;
+        section_members.prune_members_archive(&proof_chain, &sk_5.public_key())?;
         assert_lists(
-            section_peers.archive.values(),
+            section_members.archive.values(),
             nodes_2.iter().chain(&nodes_3).chain(&nodes_5),
         );
 
@@ -247,15 +247,15 @@ mod tests {
     #[test]
     fn archived_members_should_not_be_moved_to_members_list() -> Result<()> {
         let mut rng = thread_rng();
-        let mut section_peers = SectionPeers::default();
+        let mut section_members = SectionMemberHistory::default();
         let sk = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
         let node_left = gen_random_signed_node_states(1, MembershipState::Left, &sk)?[0].clone();
         let dst = RelocationDst::new(XorName::random(&mut rng));
         let node_relocated =
             gen_random_signed_node_states(1, MembershipState::Relocated(dst), &sk)?[0].clone();
 
-        assert!(section_peers.update(node_left.clone()));
-        assert!(section_peers.update(node_relocated.clone()));
+        assert!(section_members.update(node_left.clone()));
+        assert!(section_members.update(node_relocated.clone()));
 
         let (node_left_state, _) = node_left
             .proposals
@@ -267,20 +267,23 @@ mod tests {
             .unwrap_or_else(|| panic!("Proposal of Decision is empty"));
 
         let node_left_joins =
-            TestKeys::get_section_signed(&sk, NodeState::joined(*node_left_state.peer(), None))?;
+            TestKeys::get_section_signed(&sk, NodeState::joined(*node_left_state.node_id(), None))?;
         let node_left_joins = section_signed_to_decision(node_left_joins);
 
         let node_relocated_joins = TestKeys::get_section_signed(
             &sk,
-            NodeState::joined(*node_relocated_state.peer(), None),
+            NodeState::joined(*node_relocated_state.node_id(), None),
         )?;
         let node_relocated_joins = section_signed_to_decision(node_relocated_joins);
 
-        assert!(!section_peers.update(node_left_joins));
-        assert!(!section_peers.update(node_relocated_joins));
+        assert!(!section_members.update(node_left_joins));
+        assert!(!section_members.update(node_relocated_joins));
 
-        assert_lists(section_peers.archive.values(), &[node_left, node_relocated]);
-        assert!(section_peers.members().is_empty());
+        assert_lists(
+            section_members.archive.values(),
+            &[node_left, node_relocated],
+        );
+        assert!(section_members.members().is_empty());
 
         Ok(())
     }
@@ -288,15 +291,15 @@ mod tests {
     #[test]
     fn members_should_be_archived_if_they_leave_or_relocate() -> Result<()> {
         let mut rng = thread_rng();
-        let mut section_peers = SectionPeers::default();
+        let mut section_members = SectionMemberHistory::default();
         let sk = bls::SecretKeySet::random(0, &mut thread_rng()).secret_key();
 
         let node_1 = gen_random_signed_node_states(1, MembershipState::Joined, &sk)?[0].clone();
         let dst = RelocationDst::new(XorName::random(&mut rng));
         let node_2 =
             gen_random_signed_node_states(1, MembershipState::Relocated(dst), &sk)?[0].clone();
-        assert!(section_peers.update(node_1.clone()));
-        assert!(section_peers.update(node_2.clone()));
+        assert!(section_members.update(node_1.clone()));
+        assert!(section_members.update(node_2.clone()));
 
         let (node_state_1, _) = node_1
             .proposals
@@ -307,17 +310,17 @@ mod tests {
             .first_key_value()
             .unwrap_or_else(|| panic!("Proposal of Decision is empty"));
 
-        let node_1 = NodeState::left(*node_state_1.peer(), Some(node_state_1.name()));
+        let node_1 = NodeState::left(*node_state_1.node_id(), Some(node_state_1.name()));
         let node_1 = TestKeys::get_section_signed(&sk, node_1)?;
         let node_1 = section_signed_to_decision(node_1);
-        let node_2 = NodeState::left(*node_state_2.peer(), Some(node_state_2.name()));
+        let node_2 = NodeState::left(*node_state_2.node_id(), Some(node_state_2.name()));
         let node_2 = TestKeys::get_section_signed(&sk, node_2)?;
         let node_2 = section_signed_to_decision(node_2);
-        assert!(section_peers.update(node_1.clone()));
-        assert!(section_peers.update(node_2.clone()));
+        assert!(section_members.update(node_1.clone()));
+        assert!(section_members.update(node_2.clone()));
 
-        assert!(section_peers.members().is_empty());
-        assert_lists(section_peers.archive.values(), &[node_1, node_2]);
+        assert!(section_members.members().is_empty());
+        assert_lists(section_members.archive.values(), &[node_1, node_2]);
 
         Ok(())
     }
@@ -334,11 +337,11 @@ mod tests {
         for _ in 0..num_nodes {
             let addr = gen_addr();
             let name = XorName::random(&mut rng);
-            let peer = Peer::new(name, addr);
+            let node_id = NodeId::new(name, addr);
             let node_state = match membership_state {
-                MembershipState::Joined => NodeState::joined(peer, None),
-                MembershipState::Left => NodeState::left(peer, None),
-                MembershipState::Relocated(ref dst) => NodeState::relocated(peer, None, *dst),
+                MembershipState::Joined => NodeState::joined(node_id, None),
+                MembershipState::Left => NodeState::left(node_id, None),
+                MembershipState::Relocated(ref dst) => NodeState::relocated(node_id, None, *dst),
             };
             let sectioin_signed_node_state = TestKeys::get_section_signed(secret_key, node_state)?;
             decisions.push(section_signed_to_decision(sectioin_signed_node_state));

--- a/sn_interface/src/network_knowledge/test_utils.rs
+++ b/sn_interface/src/network_knowledge/test_utils.rs
@@ -1,7 +1,7 @@
 use super::SectionKeysProvider;
 use crate::{
     network_knowledge::{section_keys::build_spent_proof_share, Error, MyNodeInfo, MIN_ADULT_AGE},
-    types::{keys::ed25519, Peer},
+    types::{keys::ed25519, NodeId},
     SectionAuthorityProvider,
 };
 use eyre::{eyre, Context, ContextCompat, Result};
@@ -34,16 +34,16 @@ pub fn gen_addr() -> SocketAddr {
     ([192, 0, 2, 0], port).into()
 }
 
-// Generate a Peer with the given age
-pub fn gen_peer(age: u8) -> Peer {
+// Generate a NodeId with the given age
+pub fn gen_node_id(age: u8) -> NodeId {
     let name = ed25519::gen_name_with_age(age);
-    Peer::new(name, gen_addr())
+    NodeId::new(name, gen_addr())
 }
 
-// Generate a Peer with the given age and prefix
-pub fn gen_peer_in_prefix(age: u8, prefix: Prefix) -> Peer {
+// Generate a NodeId with the given age and prefix
+pub fn gen_node_id_in_prefix(age: u8, prefix: Prefix) -> NodeId {
     let name = ed25519::gen_name_with_age(age);
-    Peer::new(prefix.substituted_in(name), gen_addr())
+    NodeId::new(prefix.substituted_in(name), gen_addr())
 }
 
 // Generate `MyNodeInfo` with the given age and prefix

--- a/sn_interface/src/types/identities/client_id.rs
+++ b/sn_interface/src/types/identities/client_id.rs
@@ -14,16 +14,16 @@ use std::{
 };
 use xor_name::XorName;
 
-use super::utils::calc_age;
+use super::Participant;
 
-/// A Peer with name, derived from its `PublicKey`, and an address.
+/// The id is the name, derived from its `PublicKey`, and the address of a client.
 #[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct Peer {
+pub struct ClientId {
     name: XorName,
     addr: SocketAddr,
 }
 
-impl Peer {
+impl ClientId {
     pub fn new(name: XorName, addr: SocketAddr) -> Self {
         Self { name, addr }
     }
@@ -36,35 +36,27 @@ impl Peer {
         self.addr
     }
 
-    /// Returns the age.
-    pub fn age(&self) -> u8 {
-        calc_age(&self.name)
-    }
-
-    pub fn from(addr: SocketAddr, public_key: ed25519_dalek::PublicKey) -> Peer {
-        Peer {
-            addr,
-            name: XorName::from(super::PublicKey::from(public_key)),
-        }
+    pub fn from(sender: Participant) -> Self {
+        Self::new(sender.name, sender.addr)
     }
 }
 
-impl Display for Peer {
+impl Display for ClientId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{} at {}", self.name(), self.addr(),)
     }
 }
 
-impl Eq for Peer {}
+impl Eq for ClientId {}
 
-impl Hash for Peer {
+impl Hash for ClientId {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name().hash(state);
         self.addr().hash(state);
     }
 }
 
-impl Ord for Peer {
+impl Ord for ClientId {
     fn cmp(&self, other: &Self) -> Ordering {
         self.name()
             .cmp(&other.name())
@@ -72,19 +64,19 @@ impl Ord for Peer {
     }
 }
 
-impl PartialEq for Peer {
+impl PartialEq for ClientId {
     fn eq(&self, other: &Self) -> bool {
         self.name() == other.name() && self.addr() == other.addr()
     }
 }
 
-impl PartialEq<&Self> for Peer {
+impl PartialEq<&Self> for ClientId {
     fn eq(&self, other: &&Self) -> bool {
         self.name() == other.name() && self.addr() == other.addr()
     }
 }
 
-impl PartialOrd for Peer {
+impl PartialOrd for ClientId {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }

--- a/sn_interface/src/types/identities/mod.rs
+++ b/sn_interface/src/types/identities/mod.rs
@@ -1,0 +1,91 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+mod client_id;
+mod node_id;
+
+pub use client_id::ClientId;
+pub use node_id::NodeId;
+
+use std::{
+    cmp::Ordering,
+    fmt::{self, Display, Formatter},
+    hash::{Hash, Hasher},
+    net::SocketAddr,
+};
+use xor_name::XorName;
+
+/// The id is the name, derived from its `PublicKey`, and the address of a client.
+#[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Participant {
+    name: XorName,
+    addr: SocketAddr,
+}
+
+impl Participant {
+    pub fn new(name: XorName, addr: SocketAddr) -> Self {
+        Self { name, addr }
+    }
+
+    pub fn name(&self) -> XorName {
+        self.name
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn from_node(id: NodeId) -> Participant {
+        Self::new(id.name(), id.addr())
+    }
+
+    pub fn from_client(id: ClientId) -> Participant {
+        Self::new(id.name(), id.addr())
+    }
+}
+
+impl Display for Participant {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{} at {}", self.name(), self.addr(),)
+    }
+}
+
+impl Eq for Participant {}
+
+impl Hash for Participant {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
+        self.addr().hash(state);
+    }
+}
+
+impl Ord for Participant {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name()
+            .cmp(&other.name())
+            .then_with(|| self.addr().cmp(&other.addr()))
+    }
+}
+
+impl PartialEq for Participant {
+    fn eq(&self, other: &Self) -> bool {
+        self.name() == other.name() && self.addr() == other.addr()
+    }
+}
+
+impl PartialEq<&Self> for Participant {
+    fn eq(&self, other: &&Self) -> bool {
+        self.name() == other.name() && self.addr() == other.addr()
+    }
+}
+
+impl PartialOrd for Participant {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/sn_interface/src/types/identities/node_id.rs
+++ b/sn_interface/src/types/identities/node_id.rs
@@ -1,0 +1,98 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::types::{utils::calc_age, PublicKey};
+
+use std::{
+    cmp::Ordering,
+    fmt::{self, Display, Formatter},
+    hash::{Hash, Hasher},
+    net::SocketAddr,
+};
+use xor_name::XorName;
+
+use super::Participant;
+
+/// The id is the name, derived from its `PublicKey`, and the address of a node.
+#[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct NodeId {
+    name: XorName,
+    addr: SocketAddr,
+    // reward_key: bls::PublicKey,
+}
+
+impl NodeId {
+    pub fn new(name: XorName, addr: SocketAddr) -> Self {
+        Self { name, addr }
+    }
+
+    pub fn name(&self) -> XorName {
+        self.name
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Returns the age.
+    pub fn age(&self) -> u8 {
+        calc_age(&self.name)
+    }
+
+    pub fn from(sender: Participant) -> Self {
+        Self::new(sender.name, sender.addr)
+    }
+
+    pub fn from_key(addr: SocketAddr, public_key: ed25519_dalek::PublicKey) -> Self {
+        Self {
+            addr,
+            name: XorName::from(PublicKey::from(public_key)),
+        }
+    }
+}
+
+impl Display for NodeId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{} at {}", self.name(), self.addr(),)
+    }
+}
+
+impl Eq for NodeId {}
+
+impl Hash for NodeId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
+        self.addr().hash(state);
+    }
+}
+
+impl Ord for NodeId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name()
+            .cmp(&other.name())
+            .then_with(|| self.addr().cmp(&other.addr()))
+    }
+}
+
+impl PartialEq for NodeId {
+    fn eq(&self, other: &Self) -> bool {
+        self.name() == other.name() && self.addr() == other.addr()
+    }
+}
+
+impl PartialEq<&Self> for NodeId {
+    fn eq(&self, other: &&Self) -> bool {
+        self.name() == other.name() && self.addr() == other.addr()
+    }
+}
+
+impl PartialOrd for NodeId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -21,7 +21,7 @@ mod address;
 mod cache;
 mod chunk;
 mod errors;
-mod peer;
+mod identities;
 
 pub use crate::messaging::{
     data::{Error as DataError, RegisterCmd},
@@ -32,13 +32,13 @@ pub use address::{ChunkAddress, DataAddress, RegisterAddress, SpentbookAddress};
 pub use cache::Cache;
 pub use chunk::{Chunk, MAX_CHUNK_SIZE_IN_BYTES};
 pub use errors::{Error, Result};
+pub use identities::{ClientId, NodeId, Participant};
 pub use keys::{
     keypair::{BlsKeypairShare, Encryption, Keypair, OwnerType, Signing},
     public_key::PublicKey,
     secret_key::SecretKey,
     signature::{Signature, SignatureShare},
 };
-pub use peer::Peer;
 
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -19,7 +19,7 @@ use sn_interface::{
     dbcs::gen_genesis_dbc,
     messaging::system::SectionSigned,
     network_knowledge::{NetworkKnowledge, SectionsDAG, GENESIS_DBC_SK},
-    types::{log_markers::LogMarker, Peer},
+    types::{log_markers::LogMarker, NodeId},
     SectionAuthorityProvider,
 };
 
@@ -37,13 +37,12 @@ impl MyNode {
         genesis_sk_set: bls::SecretKeySet,
         fault_cmds_sender: mpsc::Sender<FaultsCmd>,
     ) -> Result<(Self, Dbc)> {
-        let peer = Peer::from(comm.socket_addr(), keypair.public);
-
+        let node_id = NodeId::from_key(comm.socket_addr(), keypair.public);
         let genesis_dbc =
             gen_genesis_dbc(&genesis_sk_set, &bls::SecretKey::from_hex(GENESIS_DBC_SK)?)?;
 
         let (network_knowledge, section_key_share) =
-            NetworkKnowledge::first_node(peer, genesis_sk_set)?;
+            NetworkKnowledge::first_node(node_id, genesis_sk_set)?;
 
         let node = Self::new(
             comm,

--- a/sn_node/src/node/connectivity.rs
+++ b/sn_node/src/node/connectivity.rs
@@ -9,49 +9,51 @@
 use crate::node::{flow_ctrl::cmds::Cmd, MyNode, Result};
 
 use sn_fault_detection::IssueType;
-use sn_interface::types::Peer;
+use sn_interface::types::Participant;
 
 use std::collections::BTreeSet;
 use xor_name::XorName;
 
 impl MyNode {
-    /// Handle error in communication with peer.
-    pub(crate) fn handle_comms_error(&self, peer: Peer, error: sn_comms::Error) {
+    /// Handle error in communication with node.
+    pub(crate) fn handle_comms_error(&self, participant: Participant, error: sn_comms::Error) {
         use sn_comms::Error::*;
         match error {
             ConnectingToUnknownNode(msg_id) => {
                 trace!(
-                    "Tried to send msg {msg_id:?} to unknown peer {}. No connection made.",
-                    peer
+                    "Tried to send msg {msg_id:?} to unknown participant {participant}. No connection made.",
                 );
             }
             CannotConnectEndpoint(_err) => {
-                trace!("Cannot connect to endpoint: {}", peer);
+                trace!("Cannot connect to endpoint: {participant}");
             }
             AddressNotReachable(_err) => {
-                trace!("Address not reachable: {}", peer);
+                trace!("Address not reachable: {participant}");
             }
             FailedSend(msg_id) => {
-                trace!("Could not send {msg_id:?}, lost known peer: {}", peer);
+                trace!("Could not send {msg_id:?}, lost known participant: {participant}");
             }
             InvalidMsgReceived(msg_id) => {
-                trace!("Invalid msg {msg_id:?} received from {}.", peer);
+                trace!("Invalid msg {msg_id:?} received from {participant}");
             }
         }
-        // Track comms issue if this is a peer we know and care about
-        if self.network_knowledge.is_section_member(&peer.name()) {
-            self.track_node_issue(peer.name(), IssueType::Communication);
+        // Track comms issue if this is a node in our section.
+        if self
+            .network_knowledge
+            .is_section_member(&participant.name())
+        {
+            self.track_node_issue(participant.name(), IssueType::Communication);
         }
     }
 
     pub(crate) fn cast_offline_proposals(&mut self, names: &BTreeSet<XorName>) -> Result<Vec<Cmd>> {
-        // Don't send the `Offline` proposal to the peer being lost as that send would fail,
+        // Don't send the `Offline` proposal to the node being lost as that send would fail,
         // triggering a chain of further `Offline` proposals.
         let elders: Vec<_> = self
             .network_knowledge
             .section_auth()
             .elders()
-            .filter(|peer| !names.contains(&peer.name()))
+            .filter(|node_id| !names.contains(&node_id.name()))
             .cloned()
             .collect();
         let mut result: Vec<Cmd> = Vec::new();

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -36,9 +36,9 @@ pub enum Error {
     /// SendChannel error for the data replication flow. This is a critical error and the node no longer functions.
     #[error("Data replication channel could not be sent to. This means the receiver has been dropped, the node can no longer replicate data and must shut down.")]
     DataReplicationChannel,
-    /// This peer has no connections, and none will be created
-    #[error("Peer link has no connections ")]
-    NoConnectionsForPeer,
+    /// This node has no connections, and none will be created
+    #[error("Node link has no connections ")]
+    NoConnectionsForNode,
     /// This should not be possible as the channel is stored in node, and used to process child commands
     #[error("No more Cmds will be received or processed. CmdChannel senders have been dropped. ")]
     CmdCtrlChannelDropped,

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -11,7 +11,7 @@ use crate::node::{
     Error, MyNode, STANDARD_CHANNEL_SIZE,
 };
 
-use sn_interface::types::{DataAddress, Peer};
+use sn_interface::types::{DataAddress, NodeId};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
@@ -23,11 +23,11 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 /// all the while logging the correlation between incoming and resulting cmds.
 pub(crate) struct CmdCtrl {
     id_counter: Arc<AtomicUsize>,
-    data_replication_sender: Sender<(Vec<DataAddress>, Peer)>,
+    data_replication_sender: Sender<(Vec<DataAddress>, NodeId)>,
 }
 
 impl CmdCtrl {
-    pub(crate) fn new() -> (Self, Receiver<(Vec<DataAddress>, Peer)>) {
+    pub(crate) fn new() -> (Self, Receiver<(Vec<DataAddress>, NodeId)>) {
         #[cfg(feature = "statemap")]
         sn_interface::statemap::log_metadata();
         let (data_replication_sender, data_replication_receiver) = channel(STANDARD_CHANNEL_SIZE);

--- a/sn_node/src/node/flow_ctrl/periodic_checks.rs
+++ b/sn_node/src/node/flow_ctrl/periodic_checks.rs
@@ -253,7 +253,7 @@ impl FlowCtrl {
 
     //     let msg_id = MsgId::new();
     //     let our_info = node.info();
-    //     let origin = our_info.peer();
+    //     let origin = our_info.id();
 
     //     let auth = auth(&node, &msg)?;
 

--- a/sn_node/src/node/membership/mod.rs
+++ b/sn_node/src/node/membership/mod.rs
@@ -468,10 +468,11 @@ impl Membership {
 mod tests {
     use super::Error;
     use crate::node::flow_ctrl::tests::network_builder::TestNetworkBuilder;
+    use sn_interface::{network_knowledge::NodeState, test_utils::gen_node_id};
+
     use assert_matches::assert_matches;
     use eyre::Result;
     use rand::thread_rng;
-    use sn_interface::{network_knowledge::NodeState, test_utils::gen_peer};
     use xor_name::Prefix;
 
     #[tokio::test]
@@ -487,8 +488,8 @@ mod tests {
             .membership
             .expect("Membership for the elder should've been initialized");
 
-        let state1 = NodeState::joined(gen_peer(5), None);
-        let state2 = NodeState::joined(gen_peer(5), None);
+        let state1 = NodeState::joined(gen_node_id(5), None);
+        let state2 = NodeState::joined(gen_node_id(5), None);
 
         let _ = membership.propose(state1, &prefix)?;
         assert_matches!(

--- a/sn_node/src/node/messaging/promotion.rs
+++ b/sn_node/src/node/messaging/promotion.rs
@@ -10,11 +10,12 @@ use crate::node::flow_ctrl::cmds::Cmd;
 use crate::node::{MyNode, Result};
 
 use sn_interface::{
-    messaging::system::{SectionSig, SectionSigShare, SectionSigned},
-    messaging::MsgId,
+    messaging::{
+        system::{SectionSig, SectionSigShare, SectionSigned},
+        MsgId,
+    },
     network_knowledge::{SectionAuthorityProvider, SectionTreeUpdate},
-    types::log_markers::LogMarker,
-    types::Peer,
+    types::{log_markers::LogMarker, NodeId},
 };
 
 impl MyNode {
@@ -23,7 +24,7 @@ impl MyNode {
         msg_id: MsgId,
         sap: SectionSigned<SectionAuthorityProvider>,
         sig_share: SectionSigShare,
-        sender: Peer,
+        sender: NodeId,
     ) -> Result<Vec<Cmd>> {
         info!("Handling handover promotion message {msg_id:?} by {sender:?} with sap: {sap:?}");
         let our_prefix = self.network_knowledge.prefix();
@@ -78,7 +79,7 @@ impl MyNode {
         sig_share1: SectionSigShare,
         sap2: SectionSigned<SectionAuthorityProvider>,
         sig_share2: SectionSigShare,
-        sender: Peer,
+        sender: NodeId,
     ) -> Result<Vec<Cmd>> {
         trace!("Handling section split promotion message {msg_id:?} by {sender:?} with saps: {sap1:?} {sap2:?}");
         let our_prefix = self.network_knowledge.prefix();

--- a/sn_node/src/node/messaging/update_section.rs
+++ b/sn_node/src/node/messaging/update_section.rs
@@ -6,12 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::node::{core::NodeContext, flow_ctrl::cmds::Cmd, messaging::Peers, MyNode};
+use crate::node::{core::NodeContext, flow_ctrl::cmds::Cmd, messaging::Recipients, MyNode};
 use rand::{rngs::OsRng, seq::SliceRandom};
 use sn_interface::{
     data_copy_count,
     messaging::system::{NodeDataCmd, NodeMsg},
-    types::{log_markers::LogMarker, DataAddress, Peer},
+    types::{log_markers::LogMarker, DataAddress, NodeId},
 };
 
 use itertools::Itertools;
@@ -22,12 +22,12 @@ use std::collections::BTreeSet;
 static MAX_REPLICATION_BATCH_SIZE: usize = 25;
 
 impl MyNode {
-    /// Given what data the peer has, we shall calculate what data the peer is missing that
-    /// we have, and send such data to the peer.
+    /// Given what data the node has, we shall calculate what data the node is missing that
+    /// we have, and send such data to the node.
     #[instrument(skip(context, data_sender_has))]
     pub(crate) async fn get_missing_data_for_node(
         context: &NodeContext,
-        sender: Peer,
+        sender: NodeId,
         data_sender_has: Vec<DataAddress>,
     ) -> Option<Cmd> {
         debug!("Getting missing data for node");
@@ -105,12 +105,12 @@ impl MyNode {
         );
 
         if members.is_empty() {
-            warn!("We have no peers to ask for data!");
+            warn!("We have no nodes to ask for data!");
         } else {
             trace!("Sending our data list to: {:?}", members);
         }
 
         let msg = NodeMsg::NodeDataCmd(NodeDataCmd::SendAnyMissingRelevantData(data_i_have));
-        Cmd::send_msg(msg, Peers::Multiple(members))
+        Cmd::send_msg(msg, Recipients::Multiple(members))
     }
 }


### PR DESCRIPTION
This removes the ambiguous `Peer` concept and creates a clearer path for client and node related logic, while finally resolving the node/peer ambiguity. Also, the peer struct is and has always been an identifier for a client or node. For that reason it is now named accordingly.

A peer could previously be both a node and a client (id). But a client doesn't have an age, and we don't want node logic paths muddled. So now we only have `ClientId` and `NodeId`, and in the few places where we don't know which of it it is (or it is shared code) it is now called a `Participant` (as in participating in the network). That name can probably be improved, but is an OK start.

This PR will give a better structure in the introduction of reward key in the [current reward key integration PR](https://github.com/maidsafe/safe_network/pull/2169).

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
