### PR TITLE
chore: manually bump sn_interface and sn_node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**'
 
 env:
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**'
 
 env:
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "sn_interface"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -4225,7 +4225,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.78.5"
+version = "0.78.6"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1.0.62"
 sha3 = "~0.9"
 sn_client = { path = "../sn_client", version = "^0.82.0" }
 sn_dbc = { version = "9.0.0", features = ["serdes"] }
-sn_interface = { path = "../sn_interface", version = "^0.20.0" }
+sn_interface = { path = "../sn_interface", version = "^0.20.5" }
 thiserror = "1.0.23"
 time = { version = "~0.3.4", features = ["formatting"] }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
@@ -77,6 +77,6 @@ hex = "~0.4"
 predicates = "2.0"
 proptest = "1.0.0"
 sn_client = { path = "../sn_client", version = "^0.82.0", features = ["test-utils"] }
-sn_interface = { path = "../sn_interface", version = "^0.20.0", features = ["test-utils"] }
+sn_interface = { path = "../sn_interface", version = "^0.20.5", features = ["test-utils"] }
 tokio = { version = "1.6.0", features = ["macros"] }
 tracing-subscriber = "~0.3.1"

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -72,7 +72,7 @@ serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
 sn_dbc = { version = "9.0.0", features = ["serdes"] }
-sn_interface = { path = "../sn_interface", version = "^0.20.3" }
+sn_interface = { path = "../sn_interface", version = "^0.20.5" }
 sn_testnet = { path = "../sn_testnet", version = "^0.1.0" }
 strum = "0.24"
 strum_macros = "0.24"
@@ -100,7 +100,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 termcolor="1.1.2"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 walkdir = "2"
-sn_interface = { path = "../sn_interface", version = "^0.20.3", features= ["test-utils"] }
+sn_interface = { path = "../sn_interface", version = "^0.20.5", features= ["test-utils"] }
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"

--- a/sn_comms/Cargo.toml
+++ b/sn_comms/Cargo.toml
@@ -19,7 +19,7 @@ custom_debug = "~0.5.0"
 dashmap = {version = "5.1.0", features = [ "serde" ]}
 futures = "~0.3.13"
 qp2p = "0.36.1"
-sn_interface = { path = "../sn_interface", version = "^0.20.0" }
+sn_interface = { path = "../sn_interface", version = "^0.20.5" }
 thiserror = "1.0.23"
 tokio = { version = "1.0.23", features = [ "sync" ] }
 tracing = "~0.1.26"

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_interface"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.20.4"
+version = "0.20.5"
 
 [features]
 test-utils = ["proptest"]

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_node"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.78.5"
+version = "0.78.6"
 
 [[bin]]
 name = "safenode"
@@ -68,7 +68,7 @@ sn_updater = { path = "../sn_updater", version = "^0.1.0" }
 sn_comms = { path = "../sn_comms", version = "^0.6.1" }
 sn_dbc = { version = "9.0.0", features = ["serdes"] }
 sn_fault_detection = { path = "../sn_fault_detection", version = "^0.15.5" }
-sn_interface = { path = "../sn_interface", version = "^0.20.4" }
+sn_interface = { path = "../sn_interface", version = "^0.20.5" }
 sn_sdkg = "3.1.2"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
@@ -117,7 +117,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 tokio-util = { version = "~0.7", features = ["time"] }
 walkdir = "2"
 sn_comms = { path = "../sn_comms", version = "^0.6.1", features = ["test"] }
-sn_interface = { path = "../sn_interface", version = "^0.20.4", features= ["test-utils", "proptest"] }
+sn_interface = { path = "../sn_interface", version = "^0.20.5", features= ["test-utils", "proptest"] }
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"


### PR DESCRIPTION
These crates already have published versions at 0.20.6 and 0.78.6, so reverting the commits didn't work correctly for these.

Also temporarily disabling the release and merge workflows again because I don't want to trigger a release before I tag these manually.
