### PR TITLE
feat(fees): impl supply/demand-adjusted fee

### DIFF
--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -33,6 +33,8 @@ pub mod dbcs;
 pub mod messaging;
 // Knowledge of the safe network
 pub mod network_knowledge;
+// Cost of write ops on the safe network.
+pub mod op_cost;
 // Types on the safe network
 pub mod types;
 // Statemap states

--- a/sn_interface/src/op_cost/mod.rs
+++ b/sn_interface/src/op_cost/mod.rs
@@ -1,0 +1,250 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use self_encryption::MAX_CHUNK_SIZE;
+use sn_dbc::Token;
+use tracing::debug;
+
+/// The conversion from token to raw value.
+const TOKEN_TO_RAW_CONVERSION: u64 = 1_000_000_000;
+/// The maximum supply of SNT, also the largest value that can be represented by a single `Token`.
+const MAX_SUPPLY: u64 = (u32::max_value() as u64 + 1) * TOKEN_TO_RAW_CONVERSION;
+
+/// Calculation of required tokens for writes.
+
+/// Calculates the required tokens of write operations,
+/// as a number of tokens to be paid for a certain number of bytes,
+/// given the current section prefix its number of storage nodes, and percent filled.
+///
+/// This uses an algorithm to calculate a fee with supply/demand adjusting properties
+/// (although indirect and therefore arguably sluggish) based on:
+/// 1. Network size (contributing to the deflationary character of SNT).
+/// 2. Storage used.
+/// 3. Requirements for space margin (1/3).
+/// 4. Requirement for as low fee as possible for as long as possible.
+/// (Point 3. and 4. are achieved by the specific design of the required tokens curve.)
+///
+/// It is assumed that a larger network means the token has a greater value, and therefore
+/// the required number of tokens per operation is also lower, following a curve as per above.
+/// The constants used may seem arbitrary but have been carefully chosen as to model the desired behaviour.
+pub fn required_tokens(
+    bytes: usize,
+    prefix_len: usize,
+    num_nodes_in_section: u8,
+    percent_filled: f64,
+) -> Token {
+    debug!(
+        "required_tokens input values; bytes: {bytes}, prefix_len: {prefix_len}, num_nodes_in_section: {num_nodes_in_section}, percent_filled: {percent_filled}",
+    );
+    let available_nodes = num_nodes_in_section as f64;
+    let supply_demand_factor =
+        0.001 + (1_f64 / (20_f64 * available_nodes)).powf(8_f64) + percent_filled.powf(3_f64);
+    let byte_size_share = bytes as f64 / MAX_CHUNK_SIZE as f64;
+    let data_size_factor = byte_size_share + byte_size_share.powf(2_f64);
+    let steepness_reductor = prefix_len as f64 + 1_f64;
+    let supply_share = max_supply_share_per_section(prefix_len) as f64;
+    let token_source = steepness_reductor * supply_share.powf(0.5_f64);
+    let required_tokens = (token_source * data_size_factor * supply_demand_factor).round() as u64;
+    Token::from_nano(u64::max(1, required_tokens)) // always return > 0
+}
+
+// The proportion of total supply "available" per section,
+// given a certain network size (i.e. prefix len).
+// This is not an actual allocation, just a theoretical value used for the calc of required tokens.
+fn max_supply_share_per_section(prefix_len: usize) -> u64 {
+    (MAX_SUPPLY as f64 / 2_f64.powf(prefix_len as f64)).floor() as u64
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::messaging::data::DataCmd;
+    use std::mem;
+
+    #[test]
+    fn tokens() {
+        let bytes = MAX_CHUNK_SIZE;
+        let prefix_len = 0;
+        let num_storage_nodes = 15;
+        let percent_filled = 1_f64 / (100_f64 * num_storage_nodes as f64);
+        let required_nanos =
+            required_tokens(bytes, prefix_len, num_storage_nodes, percent_filled).as_nano();
+        println!("required_nanos: {required_nanos}");
+        //assert_eq!(required_nanos, 15_300_364); // 15300364 nanos == 0.01500364 tokens
+    }
+
+    #[test]
+    fn calculates_required_tokens() {
+        let bytes = MAX_CHUNK_SIZE;
+        let prefix_len = 4;
+        let num_storage_nodes = 24;
+        let percent_filled = 3_f64 / num_storage_nodes as f64;
+        let required_nanos =
+            required_tokens(bytes, prefix_len, num_storage_nodes, percent_filled).as_nano();
+        println!("required_nanos: {required_nanos}");
+        assert_eq!(required_nanos, 15_300_364); // 15300364 nanos == 0.01500364 tokens
+    }
+
+    #[test]
+    fn section_share_of_max_supply_decreases_as_network_grows() {
+        // Prefix zero is one section so low usage (lots available).
+        let first_section_nanos = max_supply_share_per_section(0);
+        assert_eq!(MAX_SUPPLY, first_section_nanos);
+        // First split leads to each section "sharing" half the token supply.
+        let first_split_nanos = max_supply_share_per_section(1);
+        assert_eq!(MAX_SUPPLY / 2, first_split_nanos);
+        // At least one nano (1 billionth of a token) available in up to 2.3 * 10^18 sections, (which is more than one billion times one billion sections).
+        let last_split_nanos = max_supply_share_per_section(61);
+        assert!(last_split_nanos > 0);
+    }
+
+    // -------------------------------------------------------------
+    // --------------- Required Tokens Common Sense ---------------------
+    // -------------------------------------------------------------
+    // Test various different comparisons of the OpCost.
+    // These tests are of the type 'all things being equal, then ...'
+    // Thanks to @IanColeman for these constributions.
+
+    #[test]
+    fn smaller_chunks_require_fewer_tokens() {
+        let max_chunk_size = MAX_CHUNK_SIZE;
+        let prefix_len = 0;
+        let num_storage_nodes = 8;
+        let percent_filled = 7_f64 / num_storage_nodes as f64;
+        let standard_fee = required_tokens(
+            max_chunk_size,
+            prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+
+        // smaller chunks require fewer tokens
+        let max_chunk_size_less_one_byte = max_chunk_size - 1;
+        let small_chunk_fee = required_tokens(
+            max_chunk_size_less_one_byte,
+            prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        assert!(
+            small_chunk_fee <= standard_fee,
+            "small chunks don't require fewer tokens, expect {} <= {}",
+            small_chunk_fee,
+            standard_fee
+        );
+    }
+
+    #[test]
+    fn fewer_tokens_required_in_larger_net() {
+        let max_chunk_size = MAX_CHUNK_SIZE;
+        let prefix_len = 2; // first couple of sections see an increase in required tokens, whereafter it is strictly decreasing
+        let num_storage_nodes = 8;
+        let percent_filled = 7_f64 / num_storage_nodes as f64;
+        let standard_fee = required_tokens(
+            max_chunk_size,
+            prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        // ops require fewer tokens in a larger network than in a smaller network
+        let larger_prefix = prefix_len + 1;
+        let large_network_fee = required_tokens(
+            max_chunk_size,
+            larger_prefix,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        assert!(
+            large_network_fee <= standard_fee,
+            "larger network is not cheaper, expect {} <= {}",
+            large_network_fee,
+            standard_fee
+        );
+    }
+
+    #[test]
+    fn emptier_section_requires_fewer_tokens() {
+        let max_chunk_size = MAX_CHUNK_SIZE;
+        let prefix_len = 0;
+        let num_storage_nodes = 8;
+        let percent_filled = 7_f64 / num_storage_nodes as f64;
+        let standard_fee = required_tokens(
+            max_chunk_size,
+            prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        // less filled section require fewer tokens than more filled section
+        let less_percent_filled = 6_f64 / num_storage_nodes as f64;
+        let lower_fee = required_tokens(
+            max_chunk_size,
+            prefix_len,
+            num_storage_nodes,
+            less_percent_filled,
+        )
+        .as_nano();
+        assert!(
+            lower_fee <= standard_fee,
+            "less filled section does not require fewer tokens, expect {} <= {}",
+            lower_fee,
+            standard_fee
+        );
+    }
+
+    #[test]
+    fn splitting_into_multiple_chunks_require_fewer_tokens_than_same_bytes_in_single_chunk() {
+        // we encourage more granularity in data chunking
+        let max_chunk_size = MAX_CHUNK_SIZE;
+        let prefix_len = 2;
+        let num_storage_nodes = 8;
+        let percent_filled = 7_f64 / num_storage_nodes as f64;
+        let standard_fee = required_tokens(
+            max_chunk_size,
+            prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        // many tiny chunks require fewer tokens than the same bytes in one big chunk
+        let one_kb_bytes = 1024;
+        let reduced_fee =
+            required_tokens(one_kb_bytes, prefix_len, num_storage_nodes, percent_filled).as_nano();
+        let combined_fee = reduced_fee * (MAX_CHUNK_SIZE / one_kb_bytes) as u64;
+        assert!(
+            combined_fee <= standard_fee,
+            "many small chunks does not require fewer tokens than one big chunk, expect {} <= {}",
+            combined_fee,
+            standard_fee,
+        );
+    }
+
+    #[test]
+    fn tokens_are_required_up_to_max_network_size() {
+        // The size of the actual DataCmd is used for OpCost calc.
+        // In general, the size of a type is not stable across compilations,
+        // but it is close enough for our purposes here.
+        let minimum_storage_bytes = mem::size_of::<DataCmd>();
+        let big_prefix_len = 256;
+        let num_storage_nodes = 20;
+        let percent_filled = 10_f64 / num_storage_nodes as f64;
+        // tokens are required up to 2.3 * 10^78 nodes.
+        let required_tokens = required_tokens(
+            minimum_storage_bytes,
+            big_prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        assert!(required_tokens > 0, "tokens are not always required",);
+    }
+}

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -10,7 +10,7 @@ use super::{flow_ctrl::RejoinReason, Prefix};
 
 use crate::node::handover::Error as HandoverError;
 
-use sn_dbc::Error as DbcError;
+use sn_dbc::{Error as DbcError, Token};
 use sn_interface::{
     dbcs::Error as GenesisError,
     messaging::{data::Error as ErrorMsg, system::DkgSessionId},
@@ -69,8 +69,8 @@ pub enum Error {
     MissingFee,
     #[error("Invalid fee blinded amount.")]
     InvalidFeeBlindedAmount,
-    #[error("Too low amount for the transfer fee.")]
-    FeeTooLow,
+    #[error("Too low amount for the transfer fee: {paid}. Min required: {required}.")]
+    FeeTooLow { paid: Token, required: Token },
     #[error("The secret key share is missing for public key {0:?}")]
     MissingSecretKeyShare(bls::PublicKey),
     #[error("Messaging protocol error: {0}")]

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -1099,10 +1099,13 @@ fn get_spend(dbc: sn_dbc::Dbc, context: NodeContext) -> Result<Spend> {
     let dbc_amount = dbc.revealed_amount_bearer()?;
     let change_owner = OwnerOnce::from_owner_base(dbc.owner_base().clone(), &mut rng);
 
+    #[cfg(not(feature = "data-network"))]
+    let fee = context.current_fee();
+
     #[cfg(feature = "data-network")]
     let change_amount = Token::from_nano(dbc_amount.value());
     #[cfg(not(feature = "data-network"))]
-    let change_amount = Token::from_nano(dbc_amount.value() - context.store_cost.as_nano());
+    let change_amount = Token::from_nano(dbc_amount.value() - fee.as_nano());
 
     #[cfg(not(feature = "data-network"))]
     let fee_derived_owner = {
@@ -1116,7 +1119,7 @@ fn get_spend(dbc: sn_dbc::Dbc, context: NodeContext) -> Result<Spend> {
     #[cfg(not(feature = "data-network"))]
     let outputs = {
         vec![
-            (context.store_cost, fee_derived_owner.clone()),
+            (fee, fee_derived_owner.clone()),
             (change_amount, change_owner),
         ]
     };

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -137,7 +137,6 @@ impl MyNode {
             dkg_voter: self.dkg_voter.clone(),
             dkg_sessions_info: self.dkg_sessions_info.clone(),
             reward_secret_key: self.reward_secret_key.clone(),
-            store_cost: sn_dbc::Token::from_nano(1), // hard coded for now
             network_knowledge: self.network_knowledge().clone(),
             section_keys_provider: self.section_keys_provider.clone(),
             comm: self.comm.clone(),

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -59,6 +59,11 @@ impl DataStorage {
         }
     }
 
+    /// Returns the ratio of used storage space to min capacity.
+    pub(crate) fn used_space_ratio(&self) -> f64 {
+        self.used_space.ratio()
+    }
+
     /// Returns whether the storage min capacity has been reached or not.
     pub(crate) fn has_reached_min_capacity(&self) -> bool {
         self.used_space.has_reached_min_capacity()


### PR DESCRIPTION
This PR adds an algorithm to calculate a fee with supply/demand adjusting properties - although indirect and therefore arguably sluggish - based on:
1. Network size (contributing to the deflationary character of SNT).
2. Storage used.
3. Requirements for space margin (1/3).
4. Requirement for as low fee as possible for as long as possible.

(Point 3. and 4. are achieved by the specific design of the required tokens curve.)

***

To do transfers on the network, clients are required to pay a number of tokens as a fee. The fees are the source of rewards for Elders in a payment-network, which is essential to the network security as it gives incentive to node operators to run a node and handle the requests, thus allowing for the network to grow.

**NB 1**: This is not a replacement for a true market, where node operators and clients discover the price based on operation costs + margins and service value + affordability to client.

**NB 2**: The fee paid to the Elder is not actually accessible until the Elder can fetch the `SpendProof` from
the data holders.

**NB 3**: With 1 fee per spend, the fee amount in the dbc is not accessible to the Elder until the required fee for
a spend has decreased below the amount in the dbc. In effect, with this design there is currently a lock-in
effect on Elder rewards which require the network to grow for the amount paid to them to be accessible.
***
1. ✔️ `Previous PR`: The query and handling of it on Elders for their reward keys and hard coded fee: #2184.
2. ✔️ `Previous PR`: The logic for including Elders to outputs: #2180.
3. ✔️ `Previous PR`: Including fee ciphers for Elders in spend: #2249.
4. ✔️ `Previous PR`: Elders confirming that spends contain outputs with sufficient amount, destined for them: #2246.
5. `This PR`: Use a fee calc algo with supply/demand adjusting properties.
6. `Next PR`: Use a mempool to increase supply/demand properties of the system and protect the network #2256.

Steps in the fee/reward feature:
- <s> 1. Including Elders in outputs (any value) when spending Dbcs.</s>
- <s> 2. Including fee ciphers for Elders so that they can confirm fee paid.</s>
- <s> 3. Elders confirming that spends contain outputs with sufficient amount, destined for them.</s>
- <s> 5. Implementing a commonly known deterministic transfer/store cost paid to nodes.</s> (`This PR`)
- <s> 5. Including supply/demand adjusting fee in outputs when spending Dbcs.</s> (`This PR`)
6. A mempool which orders incoming spends by fee amount, and a Client UI option to choose priority of their spend.
7. Elders fetching and storing their payment to a local wallet.
