### PR TITLE
tests: relocation fix + refactor utils

### DIFF
--- a/sn_node/src/node/membership/mod.rs
+++ b/sn_node/src/node/membership/mod.rs
@@ -468,7 +468,10 @@ impl Membership {
 mod tests {
     use super::Error;
     use crate::node::flow_ctrl::tests::network_builder::TestNetworkBuilder;
-    use sn_interface::{network_knowledge::NodeState, test_utils::gen_node_id};
+    use sn_interface::{
+        network_knowledge::NodeState,
+        test_utils::{gen_node_id, TestSapBuilder},
+    };
 
     use assert_matches::assert_matches;
     use eyre::Result;
@@ -479,7 +482,7 @@ mod tests {
     async fn multiple_proposals_in_a_single_generation_should_not_be_possible() -> Result<()> {
         let prefix = Prefix::default();
         let env = TestNetworkBuilder::new(thread_rng())
-            .sap(prefix, 7, 0, None, None)
+            .sap(TestSapBuilder::new(prefix))
             .build()?;
 
         let mut membership = env

--- a/sn_node/src/node/messaging/anti_entropy.rs
+++ b/sn_node/src/node/messaging/anti_entropy.rs
@@ -427,10 +427,9 @@ mod tests {
     use super::*;
     use crate::node::{flow_ctrl::tests::network_builder::TestNetworkBuilder, MIN_ADULT_AGE};
     use sn_interface::{
-        elder_count,
         messaging::{AntiEntropyMsg, Dst, MsgId, MsgKind},
         network_knowledge::MyNodeInfo,
-        test_utils::{gen_addr, prefix},
+        test_utils::{gen_addr, prefix, TestSapBuilder},
         types::keys::ed25519,
     };
 
@@ -444,10 +443,10 @@ mod tests {
         let our_prefix = prefix("0");
         let other_prefix = prefix("1");
         let env = TestNetworkBuilder::new(rand::thread_rng())
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(other_prefix, elder_count(), 0, None, None)
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(other_prefix))
             .build()?;
         // get node from the latest section of our_prefix
         let node = env.get_nodes(our_prefix, 1, 0, None)?.remove(0);
@@ -474,10 +473,10 @@ mod tests {
         let our_prefix = prefix("0");
         let other_prefix = prefix("1");
         let env = TestNetworkBuilder::new(rand::thread_rng())
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(other_prefix, elder_count(), 0, None, None)
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(other_prefix))
             .build()?;
         let other_section = env.get_network_knowledge(other_prefix, None)?;
         let other_sap = other_section.signed_sap();
@@ -533,10 +532,10 @@ mod tests {
         let our_prefix = prefix("0");
         let other_prefix = prefix("1");
         let env = TestNetworkBuilder::new(rand::thread_rng())
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(other_prefix, elder_count(), 0, None, None)
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(other_prefix))
             .build()?;
         // get node from the latest section of our_prefix
         let node = env.get_nodes(our_prefix, 1, 0, None)?.remove(0);
@@ -567,10 +566,10 @@ mod tests {
         let our_prefix = prefix("0");
         let other_prefix = prefix("1");
         let env = TestNetworkBuilder::new(rand::thread_rng())
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(our_prefix, elder_count(), 0, None, None)
-            .sap(other_prefix, elder_count(), 0, None, None)
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(our_prefix))
+            .sap(TestSapBuilder::new(other_prefix))
             .build()?;
         // get node from the latest section of our_prefix
         let node = env.get_nodes(our_prefix, 1, 0, None)?.remove(0);

--- a/sn_node/src/node/messaging/dkg.rs
+++ b/sn_node/src/node/messaging/dkg.rs
@@ -850,8 +850,8 @@ mod tests {
     use crate::node::flow_ctrl::{
         cmds::Cmd,
         tests::{
-            cmd_utils::{get_next_msg, TestMsgTracker, TestNode},
             network_builder::TestNetworkBuilder,
+            test_utils::{get_next_msg, TestMsgTracker, TestNode},
         },
     };
 
@@ -864,6 +864,7 @@ mod tests {
             NetworkMsg, SectionSigShare,
         },
         network_knowledge::{supermajority, NodeState, SectionKeyShare},
+        test_utils::TestSapBuilder,
         types::NodeId,
     };
 
@@ -1098,7 +1099,7 @@ mod tests {
         SecretKeySet,
     )> {
         let mut env = TestNetworkBuilder::new(rng)
-            .sap(Prefix::default(), elder_count, 0, None, None)
+            .sap(TestSapBuilder::new(Prefix::default()).elder_count(elder_count))
             .build()
             .wrap_err("Failed to build TestEnv")?;
         let sk_set = env.get_secret_key_set(Prefix::default(), None)?;


### PR DESCRIPTION
- Adds some improvements to the `TestNetworkBuilder` by integrating the `TestSapBuilder` into it.
- The relocation tests were using an old flow ( `VoteNodeOff`) which was not representative of the actual flow. Thus now we actually trigger relocation by a membership change and go through the entire relocation process.
