### PR TITLE
feat(rewards): add bls pub key to node

### DIFF
--- a/sn_interface/src/types/keys/public_key.rs
+++ b/sn_interface/src/types/keys/public_key.rs
@@ -59,22 +59,7 @@ impl PublicKey {
     ///
     /// It is often useful to parse such raw strings in user-facing apps like CLI.
     pub fn bls_from_hex(hex: &str) -> Result<Self> {
-        let bytes = hex::decode(hex).map_err(|err| {
-            Error::FailedToParse(format!(
-                "Couldn't parse BLS public key bytes from hex: {err}",
-            ))
-        })?;
-        let bytes_fixed_len: [u8; bls::PK_SIZE] = bytes.as_slice().try_into()
-            .map_err(|_| Error::FailedToParse(format!(
-                "Couldn't parse BLS public key bytes from hex. The provided string must represent exactly {} bytes.",
-                bls::PK_SIZE
-            )))?;
-        let pk = bls::PublicKey::from_bytes(bytes_fixed_len).map_err(|err| {
-            Error::FailedToParse(format!(
-                "Couldn't parse BLS public key from fixed-length byte array: {err}",
-            ))
-        })?;
-        Ok(Self::from(pk))
+        Ok(Self::from(bls_from_hex(hex)?))
     }
 
     /// Returns the bytes of the underlying public key.
@@ -227,6 +212,29 @@ impl UpperHex for PublicKey {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", hex::encode_upper(self.to_bytes()))
     }
+}
+
+/// Construct a BLS public key from a hex-encoded string.
+///
+/// It is often useful to parse such raw strings in user-facing apps like CLI.
+pub fn bls_from_hex<T: AsRef<[u8]>>(hex: T) -> Result<bls::PublicKey> {
+    let bytes = hex::decode(hex).map_err(|err| {
+        Error::FailedToParse(format!(
+            "Couldn't parse BLS public key bytes from hex: {err}",
+        ))
+    })?;
+    let bytes_fixed_len: [u8; bls::PK_SIZE] = bytes.as_slice().try_into()
+        .map_err(|_| Error::FailedToParse(format!(
+            "Couldn't parse BLS public key bytes from hex. The provided string must represent exactly {} bytes.",
+            bls::PK_SIZE
+        )))?;
+    let pk = bls::PublicKey::from_bytes(bytes_fixed_len).map_err(|err| {
+        Error::FailedToParse(format!(
+            "Couldn't parse BLS public key from fixed-length byte array: {err}",
+        ))
+    })?;
+
+    Ok(pk)
 }
 
 #[cfg(test)]

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -35,7 +35,7 @@ pub use errors::{Error, Result};
 pub use identities::{ClientId, NodeId, Participant};
 pub use keys::{
     keypair::{BlsKeypairShare, Encryption, Keypair, OwnerType, Signing},
-    public_key::PublicKey,
+    public_key::{bls_from_hex, PublicKey},
     secret_key::SecretKey,
     signature::{Signature, SignatureShare},
 };

--- a/sn_node/src/node/api.rs
+++ b/sn_node/src/node/api.rs
@@ -32,6 +32,7 @@ impl MyNode {
     pub(crate) fn first_node(
         comm: Comm,
         keypair: Keypair,
+        reward_key: bls::PublicKey,
         used_space: UsedSpace,
         root_storage_dir: PathBuf,
         genesis_sk_set: bls::SecretKeySet,
@@ -47,6 +48,7 @@ impl MyNode {
         let node = Self::new(
             comm,
             Arc::new(keypair),
+            reward_key,
             network_knowledge,
             Some(section_key_share),
             used_space,

--- a/sn_node/src/node/flow_ctrl/tests/network_builder.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_builder.rs
@@ -804,6 +804,7 @@ impl TestNetwork {
         MyNode::new(
             comm.clone(),
             info.keypair.clone(),
+            bls::SecretKey::random().public_key(),
             network_knowledge.clone(),
             None,
             UsedSpace::new(min_capacity, max_capacity),
@@ -832,6 +833,7 @@ impl TestNetwork {
         let mut my_node = MyNode::new(
             comm.clone(),
             info.keypair.clone(),
+            bls::SecretKey::random().public_key(),
             network_knowledge.clone(),
             sk_share.clone(),
             UsedSpace::new(min_capacity, max_capacity),

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -226,6 +226,9 @@ impl MyNode {
         spent_transactions: &BTreeSet<DbcTransaction>,
         context: &NodeContext,
     ) -> Result<SpentProofShare> {
+        // verify that fee is paid (we are included as output)
+        MyNode::verify_fee(context.reward_key, tx)?;
+
         // verify the spent proofs
         MyNode::verify_spent_proofs(spent_proofs, &context.network_knowledge)?;
 
@@ -268,6 +271,11 @@ impl MyNode {
         )?;
 
         Ok(spent_proof_share)
+    }
+
+    fn verify_fee(_our_key: PublicKey, _tx: &DbcTransaction) -> Result<()> {
+        // TODO: check that we have an output to us, and that it is of sufficient value.
+        Ok(())
     }
 
     // Verify spent proof signatures are valid, and each spent proof is signed by a known section key.

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -96,6 +96,7 @@ mod core {
         root_storage_dir: PathBuf,
         pub(crate) data_storage: DataStorage, // Adult only before cache
         pub(crate) keypair: Arc<Keypair>,
+        pub(crate) reward_key: PublicKey,
         // Network resources
         pub(crate) section_keys_provider: SectionKeysProvider,
         pub(crate) network_knowledge: NetworkKnowledge,
@@ -129,6 +130,7 @@ mod core {
         pub(crate) name: XorName,
         pub(crate) info: MyNodeInfo,
         pub(crate) keypair: Arc<Keypair>,
+        pub(crate) reward_key: PublicKey,
         pub(crate) network_knowledge: NetworkKnowledge,
         pub(crate) section_keys_provider: SectionKeysProvider,
         #[debug(skip)]
@@ -185,6 +187,7 @@ mod core {
                 name: self.name(),
                 info: self.info(),
                 keypair: self.keypair.clone(),
+                reward_key: self.reward_key,
                 network_knowledge: self.network_knowledge().clone(),
                 section_keys_provider: self.section_keys_provider.clone(),
                 comm: self.comm.clone(),
@@ -196,9 +199,11 @@ mod core {
             }
         }
 
+        #[allow(clippy::too_many_arguments)]
         pub(crate) fn new(
             comm: Comm,
             keypair: Arc<Keypair>, //todo: Keypair, only test design blocks this
+            reward_key: PublicKey,
             network_knowledge: NetworkKnowledge,
             section_key_share: Option<SectionKeyShare>,
             used_space: UsedSpace,
@@ -244,6 +249,7 @@ mod core {
                 comm,
                 addr,
                 keypair,
+                reward_key,
                 network_knowledge,
                 section_keys_provider,
                 root_storage_dir,


### PR DESCRIPTION
This is the first step to simple dbc tx fees and rewards for Elders.
It allows Elders to check if dbc transactions contain any output for them.

***

Follow up PRs:

- Including Elders in outputs (any value) when spending DBCs.
- Elders confirming that spends contain outputs destined for them.
- Implementing a commonly known deterministic transfer/store cost and distribution to nodes.
- Including transfer/store cost in outputs when spending DBCs.
- Elders confirming that the amounts in those outputs are sufficient.