### PR TITLE
ci: rename sn_cli asset name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**'
 
 env:
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**'
 
 env:
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs

--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ safe-package-version-artifacts-for-release:
 
 	for arch in "$${architectures[@]}" ; do \
 		if [[ $$arch == *"windows"* ]]; then bin_name="safe.exe"; else bin_name="safe"; fi; \
-		zip -j sn_cli-${SAFE_VERSION}-$$arch.zip artifacts/prod/$$arch/release/$$bin_name; \
-		tar -C artifacts/prod/$$arch/release -zcvf sn_cli-${SAFE_VERSION}-$$arch.tar.gz $$bin_name; \
+		zip -j safe-${SAFE_VERSION}-$$arch.zip artifacts/prod/$$arch/release/$$bin_name; \
+		tar -C artifacts/prod/$$arch/release -zcvf safe-${SAFE_VERSION}-$$arch.tar.gz $$bin_name; \
 	done
 
 	mv *.tar.gz ${DEPLOY_PROD_PATH}/safe


### PR DESCRIPTION
Renames the `sn_cli` assets on the Github Release from `sn_cli` to `safe`. This was supposed to be done as part of the last modification to the process, but I seem to have accidentally missed it.

I'm also re-enabling the release and version bumping workflows to run on push now that I've cleared out the last bad release.
