### PR TITLE
feat(fees): send fees as blinded amounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4191,9 +4191,8 @@ dependencies = [
 
 [[package]]
 name = "sn_dbc"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093c22bd6b99c9944355e3ea6480f192efaddcde2aa5eafc484f421a8f04d8f"
+version = "11.0.1"
+source = "git+https://github.com/oetyng/sn_dbc?branch=rename-types-for-stringency#67edf475bc7fa954d4ed4ae5cd44f2a3b816a4de"
 dependencies = [
  "bincode",
  "blsttc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4225,6 +4225,7 @@ dependencies = [
 name = "sn_interface"
 version = "0.20.9"
 dependencies = [
+ "assert_matches",
  "base64 0.13.1",
  "bincode",
  "blsttc",

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -42,7 +42,7 @@ serde = "1.0.123"
 serde_json = "1.0.62"
 sha3 = "~0.9"
 sn_client = { path = "../sn_client", version = "^0.82.5" }
-sn_dbc = { version = "10.0.0", features = ["serdes"] }
+sn_dbc = { git = "https://github.com/oetyng/sn_dbc", branch = "rename-types-for-stringency", features = ["serdes"]}
 sn_interface = { path = "../sn_interface", version = "^0.20.8" }
 thiserror = "1.0.23"
 time = { version = "~0.3.4", features = ["formatting"] }

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls
 rmp-serde = "1.0.0"
 sn_updater = { path = "../sn_updater", version = "^0.1.0" }
 sn_api = { path = "../sn_api", version = "^0.80.3", default-features = false, features = ["app"] }
-sn_dbc = { version = "10.0.0", features = ["serdes"] }
+sn_dbc = { git = "https://github.com/oetyng/sn_dbc", branch = "rename-types-for-stringency", features = ["serdes"]}
 serde = "1.0.123"
 serde_json = "1.0.62"
 serde_yaml = "~0.8"

--- a/sn_cli/src/subcommands/helpers.rs
+++ b/sn_cli/src/subcommands/helpers.rs
@@ -175,8 +175,8 @@ pub async fn gen_wallet_table(safe: &Safe, multimap: &Multimap) -> Result<Table>
             }
         };
 
-        let balance = match dbc.amount_secrets_bearer() {
-            Ok(amount_secrets) => amount_secrets.amount().to_string(),
+        let balance = match dbc.revealed_amount_bearer() {
+            Ok(revealed_amount) => sn_dbc::Token::from_nano(revealed_amount.value()).to_string(),
             Err(err) => {
                 warn!("Ignoring amount from DBC found in wallet due to error in revealing secret amount: {:?}", err);
                 "unknown".to_string()

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -71,7 +71,7 @@ serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
-sn_dbc = { version = "10.0.0", features = ["serdes"] }
+sn_dbc = { git = "https://github.com/oetyng/sn_dbc", branch = "rename-types-for-stringency", features = ["serdes"]}
 sn_interface = { path = "../sn_interface", version = "^0.20.8" }
 sn_testnet = { path = "../sn_testnet", version = "^0.1.3" }
 strum = "0.24"

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -286,9 +286,7 @@ pub enum Error {
     #[error("A signed section authority provider was not found for section key {0:?}")]
     SignedSapNotFound(PublicKey),
     /// Occurs if a DBC spend command eventually fails after a number of retry attempts.
-    #[error(
-        "The DBC spend request failed after {attempts} attempts for public_key: {public_key:?}"
-    )]
+    #[error("The DBC spend request failed after {attempts} attempts for dbc key: {public_key:?}")]
     DbcSpendRetryAttemptsExceeded {
         /// Number of attemtps made
         attempts: u8,

--- a/sn_client/src/sessions/messaging.rs
+++ b/sn_client/src/sessions/messaging.rs
@@ -345,7 +345,7 @@ impl Session {
             payload,
             MsgKind::Client {
                 auth,
-                is_spend: matches!(query, DataQuery::Spentbook(SpendQuery::GetFees(_))),
+                is_spend: matches!(query, DataQuery::Spentbook(SpendQuery::GetFees { .. })),
                 query_index: None,
             },
             Dst {
@@ -413,7 +413,7 @@ impl Session {
         };
         let kind = MsgKind::Client {
             auth,
-            is_spend: matches!(query, DataQuery::Spentbook(SpendQuery::GetFees(_))),
+            is_spend: matches!(query, DataQuery::Spentbook(SpendQuery::GetFees { .. })),
             query_index: Some(query_node_index),
         };
         let wire_msg = WireMsg::new_msg(msg_id, payload, kind, dst);

--- a/sn_client/src/sessions/messaging.rs
+++ b/sn_client/src/sessions/messaging.rs
@@ -331,7 +331,7 @@ impl Session {
         payload: Bytes,
         dst_section: bls::PublicKey,
         recipient: NodeId,
-    ) -> Result<QueryResponse> {
+    ) -> Result<(NodeId, QueryResponse)> {
         let endpoint = self.endpoint.clone();
 
         let chunk_addr = if let DataQuery::GetChunk(address) = query {
@@ -365,6 +365,7 @@ impl Session {
         let send_query_tasks = self.send_msg(vec![recipient], wire_msg).await?;
         self.check_query_responses(msg_id, vec![recipient], chunk_addr, send_query_tasks)
             .await
+            .map(|response| (recipient, response))
     }
 
     #[instrument(

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -63,6 +63,7 @@ features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rand_xorshift = "~0.2.0"
 proptest = { version = "1.0.0" }
+assert_matches = "1.3"
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -42,7 +42,7 @@ serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
 sn_consensus = "3.3.3"
-sn_dbc = { version = "10.0.0", features = ["serdes"] }
+sn_dbc = { git = "https://github.com/oetyng/sn_dbc", branch = "rename-types-for-stringency", features = ["serdes"]}
 sn_sdkg = "3.1.3"
 strum = "0.24"
 strum_macros = "0.24"

--- a/sn_interface/src/dbcs/fee_ciphers.rs
+++ b/sn_interface/src/dbcs/fee_ciphers.rs
@@ -1,0 +1,71 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::Result;
+
+use sn_dbc::{DerivationIndex, Owner, RevealedAmount};
+
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+/// These are sent with a spend, so that an Elder
+/// can verify that the transfer fee is being paid.
+///
+/// A client asks for the fee for a spend, and an Elder returns
+/// a cipher of the amount and a blinding factor, i.e. a `RevealedAmount`.
+/// The Client decrypts it and uses the amount and blinding factor to build
+/// the payment dbc to the Elder. The amount + blinding factor is then
+/// encrypted to a _derived_ key of the Elder reward key.
+/// The client also encrypts the derivation index used, to the Elder _reward key_,
+/// and sends both the amount + blinding factor cipher and the derivation index cipher
+/// to the Elder by including this `FeeCiphers` struct in the spend cmd.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct FeeCiphers {
+    amount: bls::Ciphertext,
+    derivation_index: bls::Ciphertext,
+}
+
+impl FeeCiphers {
+    pub fn new(amount: bls::Ciphertext, derivation_index: bls::Ciphertext) -> Self {
+        Self {
+            amount,
+            derivation_index,
+        }
+    }
+
+    /// Decrypts the derivation index cipher, and derives the public key from it.
+    pub fn decrypt_derived_key(&self, base_sk: &bls::SecretKey) -> Result<bls::PublicKey> {
+        let derivation_index = self.decrypt_derivation_index(base_sk)?;
+        let owner_base = Owner::from(base_sk.clone());
+        let public_key = owner_base
+            .derive(&derivation_index)
+            .secret_key()?
+            .public_key();
+        Ok(public_key)
+    }
+
+    /// Decrypts the derivation index cipher, and uses that to decrypt
+    /// the amount cipher, and turn that to a blinded amount that is returned.
+    pub fn decrypt_revealed_amount(&self, base_sk: &bls::SecretKey) -> Result<RevealedAmount> {
+        let derivation_index = self.decrypt_derivation_index(base_sk)?;
+        let owner_base = Owner::from(base_sk.clone());
+        let derived_sk = owner_base.derive(&derivation_index).secret_key()?;
+        Ok(RevealedAmount::try_from((&derived_sk, &self.amount))?)
+    }
+
+    fn decrypt_derivation_index(&self, base_sk: &bls::SecretKey) -> Result<DerivationIndex> {
+        let bytes = base_sk
+            .decrypt(&self.derivation_index)
+            .ok_or(sn_dbc::Error::DecryptionBySecretKeyFailed)?;
+
+        let mut index = [0u8; 32];
+        index.copy_from_slice(&bytes[0..32]);
+
+        Ok(index)
+    }
+}

--- a/sn_interface/src/dbcs/mod.rs
+++ b/sn_interface/src/dbcs/mod.rs
@@ -6,14 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+mod fee_ciphers;
 mod reasons;
 
+pub use fee_ciphers::FeeCiphers;
 pub use reasons::DbcReason;
 
 use sn_dbc::{
     rng, Dbc, Error as DbcError, Hash, IndexedSignatureShare, Owner, OwnerOnce, PedersenGens,
-    RevealedCommitment, RevealedInput, SpentProofContent, SpentProofShare, Token,
-    TransactionBuilder,
+    RevealedAmount, RevealedInput, SpentProofContent, SpentProofShare, Token, TransactionBuilder,
 };
 
 use std::{fmt::Debug, result};
@@ -58,10 +59,10 @@ pub fn gen_genesis_dbc(
     let output_owner =
         OwnerOnce::from_owner_base(Owner::from(genesis_dbc_sk.clone()), &mut rng::thread_rng());
 
-    let revealed_commitment = RevealedCommitment::from_value(GENESIS_DBC_AMOUNT, rng::thread_rng());
+    let revealed_amount = RevealedAmount::from_amount(GENESIS_DBC_AMOUNT, rng::thread_rng());
 
     // Use the same key as the input and output of Genesis Tx.
-    let genesis_input = RevealedInput::new(genesis_dbc_sk.clone(), revealed_commitment);
+    let genesis_input = RevealedInput::new(genesis_dbc_sk.clone(), revealed_amount);
 
     let mut dbc_builder = TransactionBuilder::default()
         .add_input(genesis_input)
@@ -84,7 +85,7 @@ pub fn gen_genesis_dbc(
         public_key,
         transaction_hash: Hash::from(tx.hash()),
         reason: Hash::default(),
-        public_commitment: revealed_commitment.commit(&PedersenGens::default()),
+        blinded_amount: revealed_amount.blinded_amount(&PedersenGens::default()),
     };
 
     let sk_share_index = 0;

--- a/sn_interface/src/messaging/data/mod.rs
+++ b/sn_interface/src/messaging/data/mod.rs
@@ -26,6 +26,7 @@ pub use self::{
 };
 
 use crate::types::{
+    payments::Invoice,
     register::{Entry, EntryHash, Permissions, Policy, Register, User},
     Chunk,
 };
@@ -113,6 +114,7 @@ impl Display for DataResponse {
 }
 
 /// The response to a query, containing the query result.
+#[allow(clippy::large_enum_variant)]
 #[derive(Eq, PartialEq, Clone, Serialize, Deserialize, Debug)]
 pub enum QueryResponse {
     //
@@ -144,7 +146,7 @@ pub enum QueryResponse {
     GetSpentProofShares(Result<Vec<SpentProofShare>>),
     //
     /// Response to [`SpendQuery::GetFees`].
-    GetFees(Result<(bls::PublicKey, sn_dbc::Token)>),
+    GetFees(Result<Invoice>),
 }
 
 impl QueryResponse {

--- a/sn_interface/src/messaging/data/spentbook.rs
+++ b/sn_interface/src/messaging/data/spentbook.rs
@@ -22,7 +22,10 @@ use xor_name::XorName;
 #[derive(Hash, Eq, PartialEq, PartialOrd, Clone, Serialize, Deserialize, Debug)]
 pub enum SpendQuery {
     /// Query for the individual reward keys and their respective fee amount for processing a `Spend`.
-    GetFees(SpentbookAddress),
+    GetFees {
+        buyer: PublicKey,
+        address: SpentbookAddress,
+    },
     /// Query for the set of spent proofs if the provided public key has already been spent with a Tx.
     GetSpentProofShares(SpentbookAddress),
 }
@@ -67,7 +70,7 @@ impl SpendQuery {
     /// Request variant.
     pub fn to_error_response(&self, error: Error) -> QueryResponse {
         match self {
-            Self::GetFees(_) => QueryResponse::GetFees(Err(error)),
+            Self::GetFees { .. } => QueryResponse::GetFees(Err(error)),
             Self::GetSpentProofShares(_) => QueryResponse::GetSpentProofShares(Err(error)),
         }
     }
@@ -75,7 +78,7 @@ impl SpendQuery {
     /// Returns the dst address for the request.
     pub fn dst_address(&self) -> SpentbookAddress {
         match self {
-            Self::GetFees(address) => *address,
+            Self::GetFees { address, .. } => *address,
             Self::GetSpentProofShares(address) => *address,
         }
     }

--- a/sn_interface/src/messaging/data/spentbook.rs
+++ b/sn_interface/src/messaging/data/spentbook.rs
@@ -8,14 +8,15 @@
 
 use super::{CmdResponse, Error, QueryResponse};
 
-use crate::dbcs::DbcReason;
+use crate::dbcs::{DbcReason, FeeCiphers};
 use crate::messaging::system::SectionSigned;
 use crate::network_knowledge::{SectionAuthorityProvider, SectionsDAG};
 use crate::types::SpentbookAddress;
 
-use serde::{Deserialize, Serialize};
 use sn_dbc::{DbcTransaction, PublicKey, SpentProof};
-use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 use xor_name::XorName;
 
 /// Spend related read operations.
@@ -52,6 +53,11 @@ pub enum SpentbookCmd {
         spent_transactions: BTreeSet<DbcTransaction>,
         #[debug(skip)]
         network_knowledge: Option<(SectionsDAG, SectionSigned<SectionAuthorityProvider>)>,
+        /// As to avoid impl separate cmd flow, we send
+        /// all fee ciphers to all Elders for now.
+        #[debug(skip)]
+        #[cfg(not(feature = "data-network"))]
+        fee_ciphers: BTreeMap<XorName, FeeCiphers>,
     },
 }
 

--- a/sn_interface/src/network_knowledge/section_keys.rs
+++ b/sn_interface/src/network_knowledge/section_keys.rs
@@ -11,7 +11,7 @@ use crate::network_knowledge::{Error, Result, SectionAuthorityProvider};
 use crate::types::log_markers::LogMarker;
 
 use sn_dbc::{
-    Commitment, DbcTransaction, Hash, IndexedSignatureShare, SpentProofContent, SpentProofShare,
+    BlindedAmount, DbcTransaction, Hash, IndexedSignatureShare, SpentProofContent, SpentProofShare,
 };
 use uluru::LRUCache;
 
@@ -111,13 +111,13 @@ pub fn build_spent_proof_share(
     reason: DbcReason,
     sap: &SectionAuthorityProvider,
     skp: &SectionKeysProvider,
-    public_commitment: Commitment,
+    blinded_amount: BlindedAmount,
 ) -> Result<SpentProofShare> {
     let content = SpentProofContent {
         public_key: *public_key,
         transaction_hash: Hash::from(tx.hash()),
         reason: reason.into(),
-        public_commitment,
+        blinded_amount,
     };
     let (index, sig_share) = skp.sign_with(content.hash().as_ref(), &sap.section_key())?;
     Ok(SpentProofShare {

--- a/sn_interface/src/types/keys/public_key.rs
+++ b/sn_interface/src/types/keys/public_key.rs
@@ -217,7 +217,7 @@ impl UpperHex for PublicKey {
 /// Construct a BLS public key from a hex-encoded string.
 ///
 /// It is often useful to parse such raw strings in user-facing apps like CLI.
-pub fn bls_from_hex<T: AsRef<[u8]>>(hex: T) -> Result<bls::PublicKey> {
+fn bls_from_hex<T: AsRef<[u8]>>(hex: T) -> Result<bls::PublicKey> {
     let bytes = hex::decode(hex).map_err(|err| {
         Error::FailedToParse(format!(
             "Couldn't parse BLS public key bytes from hex: {err}",

--- a/sn_interface/src/types/keys/secret_key.rs
+++ b/sn_interface/src/types/keys/secret_key.rs
@@ -82,3 +82,26 @@ impl Display for SecretKey {
         Debug::fmt(self, formatter)
     }
 }
+
+/// Construct a BLS secret key from a hex-encoded string.
+///
+/// It is often useful to parse such raw strings in user-facing apps like CLI.
+pub fn bls_secret_from_hex<T: AsRef<[u8]>>(hex: T) -> Result<bls::SecretKey> {
+    let bytes = hex::decode(hex).map_err(|err| {
+        Error::FailedToParse(format!(
+            "Couldn't parse BLS secret key bytes from hex: {err}",
+        ))
+    })?;
+    let bytes_fixed_len: [u8; bls::SK_SIZE] = bytes.as_slice().try_into()
+        .map_err(|_| Error::FailedToParse(format!(
+            "Couldn't parse BLS secret key bytes from hex. The provided string must represent exactly {} bytes.",
+            bls::SK_SIZE
+        )))?;
+    let pk = bls::SecretKey::from_bytes(bytes_fixed_len).map_err(|err| {
+        Error::FailedToParse(format!(
+            "Couldn't parse BLS secret key from fixed-length byte array: {err}",
+        ))
+    })?;
+
+    Ok(pk)
+}

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -6,12 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-//! SAFE network data types.
+//! Shared types of the repository.
 
 /// public key types (ed25519)
 pub mod keys;
 /// Standardised log markers for various events
 pub mod log_markers;
+// Payments.
+pub mod payments;
 /// Register data type
 pub mod register;
 /// Encoding utils
@@ -35,8 +37,8 @@ pub use errors::{Error, Result};
 pub use identities::{ClientId, NodeId, Participant};
 pub use keys::{
     keypair::{BlsKeypairShare, Encryption, Keypair, OwnerType, Signing},
-    public_key::{bls_from_hex, PublicKey},
-    secret_key::SecretKey,
+    public_key::PublicKey,
+    secret_key::{bls_secret_from_hex, SecretKey},
     signature::{Signature, SignatureShare},
 };
 

--- a/sn_interface/src/types/payments/errors.rs
+++ b/sn_interface/src/types/payments/errors.rs
@@ -1,0 +1,25 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use thiserror::Error;
+
+/// Specialisation of `std::Result`.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Payment errors.
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("payment amount does not match invoice amount")]
+    PaymentDoesNotMatchInvoiceAmount,
+    #[error("invoice signature is invalid")]
+    InvoiceSignatureInvalid,
+    #[error("amount commitment is invalid")]
+    AmountCommitmentInvalid,
+    #[error("dbc error: {0}")]
+    Dbc(#[from] sn_dbc::Error),
+}

--- a/sn_interface/src/types/payments/invoice.rs
+++ b/sn_interface/src/types/payments/invoice.rs
@@ -1,0 +1,68 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{
+    errors::{Error, Result},
+    InvoiceContent,
+};
+
+use bls::SecretKey;
+use sn_dbc::{Hash, PublicKey, Signature, Token};
+
+use serde::{Deserialize, Serialize};
+use tiny_keccak::{Hasher, Sha3};
+
+/// A seller issues an Invoice thereby commiting to a price.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Invoice {
+    pub content: InvoiceContent,
+    pub seller_signature: Signature,
+}
+
+impl Invoice {
+    /// Create an invoice by encrypting the amount to the buyers key, and signing
+    /// it all with the seller secret key.
+    pub fn new(amount: Token, buyer_public_key: &PublicKey, seller_secret_key: &SecretKey) -> Self {
+        let content = InvoiceContent::new(amount, buyer_public_key, seller_secret_key.public_key());
+        let seller_signature = seller_secret_key.sign(content.to_bytes());
+        Self {
+            content,
+            seller_signature,
+        }
+    }
+
+    /// Verifies that seller_signature is correct.
+    pub fn verify(&self) -> Result<()> {
+        let valid = self
+            .content
+            .seller_public_key
+            .verify(&self.seller_signature, self.content.to_bytes());
+
+        match valid {
+            true => Ok(()),
+            false => Err(Error::InvoiceSignatureInvalid),
+        }
+    }
+
+    /// Represent Invoice as bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut v: Vec<u8> = Default::default();
+        v.extend(&self.content.to_bytes());
+        v.extend(&self.seller_signature.to_bytes());
+        v
+    }
+
+    /// Generate hash of Invoice.
+    pub fn hash(&self) -> Hash {
+        let mut sha3 = Sha3::v256();
+        sha3.update(&self.to_bytes());
+        let mut hash = [0; 32];
+        sha3.finalize(&mut hash);
+        Hash::from(hash)
+    }
+}

--- a/sn_interface/src/types/payments/invoice_content.rs
+++ b/sn_interface/src/types/payments/invoice_content.rs
@@ -1,0 +1,62 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use sn_dbc::{rng::thread_rng, AmountSecrets, Ciphertext, Commitment, Hash, PublicKey, Token};
+
+use serde::{Deserialize, Serialize};
+use tiny_keccak::{Hasher, Sha3};
+
+/// Represents data fields of an Invoice.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct InvoiceContent {
+    pub amount_commitment: Commitment,
+    pub amount_secrets_cipher: Ciphertext,
+    pub seller_public_key: PublicKey, // Owner's well-known key.  must match key Dbc.owner_base().public_key
+}
+
+impl InvoiceContent {
+    /// Create InvoiceContent from the amount of the invoice, the buyer and seller public keys.
+    /// The buyer public key is used to encrypt the amount.
+    pub fn new(amount: Token, buyer_public_key: &PublicKey, seller_public_key: PublicKey) -> Self {
+        let mut rng = thread_rng();
+
+        let amount_secrets = AmountSecrets::from_amount(amount.as_nano(), &mut rng);
+        let amount_commitment = amount_secrets.commitment();
+        let amount_secrets_cipher = amount_secrets.encrypt(buyer_public_key);
+
+        Self {
+            amount_commitment,
+            amount_secrets_cipher,
+            seller_public_key,
+        }
+    }
+
+    /// Represent as byte array.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut v: Vec<u8> = Default::default();
+        v.extend(&self.amount_commitment.compress().to_bytes());
+        v.extend(&self.amount_secrets_cipher.to_bytes());
+        v.extend(&self.seller_public_key.to_bytes());
+        v
+    }
+
+    /// Generate hash.
+    pub fn hash(&self) -> Hash {
+        let mut sha3 = Sha3::v256();
+        sha3.update(&self.to_bytes());
+        let mut hash = [0; 32];
+        sha3.finalize(&mut hash);
+        Hash::from(hash)
+    }
+
+    /// Checks if the provided AmountSecrets matches the amount commitment.
+    /// Note that both the amount and blinding_factor must be correct.
+    pub fn matches_commitment(&self, amount: &AmountSecrets) -> bool {
+        self.amount_commitment == amount.commitment()
+    }
+}

--- a/sn_interface/src/types/payments/mod.rs
+++ b/sn_interface/src/types/payments/mod.rs
@@ -12,7 +12,7 @@
 ///     The invoice consists of the `invoice_content` field, and `seller_signature` - the seller signature over it.
 ///     An `InvoiceContent` has the following fields:
 ///       a. `amount_commitment`: an amount commitment.
-///       b. `amount_secrets_cipher`: `AmountSecret` (amount, blindfactor) ciphertext encrypted to buyer's pubkey
+///       b. `revealed_amount_cipher`: `AmountSecret` (amount, blindfactor) ciphertext encrypted to buyer's pubkey
 ///       c. `seller_public_key`:  owner's well-known pubkey (should be one-time-use)
 ///  3. Buyer verifies seller's signature over `invoice_content`.
 ///  4. Buyer decrypts the `AmountSecret` to obtain the invoice amount.
@@ -51,7 +51,7 @@ pub use self::{
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use sn_dbc::{AmountSecrets, Token};
+    use sn_dbc::{RevealedAmount, Token};
 
     #[tokio::test]
     async fn invoice_can_be_read_buyer() -> Result<()> {
@@ -67,9 +67,9 @@ mod tests {
 
         // verify buyer can read the amount
         let decryption_result =
-            AmountSecrets::try_from((&buyer_secret, &invoice.content.amount_secrets_cipher));
-        assert_matches!(decryption_result, Ok(amount_secret) => {
-            assert!(invoice.content.matches_commitment(&amount_secret));
+            RevealedAmount::try_from((&buyer_secret, &invoice.content.revealed_amount_cipher));
+        assert_matches!(decryption_result, Ok(revealed_amount) => {
+            assert!(invoice.content.amount_equals(&revealed_amount));
         });
 
         Ok(())

--- a/sn_interface/src/types/payments/mod.rs
+++ b/sn_interface/src/types/payments/mod.rs
@@ -1,0 +1,77 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+/// Flow:
+///  1. Buyer informs seller s/he wishes to send payment, and attaches a public key.
+///  2. Seller creates an invoice and returns to buyer.
+///     The invoice consists of the `invoice_content` field, and `seller_signature` - the seller signature over it.
+///     An `InvoiceContent` has the following fields:
+///       a. `amount_commitment`: an amount commitment.
+///       b. `amount_secrets_cipher`: `AmountSecret` (amount, blindfactor) ciphertext encrypted to buyer's pubkey
+///       c. `seller_public_key`:  owner's well-known pubkey (should be one-time-use)
+///  3. Buyer verifies seller's signature over `invoice_content`.
+///  4. Buyer decrypts the `AmountSecret` to obtain the invoice amount.
+///  5. Buyer reissues necessary DBC(s) using `seller_public_key` as the recipient's well-known key
+///     in the exact amount of the invoice.
+///  6. Buyer constructs a `Payment` which consists of one or more DBCs paying to seller.
+///  7. Buyer constructs a `PaidInvoice` which consists of the `Invoice` and `Payment`.
+///  8. Buyer sends the `PaidInvoice` to the seller. Transaction is complete.
+///  9. Seller verifies that:
+///       a. the invoice is valid, with seller's own signature
+///       b. the sum of payment commitments is equal to the invoice amount commitment.
+///  10. Seller is satisfied, delivers goods to buyer.
+///
+///  11. If buyer ever needs to prove payment, buyer can show any third party the `PaidInvoice`
+///      and the 3rd party can verify that payment amount matches invoice amount, but
+///      cannot actually see the invoice or payment amount (without obtaining buyer's secret key).
+///
+///      Note that payment is not actually proven unless/until buyer can prove that
+///      seller has access to the `PaidInvoice`. This can be done by publishing it for
+///      all to see.
+mod errors;
+mod invoice;
+mod invoice_content;
+mod paid_invoice;
+mod payment;
+
+pub use self::{
+    errors::{Error, Result},
+    invoice::Invoice,
+    invoice_content::InvoiceContent,
+    paid_invoice::PaidInvoice,
+    payment::Payment,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use sn_dbc::{AmountSecrets, Token};
+
+    #[tokio::test]
+    async fn invoice_can_be_read_buyer() -> Result<()> {
+        let buyer_secret = bls::SecretKey::random();
+        let seller_secret = bls::SecretKey::random();
+
+        let amount = Token::from_nano(1234);
+        let invoice = Invoice::new(amount, &buyer_secret.public_key(), &seller_secret);
+
+        // verify invoice is built correctly
+        let invoice_verification = invoice.verify();
+        assert_matches!(invoice_verification, Ok(()));
+
+        // verify buyer can read the amount
+        let decryption_result =
+            AmountSecrets::try_from((&buyer_secret, &invoice.content.amount_secrets_cipher));
+        assert_matches!(decryption_result, Ok(amount_secret) => {
+            assert!(invoice.content.matches_commitment(&amount_secret));
+        });
+
+        Ok(())
+    }
+}

--- a/sn_interface/src/types/payments/paid_invoice.rs
+++ b/sn_interface/src/types/payments/paid_invoice.rs
@@ -1,0 +1,35 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{
+    errors::{Error, Result},
+    invoice::Invoice,
+    payment::Payment,
+};
+
+// A payment to an invoice.
+pub struct PaidInvoice {
+    pub invoice: Invoice,
+    pub payment: Payment,
+}
+
+impl PaidInvoice {
+    pub fn verify(&self) -> Result<()> {
+        self.invoice.verify()?;
+
+        let seller_public_key = self.invoice.content.seller_public_key;
+        let payment_sum = self.payment.commitment_sum_by_owner(&seller_public_key)?;
+        let invoice_amount_commitment = self.invoice.content.amount_commitment;
+
+        if payment_sum == invoice_amount_commitment {
+            Ok(())
+        } else {
+            Err(Error::PaymentDoesNotMatchInvoiceAmount)
+        }
+    }
+}

--- a/sn_interface/src/types/payments/paid_invoice.rs
+++ b/sn_interface/src/types/payments/paid_invoice.rs
@@ -23,10 +23,10 @@ impl PaidInvoice {
         self.invoice.verify()?;
 
         let seller_public_key = self.invoice.content.seller_public_key;
-        let payment_sum = self.payment.commitment_sum_by_owner(&seller_public_key)?;
-        let invoice_amount_commitment = self.invoice.content.amount_commitment;
+        let payment_sum = self.payment.sum_by_owner(&seller_public_key)?;
+        let blinded_amount = self.invoice.content.blinded_amount;
 
-        if payment_sum == invoice_amount_commitment {
+        if payment_sum == blinded_amount {
             Ok(())
         } else {
             Err(Error::PaymentDoesNotMatchInvoiceAmount)

--- a/sn_interface/src/types/payments/payment.rs
+++ b/sn_interface/src/types/payments/payment.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{Error, Result};
+
+use sn_dbc::{Commitment, Dbc, Hash, PublicKey};
+
+use serde::{Deserialize, Serialize};
+use tiny_keccak::{Hasher, Sha3};
+
+/// A payment is a list of Dbcs.
+#[derive(Clone, Deserialize, Serialize)]
+pub struct Payment {
+    pub dbcs: Vec<Dbc>,
+}
+
+impl Payment {
+    /// The hash of a payment is the hash of all constituent dbcs.
+    pub fn hash(&self) -> Hash {
+        let mut sha3 = Sha3::v256();
+        for dp in self.dbcs.iter() {
+            sha3.update(dp.hash().as_ref());
+        }
+        let mut hash = [0u8; 32];
+        sha3.finalize(&mut hash);
+        Hash::from(hash)
+    }
+
+    /// Retrieve sum of commitments for Dbcs derived from payto_public_key.
+    pub fn commitment_sum_by_owner(&self, payto_public_key: &PublicKey) -> Result<Commitment> {
+        self.dbcs
+            .iter()
+            .filter(|d| &d.content.owner_base.public_key() == payto_public_key)
+            .map(|d| d.commitment().map_err(|_| Error::AmountCommitmentInvalid))
+            .sum::<Result<Commitment, _>>()
+    }
+}

--- a/sn_interface/src/types/payments/payment.rs
+++ b/sn_interface/src/types/payments/payment.rs
@@ -8,7 +8,7 @@
 
 use super::{Error, Result};
 
-use sn_dbc::{Commitment, Dbc, Hash, PublicKey};
+use sn_dbc::{BlindedAmount, Dbc, Hash, PublicKey};
 
 use serde::{Deserialize, Serialize};
 use tiny_keccak::{Hasher, Sha3};
@@ -31,12 +31,15 @@ impl Payment {
         Hash::from(hash)
     }
 
-    /// Retrieve sum of commitments for Dbcs derived from payto_public_key.
-    pub fn commitment_sum_by_owner(&self, payto_public_key: &PublicKey) -> Result<Commitment> {
+    /// Retrieve sum of blinded amounts for Dbcs derived from buyer_public_key.
+    pub fn sum_by_owner(&self, buyer_public_key: &PublicKey) -> Result<BlindedAmount> {
         self.dbcs
             .iter()
-            .filter(|d| &d.content.owner_base.public_key() == payto_public_key)
-            .map(|d| d.commitment().map_err(|_| Error::AmountCommitmentInvalid))
-            .sum::<Result<Commitment, _>>()
+            .filter(|d| &d.content.owner_base.public_key() == buyer_public_key)
+            .map(|d| {
+                d.blinded_amount()
+                    .map_err(|_| Error::AmountCommitmentInvalid)
+            })
+            .sum::<Result<BlindedAmount, _>>()
     }
 }

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -71,7 +71,7 @@ rmp-serde = "1.0.0"
 sn_consensus = "3.3.3"
 sn_updater = { path = "../sn_updater", version = "^0.1.0" }
 sn_comms = { path = "../sn_comms", version = "^0.6.4" }
-sn_dbc = { version = "10.0.0", features = ["serdes"] }
+sn_dbc = { git = "https://github.com/oetyng/sn_dbc", branch = "rename-types-for-stringency", features = ["serdes"]}
 sn_fault_detection = { path = "../sn_fault_detection", version = "^0.15.5" }
 sn_interface = { path = "../sn_interface", version = "^0.20.9" }
 sn_sdkg = "3.1.3"

--- a/sn_node/src/node/cfg/keypair_storage.rs
+++ b/sn_node/src/node/cfg/keypair_storage.rs
@@ -8,7 +8,7 @@
 
 use crate::node::{Error, Result};
 
-use sn_interface::types::bls_from_hex;
+use sn_interface::types::bls_secret_from_hex;
 
 use ed25519_dalek::{Keypair, KEYPAIR_LENGTH};
 use hex::{decode, encode};
@@ -73,23 +73,23 @@ pub(crate) async fn store_new_reward_keypair(
     Ok(())
 }
 
-/// Returns Some(bls::PublicKey) or None if file doesn't exist. It assumes it's hex-encoded.
-pub(crate) async fn get_reward_pk(root_dir: &Path) -> Result<Option<bls::PublicKey>> {
-    let path = root_dir.join(REWARD_PUBLIC_KEY_FILENAME);
+/// Returns Some(bls::SecretKey) or None if file doesn't exist. It assumes it's hex-encoded.
+pub(crate) async fn get_reward_secret_key(root_dir: &Path) -> Result<Option<bls::SecretKey>> {
+    let path = root_dir.join(REWARD_SECRET_KEY_FILENAME);
     if !path.is_file() {
         return Ok(None);
     }
 
-    let pk_hex_bytes = fs::read(&path).await?;
-    let pk = bls_from_hex(pk_hex_bytes)?;
+    let secret_hex_bytes = fs::read(&path).await?;
+    let secret = bls_secret_from_hex(secret_hex_bytes)?;
 
-    Ok(Some(pk))
+    Ok(Some(secret))
 }
 
 #[cfg(test)]
 mod test {
     use super::{
-        get_network_keypair, get_reward_pk, store_network_keypair, store_new_reward_keypair,
+        get_network_keypair, get_reward_secret_key, store_network_keypair, store_new_reward_keypair,
     };
     use eyre::{eyre, Result};
     use rand_07::rngs::OsRng;
@@ -101,8 +101,8 @@ mod test {
         let root = create_temp_root()?;
         let root_dir = root.path();
         store_new_reward_keypair(root_dir, &secret_key).await?;
-        let pk_result = get_reward_pk(root_dir).await?;
-        assert_eq!(pk_result, Some(secret_key.public_key()));
+        let secret_result = get_reward_secret_key(root_dir).await?;
+        assert_eq!(secret_result, Some(secret_key));
         Ok(())
     }
 

--- a/sn_node/src/node/context.rs
+++ b/sn_node/src/node/context.rs
@@ -10,7 +10,6 @@ use super::{
     dkg::DkgVoter, flow_ctrl::fault_detection::FaultsCmd, DataStorage, DkgSessionInfo, Membership,
 };
 
-use bls::PublicKey;
 use ed25519_dalek::Keypair;
 use sn_comms::Comm;
 use sn_fault_detection::IssueType;
@@ -30,7 +29,7 @@ pub struct NodeContext {
     pub(crate) name: XorName,
     pub(crate) info: MyNodeInfo,
     pub(crate) keypair: Arc<Keypair>,
-    pub(crate) reward_key: PublicKey,
+    pub(crate) reward_secret_key: Arc<bls::SecretKey>,
     pub(crate) store_cost: sn_dbc::Token,
     pub(crate) network_knowledge: NetworkKnowledge,
     pub(crate) section_keys_provider: SectionKeysProvider,

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -64,6 +64,12 @@ pub enum Error {
     InvalidMessage,
     #[error("A signature share is invalid.")]
     InvalidSignatureShare,
+    #[error("The transfer fee is missing.")]
+    MissingFee,
+    #[error("Invalid fee blinded amount.")]
+    InvalidFeeBlindedAmount,
+    #[error("Too low amount for the transfer fee.")]
+    FeeTooLow,
     #[error("The secret key share is missing for public key {0:?}")]
     MissingSecretKeyShare(bls::PublicKey),
     #[error("Messaging protocol error: {0}")]

--- a/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
@@ -51,10 +51,13 @@ pub(crate) fn get_genesis_dbc_spend_info(
     BTreeSet<DbcTransaction>,
 )> {
     let genesis_dbc = gen_genesis_dbc(sk_set, &sk_set.secret_key())?;
-    let full_amount = genesis_dbc.amount_secrets_bearer()?.amount();
+    let full_amount = genesis_dbc.revealed_amount_bearer()?.value();
     let output_owner =
         OwnerOnce::from_owner_base(genesis_dbc.owner_base().clone(), &mut rand::thread_rng());
-    get_dbc_spend_info_with_outputs(genesis_dbc, vec![(output_owner, full_amount)])
+    get_dbc_spend_info_with_outputs(
+        genesis_dbc,
+        vec![(output_owner, Token::from_nano(full_amount))],
+    )
 }
 
 /// Returns the info necessary to populate the `SpentbookCmd::Spend` message to be handled, given specific outputs.
@@ -97,7 +100,7 @@ pub(crate) fn reissue_invalid_dbc_with_no_inputs(
     output_owner_sk: &bls::SecretKey,
 ) -> Result<Dbc> {
     let output_amount = Token::from_nano(amount);
-    let input_amount = input.amount_secrets_bearer()?.amount();
+    let input_amount = Token::from_nano(input.revealed_amount_bearer()?.value());
     let change_amount = input_amount
         .checked_sub(output_amount)
         .ok_or_else(|| eyre!("The input amount minus the amount must evaluate to a valid value"))?;

--- a/sn_node/src/node/flow_ctrl/tests/network_builder.rs
+++ b/sn_node/src/node/flow_ctrl/tests/network_builder.rs
@@ -657,7 +657,7 @@ impl TestNetwork {
         let mut my_node = MyNode::new(
             comm.clone(),
             info.keypair.clone(),
-            bls::SecretKey::random().public_key(),
+            bls::SecretKey::random(),
             network_knowledge.clone(),
             sk_share.clone(),
             UsedSpace::new(min_capacity, max_capacity),

--- a/sn_node/src/node/flow_ctrl/tests/test_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/test_utils.rs
@@ -450,7 +450,7 @@ pub(crate) fn build_a_node_instance(
     let node = MyNode::new(
         comm.clone(),
         info.keypair.clone(),
-        bls::SecretKey::random().public_key(),
+        bls::SecretKey::random(),
         network_knowledge.clone(),
         None,
         UsedSpace::new(min_capacity, max_capacity),

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -94,7 +94,7 @@ pub(crate) struct MyNode {
     pub(crate) root_storage_dir: PathBuf,
     pub(crate) data_storage: DataStorage, // Adult only before cache
     pub(crate) keypair: Arc<Keypair>,
-    pub(crate) reward_key: PublicKey,
+    pub(crate) reward_secret_key: Arc<bls::SecretKey>,
     // Network resources
     pub(crate) section_keys_provider: SectionKeysProvider,
     pub(crate) network_knowledge: NetworkKnowledge,
@@ -135,7 +135,7 @@ impl MyNode {
             membership: self.membership.clone(),
             dkg_voter: self.dkg_voter.clone(),
             dkg_sessions_info: self.dkg_sessions_info.clone(),
-            reward_key: self.reward_key,
+            reward_secret_key: self.reward_secret_key.clone(),
             store_cost: sn_dbc::Token::from_nano(1), // hard coded for now
             network_knowledge: self.network_knowledge().clone(),
             section_keys_provider: self.section_keys_provider.clone(),
@@ -152,7 +152,7 @@ impl MyNode {
     pub(crate) fn new(
         comm: Comm,
         keypair: Arc<Keypair>, //todo: Keypair, only test design blocks this
-        reward_key: PublicKey,
+        reward_secret_key: bls::SecretKey,
         network_knowledge: NetworkKnowledge,
         section_key_share: Option<SectionKeyShare>,
         used_space: UsedSpace,
@@ -203,7 +203,7 @@ impl MyNode {
             addr,
             root_storage_dir,
             keypair,
-            reward_key,
+            reward_secret_key: Arc::new(reward_secret_key),
             network_knowledge,
             section_keys_provider,
             dkg_sessions_info: HashMap::default(),
@@ -231,7 +231,7 @@ impl MyNode {
     pub(crate) fn first_node(
         comm: Comm,
         keypair: Keypair,
-        reward_key: PublicKey,
+        reward_secret_key: bls::SecretKey,
         used_space: UsedSpace,
         root_storage_dir: PathBuf,
         genesis_sk_set: bls::SecretKeySet,
@@ -248,7 +248,7 @@ impl MyNode {
         let node = Self::new(
             comm,
             Arc::new(keypair),
-            reward_key,
+            reward_secret_key,
             network_knowledge,
             Some(section_key_share),
             used_space,

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -182,9 +182,11 @@ impl DataStorage {
                 }
             }
             // this should be unreachable
-            DataQuery::Spentbook(SpendQuery::GetFees(addr)) => NodeQueryResponse::GetFees(Err(
-                sn_interface::messaging::data::Error::DataNotFound(DataAddress::Spentbook(*addr)),
-            )),
+            DataQuery::Spentbook(SpendQuery::GetFees { address, .. }) => {
+                NodeQueryResponse::GetFees(Err(sn_interface::messaging::data::Error::DataNotFound(
+                    DataAddress::Spentbook(*address),
+                )))
+            }
         }
     }
 


### PR DESCRIPTION
The fee amount is now blinded all the way between Elders and Clients.
The ciphers over derivation index and blinding factor is included in the spend request 
sent to elders. By that, an Elder can now verify that it has been paid the required fee amount.

**NB**: The elders do not yet verify that they have been paid (that is done in PR #2238).