### PR TITLE
ci: re-enable version and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**'
 
 env:
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**'
 
 env:
   WORKFLOW_URL: https://github.com/maidsafe/safe_network/actions/runs


### PR DESCRIPTION
The tags from the last release have now been deleted and the version bump commit has been reverted. Merging this should cause the same version bump again, but with the `sn_interface` issue resolved this time.
