### PR TITLE
feat: enable RPC service in released safenode

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -287,9 +287,7 @@ jobs:
         run: |
           curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-win64.zip
           unzip protoc-22.2-win64.zip
-          copy bin\protoc.exe .\sn_node\
-          copy bin\protoc.exe .\sn_testnet\
-          .\sn_node\protoc.exe --version
+          .\bin\protoc.exe --version
 
       - name: Build sn bins
         if: matrix.os != 'windows-latest'
@@ -300,7 +298,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cargo build --release --bins --features=verify-nodes,rpc-service
         env:
-          PROTOC: .\protoc.exe
+          PROTOC: ..\bin\protoc.exe
         timeout-minutes: 60
 
       - name: Start a local network
@@ -437,9 +435,7 @@ jobs:
         run: |
           curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-win64.zip
           unzip protoc-22.2-win64.zip
-          copy bin\protoc.exe .\sn_node\
-          copy bin\protoc.exe .\sn_testnet\
-          .\sn_node\protoc.exe --version
+          .\bin\protoc.exe --version
 
       - name: Build sn bins
         if: matrix.os != 'windows-latest'
@@ -450,7 +446,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cargo build --release --bins --features=verify-nodes,rpc-service
         env:
-          PROTOC: .\protoc.exe
+          PROTOC: ..\bin\protoc.exe
         timeout-minutes: 60
 
       - name: Start a local network
@@ -840,9 +836,7 @@ jobs:
         run: |
           curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-win64.zip
           unzip protoc-22.2-win64.zip
-          copy bin\protoc.exe .\sn_node\
-          copy bin\protoc.exe .\sn_testnet\
-          .\sn_node\protoc.exe --version
+          .\bin\protoc.exe --version
 
       - name: Build sn bins
         if: matrix.os != 'windows-latest'
@@ -853,7 +847,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cargo build --release --bins --features=verify-nodes,rpc-service
         env:
-          PROTOC: .\protoc.exe
+          PROTOC: ..\bin\protoc.exe
         timeout-minutes: 60
 
       - name: Start a local network
@@ -974,9 +968,7 @@ jobs:
         run: |
           curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-win64.zip
           unzip protoc-22.2-win64.zip
-          copy bin\protoc.exe .\sn_node\
-          copy bin\protoc.exe .\sn_testnet\
-          .\sn_node\protoc.exe --version
+          .\bin\protoc.exe --version
 
       - name: Build sn bins
         if: matrix.os != 'windows-latest'
@@ -987,7 +979,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cargo build --release --bins --features=verify-nodes,rpc-service
         env:
-          PROTOC: .\protoc.exe
+          PROTOC: ..\bin\protoc.exe
         timeout-minutes: 60
 
       - name: Start a local network
@@ -1000,11 +992,19 @@ jobs:
         run: cargo run --package sn_cli --release -- keys create --for-cli
 
       - name: Build all tests before running
-        run: cd sn_cli && cargo test --no-run --release --features check-replicas,data-network
+        if: matrix.os != 'windows-latest'
+        run: cd sn_cli && cargo test --no-run --release --features check-replicas,data-network,node-ctrl
+        timeout-minutes: 50
+
+      - name: Build all tests before running (Windows)
+        if: matrix.os == 'windows-latest'
+        run: cd sn_cli && cargo test --no-run --release --features check-replicas,data-network,node-ctrl
+        env:
+          PROTOC: ..\bin\protoc.exe
         timeout-minutes: 50
 
       - name: Run CLI tests
-        run: cd sn_cli && cargo test --release --features check-replicas,data-network -- --test-threads=1
+        run: cd sn_cli && cargo test --release --features check-replicas,data-network,node-ctrl -- --test-threads=1
         timeout-minutes: 7
 
       - name: Are nodes still running...?

--- a/Justfile
+++ b/Justfile
@@ -38,6 +38,17 @@ build-release-artifacts arch:
     rustup target add x86_64-unknown-linux-musl
   fi
 
+  if [[ "$arch" == "x86_64-pc-windows-msvc" ]]; then
+    curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-win64.zip
+    unzip protoc-22.2-win64.zip
+    ./bin/protoc.exe --version
+    export PROTOC=`pwd`/bin/protoc.exe
+  elif [[ "$arch" == "x86_64-apple-darwin" ]]; then
+    brew install protobuf && protoc --version
+  elif [[ "$arch" == "x86_64-unknown-linux-musl" ]]; then
+    sudo apt install -y protobuf-compiler libprotobuf-dev && protoc --version
+  fi
+
   rm -rf artifacts
   mkdir artifacts
   cargo clean
@@ -47,8 +58,8 @@ build-release-artifacts arch:
     cross build --release --target $arch --bin safe --features limit-client-upload-size,data-network
     cross build --release --target $arch --bin testnet
   else
-    cargo build --release --target $arch --bin safenode --features otlp
-    cargo build --release --target $arch --bin safe --features limit-client-upload-size,data-network
+    cargo build --release --target $arch --bin safenode --features otlp,rpc-service
+    cargo build --release --target $arch --bin safe --features limit-client-upload-size,data-network,node-ctrl
     cargo build --release --target $arch --bin testnet
   fi
 


### PR DESCRIPTION
Enables the RPC service in the released `safenode` bin, as well as enabling CLI `node` subcommands for interacting with such service.