### PR TITLE
fix(github_action): check if all jobs are not failed before merging

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -966,3 +966,23 @@ jobs:
           path: log_files.tar.gz
         if: failure()
         continue-on-error: true
+
+  # make sure all the jobs are not failed.
+  # Note that the duplicated jobs might be skipped.
+  merge-after-tests:
+    needs:
+      - pre_job
+      - cargo-udeps
+      - lint
+      - checks
+      - build-arm
+      - unit
+      - e2e
+      - e2e-msg-happy-path
+      - e2e-churn
+      - api
+      - cli
+    runs-on: ubuntu-latest
+    if: "! failure()"
+    steps:
+      - run: echo "All checks passed, ready to merge"


### PR DESCRIPTION
We are using [skip-duplicate-actions](https://github.com/fkirc/skip-duplicate-actions) to detect the duplicated jobs. This helps to reduce the time merge. However,  are situations that the skip won't trig the merger job and as a result the PR won't be merged (even if it is in merge queue) . 

In this PR we check all jobs are not failed before merging in the last job