### PR TITLE
fix(node): check when handling msg if is from member

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -967,6 +967,5 @@ jobs:
       - api
       - cli
     runs-on: ubuntu-latest
-    if: "! failure()"
     steps:
       - run: echo "All checks passed, ready to merge"


### PR DESCRIPTION
The previous check for "is from me" was failing due to a local 0.0.0.0 representation in testnets vs 127 from other nodes...

This was leading to looping.

But only checking if it was forwarded from ourselves would mean if an elder was a storage node, we'dsee and forward on the same message several times (as each elder sends it on to us, and its not from us, so we forward to the adults in question etc).

This check solves both situations

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
