### PR TITLE
feat(node): push non-blocking Cmds off thread

### DIFF
--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -202,6 +202,8 @@ pub enum Error {
     DbcError(#[from] DbcError),
     #[error("BLS error: {0}")]
     BlsError(#[from] bls::Error),
+    #[error("Tokio channel could not be sent to: {0}")]
+    TokioChannel(String),
     #[cfg(feature = "otlp")]
     #[error("OpenTelemetry Tracing error: {0}")]
     OpenTelemetryTracing(#[from] opentelemetry::trace::TraceError),

--- a/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
+++ b/sn_node/src/node/flow_ctrl/cmd_ctrl.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::node::{
-    flow_ctrl::{cmds::Cmd, CmdProcessorEvent, RejoinReason},
+    flow_ctrl::{cmds::Cmd, FlowCtrlCmd, RejoinReason},
     Error, MyNode, STANDARD_CHANNEL_SIZE,
 };
 
@@ -47,7 +47,7 @@ impl CmdCtrl {
         node: &mut MyNode,
         cmd: Cmd,
         mut id: Vec<usize>,
-        cmd_process_api: Sender<CmdProcessorEvent>,
+        cmd_process_api: Sender<FlowCtrlCmd>,
         rejoin_network_sender: Sender<RejoinReason>,
     ) {
         let node_identifier = node.info().name();
@@ -75,7 +75,7 @@ impl CmdCtrl {
                         // let child_id = [id.clone(), [child_nr].to_vec()].concat();
 
                         // match cmd_process_api.send((cmd, child_id)).await {
-                        match cmd_process_api.send(CmdProcessorEvent::Cmd(cmd)).await {
+                        match cmd_process_api.send(FlowCtrlCmd::Handle(cmd)).await {
                             Ok(_) => (), // no issues
                             Err(error) => {
                                 let child_id = [id.clone(), [child_nr].to_vec()].concat();

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -377,7 +377,7 @@ impl FlowCtrl {
                         // Go off thread for parsing and handling by default
                         // we only punt certain cmds back into the mutating channel
                         let _handle = tokio::spawn(async move {
-                            let results = handle_cmd_process(
+                            let results = handle_cmd(
                                 incoming_cmd,
                                 context.clone(),
                                 mutating_cmd_channel.clone(),
@@ -389,7 +389,7 @@ impl FlowCtrl {
                                 let mut new_cmds = vec![];
 
                                 for cmd in offspring {
-                                    let cmds = handle_cmd_process(
+                                    let cmds = handle_cmd(
                                         cmd,
                                         context.clone(),
                                         mutating_cmd_channel.clone(),
@@ -456,7 +456,7 @@ impl FlowCtrl {
 }
 
 /// Handles Cmd, either spawn a fresh thread if non blocking, or pass to the blocking processor thread
-async fn handle_cmd_process(
+async fn handle_cmd(
     cmd: Cmd,
     context: NodeContext,
     mutating_cmd_channel: CmdChannel,

--- a/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/cmd_utils.rs
@@ -150,7 +150,7 @@ impl ProcessAndInspectCmds {
                 ..
             })) => {
                 let cmds = MyNode::handle_msg(
-                    node,
+                    node.context(),
                     sn_interface::types::Participant::from_node(node_id),
                     wire_msg,
                     Some(send_stream),

--- a/sn_node/src/node/messaging/mod.rs
+++ b/sn_node/src/node/messaging/mod.rs
@@ -23,7 +23,7 @@ mod signature;
 mod streams;
 mod update_section;
 
-use crate::node::{flow_ctrl::cmds::Cmd, Error, MyNode, Result};
+use crate::node::{core::NodeContext, flow_ctrl::cmds::Cmd, Error, MyNode, Result};
 
 use sn_interface::{
     messaging::{AntiEntropyMsg, MsgKind, NetworkMsg, WireMsg},
@@ -63,9 +63,9 @@ impl IntoIterator for Recipients {
 
 // Message handling
 impl MyNode {
-    #[instrument(skip(node, wire_msg, send_stream))]
+    #[instrument(skip(wire_msg, send_stream))]
     pub(crate) async fn handle_msg(
-        node: &MyNode,
+        context: NodeContext,
         sender: Participant,
         wire_msg: WireMsg,
         send_stream: Option<SendStream>,
@@ -74,8 +74,6 @@ impl MyNode {
         let msg_kind = wire_msg.kind();
 
         trace!("Handling msg {msg_id:?}. from {sender:?} Checking for AE first...");
-
-        let context = node.context();
 
         // alternatively we could flag in msg kind for this...
         // todo: this sender is actually client + forwarder ip....


### PR DESCRIPTION
Moves heaps of non critical Cmds out of the blocking mut MyNode context. Allows them to run w/ latest context; only pushing a subset of Cmds into the blocking process loop

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
