### PR TITLE
Fix commit check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3949,7 +3949,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "sn_api"
-version = "0.80.3"
+version = "0.80.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "sn_cli"
-version = "0.74.2"
+version = "0.74.1"
 dependencies = [
  "ansi_term",
  "assert_cmd",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "sn_client"
-version = "0.82.4"
+version = "0.82.3"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "sn_comms"
-version = "0.6.4"
+version = "0.6.3"
 dependencies = [
  "assert_matches",
  "blsttc",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "sn_interface"
-version = "0.20.7"
+version = "0.20.6"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.80.1"
+version = "0.80.0"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "sn_testnet"
-version = "0.1.3"
+version = "0.1.2"
 dependencies = [
  "assert_fs",
  "clap",

--- a/Justfile
+++ b/Justfile
@@ -200,7 +200,7 @@ publish-crates:
   # This check is for when the process needs to be performed manually, which should also
   # be done on a version bump commit. The caller should do a `git checkout <commit_hash>`
   # to get on the release commit if need be.
-  if ! git log -1 --pretty=format:%s | grep -q "^chore\(release\):"; then
+  if ! git log -1 --pretty=format:%s | grep -q "^chore(release):"; then
     echo "The HEAD must be on a release commit to perform a publish."
     exit 1
   fi

--- a/log_cmds_inspector/Cargo.toml
+++ b/log_cmds_inspector/Cargo.toml
@@ -27,4 +27,4 @@ clap = { version = "3.0.0", features = ["derive", "env"] }
 strum = "0.24"
 strum_macros = "0.24"
 walkdir = "2"
-sn_interface = { path = "../sn_interface", version = "^0.20.7" }
+sn_interface = { path = "../sn_interface", version = "^0.20.6" }

--- a/sn_api/CHANGELOG.md
+++ b/sn_api/CHANGELOG.md
@@ -5,35 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.80.3 (2023-03-22)
-
-### Chore
-
- - <csr-id-29edfcea7d2cb1334422f2fe5dc90e72c7e5ac7c/> bump sn_dbc
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 1 commit contributed to the release.
- - 6 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Bump sn_dbc ([`29edfce`](https://github.com/maidsafe/safe_network/commit/29edfcea7d2cb1334422f2fe5dc90e72c7e5ac7c))
-</details>
-
 ## v0.80.2 (2023-03-16)
-
-<csr-id-ed26bc19831a28e2e13f63c77d26e0cd086cf85c/>
-<csr-id-57539fec4288cdd20672186dcfa49f7f6c9f686f/>
 
 ### Chore
 
@@ -45,17 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    release before I tag these manually.
  - <csr-id-57539fec4288cdd20672186dcfa49f7f6c9f686f/> sn_interface-0.20.5/sn_client-0.82.2/sn_node-0.78.6/sn_api-0.80.2/sn_cli-0.74.0
 
-### Chore
-
- - <csr-id-88d3403ea11f877e1ffa23fe15beafeb9d68111f/> sn_comms-0.6.2/sn_client-0.82.2/sn_api-0.80.2/sn_cli-0.74.0
-
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 5 commits contributed to the release over the course of 1 calendar day.
+ - 4 commits contributed to the release over the course of 1 calendar day.
  - 2 days passed between releases.
- - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
 ### Commit Details
@@ -65,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Sn_comms-0.6.2/sn_client-0.82.2/sn_api-0.80.2/sn_cli-0.74.0 ([`88d3403`](https://github.com/maidsafe/safe_network/commit/88d3403ea11f877e1ffa23fe15beafeb9d68111f))
     - Manually bump sn_interface and sn_node ([`ed26bc1`](https://github.com/maidsafe/safe_network/commit/ed26bc19831a28e2e13f63c77d26e0cd086cf85c))
     - Revert "chore(release): sn_interface-0.20.5/sn_client-0.82.2/sn_node-0.78.6/sn_api-0.80.2/sn_cli-0.74.0" ([`9dc0fe9`](https://github.com/maidsafe/safe_network/commit/9dc0fe938e1b1c43ca1292fa8640b7ced22aa39b))
     - Sn_interface-0.20.5/sn_client-0.82.2/sn_node-0.78.6/sn_api-0.80.2/sn_cli-0.74.0 ([`57539fe`](https://github.com/maidsafe/safe_network/commit/57539fec4288cdd20672186dcfa49f7f6c9f686f))
@@ -73,8 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 </details>
 
 ## v0.80.1 (2023-03-13)
-
-<csr-id-fce579d1202015bfd111361b780290f88f64a2c8/>
 
 ### Chore
 

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sn_api"
-version = "0.80.3"
+version = "0.80.2"
 description = "Safe API"
 authors = [
   "bochaco <gabrielviganotti@gmail.com>",
@@ -41,9 +41,9 @@ pbkdf2 = { version = "~0.7", default-features = false }
 serde = "1.0.123"
 serde_json = "1.0.62"
 sha3 = "~0.9"
-sn_client = { path = "../sn_client", version = "^0.82.4" }
+sn_client = { path = "../sn_client", version = "^0.82.2" }
 sn_dbc = { version = "10.0.0", features = ["serdes"] }
-sn_interface = { path = "../sn_interface", version = "^0.20.7" }
+sn_interface = { path = "../sn_interface", version = "^0.20.5" }
 thiserror = "1.0.23"
 time = { version = "~0.3.4", features = ["formatting"] }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
@@ -76,7 +76,7 @@ async_once = "~0.2.6"
 hex = "~0.4"
 predicates = "2.0"
 proptest = "1.0.0"
-sn_client = { path = "../sn_client", version = "^0.82.4", features = ["test-utils"] }
-sn_interface = { path = "../sn_interface", version = "^0.20.7", features = ["test-utils"] }
+sn_client = { path = "../sn_client", version = "^0.82.2", features = ["test-utils"] }
+sn_interface = { path = "../sn_interface", version = "^0.20.5", features = ["test-utils"] }
 tokio = { version = "1.6.0", features = ["macros"] }
 tracing-subscriber = "~0.3.1"

--- a/sn_cli/CHANGELOG.md
+++ b/sn_cli/CHANGELOG.md
@@ -4,51 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## v0.74.2 (2023-03-22)
-
-### Chore
-
- - <csr-id-29edfcea7d2cb1334422f2fe5dc90e72c7e5ac7c/> bump sn_dbc
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 1 commit contributed to the release.
- - 6 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Bump sn_dbc ([`29edfce`](https://github.com/maidsafe/safe_network/commit/29edfcea7d2cb1334422f2fe5dc90e72c7e5ac7c))
-</details>
-
 ## v0.74.1 (2023-03-16)
-
-<csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/>
-<csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/>
 
 ### Chore
 
  - <csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
  - <csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/> safenode renaming
 
-### Chore
-
- - <csr-id-50f6ede2104025bd79de8922ca7f27c742cf52bb/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
-
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 4 commits contributed to the release.
- - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 3 commits contributed to the release.
+ - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
 ### Commit Details
@@ -58,7 +26,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1 ([`50f6ede`](https://github.com/maidsafe/safe_network/commit/50f6ede2104025bd79de8922ca7f27c742cf52bb))
     - Revert "chore(release): sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1" ([`a24dca6`](https://github.com/maidsafe/safe_network/commit/a24dca63d1fde8c5e13fa7bbfadf71cda15af5c5))
     - Sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1 ([`807d69e`](https://github.com/maidsafe/safe_network/commit/807d69ef609decfe94230e2086144afc5cc56d7b))
     - Safenode renaming ([`1a8b9c9`](https://github.com/maidsafe/safe_network/commit/1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c))
@@ -68,7 +35,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <csr-id-57539fec4288cdd20672186dcfa49f7f6c9f686f/>
 <csr-id-d3d328db75c83e7a71c3fe6eff036c16120b6251/>
-<csr-id-88d3403ea11f877e1ffa23fe15beafeb9d68111f/>
 
 ### Chore
 

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sn_cli"
-version = "0.74.2"
+version = "0.74.1"
 description = "Safe CLI"
 authors = [
   "bochaco <gabrielviganotti@gmail.com>",
@@ -37,7 +37,7 @@ relative-path = "1.3.2"
 reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls"] }
 rmp-serde = "1.0.0"
 sn_updater = { path = "../sn_updater", version = "^0.1.0" }
-sn_api = { path = "../sn_api", version = "^0.80.3", default-features = false, features = ["app"] }
+sn_api = { path = "../sn_api", version = "^0.80.2", default-features = false, features = ["app"] }
 sn_dbc = { version = "10.0.0", features = ["serdes"] }
 serde = "1.0.123"
 serde_json = "1.0.62"
@@ -82,7 +82,7 @@ walkdir = "2.3.1"
 multibase = "~0.9.1"
 xor_name = "~5.0.0"
 futures = "0.3.21"
-sn_api = { path = "../sn_api", version = "^0.80.3", features = ["app", "test-utils"] }
+sn_api = { path = "../sn_api", version = "^0.80.2", features = ["app", "test-utils"] }
 httpmock = "~0.6.6"
 
 [dev-dependencies.sn_cmd_test_utilities]

--- a/sn_client/CHANGELOG.md
+++ b/sn_client/CHANGELOG.md
@@ -1113,19 +1113,18 @@ needed, as they keypair itself contains the Arcs we need.
     - Self authentication Example
     - Example to demonstrate Storage API
 
-## v0.82.4 (2023-03-22)
+## v0.82.3 (2023-03-16)
 
 ### Chore
 
- - <csr-id-29edfcea7d2cb1334422f2fe5dc90e72c7e5ac7c/> bump sn_dbc
- - <csr-id-a5bb5e86518e23dcc59f252b231de89ed90efcf9/> clarify naming
+ - <csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
+ - <csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/> safenode renaming
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 2 commits contributed to the release over the course of 2 calendar days.
- - 6 days passed between releases.
+ - 3 commits contributed to the release.
  - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1136,40 +1135,6 @@ needed, as they keypair itself contains the Arcs we need.
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Bump sn_dbc ([`29edfce`](https://github.com/maidsafe/safe_network/commit/29edfcea7d2cb1334422f2fe5dc90e72c7e5ac7c))
-    - Clarify naming ([`a5bb5e8`](https://github.com/maidsafe/safe_network/commit/a5bb5e86518e23dcc59f252b231de89ed90efcf9))
-</details>
-
-## v0.82.3 (2023-03-16)
-
-<csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/>
-<csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/>
-
-### Chore
-
- - <csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
- - <csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/> safenode renaming
-
-### Chore
-
- - <csr-id-50f6ede2104025bd79de8922ca7f27c742cf52bb/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 4 commits contributed to the release.
- - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1 ([`50f6ede`](https://github.com/maidsafe/safe_network/commit/50f6ede2104025bd79de8922ca7f27c742cf52bb))
     - Revert "chore(release): sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1" ([`a24dca6`](https://github.com/maidsafe/safe_network/commit/a24dca63d1fde8c5e13fa7bbfadf71cda15af5c5))
     - Sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1 ([`807d69e`](https://github.com/maidsafe/safe_network/commit/807d69ef609decfe94230e2086144afc5cc56d7b))
     - Safenode renaming ([`1a8b9c9`](https://github.com/maidsafe/safe_network/commit/1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c))
@@ -1180,7 +1145,6 @@ needed, as they keypair itself contains the Arcs we need.
 <csr-id-ed26bc19831a28e2e13f63c77d26e0cd086cf85c/>
 <csr-id-4f04bd1a5d1c747bfc6b5d39824dd108f8546b7b/>
 <csr-id-57539fec4288cdd20672186dcfa49f7f6c9f686f/>
-<csr-id-88d3403ea11f877e1ffa23fe15beafeb9d68111f/>
 
 ### Chore
 

--- a/sn_client/Cargo.toml
+++ b/sn_client/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_client"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.82.4"
+version = "0.82.3"
 
 [[bench]]
 name = "upload_bytes"
@@ -72,8 +72,8 @@ serde_bytes = "~0.11.5"
 serde_json = "1.0.53"
 signature = "1.1.10"
 sn_dbc = { version = "10.0.0", features = ["serdes"] }
-sn_interface = { path = "../sn_interface", version = "^0.20.7" }
-sn_testnet = { path = "../sn_testnet", version = "^0.1.3" }
+sn_interface = { path = "../sn_interface", version = "^0.20.6" }
+sn_testnet = { path = "../sn_testnet", version = "^0.1.1" }
 strum = "0.24"
 strum_macros = "0.24"
 tempfile = "3.2.0"
@@ -100,7 +100,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 termcolor="1.1.2"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 walkdir = "2"
-sn_interface = { path = "../sn_interface", version = "^0.20.7", features= ["test-utils"] }
+sn_interface = { path = "../sn_interface", version = "^0.20.6", features= ["test-utils"] }
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"

--- a/sn_cmd_test_utilities/Cargo.toml
+++ b/sn_cmd_test_utilities/Cargo.toml
@@ -17,7 +17,7 @@ dirs-next = "2.0.0"
 rand = "~0.8"
 serde = "1.0.123"
 serde_json = "1.0.62"
-sn_api = { path = "../sn_api", version = "^0.80.3", default-features=false, features = ["app", "authd_client"] }
+sn_api = { path = "../sn_api", version = "^0.80.2", default-features=false, features = ["app", "authd_client"] }
 walkdir = "2.3.1"
 multibase = "~0.9.1"
 

--- a/sn_comms/CHANGELOG.md
+++ b/sn_comms/CHANGELOG.md
@@ -5,51 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.6.4 (2023-03-22)
-
-### Chore
-
- - <csr-id-a5bb5e86518e23dcc59f252b231de89ed90efcf9/> clarify naming
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 1 commit contributed to the release over the course of 2 calendar days.
- - 6 days passed between releases.
- - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Clarify naming ([`a5bb5e8`](https://github.com/maidsafe/safe_network/commit/a5bb5e86518e23dcc59f252b231de89ed90efcf9))
-</details>
-
 ## v0.6.3 (2023-03-16)
-
-<csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/>
-<csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/>
 
 ### Chore
 
  - <csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
  - <csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/> safenode renaming
 
-### Chore
-
- - <csr-id-50f6ede2104025bd79de8922ca7f27c742cf52bb/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
-
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 4 commits contributed to the release.
- - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 3 commits contributed to the release.
+ - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
 ### Commit Details
@@ -59,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1 ([`50f6ede`](https://github.com/maidsafe/safe_network/commit/50f6ede2104025bd79de8922ca7f27c742cf52bb))
     - Revert "chore(release): sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1" ([`a24dca6`](https://github.com/maidsafe/safe_network/commit/a24dca63d1fde8c5e13fa7bbfadf71cda15af5c5))
     - Sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1 ([`807d69e`](https://github.com/maidsafe/safe_network/commit/807d69ef609decfe94230e2086144afc5cc56d7b))
     - Safenode renaming ([`1a8b9c9`](https://github.com/maidsafe/safe_network/commit/1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c))
@@ -68,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.6.2 (2023-03-16)
 
 <csr-id-ed26bc19831a28e2e13f63c77d26e0cd086cf85c/>
-<csr-id-88d3403ea11f877e1ffa23fe15beafeb9d68111f/>
 
 ### Chore
 

--- a/sn_comms/Cargo.toml
+++ b/sn_comms/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_comms"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.6.4"
+version = "0.6.3"
 
 [features]
 default = []
@@ -19,7 +19,7 @@ custom_debug = "~0.5.0"
 dashmap = {version = "5.1.0", features = [ "serde" ]}
 futures = "~0.3.13"
 qp2p = "0.36.1"
-sn_interface = { path = "../sn_interface", version = "^0.20.7" }
+sn_interface = { path = "../sn_interface", version = "^0.20.6" }
 thiserror = "1.0.23"
 tokio = { version = "1.0.23", features = [ "sync" ] }
 tracing = "~0.1.26"

--- a/sn_interface/CHANGELOG.md
+++ b/sn_interface/CHANGELOG.md
@@ -6,24 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## v0.20.7 (2023-03-22)
+## v0.20.6 (2023-03-16)
 
 ### Chore
 
- - <csr-id-29edfcea7d2cb1334422f2fe5dc90e72c7e5ac7c/> bump sn_dbc
- - <csr-id-89d66365a5a0b26bf832dfebd5a4032363071e6f/> make DKgVoter cloneable
- - <csr-id-a5bb5e86518e23dcc59f252b231de89ed90efcf9/> clarify naming
-
-### Bug Fixes
-
- - <csr-id-39b432d365ec745dc31147ca91df23284c1011ac/> node to update its own members list upon being relocated
+ - <csr-id-414670a541cd9392b07d998fd546a783c81133a4/> apply fixes from sn_consensus changes
+ - <csr-id-847703ef5c87db2b22fc21cd6252dcf9dd4a26e9/> bump consensus
+ - <csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
+ - <csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/> safenode renaming
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 4 commits contributed to the release over the course of 2 calendar days.
- - 6 days passed between releases.
+ - 5 commits contributed to the release.
  - 4 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -34,46 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Bump sn_dbc ([`29edfce`](https://github.com/maidsafe/safe_network/commit/29edfcea7d2cb1334422f2fe5dc90e72c7e5ac7c))
-    - Make DKgVoter cloneable ([`89d6636`](https://github.com/maidsafe/safe_network/commit/89d66365a5a0b26bf832dfebd5a4032363071e6f))
-    - Clarify naming ([`a5bb5e8`](https://github.com/maidsafe/safe_network/commit/a5bb5e86518e23dcc59f252b231de89ed90efcf9))
-    - Node to update its own members list upon being relocated ([`39b432d`](https://github.com/maidsafe/safe_network/commit/39b432d365ec745dc31147ca91df23284c1011ac))
-</details>
-
-## v0.20.6 (2023-03-16)
-
-<csr-id-414670a541cd9392b07d998fd546a783c81133a4/>
-<csr-id-847703ef5c87db2b22fc21cd6252dcf9dd4a26e9/>
-<csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/>
-<csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/>
-
-### Chore
-
- - <csr-id-414670a541cd9392b07d998fd546a783c81133a4/> apply fixes from sn_consensus changes
- - <csr-id-847703ef5c87db2b22fc21cd6252dcf9dd4a26e9/> bump consensus
- - <csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
- - <csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/> safenode renaming
-
-### Chore
-
- - <csr-id-50f6ede2104025bd79de8922ca7f27c742cf52bb/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 6 commits contributed to the release.
- - 5 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1 ([`50f6ede`](https://github.com/maidsafe/safe_network/commit/50f6ede2104025bd79de8922ca7f27c742cf52bb))
     - Revert "chore(release): sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1" ([`a24dca6`](https://github.com/maidsafe/safe_network/commit/a24dca63d1fde8c5e13fa7bbfadf71cda15af5c5))
     - Apply fixes from sn_consensus changes ([`414670a`](https://github.com/maidsafe/safe_network/commit/414670a541cd9392b07d998fd546a783c81133a4))
     - Bump consensus ([`847703e`](https://github.com/maidsafe/safe_network/commit/847703ef5c87db2b22fc21cd6252dcf9dd4a26e9))
@@ -82,11 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 </details>
 
 ## v0.20.5 (2023-03-16)
-
-<csr-id-ed26bc19831a28e2e13f63c77d26e0cd086cf85c/>
-<csr-id-57539fec4288cdd20672186dcfa49f7f6c9f686f/>
-<csr-id-7ec944309e26c7428f5ebd55efc266cb2594da29/>
-<csr-id-5c19f7e9e9472c616de88d16ad244de0fa638bef/>
 
 ### Chore
 
@@ -135,7 +86,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.20.4 (2023-03-10)
 
 <csr-id-6d17af24fcaf1e340dc3aec3d40e55ee80b154cf/>
-<csr-id-bc33b08ae2a49ec28fdca5cf7fd5bffacc79567f/>
 
 ### Chore
 

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_interface"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.20.7"
+version = "0.20.6"
 
 [features]
 test-utils = ["proptest"]

--- a/sn_node/CHANGELOG.md
+++ b/sn_node/CHANGELOG.md
@@ -5,84 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.80.1 (2023-03-22)
-
-### Chore
-
- - <csr-id-29edfcea7d2cb1334422f2fe5dc90e72c7e5ac7c/> bump sn_dbc
- - <csr-id-5b3c08fe6330ea1b13c48e51e606ad31be442f4d/> rename periodic context sender
- - <csr-id-5a7e5cd67dd94bd1d73ba05ba08d9842223a2558/> lower rejoin attempt time
- - <csr-id-ad6bf57c4ff0e3e859068f5d5a1a31094183243f/> move DkgSessionInfo into context; make periodics requrie context only
- - <csr-id-3bcf453d99241d72d91105a0f3b0ec8341eb7664/> remove duplicate Cmd handling
- - <csr-id-3189234825323f6480207ef424dab027c3bca409/> remove duplicate NodeMsg handling
- - <csr-id-89d66365a5a0b26bf832dfebd5a4032363071e6f/> make DKgVoter cloneable
- - <csr-id-b4fc6539813db7d6657f91e7b8b1a89b90eb6265/> perform relocation finalisation asap after update
- - <csr-id-a5bb5e86518e23dcc59f252b231de89ed90efcf9/> clarify naming
-
-### New Features
-
- - <csr-id-1c7fb145c7fd2f3d9109c3e9418ccb5619ab8e5b/> move DkgAe off thread
-
-### Bug Fixes
-
- - <csr-id-89e10d965fd4001ade575082911594c178c47b76/> process both blocking and non-blocking cmds
- - <csr-id-5ee1887e79773b4ac784c7631fdd5d6f460058f1/> move periodic checks into their own loop
- - <csr-id-66a4e6d95b6b5f62832316fa42dfaaf46e644ebd/> check when handling msg if is from member
-   The previous check for "is from me" was failing due to
-   a local 0.0.0.0 representation in testnets vs 127 from other nodes...
-   
-   This was leading to looping.
-   
-   But only checking if it was forwarded from ourselves would mean if
-   an elder was a storage node, we'dsee and forward on the same message
-   several times (as each elder sends it on to us, and its not from us, so
-   we forward to the adults in question etc).
-   
-   This check solves both situations
- - <csr-id-6c4f873df4ee253b2023e85b1b90baaabd49e109/> push replication send msgs onto flowctrl channel
- - <csr-id-39b432d365ec745dc31147ca91df23284c1011ac/> node to update its own members list upon being relocated
-
-### Refactor
-
- - <csr-id-d3c6c9727a69389f4204b746c54a537cd783232c/> remove unused wiremsg-debuginfo ft
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 16 commits contributed to the release over the course of 2 calendar days.
- - 6 days passed between releases.
- - 16 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Bump sn_dbc ([`29edfce`](https://github.com/maidsafe/safe_network/commit/29edfcea7d2cb1334422f2fe5dc90e72c7e5ac7c))
-    - Process both blocking and non-blocking cmds ([`89e10d9`](https://github.com/maidsafe/safe_network/commit/89e10d965fd4001ade575082911594c178c47b76))
-    - Rename periodic context sender ([`5b3c08f`](https://github.com/maidsafe/safe_network/commit/5b3c08fe6330ea1b13c48e51e606ad31be442f4d))
-    - Move periodic checks into their own loop ([`5ee1887`](https://github.com/maidsafe/safe_network/commit/5ee1887e79773b4ac784c7631fdd5d6f460058f1))
-    - Lower rejoin attempt time ([`5a7e5cd`](https://github.com/maidsafe/safe_network/commit/5a7e5cd67dd94bd1d73ba05ba08d9842223a2558))
-    - Move DkgSessionInfo into context; make periodics requrie context only ([`ad6bf57`](https://github.com/maidsafe/safe_network/commit/ad6bf57c4ff0e3e859068f5d5a1a31094183243f))
-    - Check when handling msg if is from member ([`66a4e6d`](https://github.com/maidsafe/safe_network/commit/66a4e6d95b6b5f62832316fa42dfaaf46e644ebd))
-    - Remove unused wiremsg-debuginfo ft ([`d3c6c97`](https://github.com/maidsafe/safe_network/commit/d3c6c9727a69389f4204b746c54a537cd783232c))
-    - Remove duplicate Cmd handling ([`3bcf453`](https://github.com/maidsafe/safe_network/commit/3bcf453d99241d72d91105a0f3b0ec8341eb7664))
-    - Remove duplicate NodeMsg handling ([`3189234`](https://github.com/maidsafe/safe_network/commit/3189234825323f6480207ef424dab027c3bca409))
-    - Move DkgAe off thread ([`1c7fb14`](https://github.com/maidsafe/safe_network/commit/1c7fb145c7fd2f3d9109c3e9418ccb5619ab8e5b))
-    - Make DKgVoter cloneable ([`89d6636`](https://github.com/maidsafe/safe_network/commit/89d66365a5a0b26bf832dfebd5a4032363071e6f))
-    - Perform relocation finalisation asap after update ([`b4fc653`](https://github.com/maidsafe/safe_network/commit/b4fc6539813db7d6657f91e7b8b1a89b90eb6265))
-    - Clarify naming ([`a5bb5e8`](https://github.com/maidsafe/safe_network/commit/a5bb5e86518e23dcc59f252b231de89ed90efcf9))
-    - Push replication send msgs onto flowctrl channel ([`6c4f873`](https://github.com/maidsafe/safe_network/commit/6c4f873df4ee253b2023e85b1b90baaabd49e109))
-    - Node to update its own members list upon being relocated ([`39b432d`](https://github.com/maidsafe/safe_network/commit/39b432d365ec745dc31147ca91df23284c1011ac))
-</details>
-
 ## v0.80.0 (2023-03-16)
-
-<csr-id-4dca7700c0a017dbdeb53a0387f895c0dabd00cc/>
 
 ### Refactor (BREAKING)
 
@@ -93,16 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    with a channel where NodeEvents are broadcasted, including a rejoin-required event type.
    - An initial set of `NodeEvents` is defined and broadcasted by the sn_node flows.
 
-### Chore
-
- - <csr-id-c9f3e7ccad8836c609193f1c6b53f351e5705805/> sn_node-0.80.0
-
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 2 commits contributed to the release.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 1 commit contributed to the release.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
 ### Commit Details
@@ -112,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Sn_node-0.80.0 ([`c9f3e7c`](https://github.com/maidsafe/safe_network/commit/c9f3e7ccad8836c609193f1c6b53f351e5705805))
     - Improving sn_node public API and exposing NodeEvents ([`4dca770`](https://github.com/maidsafe/safe_network/commit/4dca7700c0a017dbdeb53a0387f895c0dabd00cc))
 </details>
 
@@ -130,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-id-847703ef5c87db2b22fc21cd6252dcf9dd4a26e9/>
 <csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/>
 <csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/>
-<csr-id-50f6ede2104025bd79de8922ca7f27c742cf52bb/>
 
 ### Chore
 

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_node"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.80.1"
+version = "0.80.0"
 
 [[bin]]
 name = "safenode"
@@ -64,10 +64,10 @@ rayon = "1.5.1"
 rmp-serde = "1.0.0"
 sn_consensus = "3.3.3"
 sn_updater = { path = "../sn_updater", version = "^0.1.0" }
-sn_comms = { path = "../sn_comms", version = "^0.6.4" }
+sn_comms = { path = "../sn_comms", version = "^0.6.3" }
 sn_dbc = { version = "10.0.0", features = ["serdes"] }
 sn_fault_detection = { path = "../sn_fault_detection", version = "^0.15.5" }
-sn_interface = { path = "../sn_interface", version = "^0.20.7" }
+sn_interface = { path = "../sn_interface", version = "^0.20.6" }
 sn_sdkg = "3.1.3"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
@@ -115,8 +115,8 @@ proptest = "1.0.0"
 rand = { version = "~0.8.5", features = ["small_rng"] }
 tokio-util = { version = "~0.7", features = ["time"] }
 walkdir = "2"
-sn_comms = { path = "../sn_comms", version = "^0.6.4", features = ["test"] }
-sn_interface = { path = "../sn_interface", version = "^0.20.7", features= ["test-utils", "proptest"] }
+sn_comms = { path = "../sn_comms", version = "^0.6.3", features = ["test"] }
+sn_interface = { path = "../sn_interface", version = "^0.20.6", features= ["test-utils", "proptest"] }
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"

--- a/sn_testnet/CHANGELOG.md
+++ b/sn_testnet/CHANGELOG.md
@@ -5,26 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.1.3 (2023-03-22)
+## v0.1.2 (2023-03-16)
 
 ### Chore
 
- - <csr-id-c9f3e7ccad8836c609193f1c6b53f351e5705805/> sn_node-0.80.0
  - <csr-id-50f6ede2104025bd79de8922ca7f27c742cf52bb/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
  - <csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
  - <csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/> safenode renaming
-
-### Refactor
-
- - <csr-id-d3c6c9727a69389f4204b746c54a537cd783232c/> remove unused wiremsg-debuginfo ft
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 7 commits contributed to the release over the course of 6 calendar days.
- - 6 days passed between releases.
- - 5 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 4 commits contributed to the release.
+ - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
 ### Commit Details
@@ -34,26 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Remove unused wiremsg-debuginfo ft ([`d3c6c97`](https://github.com/maidsafe/safe_network/commit/d3c6c9727a69389f4204b746c54a537cd783232c))
-    - Fix(testnet): move os cond. to if-clause body - Running cargo clippy on win machine was borked with the conditional over an error in a fn, as the following code became unreachable. - Placing it in the if clause body removes this clippy error, as the rest of the code in that can still be executed if the flame arg was not set. ([`022fae6`](https://github.com/maidsafe/safe_network/commit/022fae6616a4dbf13d01e53ada76ebf1c9dab7ad))
-    - Sn_node-0.80.0 ([`c9f3e7c`](https://github.com/maidsafe/safe_network/commit/c9f3e7ccad8836c609193f1c6b53f351e5705805))
     - Sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1 ([`50f6ede`](https://github.com/maidsafe/safe_network/commit/50f6ede2104025bd79de8922ca7f27c742cf52bb))
     - Revert "chore(release): sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1" ([`a24dca6`](https://github.com/maidsafe/safe_network/commit/a24dca63d1fde8c5e13fa7bbfadf71cda15af5c5))
     - Sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1 ([`807d69e`](https://github.com/maidsafe/safe_network/commit/807d69ef609decfe94230e2086144afc5cc56d7b))
     - Safenode renaming ([`1a8b9c9`](https://github.com/maidsafe/safe_network/commit/1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c))
 </details>
-
-## v0.1.2 (2023-03-16)
-
-<csr-id-50f6ede2104025bd79de8922ca7f27c742cf52bb/>
-<csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/>
-<csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/>
-
-### Chore
-
- - <csr-id-50f6ede2104025bd79de8922ca7f27c742cf52bb/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
- - <csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/> sn_interface-0.20.6/sn_comms-0.6.3/sn_client-0.82.3/sn_node-0.79.0/sn_cli-0.74.1
- - <csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/> safenode renaming
 
 ## v0.1.1 (2023-03-16)
 

--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_testnet"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.1.3"
+version = "0.1.2"
 
 [features]
 # required to pass on flag to node builds


### PR DESCRIPTION
- 404e0a7a2 **fix: check release commit correctly**

  I was led to believe that the parentheses would need to be escaped, but seemingly this is not the
  case.

- 4cf488c00 **Revert "chore(release): sn_testnet-0.1.3/sn_interface-0.20.7/sn_comms-0.6.4/sn_client-0.82.4/sn_node-0.80.1/sn_api-0.80.3/sn_cli-0.74.2"**

  This reverts commit b0627339e2458fd762084cc4805d7adedfd8c05e.