### PR TITLE
feat(payments): confirm spend contains fee

### DIFF
--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -64,6 +64,8 @@ pub enum Error {
     InvalidMessage,
     #[error("A signature share is invalid.")]
     InvalidSignatureShare,
+    #[error("The transfer fee is missing.")]
+    MissingFee,
     #[error("The secret key share is missing for public key {0:?}")]
     MissingSecretKeyShare(bls::PublicKey),
     #[error("Messaging protocol error: {0}")]

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -769,7 +769,7 @@ async fn spentbook_spend_client_message_should_replicate_to_adults_and_send_ack(
 }
 
 #[tokio::test]
-async fn spentbook_spend_transaction_with_no_inputs_should_return_spentbook_error() -> Result<()> {
+async fn spentbook_spend_transaction_with_no_inputs_should_return_error() -> Result<()> {
     init_logger();
     let prefix = prefix("1");
     let replication_count = 5;
@@ -825,6 +825,13 @@ async fn spentbook_spend_transaction_with_no_inputs_should_return_spentbook_erro
             ..
         } = cmd
         {
+            #[cfg(not(feature = "data-network"))]
+            assert_eq!(
+                error,
+                &MessagingDataError::from(Error::MissingFee),
+                "A different error was expected for this case: {error:?}"
+            );
+            #[cfg(feature = "data-network")]
             assert_eq!(
                 error,
                 &MessagingDataError::from(Error::SpentbookError(


### PR DESCRIPTION
This PR adds confirmation by each Elder that a spend contains an output for them
This is done by finding an output with owner being the `Elder` reward key.
**NB**: This does not yet validate the fee amount.

***

1.  ✔️ `Previous feat` Including Elders in outputs (any value) when spending DBCs.
2. `This PR`: Elders confirming that spends contain outputs destined for them.

Steps in the fee/reward feature:
- <s> 1. Including Elders in outputs (any value) when spending DBCs.</s>
- <s> 2. Elders confirming that spends contain outputs destined for them.</s>
- Implementing a commonly known deterministic transfer/store cost and distribution to nodes.
- Including transfer/store cost in outputs when spending DBCs.
- Elders confirming that the amounts in those outputs are sufficient.
