### PR TITLE
feat(rewards): send fee query to elders

### DIFF
--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -13,6 +13,7 @@ mod data;
 mod file_apis;
 mod queries;
 mod register_apis;
+mod spend_queries;
 mod spentbook_apis;
 
 pub use client_builder::ClientBuilder;

--- a/sn_client/src/api/queries.rs
+++ b/sn_client/src/api/queries.rs
@@ -49,8 +49,6 @@ impl Client {
     async fn send_query_with_retry(&self, query: DataQuery, retry: bool) -> Result<QueryResponse> {
         let client_pk = self.public_key();
 
-        // Add jitter so not all clients retry at the same rate. This divider will knock on to the overall retry window
-        // and should help prevent elders from being conseceutively overwhelmed
         trace!("Setting up query retry");
 
         let span = info_span!("Attempting a query");
@@ -77,7 +75,7 @@ impl Client {
             debug!("Attempting {query:?} (node_index #{})", node_index);
 
             // grab up to date destination section from our local network knowledge
-            let (section_pk, elders) = self.session.get_query_elders(dst).await?;
+            let (section_pk, elders) = self.session.get_data_query_elders(dst).await?;
 
             let res = self
                 .send_signed_query_to_section(
@@ -181,7 +179,7 @@ impl Client {
         let dst = query.dst_name();
 
         // grab up to date destination section from our local network knowledge
-        let (section_pk, elders) = self.session.get_query_elders(dst).await?;
+        let (section_pk, elders) = self.session.get_data_query_elders(dst).await?;
 
         // Send queries to the replicas concurrently
         let mut tasks = vec![];

--- a/sn_client/src/api/spend_queries.rs
+++ b/sn_client/src/api/spend_queries.rs
@@ -1,0 +1,161 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::Client;
+use crate::errors::{Error, Result};
+
+use sn_dbc::{PublicKey, Token};
+use sn_interface::{
+    messaging::{
+        data::{ClientMsg, DataQuery, Error as ErrorMsg, QueryResponse, SpendQuery},
+        ClientAuth, WireMsg,
+    },
+    types::SpentbookAddress,
+};
+
+use backoff::{backoff::Backoff, ExponentialBackoff};
+use futures::future::join_all;
+use std::collections::BTreeMap;
+use tokio::time::sleep;
+use tracing::{debug, info_span};
+use xor_name::XorName;
+
+impl Client {
+    /// Return the set of Elder reward keys and the individual fee they ask for processing a spend.
+    #[instrument(skip(self), level = "debug")]
+    pub async fn get_mint_fees(&self, dbc_key: PublicKey) -> Result<BTreeMap<PublicKey, Token>> {
+        let address = SpentbookAddress::new(XorName::from_content(&dbc_key.to_bytes()));
+        let fee_query = DataQuery::Spentbook(SpendQuery::GetFees(address));
+
+        let (_, elders) = self
+            .session
+            .get_all_elders_of_dst(fee_query.dst_name())
+            .await?;
+        let tasks = elders.into_iter().enumerate().map(|(index, _)| {
+            let client = self.clone();
+            let query = fee_query.clone();
+            tokio::spawn(async move { client.send_fee_query(query, index).await })
+        });
+
+        // We just want to receive at least supermajority of results, we don't care about any errors
+        // so we log them, but return whatever results we get. If not enough for upper layer, it will error there.
+        let results = join_all(tasks)
+            .await
+            .into_iter()
+            .flat_map(|res| {
+                if let Err(error) = &res {
+                    warn!("Error when joining fee query threads: {error}");
+                }
+                res
+            })
+            .flat_map(|res| {
+                if let Err(error) = &res {
+                    warn!("Error when querying for fees: {error}");
+                }
+                res
+            })
+            .filter_map(|r| match r {
+                QueryResponse::GetFees(Ok(res)) => Some(res),
+                QueryResponse::GetFees(Err(error)) => {
+                    warn!("Fee query unexpectedly failed: {error}");
+                    None
+                }
+                other => {
+                    warn!("Unexpected response to fee query: {other:?}");
+                    None
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    /// Send a Query to the network and await a response.
+    /// Queries are automatically retried using exponential backoff if the timeout is hit.
+    #[instrument(skip(self), level = "debug")]
+    async fn send_fee_query(&self, query: DataQuery, elder_index: usize) -> Result<QueryResponse> {
+        let client_pk = self.public_key();
+
+        trace!("Setting up fee query retry.");
+
+        let span = info_span!("Attempting a fee query.");
+        let _ = span.enter();
+
+        let max_interval = self.max_backoff_interval;
+
+        let mut backoff = ExponentialBackoff {
+            initial_interval: max_interval / 2,
+            max_interval,
+            max_elapsed_time: self.query_timeout,
+            randomization_factor: 1.5,
+            ..Default::default()
+        };
+
+        // this seems needed for custom settings to take effect
+        backoff.reset();
+
+        let dst = query.dst_name();
+        let msg = ClientMsg::Query(query.clone());
+        let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
+        let auth = ClientAuth {
+            public_key: client_pk,
+            signature: self.keypair.sign(&serialised_query),
+        };
+
+        let mut result = Err(Error::ErrorMsg {
+            source: ErrorMsg::InconsistentStorageNodeResponses,
+        });
+
+        while let Some(delay) = backoff.next_backoff() {
+            debug!("Attempting {query:?}");
+
+            // grab up to date destination section from our local network knowledge
+            let (section_pk, elders) = self.session.get_all_elders_of_dst(dst).await?;
+
+            let elder = *elders
+                .get(elder_index)
+                .ok_or(Error::InsufficientElderConnections {
+                    connections: elders.len(),
+                    required: elder_index + 1,
+                })?;
+
+            result = self
+                .session
+                .send_single_query(
+                    query.clone(),
+                    auth.clone(),
+                    serialised_query.clone(),
+                    section_pk,
+                    elder,
+                )
+                .await;
+
+            // if the response is acceptable, return instead of wait/retry loop
+            if let Ok(response) = &result {
+                if response.is_error() {
+                    warn!(
+                        "Fee query errored... querying again until we hit query_timeout ({:?})",
+                        self.query_timeout
+                    );
+                } else {
+                    debug!("{query:?} sent and received okay");
+                    return Ok(response.clone());
+                }
+            }
+
+            debug!("Sleeping before trying query again: {delay:?} sleep for {query:?}");
+            sleep(delay).await;
+        }
+
+        // The warning says "last response", because there is no path for it to use the initial result value.
+        warn!("Finished trying and last response to {query:?} is {result:?}");
+
+        // we're done trying
+        result
+    }
+}

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -148,6 +148,22 @@ pub enum QueryResponse {
 }
 
 impl QueryResponse {
+    /// Returns true if the result returned is an error.
+    pub fn is_error(&self) -> bool {
+        use QueryResponse::*;
+        match self {
+            GetChunk(r) => r.is_err(),
+            GetRegister(r) => r.is_err(),
+            GetRegisterEntry(r) => r.is_err(),
+            GetRegisterOwner(r) => r.is_err(),
+            ReadRegister(r) => r.is_err(),
+            GetRegisterPolicy(r) => r.is_err(),
+            GetRegisterUserPermissions(r) => r.is_err(),
+            GetSpentProofShares(r) => r.is_err(),
+            GetFees(r) => r.is_err(),
+        }
+    }
+
     /// Returns true if the result returned is DataNotFound
     pub fn is_data_not_found(&self) -> bool {
         use QueryResponse::*;


### PR DESCRIPTION
This PR adds concurrent querying of each elder for their respective reward
key and fee, and replaces the dummy fee with the result from the implemented query.

***

1. Including Elders in outputs (any value) when spending DBCs.
1.1 `Previous PR`: The query and handling of it on Elders for their reward keys and hard coded fee (#2184).
1.2 `Previous PR`: The logic for including Elders to outputs (#2180).
1.3 `This PR`: ✔️ Connecting the two above, by the client logic for querying Elders for their reward keys and fee.

PRs in the overall feature:
- <s> 1. Including Elders in outputs (any value) when spending DBCs.</s>
- Elders confirming that spends contain outputs destined for them.
- Implementing a commonly known deterministic transfer/store cost and distribution to nodes.
- Including transfer/store cost in outputs when spending DBCs.
- Elders confirming that the amounts in those outputs are sufficient.
