### PR TITLE
chore(msgs): remove unnecessary serializing

### DIFF
--- a/sn_comms/src/listener.rs
+++ b/sn_comms/src/listener.rs
@@ -58,6 +58,10 @@ pub(crate) async fn listen_for_msgs(
                 debug!(
                     "New msg arrived over conn_id={conn_id} from {remote_address:?}{stream_info}"
                 );
+
+                let (header, dst, payload) = &msg_bytes.0;
+                let original_bytes_len = header.len() + dst.len() + payload.len();
+
                 let wire_msg = match WireMsg::from(msg_bytes.0) {
                     Ok(wire_msg) => wire_msg,
                     Err(error) => {
@@ -74,8 +78,12 @@ pub(crate) async fn listen_for_msgs(
                     | MsgKind::DataResponse(name) => *name,
                 };
 
-                let src = Participant::new(src_name, remote_address);
                 let msg_id = wire_msg.msg_id();
+                let src = Participant::new(src_name, remote_address);
+                trace!(
+                    "{:?} from {src:?} length {original_bytes_len}",
+                    LogMarker::MsgReceived,
+                );
                 debug!(
                         "Msg {msg_id:?} received, over conn_id={conn_id}, from: {src:?}{stream_info} was: {wire_msg:?}"
                     );

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -330,22 +330,9 @@ impl FlowCtrl {
                         wire_msg,
                         send_stream,
                     }) => {
-                        if let Ok((header, dst, payload)) = wire_msg.serialize() {
-                            let original_bytes_len = header.len() + dst.len() + payload.len();
-                            let span =
-                                trace_span!("handle_message", ?sender, msg_id = ?wire_msg.msg_id());
-                            let _span_guard = span.enter();
-                            trace!(
-                                "{:?} from {sender:?} length {original_bytes_len}",
-                                LogMarker::MsgReceived,
-                            );
-                        } else {
-                            // this should be unreachable
-                            trace!(
-                                "{:?} from {sender:?}, unknown length due to serialization issues.",
-                                LogMarker::MsgReceived,
-                            );
-                        }
+                        let span =
+                            trace_span!("handle_message", ?sender, msg_id = ?wire_msg.msg_id());
+                        let _span_guard = span.enter();
 
                         Cmd::HandleMsg {
                             sender,


### PR DESCRIPTION
The serialization is only for logging and we already have 
the serialized msg earlier in the flow, so the log can be moved to that place.