### PR TITLE
refactor(node): remove unused join response

### DIFF
--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -12,13 +12,6 @@ use sn_consensus::Decision;
 
 /// Response to a request to join a section
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct JoinRequest {
-    /// The public key of the section to join.
-    pub section_key: bls::PublicKey,
-}
-
-/// Response to a request to join a section
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum JoinResponse {
     /// Message sent to joining node containing the current node's
     /// state as a member of the section.

--- a/sn_interface/src/messaging/system/join.rs
+++ b/sn_interface/src/messaging/system/join.rs
@@ -9,7 +9,6 @@
 use super::NodeState;
 use serde::{Deserialize, Serialize};
 use sn_consensus::Decision;
-use std::{fmt, net::SocketAddr};
 
 /// Response to a request to join a section
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -24,24 +23,9 @@ pub enum JoinResponse {
     /// Message sent to joining node containing the current node's
     /// state as a member of the section.
     Approved(Decision<NodeState>),
-    /// Join was rejected
-    Rejected(JoinRejectReason),
-    /// Join is being considered
-    UnderConsideration,
-}
-
-/// Reason of a join request being rejected
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum JoinRejectReason {
     /// No new nodes are currently accepted for joining
     /// NB: Relocated nodes that try to join, are accepted even if joins are disallowed.
     JoinsDisallowed,
-    /// The requesting node is not externally reachable
-    NodeNotReachable(SocketAddr),
-}
-
-impl fmt::Display for JoinRejectReason {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{self:?}")
-    }
+    /// Join is being considered
+    UnderConsideration,
 }

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -17,7 +17,7 @@ use crate::network_knowledge::{NodeState, RelocationProof, SapCandidate};
 use crate::SectionAuthorityProvider;
 
 pub use dkg::DkgSessionId;
-pub use join::{JoinRejectReason, JoinRequest, JoinResponse};
+pub use join::{JoinRequest, JoinResponse};
 pub use node_msgs::{NodeDataCmd, NodeEvent, NodeQueryResponse};
 pub use section_sig::{SectionSig, SectionSigShare, SectionSigned};
 

--- a/sn_interface/src/messaging/system/mod.rs
+++ b/sn_interface/src/messaging/system/mod.rs
@@ -17,7 +17,7 @@ use crate::network_knowledge::{NodeState, RelocationProof, SapCandidate};
 use crate::SectionAuthorityProvider;
 
 pub use dkg::DkgSessionId;
-pub use join::{JoinRequest, JoinResponse};
+pub use join::JoinResponse;
 pub use node_msgs::{NodeDataCmd, NodeEvent, NodeQueryResponse};
 pub use section_sig::{SectionSig, SectionSigShare, SectionSigned};
 

--- a/sn_node/src/bin/sn_node/main.rs
+++ b/sn_node/src/bin/sn_node/main.rs
@@ -203,16 +203,6 @@ fn create_runtime_and_node(config: &Config) -> Result<()> {
                             join_retry_sec = JOIN_DISALLOWED_RETRY_TIME_SEC;
                             continue;
                         }
-                        NodeError::RejoinRequired(NodeNotReachable(addr)) => {
-                            let err = Err(NodeError::RejoinRequired(NodeNotReachable(addr))).suggestion(
-                                "Unfortunately we are unable to establish a connection to your machine through its \
-                                public IP address. This might involve forwarding ports on your router."
-                                    .header("Please ensure your node is externally reachable")
-                            );
-                            println!("{err:?}");
-                            error!("{err:?}");
-                            return err;
-                        }
                         #[cfg(feature = "chaos")]
                         NodeError::ChaoticStartupCrash => {
                             continue;

--- a/sn_node/src/node/flow_ctrl/mod.rs
+++ b/sn_node/src/node/flow_ctrl/mod.rs
@@ -31,14 +31,13 @@ use crate::node::{
 use sn_comms::{CommEvent, MsgReceived};
 use sn_fault_detection::FaultDetection;
 use sn_interface::{
-    messaging::system::{JoinRejectReason, NodeDataCmd, NodeMsg},
+    messaging::system::{NodeDataCmd, NodeMsg},
     messaging::{AntiEntropyMsg, NetworkMsg},
     types::{log_markers::LogMarker, DataAddress, NodeId, Participant},
 };
 
 use std::{
     collections::BTreeSet,
-    net::SocketAddr,
     time::{Duration, Instant},
 };
 use tokio::sync::mpsc::{self, Receiver, Sender};
@@ -56,18 +55,6 @@ pub enum RejoinReason {
     JoinsDisallowed,
     /// Happens when already part of the network; we need to start from scratch.
     RemovedFromSection,
-    /// Unrecoverable error, requires node operator network config.
-    NodeNotReachable(SocketAddr),
-}
-
-impl RejoinReason {
-    pub(crate) fn from_reject_reason(reason: JoinRejectReason) -> RejoinReason {
-        use JoinRejectReason::*;
-        match reason {
-            JoinsDisallowed => RejoinReason::JoinsDisallowed,
-            NodeNotReachable(add) => RejoinReason::NodeNotReachable(add),
-        }
-    }
 }
 
 /// Flow ctrl of node cmds by . This determines if to run in blocking

--- a/sn_node/src/node/messaging/join_section.rs
+++ b/sn_node/src/node/messaging/join_section.rs
@@ -44,10 +44,7 @@ mod tests {
     use sn_comms::CommEvent;
     use sn_interface::{
         elder_count, init_logger,
-        messaging::{
-            system::{JoinRejectReason, JoinResponse},
-            MsgId, NetworkMsg,
-        },
+        messaging::{system::JoinResponse, MsgId, NetworkMsg},
         network_knowledge::{MembershipState, NetworkKnowledge},
         types::Participant,
     };
@@ -356,7 +353,7 @@ mod tests {
             ..
         }) => {
             // the msg should be a rejection for joins disallowed
-            assert_matches!(msg, NodeMsg::JoinResponse(JoinResponse::Rejected(JoinRejectReason::JoinsDisallowed)));
+            assert_matches!(msg, NodeMsg::JoinResponse(JoinResponse::JoinsDisallowed));
             // the recipient should be the joining node
             assert_matches!(recipients, Recipients::Single(recipient) => {
                 assert_eq!(recipient, &Participant::from_node(joiner_node_id));

--- a/sn_node/src/node/messaging/joining_nodes.rs
+++ b/sn_node/src/node/messaging/joining_nodes.rs
@@ -13,7 +13,7 @@ use crate::node::{
 use qp2p::SendStream;
 use sn_interface::{
     messaging::{
-        system::{JoinRejectReason, JoinResponse, NodeMsg},
+        system::{JoinResponse, NodeMsg},
         MsgId,
     },
     network_knowledge::{NodeState, RelocationProof, MIN_ADULT_AGE},
@@ -77,9 +77,7 @@ impl MyNode {
 
             if !context.joins_allowed {
                 trace!("Rejecting join request from {node_id} - joins currently not allowed.");
-                let msg = NodeMsg::JoinResponse(JoinResponse::Rejected(
-                    JoinRejectReason::JoinsDisallowed,
-                ));
+                let msg = NodeMsg::JoinResponse(JoinResponse::JoinsDisallowed);
                 trace!("{}", LogMarker::SendJoinRejected);
                 trace!("Sending {msg:?} to {node_id}");
 

--- a/sn_node/src/node/messaging/node_msgs.rs
+++ b/sn_node/src/node/messaging/node_msgs.rs
@@ -188,9 +188,9 @@ impl MyNode {
                 }
 
                 match join_response {
-                    JoinResponse::Rejected(reason) => Err(super::Error::RejoinRequired(
-                        RejoinReason::from_reject_reason(reason),
-                    )),
+                    JoinResponse::JoinsDisallowed => {
+                        Err(super::Error::RejoinRequired(RejoinReason::JoinsDisallowed))
+                    }
                     JoinResponse::Approved(decision) => {
                         info!("{}", LogMarker::ReceivedJoinApproval);
                         let target_sap = context.network_knowledge.signed_sap();


### PR DESCRIPTION
The join response about the node not being reachable is something we
will never get or send. This is because we do not check specifically for
reachability anymore.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
