### PR TITLE
feat(fees): verify amount at elder 

### DIFF
--- a/sn_api/src/app/test_helpers.rs
+++ b/sn_api/src/app/test_helpers.rs
@@ -106,7 +106,7 @@ async fn reissue_bearer_dbcs() -> Result<Vec<(Dbc, Token)>> {
     let safe = new_safe_instance().await?;
 
     let (output_dbcs, _) = safe
-        .reissue_dbcs(
+        .send_tokens(
             vec![GENESIS_DBC.clone()],
             Token::from_nano(total_output_amount),
             outputs_owners,

--- a/sn_api/src/app/test_helpers.rs
+++ b/sn_api/src/app/test_helpers.rs
@@ -91,9 +91,7 @@ async fn reissue_bearer_dbcs() -> Result<Vec<(Dbc, Token)>> {
         .map(|_| rng.gen_range(REISSUED_DBC_MIN_BALANCE..REISSUED_DBC_MAX_BALANCE))
         .collect();
 
-    let total_output_amount: u64 = amounts.iter().sum();
-
-    let outputs_owners: Vec<_> = amounts
+    let recipients: Vec<_> = amounts
         .into_iter()
         .map(|amount| {
             let mut rng = rng::thread_rng();
@@ -106,11 +104,7 @@ async fn reissue_bearer_dbcs() -> Result<Vec<(Dbc, Token)>> {
     let safe = new_safe_instance().await?;
 
     let (output_dbcs, _) = safe
-        .send_tokens(
-            vec![GENESIS_DBC.clone()],
-            Token::from_nano(total_output_amount),
-            outputs_owners,
-        )
+        .send_tokens(vec![GENESIS_DBC.clone()], recipients)
         .await?;
 
     Ok(output_dbcs

--- a/sn_api/src/app/wallet.rs
+++ b/sn_api/src/app/wallet.rs
@@ -420,8 +420,10 @@ impl Safe {
         Ok(output_dbcs.into_iter().map(|(dbc, _, _)| dbc).collect())
     }
 
-    /// Send the tokens to the provided owners, using the provided dbcs.
+    /// Send the tokens to the specified destination keys, using the provided dbcs.
     /// This is used with external Dbcs, i.e. not selecting dbcs from the wallet.
+    /// The new dbcs that are created, one per specified destination, will have the
+    /// unique id which is the public key of the `OwnerOnce` instances provided.
     ///
     /// Transfer fees will be paid if not in data-network.
     /// The input dbcs will be spent on the network, and the resulting
@@ -1064,7 +1066,7 @@ mod tests {
 
         // 2 dbc inputs = 2 fees
         let fee_1 = get_spend_fee(&safe, &dbc1).await?;
-        let fee_2 = get_spend_fee(&safe, &dbc1).await?;
+        let fee_2 = get_spend_fee(&safe, &dbc2).await?;
         let total_fee = fee_1.as_nano() + fee_2.as_nano();
 
         // we arbitrarily expect a change as big as the fees here
@@ -1457,7 +1459,7 @@ mod tests {
 
         // 2 dbc inputs = 2 fees
         let fee_1 = get_spend_fee(&safe, &dbc1).await?;
-        let fee_2 = get_spend_fee(&safe, &dbc1).await?;
+        let fee_2 = get_spend_fee(&safe, &dbc2).await?;
         let total_fee = fee_1.as_nano() + fee_2.as_nano();
 
         let expected_change = 1000;

--- a/sn_api/src/app/wallet.rs
+++ b/sn_api/src/app/wallet.rs
@@ -253,7 +253,11 @@ impl Safe {
 
         // Let's get the list of balances from the Wallet
         let balances = self.wallet_get(wallet_url).await?;
-        debug!("Spendable balances to check: {:?}", balances);
+        let key_hashes: Vec<_> = balances
+            .iter()
+            .map(|(key, (_, hash))| (key, hash))
+            .collect();
+        debug!("Spendable balances to check: {key_hashes:?}");
 
         // Iterate through the DBCs adding up the amounts
         let mut total_balance = Token::from_nano(0);
@@ -861,11 +865,6 @@ mod tests {
     use anyhow::{anyhow, Result};
     use xor_name::XorName;
 
-    #[cfg(feature = "data-network")]
-    const FEE_PER_INPUT: u64 = 0;
-    #[cfg(not(feature = "data-network"))]
-    const FEE_PER_INPUT: u64 = DEFAULT_ELDER_COUNT as u64;
-
     #[tokio::test]
     async fn test_wallet_create() -> Result<()> {
         let safe = new_safe_instance().await?;
@@ -1233,10 +1232,14 @@ mod tests {
         safe.wallet_deposit(&wallet_xorurl, Some("deposited-dbc-2"), &dbc2, None)
             .await?;
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
+        // 2 dbc inputs = 2 fees
+        let fee_1 = get_spend_fee(&safe, &dbc1).await?;
+        let fee_2 = get_spend_fee(&safe, &dbc1).await?;
+        let total_fee = fee_1.as_nano() + fee_2.as_nano();
 
-        let change_plus_fees = 100;
-        let expected_change = change_plus_fees - (2 * FEE_PER_INPUT); // 2 dbc inputs = 2 fees
+        // we arbitrarily expect a change as big as the fees here
+        let expected_change = total_fee;
+        let change_plus_fees = 2 * total_fee;
 
         let amount_to_reissue =
             Token::from_nano(dbc1_balance.as_nano() + dbc2_balance.as_nano() - change_plus_fees);
@@ -1281,6 +1284,9 @@ mod tests {
         safe.wallet_deposit(&wallet_xorurl, Some("deposited-dbc-1"), &dbc, None)
             .await?;
 
+        // 1 input dbc = 1 fee
+        let fee = get_spend_fee(&safe, &dbc).await?;
+
         let output_dbc = safe
             .wallet_reissue(&wallet_xorurl, "1", None, DbcReason::none())
             .await?;
@@ -1290,9 +1296,7 @@ mod tests {
             .map_err(|err| anyhow!("Couldn't read balance from output DBC: {:?}", err))?;
         assert_eq!(output_balance.value(), 1_000_000_000);
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
-
-        let change_amount = Token::from_nano(dbc_balance.as_nano() - 1_000_000_000 - FEE_PER_INPUT); // 1 dbc input = 1 fee
+        let change_amount = Token::from_nano(dbc_balance.as_nano() - 1_000_000_000 - fee.as_nano()); // 1 dbc input = 1 fee
         let current_balance = safe.wallet_balance(&wallet_xorurl).await?;
 
         assert_eq!(current_balance, change_amount);
@@ -1442,7 +1446,8 @@ mod tests {
         safe.multimap_insert(&wallet_xorurl, entry, BTreeSet::default())
             .await?;
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
+        // 1 input dbc = 1 fee
+        let fee = get_spend_fee(&safe, &dbc).await?;
 
         // Now check we can still reissue from the wallet and the corrupted entry is ignored
         let _ = safe
@@ -1451,7 +1456,7 @@ mod tests {
         let current_balance = safe.wallet_balance(&wallet_xorurl).await?;
         assert_eq!(
             current_balance,
-            Token::from_nano(dbc_balance.as_nano() - 400_000_000 - FEE_PER_INPUT) // 1 input dbc = 1 fee
+            Token::from_nano(dbc_balance.as_nano() - 400_000_000 - fee.as_nano())
         );
 
         Ok(())
@@ -1465,12 +1470,14 @@ mod tests {
         safe.wallet_deposit(&wallet_xorurl, Some("my-first-dbc"), &dbc, None)
             .await?;
 
+        let fee = get_spend_fee(&safe, &dbc).await?;
+
         // Now check that after reissuing with the total balance,
         // there is no change deposited in the wallet, i.e. wallet is empty with 0 balance
         let _ = safe
             .wallet_reissue(
                 &wallet_xorurl,
-                &Token::from_nano(dbc_balance.as_nano() - FEE_PER_INPUT).to_string(), // send all, leave enough to pay the fee amount
+                &Token::from_nano(dbc_balance.as_nano() - fee.as_nano()).to_string(), // send all, leave enough to pay the fee amount
                 None,
                 DbcReason::none(),
             )
@@ -1616,17 +1623,22 @@ mod tests {
         safe.wallet_deposit(&wallet_xorurl, Some("deposited-dbc-2"), &dbc2, None)
             .await?;
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+        // 2 dbc inputs = 2 fees
+        let fee_1 = get_spend_fee(&safe, &dbc1).await?;
+        let fee_2 = get_spend_fee(&safe, &dbc1).await?;
+        let total_fee = fee_1.as_nano() + fee_2.as_nano();
 
-        let change_plus_fees = 1000;
-        let expected_change = change_plus_fees - (2 * FEE_PER_INPUT); // 2 dbc inputs = 2 fees
+        let expected_change = 1000;
+        let change_plus_fees = 1000 + total_fee;
 
         let amount_to_reissue =
             Token::from_nano(dbc1_balance.as_nano() + dbc2_balance.as_nano() - change_plus_fees);
         // let's partition the total amount to reissue in a few amounts
+        // We subtract `total_fee` + `expected_change` + the sum of the four last outputs (400) from our total available.
+        // That ensures that we will reissue all we have except for `expected_change` and `total_fee`.
         let output_amounts = vec![
-            dbc1_balance.as_nano() - 700,
-            dbc2_balance.as_nano() - 700,
+            dbc1_balance.as_nano() - total_fee,
+            dbc2_balance.as_nano() - (expected_change + 400),
             150,
             100,
             60,
@@ -1646,9 +1658,14 @@ mod tests {
             .wallet_reissue_many(&wallet_xorurl, outputs_owners, DbcReason::none())
             .await?;
 
+        #[cfg(feature = "data-network")]
+        let expected_fee_outputs = 0; // currently, no transfer fee in data-network
+        #[cfg(not(feature = "data-network"))]
+        let expected_fee_outputs = 2 * DEFAULT_ELDER_COUNT; // 2 fees = 2 * elder_count outputs
+
         assert_eq!(
             output_dbcs.len(),
-            output_amounts.len() + (2 * FEE_PER_INPUT) as usize
+            output_amounts.len() + expected_fee_outputs
         );
 
         let mut num_fee_outputs = 0;
@@ -1659,7 +1676,7 @@ mod tests {
                 num_fee_outputs += 1;
             }
         }
-        assert_eq!(num_fee_outputs, 2 * FEE_PER_INPUT);
+        assert_eq!(num_fee_outputs, expected_fee_outputs);
 
         let current_balance = safe.wallet_balance(&wallet_xorurl).await?;
         assert_eq!(current_balance, Token::from_nano(expected_change));
@@ -1678,5 +1695,33 @@ mod tests {
         assert_eq!(change.value(), expected_change);
 
         Ok(())
+    }
+
+    async fn get_spend_fee(safe: &Safe, dbc: &Dbc) -> Result<Token> {
+        let secret_key = dbc.as_revealed_input_bearer()?.secret_key;
+        let dbc_id = secret_key.public_key(); // this is same as dbc.public_key()
+        let client = safe.get_safe_client()?;
+        let elder_fees = client.get_section_fees(dbc_id).await?;
+        let mut decrypted_fees = vec![];
+
+        for (elder, fee) in elder_fees {
+            match fee.content.decrypt_amount(&secret_key) {
+                Ok(amount) => decrypted_fees.push(amount),
+                Err(_) => Err(Error::DbcReissueError(format!(
+                    "Could not decrypt fee amount sent from {elder}."
+                )))?,
+            }
+        }
+
+        let fee_per_input = decrypted_fees.into_iter()
+            .fold(Some(Token::zero()), |total, fee| {
+                total.and_then(|t| t.checked_add(fee))
+            })
+            .ok_or_else(|| Error::DbcReissueError(
+                "Overflow occurred while summing the individual Elder's fees in order to calculate the total amount for the output DBCs."
+                    .to_string(),
+            ))?;
+
+        Ok(fee_per_input)
     }
 }

--- a/sn_api/src/app/wallet.rs
+++ b/sn_api/src/app/wallet.rs
@@ -688,7 +688,7 @@ mod tests {
         new_safe_instance_with_dbc, new_safe_instance_with_dbc_owner, GENESIS_DBC,
     };
 
-    use sn_client::{Error as ClientError, ErrorMsg};
+    use sn_client::{api::TransferError, Error as ClientError, ErrorMsg};
     use sn_dbc::{Error as DbcError, Owner};
     use sn_interface::network_knowledge::DEFAULT_ELDER_COUNT;
 
@@ -1231,7 +1231,9 @@ mod tests {
             )
             .await
         {
-            Err(Error::NotEnoughBalance(msg)) => {
+            Err(Error::ClientError(ClientError::TransferError(
+                TransferError::NotEnoughBalance(msg),
+            ))) => {
                 assert_eq!(msg, dbc_balance.to_string());
                 Ok(())
             }

--- a/sn_api/src/errors.rs
+++ b/sn_api/src/errors.rs
@@ -99,9 +99,6 @@ pub enum Error {
     /// InvalidMediaType
     #[error("InvalidMediaType: {0}")]
     InvalidMediaType(String),
-    /// Not enough balance to perform a transaction
-    #[error("Not enough balance: {0}")]
-    NotEnoughBalance(String),
     /// NrsNameAlreadyExists
     #[error("NrsNameAlreadyExists: {0}")]
     NrsNameAlreadyExists(String),

--- a/sn_client/src/api/mod.rs
+++ b/sn_client/src/api/mod.rs
@@ -15,10 +15,12 @@ mod queries;
 mod register_apis;
 mod spend_queries;
 mod spentbook_apis;
+mod transfers;
 
 pub use client_builder::ClientBuilder;
 pub use file_apis::QueriedDataReplicas;
 pub use register_apis::RegisterWriteAheadLog;
+pub use transfers::{select_inputs as select_dbc_inputs, send_tokens, Error as TransferError};
 
 use crate::{
     errors::{Error, Result},

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -476,10 +476,14 @@ mod tests {
         let output_owner = OwnerOnce::from_owner_base(dbc_owner, &mut rng::thread_rng());
         let dbc_builder = TransactionBuilder::default().add_input_dbc_bearer(&genesis_dbc)?;
 
+        // get fees
+
         let inputs_amount_sum = dbc_builder.inputs_amount_sum();
         let dbc_builder = dbc_builder
             .add_output_by_amount(inputs_amount_sum, output_owner)
             .build(rng::thread_rng())?;
+
+        // get outputs and produce fee ciphers
 
         assert_eq!(dbc_builder.inputs().len(), 1);
         let (public_key, tx) = dbc_builder.inputs()[0].clone();

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -333,7 +333,7 @@ mod tests {
                 ..
             }) => {
                 let correct_error_str =
-                    format!("{:?}", sn_dbc::Error::MissingAmountForPubkey(dbc_id_1));
+                    format!("{:?}", sn_dbc::Error::MissingAmountForPubkey(dbc_id_2)); // dbc_id_1
                 assert!(
                     error_string.contains(&correct_error_str),
                     "A different SpentbookError error was expected for this case. What we got: {error_string:?}, expected: {correct_error_str:?}"

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -333,7 +333,7 @@ mod tests {
                 ..
             }) => {
                 let correct_error_str =
-                    format!("{:?}", sn_dbc::Error::MissingAmountForPubkey(dbc_id_2)); // dbc_id_1
+                    format!("{:?}", sn_dbc::Error::MissingAmountForPubkey(dbc_id_2));
                 assert!(
                     error_string.contains(&correct_error_str),
                     "A different SpentbookError error was expected for this case. What we got: {error_string:?}, expected: {correct_error_str:?}"

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -129,93 +129,42 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
+    use crate::api::send_tokens;
     use crate::utils::test_utils::{
         create_test_client_with, init_logger, read_genesis_dbc_from_first_node,
     };
     use crate::Client;
-
-    use sn_dbc::{rng, DbcTransaction, Hash, OwnerOnce, TransactionBuilder};
-    use sn_interface::dbcs::DbcReason;
+    use eyre::{bail, Result};
+    use sn_dbc::{rng, OwnerOnce, Token};
     use sn_interface::messaging::data::Error as ErrorMsg;
 
-    use eyre::{bail, Result};
-    use std::collections::{BTreeMap, BTreeSet, HashSet};
-    use tokio::time::Duration;
-
-    const MAX_ATTEMPTS: u8 = 5;
-    const SLEEP_DURATION: Duration = Duration::from_secs(3);
-
-    // Number of attempts to make trying to spend inputs when reissuing DBCs
-    // As the spend and query cmds are cascaded closely, there is high chance
-    // that the first two query attempts could both be failed.
-    // Hence the max number of attempts set to a higher value.
-    const NUM_OF_DBC_REISSUE_ATTEMPTS: u8 = 5;
-
-    async fn verify_spent_proof_share(
-        public_key: bls::PublicKey,
-        tx: DbcTransaction,
-        client: &Client,
-    ) -> Result<()> {
-        // The query could be too close to the spend which make adult only accumulated
-        // part of shares. To avoid assertion faiure, more attempts are needed.
-        let mut attempts = 0;
-        loop {
-            attempts += 1;
-
-            // Get spent proof shares for the public_key.
-            let spent_proof_shares = client.spent_proof_shares(public_key).await?;
-
-            // Note this test could have been run more than once thus the genesis DBC
-            // could have been spent a few times already, so we filter
-            // the SpentProofShares that belong to the TX we just spent in this run.
-            // TODO: once we have our Spentbook which prevents double spents
-            // we shouldnt't need this filtering.
-            let num_of_spent_proof_shares = spent_proof_shares
-                .iter()
-                .filter(|proof| proof.content.transaction_hash == Hash::from(tx.hash()))
-                .count();
-
-            if (5..=7).contains(&num_of_spent_proof_shares) {
-                break Ok(());
-            } else if attempts == MAX_ATTEMPTS {
-                bail!(
-                    "Failed to obtained enough spent proof shares after {} attempts, {} retrieved in last attempt",
-                    MAX_ATTEMPTS, num_of_spent_proof_shares
-                );
-            }
-
-            tokio::time::sleep(SLEEP_DURATION).await;
-        }
-    }
+    const ONE_BN_NANOS: u64 = 1_000_000_000;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_spentbook_spend_dbc() -> Result<()> {
         init_logger();
         let _outer_span = tracing::info_span!("test__spentbook_spend_dbc").entered();
 
-        let (
-            client,
-            SpendDetails {
-                public_key,
-                genesis_dbc,
-                tx,
-            },
-        ) = setup(false).await?;
+        let (client, genesis_dbc) = get_genesis(false).await?;
 
-        // Spend the public_key.
-        client
-            .spend_dbc(
-                public_key,
-                tx.clone(),
-                DbcReason::none(),
-                genesis_dbc.inputs_spent_proofs,
-                genesis_dbc.inputs_spent_transactions,
-                #[cfg(not(feature = "data-network"))]
-                BTreeMap::new(),
-            )
-            .await?;
+        let mut rng = rng::thread_rng();
+        let base_owner = sn_dbc::Owner::from_random_secret_key(&mut rng);
+        let recipient = OwnerOnce::from_owner_base(base_owner, &mut rng);
+        let half_amount = genesis_dbc
+            .as_revealed_input_bearer()?
+            .revealed_amount()
+            .value()
+            / 2;
+        let recipients = vec![(Token::from_nano(half_amount), recipient)];
 
-        verify_spent_proof_share(public_key, tx, &client).await
+        // Send the tokens..
+        let (_, change) = send_tokens(&client, vec![genesis_dbc], recipients).await?;
+
+        // We only assert that we have some change back
+        // since we don't need/want to account for the fees here.
+        assert!(change.is_some());
+
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -227,18 +176,21 @@ mod tests {
         )
         .entered();
 
-        let (
-            client,
-            SpendDetails {
-                public_key,
-                genesis_dbc,
-                tx,
-            },
-        ) = setup(false).await?;
+        let (client, mut genesis_dbc) = get_genesis(false).await?;
 
-        // insert the invalid pk to proofs
+        let mut rng = rng::thread_rng();
+        let base_owner = sn_dbc::Owner::from_random_secret_key(&mut rng);
+        let recipient = OwnerOnce::from_owner_base(base_owner, &mut rng);
+        let half_amount = genesis_dbc
+            .as_revealed_input_bearer()?
+            .revealed_amount()
+            .value()
+            / 2;
+        let recipients = vec![(Token::from_nano(half_amount), recipient)];
+
+        // Insert the invalid pk to proofs.
         let invalid_pk = bls::SecretKey::random().public_key();
-        let invalid_spent_proofs = genesis_dbc
+        genesis_dbc.inputs_spent_proofs = genesis_dbc
             .inputs_spent_proofs
             .into_iter()
             .map(|mut proof| {
@@ -247,18 +199,8 @@ mod tests {
             })
             .collect();
 
-        // Try spend the public_key.
-        let result = client
-            .spend_dbc(
-                public_key,
-                tx.clone(),
-                DbcReason::none(),
-                invalid_spent_proofs,
-                genesis_dbc.inputs_spent_transactions,
-                #[cfg(not(feature = "data-network"))]
-                BTreeMap::new(),
-            )
-            .await;
+        // Send the tokens..
+        let result = send_tokens(&client, vec![genesis_dbc], recipients).await;
 
         match result {
             Ok(_) => bail!("We expected an error to be returned"),
@@ -284,29 +226,22 @@ mod tests {
         init_logger();
         let _outer_span = tracing::info_span!("test__spentbook_spend_spent_proof_with_key_not_in_section_chain_should_return_cmd_error_response").entered();
 
-        let (
-            client,
-            SpendDetails {
-                public_key,
-                genesis_dbc,
-                tx,
-            },
-        ) = setup(true).await?; // pass in true, for getting an invalid genesis
+        let (client, genesis_dbc) = get_genesis(true).await?; // pass in true, for getting an invalid genesis
+
+        let mut rng = rng::thread_rng();
+        let base_owner = sn_dbc::Owner::from_random_secret_key(&mut rng);
+        let recipient = OwnerOnce::from_owner_base(base_owner, &mut rng);
+        let half_amount = genesis_dbc
+            .as_revealed_input_bearer()?
+            .revealed_amount()
+            .value()
+            / 2;
+        let recipients = vec![(Token::from_nano(half_amount), recipient)];
 
         let genesis_dbc_owner_pk = genesis_dbc.owner_base().public_key();
 
-        // Try spend the public_key.
-        let result = client
-            .spend_dbc(
-                public_key,
-                tx.clone(),
-                DbcReason::none(),
-                genesis_dbc.inputs_spent_proofs,
-                genesis_dbc.inputs_spent_transactions,
-                #[cfg(not(feature = "data-network"))]
-                BTreeMap::new(),
-            )
-            .await;
+        // Send the tokens..
+        let result = send_tokens(&client, vec![genesis_dbc], recipients).await;
 
         match result {
             Ok(_) => bail!("We expected an error to be returned"),
@@ -327,8 +262,6 @@ mod tests {
         init_logger();
         let _outer_span = tracing::info_span!("test__spentbook_spend_spent_proofs_do_not_relate_to_input_dbcs_should_return_spentbook_error").entered();
 
-        let (client, SpendDetails { genesis_dbc, .. }) = setup(false).await?;
-
         // The idea for this test case is to pass the wrong spent proofs and transactions for
         // the public key we're trying to spend. To do so, we reissue `output_dbc_1` from
         // `genesis_dbc`, then reissue `output_dbc_2` from `output_dbc_1`, then when we try to spend
@@ -336,53 +269,62 @@ mod tests {
         // not be permitted. The correct way would be to pass the spent proofs/transactions
         // from `output_dbc_1`, which was our input to `output_dbc_2`.
 
-        let spend_amount_1 = 10;
-        let recipient_owneronce_1 =
-            OwnerOnce::from_owner_base(client.dbc_owner().clone(), &mut rng::thread_rng());
-        let outputs_1 = vec![(
-            sn_dbc::Token::from_nano(spend_amount_1),
-            recipient_owneronce_1,
-        )];
-        let (output_dbcs_1, _change_dbc_1) = reissue_dbcs(
+        let (client, genesis_dbc) = get_genesis(false).await?;
+
+        let mut rng = rng::thread_rng();
+
+        let recipient_1 = OwnerOnce::from_owner_base(client.dbc_owner().clone(), &mut rng);
+        let dbc_id_1 = recipient_1.as_owner().public_key();
+
+        // Send the tokens..
+        let (outputs_1, _) = send_tokens(
             &client,
             vec![genesis_dbc.clone()],
-            outputs_1,
-            sn_dbc::Token::from_nano(sn_interface::dbcs::GENESIS_DBC_AMOUNT - spend_amount_1),
+            vec![(Token::from_nano(ONE_BN_NANOS), recipient_1)],
         )
         .await?;
 
-        let (output_dbc_1, _output_owneronce_1, _amount_secrects_1) = output_dbcs_1[0].clone();
+        let output_dbc_1 = match outputs_1
+            .iter()
+            .find(|(dbc, _, _)| dbc.public_key() == dbc_id_1)
+        {
+            Some((dbc, _, _)) => dbc.clone(),
+            None => bail!("We expected to find the dbc we were looking for."),
+        };
 
-        let pk = output_dbc_1.public_key();
-        let spend_amount_2 = 5;
-        let recipient_owneronce_2 =
-            OwnerOnce::from_owner_base(client.dbc_owner().clone(), &mut rng::thread_rng());
-        let outputs_2 = vec![(
-            sn_dbc::Token::from_nano(spend_amount_2),
-            recipient_owneronce_2,
-        )];
-        let (output_dbcs_2, _change_dbc_2) = reissue_dbcs(
+        // -> Next
+
+        let recipient_2 = OwnerOnce::from_owner_base(client.dbc_owner().clone(), &mut rng);
+        let dbc_id_2 = recipient_2.as_owner().public_key();
+
+        // Send the tokens..
+        let (outputs_2, _) = send_tokens(
             &client,
             vec![output_dbc_1],
-            outputs_2,
-            sn_dbc::Token::from_nano(spend_amount_1 - spend_amount_2),
+            vec![(Token::from_nano(ONE_BN_NANOS / 2), recipient_2)],
         )
         .await?;
 
-        let (output_dbc_2, output_owneronce_2, _amount_secrects_2) = output_dbcs_2[0].clone();
+        let mut output_dbc_2 = match outputs_2
+            .iter()
+            .find(|(dbc, _, _)| dbc.public_key() == dbc_id_2)
+        {
+            Some((dbc, _, _)) => dbc.clone(),
+            None => bail!("We expected to find the dbc we were looking for."),
+        };
 
-        // Try spend the dbc.
-        let result = client
-            .spend_dbc(
-                output_owneronce_2.as_owner().public_key(),
-                output_dbc_2.transaction.clone(),
-                DbcReason::none(),
-                genesis_dbc.inputs_spent_proofs.clone(),
-                genesis_dbc.inputs_spent_transactions,
-                #[cfg(not(feature = "data-network"))]
-                BTreeMap::new(),
-            )
-            .await;
+        output_dbc_2.inputs_spent_proofs = genesis_dbc.inputs_spent_proofs.clone();
+        output_dbc_2.inputs_spent_transactions = genesis_dbc.inputs_spent_transactions;
+
+        let recipient_3 = OwnerOnce::from_owner_base(client.dbc_owner().clone(), &mut rng);
+
+        // Send the tokens..
+        let result = send_tokens(
+            &client,
+            vec![output_dbc_2],
+            vec![(Token::from_nano(ONE_BN_NANOS / 4), recipient_3)],
+        )
+        .await;
 
         match result {
             Ok(_) => bail!("We expected an error to be returned"),
@@ -390,7 +332,8 @@ mod tests {
                 source: ErrorMsg::InvalidOperation(error_string),
                 ..
             }) => {
-                let correct_error_str = format!("{:?}", sn_dbc::Error::MissingAmountForPubkey(pk));
+                let correct_error_str =
+                    format!("{:?}", sn_dbc::Error::MissingAmountForPubkey(dbc_id_1));
                 assert!(
                     error_string.contains(&correct_error_str),
                     "A different SpentbookError error was expected for this case. What we got: {error_string:?}, expected: {correct_error_str:?}"
@@ -401,65 +344,10 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn spentbook_spend_with_random_public_key_should_return_spentbook_error() -> Result<()> {
-        init_logger();
-        let _outer_span = tracing::info_span!(
-            "test__spentbook_spend_with_random_public_key_should_return_spentbook_error"
-        )
-        .entered();
-
-        let (
-            client,
-            SpendDetails {
-                genesis_dbc, tx, ..
-            },
-        ) = setup(false).await?;
-
-        // generate the random public key
-        let random_public_key = bls::SecretKey::random().public_key();
-
-        // Try spend the random_public_key.
-        let result = client
-            .spend_dbc(
-                random_public_key,
-                tx.clone(),
-                DbcReason::none(),
-                genesis_dbc.inputs_spent_proofs.clone(),
-                genesis_dbc.inputs_spent_transactions,
-                #[cfg(not(feature = "data-network"))]
-                BTreeMap::new(),
-            )
-            .await;
-
-        match result {
-            Ok(_) => bail!("We expected an error to be returned"),
-            Err(crate::Error::CmdError {
-                source: ErrorMsg::InvalidOperation(error_string),
-                ..
-            }) => {
-                let correct_error_str =
-                    format!("SpentbookError(\"There are no amounts for the given public key {random_public_key:?}\"");
-                assert!(
-                    error_string.contains(&correct_error_str),
-                    "A different SpentbookError error was expected for this case. What we got: {error_string:?}"
-                );
-                Ok(())
-            }
-            Err(error) => bail!("We expected a different error to be returned. Actual: {error:?}"),
-        }
-    }
-
-    struct SpendDetails {
-        genesis_dbc: sn_dbc::Dbc,
-        tx: DbcTransaction,
-        public_key: sn_dbc::PublicKey,
-    }
-
     // returns a client which is the owner to the genesis dbc,
     // we can do this since our genesis dbc is currently generated as a bearer dbc, and stored locally
     // so we can fetch that owner key from the first node, and pass it to the client
-    async fn setup(invalid_genesis_dbc: bool) -> Result<(Client, SpendDetails)> {
+    async fn get_genesis(invalid_genesis_dbc: bool) -> Result<(Client, sn_dbc::Dbc)> {
         init_logger();
 
         let genesis_dbc = if invalid_genesis_dbc {
@@ -471,175 +359,6 @@ mod tests {
         let dbc_owner = genesis_dbc.owner_base().clone();
         let client = create_test_client_with(None, Some(dbc_owner.clone()), None).await?;
 
-        let genesis_public_key = genesis_dbc.public_key();
-
-        let output_owner = OwnerOnce::from_owner_base(dbc_owner, &mut rng::thread_rng());
-        let dbc_builder = TransactionBuilder::default().add_input_dbc_bearer(&genesis_dbc)?;
-
-        // get fees
-
-        let inputs_amount_sum = dbc_builder.inputs_amount_sum();
-        let dbc_builder = dbc_builder
-            .add_output_by_amount(inputs_amount_sum, output_owner)
-            .build(rng::thread_rng())?;
-
-        // get outputs and produce fee ciphers
-
-        assert_eq!(dbc_builder.inputs().len(), 1);
-        let (public_key, tx) = dbc_builder.inputs()[0].clone();
-        assert_eq!(genesis_public_key, public_key);
-
-        Ok((
-            client,
-            SpendDetails {
-                genesis_dbc,
-                tx,
-                public_key,
-            },
-        ))
-    }
-
-    // Reissue DBCs and log the spent input DBCs on the network. Return the output DBC and the
-    // change DBC if there is one.
-    async fn reissue_dbcs(
-        client: &Client,
-        input_dbcs: Vec<sn_dbc::Dbc>,
-        outputs: Vec<(sn_dbc::Token, OwnerOnce)>,
-        change_amount: sn_dbc::Token,
-    ) -> Result<(
-        Vec<(sn_dbc::Dbc, OwnerOnce, sn_dbc::RevealedAmount)>,
-        Option<sn_dbc::Dbc>,
-    )> {
-        let mut tx_builder = TransactionBuilder::default()
-            .add_inputs_dbc_bearer(input_dbcs.iter())?
-            .add_outputs_by_amount(outputs.into_iter().map(|(token, owner)| (token, owner)));
-
-        let change_owneronce =
-            OwnerOnce::from_owner_base(client.dbc_owner().clone(), &mut rng::thread_rng());
-        if change_amount.as_nano() > 0 {
-            tx_builder = tx_builder.add_output_by_amount(change_amount, change_owneronce.clone());
-        }
-
-        let spent_proofs: BTreeSet<sn_dbc::SpentProof> = input_dbcs
-            .iter()
-            .flat_map(|dbc| dbc.inputs_spent_proofs.clone())
-            .collect();
-
-        let spent_transactions: BTreeSet<DbcTransaction> = input_dbcs
-            .iter()
-            .flat_map(|dbc| dbc.inputs_spent_transactions.clone())
-            .collect();
-
-        let proof_key_verifier = SpentProofKeyVerifier { client };
-
-        // Let's build the output DBCs
-        let mut dbc_builder = tx_builder.build(rng::thread_rng())?;
-
-        // Spend all the input DBCs, collecting the spent proof shares for each of them
-        for (public_key, tx) in dbc_builder.inputs() {
-            let tx_hash = Hash::from(tx.hash());
-            // TODO: spend DBCs concurrently spawning tasks
-            let mut attempts = 0;
-            loop {
-                attempts += 1;
-                client
-                    .spend_dbc(
-                        public_key,
-                        tx.clone(),
-                        DbcReason::none(),
-                        spent_proofs.clone(),
-                        spent_transactions.clone(),
-                        #[cfg(not(feature = "data-network"))]
-                        BTreeMap::new(),
-                    )
-                    .await?;
-
-                let spent_proof_shares = client.spent_proof_shares(public_key).await?;
-
-                // TODO: we temporarilly filter the spent proof shares which correspond to the TX we
-                // are spending now. This is because current implementation of Spentbook allows
-                // double spents, so we may be retrieving spent proof shares for others spent TXs.
-                let shares_for_current_tx: HashSet<sn_dbc::SpentProofShare> = spent_proof_shares
-                    .into_iter()
-                    .filter(|proof_share| proof_share.content.transaction_hash == tx_hash)
-                    .collect();
-
-                match verify_spent_proof_shares_for_tx(
-                    public_key,
-                    tx_hash,
-                    &shares_for_current_tx,
-                    &proof_key_verifier,
-                ) {
-                    Ok(()) => {
-                        dbc_builder = dbc_builder
-                            .add_spent_proof_shares(shares_for_current_tx.into_iter())
-                            .add_spent_transaction(tx);
-
-                        break;
-                    }
-                    Err(err) if attempts == NUM_OF_DBC_REISSUE_ATTEMPTS => {
-                        bail!(format!(
-                            "Failed to spend input, {} proof shares obtained from spentbook: {}",
-                            shares_for_current_tx.len(),
-                            err
-                        ))
-                        // return Err(crate::Error::DbcSpendRetryAttemptsExceeded {
-                        //     attempts,
-                        //     public_key,
-                        // });
-                    }
-                    Err(_) => {}
-                }
-            }
-        }
-
-        // Perform verifications of input TX and spentproofs,
-        // as well as building the output DBCs.
-        let mut output_dbcs = dbc_builder.build(&proof_key_verifier)?;
-
-        let mut change_dbc = None;
-        output_dbcs.retain(|(dbc, owneronce, _)| {
-            if owneronce == &change_owneronce && change_amount.as_nano() > 0 {
-                change_dbc = Some(dbc.clone());
-                false
-            } else {
-                true
-            }
-        });
-
-        Ok((output_dbcs, change_dbc))
-    }
-
-    // Private helper to verify if a set of spent proof shares are valid for a given public_key and TX
-    fn verify_spent_proof_shares_for_tx(
-        public_key: sn_dbc::PublicKey,
-        tx_hash: Hash,
-        proof_shares: &HashSet<sn_dbc::SpentProofShare>,
-        proof_key_verifier: &SpentProofKeyVerifier,
-    ) -> Result<()> {
-        sn_dbc::SpentProof::try_from_proof_shares(public_key, tx_hash, proof_shares)
-            .and_then(|spent_proof| spent_proof.verify(tx_hash, proof_key_verifier))?;
-
-        Ok(())
-    }
-
-    /// Verifier required by test to check a SpentProof
-    /// is signed by known sections keys.
-    struct SpentProofKeyVerifier<'a> {
-        client: &'a Client,
-    }
-
-    impl sn_dbc::SpentProofKeyVerifier for SpentProofKeyVerifier<'_> {
-        type Error = crate::Error;
-
-        // Called by test when it needs to verify a SpentProof is signed by a known key,
-        // we check if the key is any of the network sections keys we are aware of
-        fn verify_known_key(&self, key: &sn_dbc::PublicKey) -> crate::Result<()> {
-            if !futures::executor::block_on(self.client.is_known_section_key(key)) {
-                Err(crate::Error::SectionsDagKeyNotFound(*key))
-            } else {
-                Ok(())
-            }
-        }
+        Ok((client, genesis_dbc))
     }
 }

--- a/sn_client/src/api/transfers/errors.rs
+++ b/sn_client/src/api/transfers/errors.rs
@@ -1,0 +1,32 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use sn_dbc::Error as DbcError;
+
+use thiserror::Error;
+
+pub(super) type Result<T> = std::result::Result<T, Error>;
+
+/// Error type returned by the API
+#[derive(Debug, Error)]
+#[allow(clippy::large_enum_variant)]
+#[non_exhaustive]
+pub enum Error {
+    /// Not enough balance to perform a transaction
+    #[error("Not enough balance: {0}")]
+    NotEnoughBalance(String),
+    /// DbcError
+    #[error("DbcError: {0}")]
+    DbcError(#[from] DbcError),
+    /// DbcReissueError
+    #[error("DbcReissueError: {0}")]
+    DbcReissueError(String),
+    /// Verification of DBC validly signed by a known section failed
+    #[error("DBC validity verification failed: {0}")]
+    DbcVerificationFailed(String),
+}

--- a/sn_client/src/api/transfers/mod.rs
+++ b/sn_client/src/api/transfers/mod.rs
@@ -1,0 +1,430 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+mod errors;
+
+use crate::Client;
+use crate::Result;
+
+use sn_dbc::{
+    rng, Dbc, DbcTransaction, Hash, Owner, OwnerOnce, RevealedAmount, SpentProof, SpentProofShare,
+    Token, TransactionBuilder,
+};
+use sn_interface::{
+    dbcs::DbcReason,
+    elder_count,
+    network_knowledge::supermajority,
+    types::fees::{FeeCiphers, RequiredFee},
+};
+
+use bls::PublicKey;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use xor_name::XorName;
+
+pub use errors::Error;
+
+type ReissueCiphers = BTreeMap<PublicKey, BTreeMap<XorName, (RequiredFee, OwnerOnce)>>;
+type ReissueInputs = (Vec<Dbc>, Vec<(Token, OwnerOnce)>, Token, ReissueCiphers);
+
+// Number of attempts to make trying to spend inputs when reissuing DBCs
+// As the spend and query cmds are cascaded closely, there is high chance
+// that the first two query attempts could both be failed.
+// Hence the max number of attempts set to a higher value.
+const NUM_OF_DBC_REISSUE_ATTEMPTS: u8 = 5;
+
+/// Send the tokens to the provided owners, using the provided dbcs.
+/// This is used with external Dbcs, i.e. not selecting dbcs from the wallet.
+///
+/// Transfer fees will be paid if not in data-network.
+/// The input dbcs will be spent on the network, and the resulting
+/// dbcs (and change dbc if any) are returned.
+/// NB: We are skipping the DbcReason arg for now. It can be added later.
+pub async fn send_tokens(
+    client: &Client,
+    dbcs: Vec<Dbc>,
+    total_output_amount: Token,
+    outputs_owners: Vec<(Token, OwnerOnce)>,
+) -> Result<(Vec<(Dbc, OwnerOnce, RevealedAmount)>, Option<Dbc>)> {
+    // We need to select the necessary number of dbcs from those that we were passed.
+    // This will also account for any fees.
+    let (input_dbcs_to_spend, outputs_owners, change_amount, all_fee_cipher_params) =
+        select_inputs(client, dbcs, total_output_amount, outputs_owners).await?;
+
+    // then we can reissue
+    reissue_dbcs(
+        client,
+        input_dbcs_to_spend,
+        outputs_owners,
+        change_amount,
+        DbcReason::none(),
+        #[cfg(not(feature = "data-network"))]
+        all_fee_cipher_params,
+    )
+    .await
+}
+
+/// Select the necessary number of dbcs out of those passed in,
+/// to pay for the outputs specified.
+/// This will also account for any fees.
+pub async fn select_inputs(
+    client: &Client,
+    dbcs: Vec<Dbc>,
+    mut total_output_amount: Token,
+    mut outputs_owners: Vec<(Token, OwnerOnce)>,
+) -> Result<ReissueInputs> {
+    // We'll combine one or more input DBCs and reissue:
+    // - one output DBC for the recipient,
+    // - and a second DBC for the change, which will be stored in the source wallet.
+    let mut input_dbcs_to_spend = Vec::<Dbc>::new();
+    let mut total_input_amount = Token::zero();
+    let mut change_amount = total_output_amount;
+    let mut rng = rng::thread_rng();
+    #[cfg(not(feature = "data-network"))]
+    let mut all_fee_cipher_params = BTreeMap::new();
+
+    for dbc in dbcs {
+        let revealed_bearer = dbc.as_revealed_input_bearer().map_err(Error::DbcError)?;
+        let input_key = revealed_bearer.public_key();
+
+        // ------------ fee part start ----------------
+        #[cfg(not(feature = "data-network"))]
+        let fee_per_input = {
+            // Each section will have elder_count() instances to pay individually (for now, later they will be more).
+            let elder_fees = client.get_section_fees(input_key).await?;
+            let num_responses = elder_fees.len();
+            let required_responses = supermajority(elder_count());
+            if required_responses > num_responses {
+                warn!("Not enough elders contacted for the section to spend the input. Got: {num_responses}, needed: {required_responses}");
+                continue;
+            }
+
+            // Fees that were not encrypted to us.
+            let mut invalid_fees = BTreeSet::new();
+            // As the mints encrypt the amount to our public key, we need to decrypt it.
+            let mut decrypted_elder_fees = vec![];
+
+            for (elder, fee) in elder_fees {
+                match fee.content.decrypt_amount(&revealed_bearer.secret_key) {
+                    Ok(amount) => decrypted_elder_fees.push(((elder, fee), amount)),
+                    Err(_) => {
+                        let _ = invalid_fees.insert(fee.content.elder_reward_key);
+                    }
+                }
+            }
+
+            let max_invalid_fees = elder_count() - required_responses;
+            if invalid_fees.len() > max_invalid_fees {
+                let valid_responses = num_responses - invalid_fees.len();
+                warn!("Not enough valid fees received from the section to spend the input. Found: {valid_responses}, needed: {required_responses}", );
+                continue;
+            }
+
+            // Total fee paid to all recipients in the section for this input.
+            let fee_per_input = decrypted_elder_fees
+                .iter()
+                .fold(Some(Token::zero()), |total, (_, fee)| {
+                    total.and_then(|t| t.checked_add(*fee))
+                })
+                .ok_or_else(|| Error::DbcReissueError(
+                    "Overflow occurred while summing the individual Elder's fees in order to calculate the total amount for the output DBCs."
+                        .to_string(),
+                ))?;
+
+            #[cfg(not(feature = "data-network"))]
+            let mut fee_cipher_params = BTreeMap::new();
+
+            // Add elders to outputs and generate their fee ciphers.
+            decrypted_elder_fees
+                .iter()
+                .for_each(|((elder, required_fee), fee)| {
+                    let owner = Owner::from(required_fee.content.elder_reward_key);
+                    let owner_once = OwnerOnce::from_owner_base(owner, &mut rng);
+                    outputs_owners.push((*fee, owner_once.clone()));
+
+                    #[cfg(not(feature = "data-network"))]
+                    let _ =
+                        fee_cipher_params.insert(elder.name(), (required_fee.clone(), owner_once));
+                });
+
+            #[cfg(not(feature = "data-network"))]
+            let _ = all_fee_cipher_params.insert(input_key, fee_cipher_params);
+
+            fee_per_input
+        };
+        // ---------------- fee part end ----------------
+
+        let dbc_balance = match dbc.revealed_amount_bearer() {
+            Ok(revealed_amount) => Token::from_nano(revealed_amount.value()),
+            Err(err) => {
+                warn!("Ignoring input Dbc (id: {input_key:?}) due to not being a bearer: {err:?}");
+                continue;
+            }
+        };
+
+        // Add this Dbc as input to be spent.
+        input_dbcs_to_spend.push(dbc.clone());
+
+        // Input amount increases with the amount of the dbc.
+        total_input_amount = total_input_amount.checked_add(dbc_balance)
+            .ok_or_else(|| {
+                Error::DbcReissueError(
+                    "Overflow occurred while increasing total input amount while trying to cover the output DBCs."
+                    .to_string(),
+            )
+            })?;
+
+        #[cfg(not(feature = "data-network"))]
+        {
+            // Output amount now increases a bit, as we have to cover the fee as well..
+            total_output_amount = total_output_amount.checked_add(fee_per_input)
+            .ok_or_else(|| {
+                Error::DbcReissueError(
+                "Overflow occurred while adding mint fee in order to calculate the total amount for the output DBCs."
+                    .to_string(),
+            )
+            })?;
+            // ..and so does `change_amount` (that we subtract from to know if we've covered `total_output_amount`).
+            change_amount = change_amount.checked_add(fee_per_input)
+            .ok_or_else(|| {
+                Error::DbcReissueError(
+                "Overflow occurred while adding mint fee in order to calculate the total amount for the output DBCs."
+                    .to_string(),
+            )
+            })?;
+        }
+
+        // If we've already combined input DBCs for the total output amount, then stop.
+        match change_amount.checked_sub(dbc_balance) {
+            Some(pending_output) => {
+                change_amount = pending_output;
+                if change_amount.as_nano() == 0 {
+                    break;
+                }
+            }
+            None => {
+                change_amount = Token::from_nano(dbc_balance.as_nano() - change_amount.as_nano());
+                break;
+            }
+        }
+    }
+
+    // If not enough spendable was found, this check will return an error.
+    verify_amounts(total_input_amount, total_output_amount)?;
+
+    Ok((
+        input_dbcs_to_spend,
+        outputs_owners,
+        change_amount,
+        #[cfg(not(feature = "data-network"))]
+        all_fee_cipher_params,
+    ))
+}
+
+/// The input dbcs will be spent on the network, and the resulting
+/// dbcs (and change dbc if any) are returned.
+/// This will pay transfer fees if not in data-network.
+async fn reissue_dbcs(
+    client: &Client,
+    input_dbcs: Vec<Dbc>,
+    outputs: Vec<(Token, OwnerOnce)>,
+    change_amount: Token,
+    reason: DbcReason,
+    #[cfg(not(feature = "data-network"))] all_fee_cipher_params: BTreeMap<
+        PublicKey,
+        BTreeMap<XorName, (RequiredFee, OwnerOnce)>,
+    >,
+) -> Result<(Vec<(Dbc, OwnerOnce, RevealedAmount)>, Option<Dbc>)> {
+    let mut tx_builder = TransactionBuilder::default()
+        .add_inputs_dbc_bearer(input_dbcs.iter())
+        .map_err(Error::DbcError)?
+        .add_outputs_by_amount(outputs.into_iter().map(|(token, owner)| (token, owner)));
+
+    let change_owneronce =
+        OwnerOnce::from_owner_base(client.dbc_owner().clone(), &mut rng::thread_rng());
+    if change_amount.as_nano() > 0 {
+        tx_builder = tx_builder.add_output_by_amount(change_amount, change_owneronce.clone());
+    }
+
+    let proof_key_verifier = SpentProofKeyVerifier { client };
+    let inputs_spent_proofs: BTreeSet<SpentProof> = input_dbcs
+        .iter()
+        .flat_map(|dbc| dbc.inputs_spent_proofs.clone())
+        .collect();
+    let inputs_spent_transactions: BTreeSet<DbcTransaction> = input_dbcs
+        .iter()
+        .flat_map(|dbc| dbc.inputs_spent_transactions.clone())
+        .collect();
+
+    // Finalize the tx builder to get the dbc builder.
+    let mut dbc_builder = tx_builder
+        .build(rng::thread_rng())
+        .map_err(Error::DbcError)?;
+
+    // Get fee outputs to generate the fee ciphers.
+    #[cfg(not(feature = "data-network"))]
+    let outputs = dbc_builder
+        .revealed_outputs
+        .iter()
+        .map(|output| (output.public_key, output.revealed_amount))
+        .collect();
+
+    // Spend all the input DBCs, collecting the spent proof shares for each of them
+    for (public_key, tx) in dbc_builder.inputs() {
+        // Generate the fee ciphers.
+        #[cfg(not(feature = "data-network"))]
+        let input_fee_ciphers = {
+            let fee_cipher_params = all_fee_cipher_params
+                .get(&public_key)
+                .ok_or(Error::DbcReissueError("Missing fee!".to_string()))?;
+            fee_ciphers(&outputs, fee_cipher_params)?
+        };
+
+        let tx_hash = Hash::from(tx.hash());
+        // TODO: spend DBCs concurrently spawning tasks
+        let mut attempts = 0;
+        loop {
+            attempts += 1;
+            client
+                .spend_dbc(
+                    public_key,
+                    tx.clone(),
+                    reason,
+                    inputs_spent_proofs.clone(),
+                    inputs_spent_transactions.clone(),
+                    #[cfg(not(feature = "data-network"))]
+                    input_fee_ciphers.clone(),
+                )
+                .await?;
+
+            let spent_proof_shares = client.spent_proof_shares(public_key).await?;
+
+            // TODO: we temporarilly filter the spent proof shares which correspond to the TX we
+            // are spending now. This is because current implementation of Spentbook allows
+            // double spents, so we may be retrieving spent proof shares for others spent TXs.
+            let shares_for_current_tx: HashSet<SpentProofShare> = spent_proof_shares
+                .into_iter()
+                .filter(|proof_share| proof_share.content.transaction_hash == tx_hash)
+                .collect();
+
+            match verify_spent_proof_shares_for_tx(
+                public_key,
+                tx_hash,
+                &shares_for_current_tx,
+                &proof_key_verifier,
+            ) {
+                Ok(()) => {
+                    dbc_builder = dbc_builder
+                        .add_spent_proof_shares(shares_for_current_tx.into_iter())
+                        .add_spent_transaction(tx);
+                    break;
+                }
+                Err(err) if attempts == NUM_OF_DBC_REISSUE_ATTEMPTS => {
+                    return Err(Error::DbcReissueError(format!(
+                        "Failed to spend input, {} proof shares obtained from spentbook: {}",
+                        shares_for_current_tx.len(),
+                        err
+                    )))?;
+                }
+                Err(_) => {}
+            }
+        }
+    }
+
+    // Perform verifications of input TX and spentproofs,
+    // as well as building the output DBCs.
+    let mut output_dbcs = dbc_builder
+        .build(&proof_key_verifier)
+        .map_err(Error::DbcError)?;
+
+    let mut change_dbc = None;
+    output_dbcs.retain(|(dbc, owneronce, _)| {
+        if owneronce == &change_owneronce && change_amount.as_nano() > 0 {
+            change_dbc = Some(dbc.clone());
+            false
+        } else {
+            true
+        }
+    });
+
+    Ok((output_dbcs, change_dbc))
+}
+
+/// This will encrypt the necessary components of a fee payment,
+/// so that an Elder can find and verify the fee paid to them, from
+/// within a request to spend a dbc.
+#[cfg(not(feature = "data-network"))]
+fn fee_ciphers(
+    outputs: &BTreeMap<PublicKey, RevealedAmount>,
+    fee_cipher_params: &BTreeMap<XorName, (RequiredFee, OwnerOnce)>,
+) -> errors::Result<BTreeMap<XorName, FeeCiphers>> {
+    let mut input_fee_ciphers = BTreeMap::new();
+    for (elder_name, (required_fee, owner_once)) in fee_cipher_params {
+        // Encrypt the index to the _well-known reward key_.
+        let derivation_index_cipher = required_fee
+            .content
+            .elder_reward_key
+            .encrypt(owner_once.derivation_index);
+
+        let output_owner_pk = owner_once.as_owner().public_key();
+        let revealed_amount = outputs
+            .get(&output_owner_pk)
+            .ok_or(Error::DbcReissueError("Missing output!".to_string()))?;
+
+        // Encrypt the amount to the _derived key_ (i.e. new dbc id).
+        let amount_cipher = revealed_amount.encrypt(&output_owner_pk);
+        let _ = input_fee_ciphers.insert(
+            *elder_name,
+            FeeCiphers::new(amount_cipher, derivation_index_cipher),
+        );
+    }
+    Ok(input_fee_ciphers)
+}
+
+// Private helper to verify if a set of spent proof shares are valid for a given public_key and TX
+fn verify_spent_proof_shares_for_tx(
+    public_key: PublicKey,
+    tx_hash: Hash,
+    proof_shares: &HashSet<SpentProofShare>,
+    proof_key_verifier: &SpentProofKeyVerifier,
+) -> errors::Result<()> {
+    SpentProof::try_from_proof_shares(public_key, tx_hash, proof_shares)
+        .and_then(|spent_proof| spent_proof.verify(tx_hash, proof_key_verifier))?;
+
+    Ok(())
+}
+
+// Make sure total input amount gathered with input DBCs are enough for the output amount
+fn verify_amounts(total_input_amount: Token, total_output_amount: Token) -> errors::Result<()> {
+    if total_output_amount > total_input_amount {
+        return Err(Error::NotEnoughBalance(total_input_amount.to_string()));
+    }
+    Ok(())
+}
+
+/// Verifier required by sn_dbc API to check a SpentProof
+/// is signed by known sections keys.
+struct SpentProofKeyVerifier<'a> {
+    client: &'a Client,
+}
+
+impl sn_dbc::SpentProofKeyVerifier for SpentProofKeyVerifier<'_> {
+    type Error = crate::Error;
+
+    // Called by sn_dbc API when it needs to verify a SpentProof is signed by a known key,
+    // we check if the key is any of the network sections keys we are aware of
+    fn verify_known_key(&self, key: &PublicKey) -> Result<()> {
+        if !futures::executor::block_on(self.client.is_known_section_key(key)) {
+            Err(Error::DbcVerificationFailed(format!(
+                "SpentProof key is an unknown section key: {}",
+                key.to_hex()
+            )))?
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/sn_client/src/api/transfers/mod.rs
+++ b/sn_client/src/api/transfers/mod.rs
@@ -37,8 +37,9 @@ type ReissueInputs = (Vec<Dbc>, Vec<(Token, OwnerOnce)>, Token, ReissueCiphers);
 // Hence the max number of attempts set to a higher value.
 const NUM_OF_DBC_REISSUE_ATTEMPTS: u8 = 5;
 
-/// Send the tokens to the provided owners, using the provided dbcs.
-/// This is used with external Dbcs, i.e. not selecting dbcs from the wallet.
+/// Send the tokens to the specified destination keys, using the provided dbcs.
+/// The new dbcs that are created, one per specified destination, will have the
+/// unique id which is the public key of the `OwnerOnce` instances provided.
 ///
 /// Transfer fees will be paid if not in data-network.
 /// The input dbcs will be spent on the network, and the resulting
@@ -76,8 +77,8 @@ pub async fn select_inputs(
     mut recipients: Vec<(Token, OwnerOnce)>,
 ) -> Result<ReissueInputs> {
     // We'll combine one or more input DBCs and reissue:
-    // - one output DBC for the recipient,
-    // - and a second DBC for the change, which will be stored in the source wallet.
+    // - one output DBC per recipient,
+    // - and a single DBC for the change - if any - which will be returned from this function.
     let mut input_dbcs_to_spend = Vec::<Dbc>::new();
     let mut total_input_amount = Token::zero();
     let mut total_output_amount = recipients
@@ -130,7 +131,7 @@ pub async fn select_inputs(
 
             // Fees that were not encrypted to us.
             let mut invalid_fees = BTreeSet::new();
-            // As the mints encrypt the amount to our public key, we need to decrypt it.
+            // As the Elders encrypt the amount to our public key, we need to decrypt it.
             let mut decrypted_elder_fees = vec![];
 
             for (elder, fee) in elder_fees {

--- a/sn_client/src/errors.rs
+++ b/sn_client/src/errors.rs
@@ -8,6 +8,7 @@
 
 use crate::LinkError;
 
+use sn_dbc::PublicKey as DbcPublicKey;
 use sn_interface::{
     messaging::{
         data::{DataQuery, Error as ErrorMsg, QueryResponse},
@@ -18,7 +19,6 @@ use sn_interface::{
 };
 
 use bls::PublicKey;
-use sn_dbc::PublicKey as DbcPublicKey;
 use std::{io, time::Duration};
 use thiserror::Error;
 use xor_name::XorName;
@@ -149,6 +149,9 @@ pub enum Error {
         /// Address name of the chunk
         address: XorName,
     },
+    /// Transfer errors.
+    #[error(transparent)]
+    TransferError(#[from] crate::api::TransferError),
     /// Node closed the bi-stream we expected a response on
     #[error("The bi-stream we expected a msg response on, for {msg_id:?}, was closed by remote node: {node_id:?}")]
     ResponseStreamClosed {

--- a/sn_interface/src/types/keys/secret_key.rs
+++ b/sn_interface/src/types/keys/secret_key.rs
@@ -97,11 +97,11 @@ pub fn bls_secret_from_hex<T: AsRef<[u8]>>(hex: T) -> Result<bls::SecretKey> {
             "Couldn't parse BLS secret key bytes from hex. The provided string must represent exactly {} bytes.",
             bls::SK_SIZE
         )))?;
-    let pk = bls::SecretKey::from_bytes(bytes_fixed_len).map_err(|err| {
+    let sk = bls::SecretKey::from_bytes(bytes_fixed_len).map_err(|err| {
         Error::FailedToParse(format!(
             "Couldn't parse BLS secret key from fixed-length byte array: {err}",
         ))
     })?;
 
-    Ok(pk)
+    Ok(sk)
 }

--- a/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
+++ b/sn_node/src/node/flow_ctrl/tests/dbc_utils.rs
@@ -10,9 +10,9 @@ use sn_dbc::{
     Dbc, DbcTransaction, Owner, OwnerOnce, PublicKey, SpentProof, SpentProofShare, Token,
     TransactionBuilder,
 };
+use sn_interface::{messaging::data::RegisterCmd, types::ReplicatedData};
 
 use eyre::{eyre, Result};
-use sn_interface::{messaging::data::RegisterCmd, types::ReplicatedData};
 use std::collections::BTreeSet;
 
 /// Get the spent proof share that's packaged inside the data that's to be replicated to the adults

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -841,7 +841,7 @@ async fn spentbook_spend_client_message_should_replicate_to_adults_and_send_ack(
         }
     }
 
-    bail!("No cmd msg was generate to replicate the data to node holders");
+    bail!("No cmd msg was generated to replicate the data to node holders");
 }
 
 #[tokio::test]
@@ -903,6 +903,13 @@ async fn spentbook_spend_transaction_with_no_inputs_should_return_spentbook_erro
             ..
         } = cmd
         {
+            #[cfg(not(feature = "data-network"))]
+            assert_eq!(
+                error,
+                &MessagingDataError::from(Error::MissingFee),
+                "A different error was expected for this case: {error:?}"
+            );
+            #[cfg(feature = "data-network")]
             assert_eq!(
                 error,
                 &MessagingDataError::from(Error::SpentbookError(


### PR DESCRIPTION
With this PR an Elder now verifies that a spend contains an output for them
with correct amount.

This is done by decrypting the fee ciphers sent from client in a spend,
confirming that there is an output to the key derived from the elder reward key,
and that the amount of the output is equivalent to the decrypted amount.

The basic rule for now is that if the paid fee is over 1% less than the required fee, we don't accept the fee.
This is a temporary diff value/design.
(And yes, this means that for now, the Client can try to get away cheaper by sending in up to 1% lower fee than they were asked for.)

***

1.  ✔️ `Previous feat`: Including Elders in outputs (any value) when spending Dbcs.
2. ✔️ `Previous feat`: Including fee ciphers for Elders in spend: #2249.
3. `This PR`: Elders confirming that spends contain outputs with sufficient amount, destined for them.
4. `Next PR`: Use a fee calc algo with supply/demand adjusting properties: #2247.

Steps in the fee/reward feature:
<s> 1. Including Elders in outputs (any value) when spending Dbcs.</s>
<s> 2. Including fee ciphers for Elders so that they can confirm fee paid.</s>
<s> 3. Elders confirming that spends contain outputs with sufficient amount, destined for them.</s> (`This PR`)
4. Implementing a commonly known deterministic transfer/store cost paid to nodes.
5. Including supply/demand adjusting fee in outputs when spending Dbcs.
6. Elders fetching and storing their payment to a local wallet.
(7. A mempool which orders incoming spends by fee amount, and a Client UI option to choose priority of their spend.)

***
