### PR TITLE
feat(fees): add fee types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4225,6 +4225,7 @@ dependencies = [
 name = "sn_interface"
 version = "0.20.11"
 dependencies = [
+ "assert_matches",
  "base64 0.13.1",
  "bincode",
  "blsttc",

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -60,9 +60,10 @@ version = "^1.19"
 features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 
 [dev-dependencies]
+assert_matches = "1.3"
+proptest = { version = "1.0.0" }
 rand = { version = "~0.8.5", features = ["small_rng"] }
 rand_xorshift = "~0.2.0"
-proptest = { version = "1.0.0" }
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"

--- a/sn_interface/src/types/fees/errors.rs
+++ b/sn_interface/src/types/fees/errors.rs
@@ -1,0 +1,23 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use thiserror::Error;
+
+/// Specialisation of `std::Result`.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Payment errors.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("signature is invalid")]
+    RequiredFeeSignatureInvalid,
+    #[error("Decryption of the amount failed. Wrong secret key used.")]
+    AmountDecryptionFailed,
+    #[error("dbc error: {0}")]
+    Dbc(#[from] sn_dbc::Error),
+}

--- a/sn_interface/src/types/fees/fee_ciphers.rs
+++ b/sn_interface/src/types/fees/fee_ciphers.rs
@@ -1,0 +1,73 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::Result;
+
+use sn_dbc::{DerivationIndex, Owner, RevealedAmount};
+
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+/// These are sent with a spend, so that an Elder
+/// can verify that the transfer fee is being paid.
+///
+/// A client asks for the fee for a spend, and an Elder returns
+/// a cipher of the amount and a blinding factor, i.e. a `RevealedAmount`.
+/// The Client decrypts it and uses the amount and blinding factor to build
+/// the payment dbc to the Elder. The amount + blinding factor is then
+/// encrypted to a _derived_ key of the Elder reward key.
+/// The client also encrypts the derivation index used, to the Elder _reward key_,
+/// and sends both the amount + blinding factor cipher and the derivation index cipher
+/// to the Elder by including this `FeeCiphers` struct in the spend cmd.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct FeeCiphers {
+    amount: bls::Ciphertext,
+    derivation_index: bls::Ciphertext,
+}
+
+impl FeeCiphers {
+    pub fn new(amount: bls::Ciphertext, derivation_index: bls::Ciphertext) -> Self {
+        Self {
+            amount,
+            derivation_index,
+        }
+    }
+
+    /// Decrypts the derivation index cipher using the reward secret, then derives the secret key
+    /// that was used to decrypt the amount cipher, giving the RevealedAmount containing amount and blinding factor.
+    /// Returns the public key of the derived secret, and the revealed amount.
+    pub fn decrypt(
+        &self,
+        elder_reward_secret: &bls::SecretKey,
+    ) -> Result<(bls::PublicKey, RevealedAmount)> {
+        let derivation_index = self.decrypt_derivation_index(elder_reward_secret)?;
+        let owner_base = Owner::from(elder_reward_secret.clone());
+
+        let derived_sk = owner_base.derive(&derivation_index).secret_key()?;
+        let derived_pk = derived_sk.public_key();
+        let amount = RevealedAmount::try_from((&derived_sk, &self.amount))?;
+
+        Ok((derived_pk, amount))
+    }
+
+    /// The derivation index is encrypted to the well-known Elder reward key.
+    /// The key which can be derived from the Elder reward key using that index, is then used to decrypt the amount cihper.
+    fn decrypt_derivation_index(
+        &self,
+        elder_reward_secret: &bls::SecretKey,
+    ) -> Result<DerivationIndex> {
+        let bytes = elder_reward_secret
+            .decrypt(&self.derivation_index)
+            .ok_or(sn_dbc::Error::DecryptionBySecretKeyFailed)?;
+
+        let mut index = [0u8; 32];
+        index.copy_from_slice(&bytes[0..32]);
+
+        Ok(index)
+    }
+}

--- a/sn_interface/src/types/fees/mod.rs
+++ b/sn_interface/src/types/fees/mod.rs
@@ -1,0 +1,81 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+/// Flow:
+///  1. Client informs Elder s/he wishes to spend a dbc, and attaches the dbc id (a `PublicKey`).
+///  2. Elder calculates required fee, and returns to Client.
+///     The required fee consists of the `content` field, and `elder_reward_key_sig` - the Elder signature over it.
+///     A `RequiredFeeContent` has the following fields:
+///       a. `amount_cipher`: `RevealedAmount` (amount, blindfactor) ciphertext encrypted to id of dbc to spend (i.e. its public key).
+///       b. `elder_reward_key`:  Elder's well-known reward public key.
+///  3. Client verifies Elder's signature over `content`.
+///  4. Client decrypts the `amount_cipher` to obtain the fee amount.
+///  5. Client includes necessary Dbc output in the intended spend, with the fee amount, deriving a new dbc id
+///     using `elder_reward_key` which is used in the Dbc output to denote the new Dbc destined to the Elder.
+///  6. Client then constructs the `FeeCiphers`to be included in the `Spend` request.
+///     The FeeCiphers consists of the following fields:
+///         a. `derivation_index_cipher`: The encrypted derivation index used to derive the new dbc id.
+///         b. `amount_cipher`: The encrypted amount + blinding factor (`RevealedAmount`) which was used in the Dbc output.
+///  7. Client sends the `Spend` request to the Elder.
+///  9. Elder verifies that:
+///       a. the spend contains an output for them
+///       b. the fee ciphers can be decrypted
+///       c. the tx contains an output for a key derived from the Elder reward key using the decrypted derivation index
+///       d. the amount in that output is the same as the decrypted amount
+///       e. the decrypted amount is at most 1% less than the required fee at the time
+///  10. Elder is satisfied, signs the spend and forwards it to data holders.
+///
+///      Note 1: The fee paid to the Elder is not actually accessible until the Elder can fetch the `SpendProof` from
+///         the data holders.
+///      Note 2: With 1 fee per spend, the fee amount in the dbc is not accessible to the Elder until the required fee for
+///         a spend has decreased below the amount in the dbc. In effect, with this design there is currently a lock-in
+///         effect on Elder rewards which require the network to grow for the amount paid to them to be accessible.
+///         A more directly accessible reward design has been discussed, where Clients pay per tx instead of per spend.
+///         Such a tx can contain any number of inputs to be spent, so a wise choice would be to multiply a base fee by number of inputs.
+///         An example could be that the fee is be paid to the section closest to the XOR of all input dbc ids. Any Elder processing
+///         a spend, would then have to find that section, query it for their reward keys and verify that outputs to them exist. However,
+///         they can still not verify the amounts by this. So that example is still not feasible. TBD.
+mod errors;
+mod fee_ciphers;
+mod required_fee;
+mod required_fee_content;
+
+pub use self::{
+    errors::{Error, Result},
+    fee_ciphers::FeeCiphers,
+    required_fee::RequiredFee,
+    required_fee_content::RequiredFeeContent,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use sn_dbc::Token;
+
+    #[tokio::test]
+    async fn required_fee_can_be_read_by_client() -> Result<()> {
+        let dbc_secret = bls::SecretKey::random();
+        let reward_key_secret = bls::SecretKey::random();
+
+        let fee = Token::from_nano(1234);
+        let required_fee = RequiredFee::new(fee, &dbc_secret.public_key(), &reward_key_secret);
+
+        // verify required fee is correctly signed
+        let fee_sig_verification = required_fee.verify();
+        assert_matches!(fee_sig_verification, Ok(()));
+
+        // verify client can read the amount
+        let decryption_result = required_fee.content.decrypt_amount(&dbc_secret);
+        assert_matches!(decryption_result, Ok(amount) => {
+            assert_eq!(amount, fee);
+        });
+
+        Ok(())
+    }
+}

--- a/sn_interface/src/types/fees/required_fee.rs
+++ b/sn_interface/src/types/fees/required_fee.rs
@@ -1,0 +1,66 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{Error, RequiredFeeContent, Result};
+
+use sn_dbc::{Hash, PublicKey, Signature, Token};
+
+use bls::SecretKey;
+use serde::{Deserialize, Serialize};
+use tiny_keccak::{Hasher, Sha3};
+
+/// An Elder responds to a Client who wishes to spend a dbc,
+/// informing the Client of the required fee for the spend.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RequiredFee {
+    pub content: RequiredFeeContent,
+    pub elder_reward_key_sig: Signature,
+}
+
+impl RequiredFee {
+    /// Instantiate RequiredFee by encrypting the amount to the id of the dbc to spend, and signing
+    /// it all with the Elder reward secret key.
+    pub fn new(amount: Token, dbc_id: &PublicKey, elder_reward_key_secret: &SecretKey) -> Self {
+        let content = RequiredFeeContent::new(amount, dbc_id, elder_reward_key_secret.public_key());
+        let elder_reward_key_sig = elder_reward_key_secret.sign(content.to_bytes());
+        Self {
+            content,
+            elder_reward_key_sig,
+        }
+    }
+
+    /// Verifies that elder_reward_key_sig is correct.
+    pub fn verify(&self) -> Result<()> {
+        let valid = self
+            .content
+            .elder_reward_key
+            .verify(&self.elder_reward_key_sig, self.content.to_bytes());
+
+        match valid {
+            true => Ok(()),
+            false => Err(Error::RequiredFeeSignatureInvalid),
+        }
+    }
+
+    /// Represent RequiredFee as bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut v: Vec<u8> = Default::default();
+        v.extend(&self.content.to_bytes());
+        v.extend(&self.elder_reward_key_sig.to_bytes());
+        v
+    }
+
+    /// Generate hash of RequiredFee.
+    pub fn hash(&self) -> Hash {
+        let mut sha3 = Sha3::v256();
+        sha3.update(&self.to_bytes());
+        let mut hash = [0; 32];
+        sha3.finalize(&mut hash);
+        Hash::from(hash)
+    }
+}

--- a/sn_interface/src/types/fees/required_fee_content.rs
+++ b/sn_interface/src/types/fees/required_fee_content.rs
@@ -1,0 +1,72 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{Error, Result};
+
+use sn_dbc::{Ciphertext, Hash, PublicKey, Token};
+
+use bls::SecretKey;
+use serde::{Deserialize, Serialize};
+use tiny_keccak::{Hasher, Sha3};
+
+const AMOUNT_SIZE: usize = std::mem::size_of::<u64>(); // Amount size: 8 bytes (u64)
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RequiredFeeContent {
+    /// A simple u64, encrypted to the dbc id of the dbc being spent,
+    /// for which a fee is being required.
+    pub amount_cipher: Ciphertext,
+    // Elder's well-known reward key. Used to derive
+    // a dbc id for a new dbc with the fee payment in it.
+    // Deriving a dbc id from a public key, means that the holder
+    // of the secret key corresponding to this public key, can access
+    // the tokens in that dbc.
+    pub elder_reward_key: PublicKey,
+}
+
+impl RequiredFeeContent {
+    /// Create RequiredFeeContent from the fee amount, the id of the dbc to spend, and elder reward public key.
+    /// The dbc id is used to encrypt the amount, so that only the holder of the dbc to spend can see the fee amount.
+    pub fn new(amount: Token, dbc_id: &PublicKey, elder_reward_key: PublicKey) -> Self {
+        let amount_cipher = dbc_id.encrypt(amount.as_nano().to_le_bytes());
+        Self {
+            amount_cipher,
+            elder_reward_key,
+        }
+    }
+
+    /// Represent as byte array.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut v: Vec<u8> = Default::default();
+        v.extend(&self.amount_cipher.to_bytes());
+        v.extend(&self.elder_reward_key.to_bytes());
+        v
+    }
+
+    /// Generate hash.
+    pub fn hash(&self) -> Hash {
+        let mut sha3 = Sha3::v256();
+        sha3.update(&self.to_bytes());
+        let mut hash = [0; 32];
+        sha3.finalize(&mut hash);
+        Hash::from(hash)
+    }
+
+    /// Decrypts the amount using the secret key of the dbc to spend.
+    pub fn decrypt_amount(&self, dbc_secret_key: &SecretKey) -> Result<Token> {
+        let bytes = dbc_secret_key
+            .decrypt(&self.amount_cipher)
+            .ok_or(Error::AmountDecryptionFailed)?;
+        let amount = u64::from_le_bytes({
+            let mut b = [0u8; AMOUNT_SIZE];
+            b.copy_from_slice(&bytes[0..AMOUNT_SIZE]);
+            b
+        });
+        Ok(Token::from_nano(amount))
+    }
+}

--- a/sn_interface/src/types/mod.rs
+++ b/sn_interface/src/types/mod.rs
@@ -8,6 +8,8 @@
 
 //! SAFE network data types.
 
+/// Fees for a spend.
+pub mod fees;
 /// public key types (ed25519)
 pub mod keys;
 /// Standardised log markers for various events

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -14,6 +14,7 @@ use sn_dbc::Error as DbcError;
 use sn_interface::{
     dbcs::Error as GenesisError,
     messaging::{data::Error as ErrorMsg, system::DkgSessionId},
+    types::fees::Error as FeeError,
 };
 
 use ed25519::Signature;
@@ -197,6 +198,9 @@ pub enum Error {
     /// Error occurred when minting the Genesis DBC.
     #[error("Genesis DBC error:: {0}")]
     GenesisDbcError(#[from] GenesisError),
+    /// An error when generating/verifying fee.
+    #[error(transparent)]
+    FeeError(#[from] FeeError),
     /// Error thrown by DBC public API
     #[error("DbcError: {0}")]
     DbcError(#[from] DbcError),


### PR DESCRIPTION
These types allow Elders to verify that a fee amount, and a sufficient
amount, has been included in a spend output.

***

The fee amount is hidden both ways between Elders and Clients.
The ciphers of the derivation index and blinding factor is included in the spend request 
sent to elders. By that, an Elder can now verify that it has been paid the required fee amount.

**NB**: The elders do not yet verify that they have been paid (that is done in PR #2246).
