### PR TITLE
feat(mempool)!: prioritise spends based on fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,16 +77,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstyle"
-version = "0.3.1"
+name = "anstream"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c697cc33851b02ab0c26b2e8a211684fbe627ff1cc506131f35026dd7686dd"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "arrayvec"
@@ -115,14 +149,14 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.9"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0dcbed38184f9219183fcf38beb4cdbf5df7163a6d7cd227c6ac89b7966d6fe"
+checksum = "ec0b2340f55d9661d76793b2bfc2eb0e62689bd79d067a95707ea762afd5e9dd"
 dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
- "predicates 3.0.1",
+ "predicates 3.0.2",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -130,14 +164,14 @@ dependencies = [
 
 [[package]]
 name = "assert_fs"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e9c67bc212f1414075b1ff074e8713d103dd82c98dc4b5a28405216695ff28"
+checksum = "e9d5bf7e5441c6393b5a9670a5036abe6b4847612f594b870f7332dbf10cf6fa"
 dependencies = [
  "anstyle",
  "doc-comment",
  "globwalk",
- "predicates 3.0.1",
+ "predicates 3.0.2",
  "predicates-core",
  "predicates-tree",
  "tempfile",
@@ -191,22 +225,22 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
  "async-lock",
  "autocfg",
+ "cfg-if",
  "concurrent-queue",
  "futures-lite",
- "libc",
  "log",
  "parking",
  "polling",
+ "rustix",
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -291,24 +325,24 @@ checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "async-task"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.66"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -342,9 +376,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
+checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -603,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
 dependencies = [
  "memchr",
  "once_cell",
@@ -790,7 +824,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -861,21 +895,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "concolor"
-version = "0.0.12"
+name = "concolor-override"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3e3c41e9488eeda196b6806dbf487742107d61b2e16485bcca6c25ed5755b"
-dependencies = [
- "bitflags",
- "concolor-query",
- "is-terminal",
-]
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
 
 [[package]]
 name = "concolor-query"
-version = "0.1.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a90734b3d5dcf656e7624cca6bce9c3a90ee11f900e80141a7427ccfb3d317"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -943,9 +975,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -1108,7 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1128,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.60+curl-7.88.1"
+version = "0.4.61+curl-8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "717abe2cb465a5da6ce06617388a3980c9a2844196734bec8ccb8e575250f13f"
+checksum = "14d05c10f541ae6f3bc5b3d923c20001f47db7d5f0b2bc6ad16490133842db79"
 dependencies = [
  "cc",
  "libc",
@@ -1185,15 +1217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a9f3941234c9f62ceaa2782974827749de9b0a8a6487275a278da068e1baf7"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
  "synstructure",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1203,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1213,24 +1245,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -1270,7 +1302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1373,9 +1405,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "ena"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e5d13ca2353ab7d0230988629def93914a8c4015f621f9b13ed2955614731d"
+checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
 dependencies = [
  "log",
 ]
@@ -1426,19 +1458,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
  "synstructure",
 ]
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1505,7 +1537,7 @@ checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "windows-sys 0.45.0",
 ]
 
@@ -1632,7 +1664,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1676,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -2020,16 +2052,16 @@ dependencies = [
 
 [[package]]
 name = "human-panic"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d13dc3bae03e53a5e81a3944773631df2c5a33c060e195c1f7bf3fd0d2a696"
+checksum = "0a6557b29bbdc9d6c7a5cdbe2962e78eaf48115e8d55b0b62282956981c1f605"
 dependencies = [
+ "anstream",
+ "anstyle",
  "backtrace",
- "concolor",
  "os_info",
  "serde",
  "serde_derive",
- "termcolor",
  "toml",
  "uuid",
 ]
@@ -2091,16 +2123,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -2148,9 +2180,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -2189,25 +2221,26 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -2286,15 +2319,15 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.8"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
+checksum = "f34313ec00c2eb5c3c87ca6732ea02dcf3af99c3ff7a8fb622ffb99c9d860a87"
 dependencies = [
  "ascii-canvas",
- "atty",
  "bit-set",
  "diff",
  "ena",
+ "is-terminal",
  "itertools",
  "lalrpop-util",
  "petgraph",
@@ -2309,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.8"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
+checksum = "e5c1f7869c94d214466c5fd432dfed12c379fd87786768d36455892d46b18edd"
 dependencies = [
  "regex",
 ]
@@ -2373,9 +2406,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
 
 [[package]]
 name = "lock_api"
@@ -2463,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
@@ -2506,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -2521,14 +2554,14 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2659,9 +2692,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.81"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176be2629957c157240f68f61f2d0053ad3a4ecfdd9ebf1e6521d18d9635cf67"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",
@@ -2720,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c424bc68d15e0778838ac013b5b3449544d8133633d8016319e7e05a820b8c0"
+checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
 dependencies = [
  "log",
  "serde",
@@ -2741,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "overload"
@@ -2792,7 +2825,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "petgraph",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "thread-id",
  "windows-sys 0.45.0",
@@ -2870,7 +2903,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2969,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba7d6ead3e3966038f68caa9fc1f860185d95a793180bbcfe0d0da47b3961ed"
+checksum = "c575290b64d24745b6c57a12a31465f0a66f3a4799686a6921526a33b0797965"
 dependencies = [
  "anstyle",
  "difflib",
@@ -3003,12 +3036,22 @@ checksum = "bc5c99d529f0d30937f6f4b8a86d988047327bb88d04d2c4afc356de74722131"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "priority-queue"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9c6be70d989d21a136eb86c2d83e4b328447fac4a88dace2143c179c86267"
+dependencies = [
+ "autocfg",
+ "indexmap",
 ]
 
 [[package]]
@@ -3020,7 +3063,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -3037,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -3121,7 +3164,7 @@ dependencies = [
  "prost 0.11.8",
  "prost-types 0.11.8",
  "regex",
- "syn",
+ "syn 1.0.109",
  "tempfile",
  "which",
 ]
@@ -3136,7 +3179,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3149,7 +3192,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3201,7 +3244,7 @@ dependencies = [
  "bytes",
  "futures",
  "quinn 0.9.3",
- "quinn-proto 0.9.2",
+ "quinn-proto 0.9.3",
  "rcgen",
  "rustls",
  "serde",
@@ -3259,7 +3302,7 @@ checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
 dependencies = [
  "bytes",
  "pin-project-lite",
- "quinn-proto 0.9.2",
+ "quinn-proto 0.9.3",
  "quinn-udp 0.3.2",
  "rustc-hash",
  "rustls",
@@ -3290,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
+checksum = "67c10f662eee9c94ddd7135043e544f3c82fa839a1e7b865911331961b53186c"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -3327,7 +3370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
 dependencies = [
  "libc",
- "quinn-proto 0.9.2",
+ "quinn-proto 0.9.3",
  "socket2",
  "tracing",
  "windows-sys 0.42.0",
@@ -3481,21 +3524,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.8",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3513,9 +3565,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "relative-path"
@@ -3525,9 +3577,9 @@ checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -3601,9 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
 
 [[package]]
 name = "rustc-hash"
@@ -3613,9 +3665,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
 dependencies = [
  "bitflags",
  "errno",
@@ -3771,9 +3823,9 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
@@ -3789,20 +3841,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.156"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
@@ -3830,9 +3882,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.156"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c93038456d65c93efcfaa9e35de69a0ae8c34e8cdfa386070a290e5a65c8e2"
+checksum = "f259aa64e48efaf5a4fea11f97cacb109f7fc3ae9db7244cbb40c01c7faf42bc"
 dependencies = [
  "serde",
 ]
@@ -4180,9 +4232,9 @@ dependencies = [
 
 [[package]]
 name = "sn_consensus"
-version = "3.3.3"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68aa5487b98437f08e4ccb0aeebdc700b816fe8fcbea817996603b1678e762d5"
+checksum = "e331f207fab1ac18da41639bd5644cfbac4b7dd37f20e9cc844f7560ffdebdcb"
 dependencies = [
  "bincode",
  "blsttc",
@@ -4247,6 +4299,7 @@ dependencies = [
  "lazy_static",
  "multibase",
  "num_cpus",
+ "priority-queue",
  "proptest",
  "qp2p",
  "rand 0.7.3",
@@ -4353,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "sn_sdkg"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b21d0b80ad2ac1c1d34dc2efb3b73131a19f517722cfda087cbc903b2bd2a781"
+checksum = "7a6be98ee29bf59c4b3cec893e493803518c99edc59c9cff9ac5e729694ec2fe"
 dependencies = [
  "bincode",
  "blsttc",
@@ -4450,7 +4503,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4477,6 +4530,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4490,7 +4554,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "unicode-xid",
 ]
 
@@ -4528,15 +4592,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4573,22 +4637,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -4598,7 +4662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
 dependencies = [
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "winapi",
 ]
 
@@ -4684,14 +4748,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -4715,13 +4778,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -4798,9 +4861,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.7"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
  "indexmap",
  "serde",
@@ -4881,7 +4944,7 @@ dependencies = [
  "proc-macro2",
  "prost-build 0.9.0",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4894,7 +4957,7 @@ dependencies = [
  "proc-macro2",
  "prost-build 0.11.8",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4961,7 +5024,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5088,9 +5151,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -5149,6 +5212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a1f0175e03a0973cf4afd476bef05c26e228520400eb1fd473ad417b1c00ffb"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5202,12 +5271,11 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -5254,7 +5322,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -5288,7 +5356,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5381,6 +5449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5463,9 +5540,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.3.6"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
  "memchr",
 ]
@@ -5531,23 +5608,22 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "25588073e5216b50bca71d61cb8595cdb9745e87032a58c199730def2862c934"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "synstructure",
+ "syn 2.0.11",
 ]
 
 [[package]]

--- a/sn_api/src/app/test_helpers.rs
+++ b/sn_api/src/app/test_helpers.rs
@@ -12,7 +12,7 @@ use crate::{Safe, SafeUrl};
 
 use sn_client::utils::test_utils::read_genesis_dbc_from_first_node;
 use sn_dbc::{rng, Dbc, Owner, OwnerOnce, Token};
-use sn_interface::types::Keypair;
+use sn_interface::types::{fees::SpendPriority, Keypair};
 
 use anyhow::{anyhow, Context, Result};
 use async_once::AsyncOnce;
@@ -104,7 +104,11 @@ async fn reissue_bearer_dbcs() -> Result<Vec<(Dbc, Token)>> {
     let safe = new_safe_instance().await?;
 
     let (output_dbcs, _) = safe
-        .send_tokens(vec![GENESIS_DBC.clone()], recipients)
+        .send_tokens(
+            vec![GENESIS_DBC.clone()],
+            recipients,
+            SpendPriority::Highest,
+        )
         .await?;
 
     Ok(output_dbcs

--- a/sn_api/src/lib.rs
+++ b/sn_api/src/lib.rs
@@ -23,7 +23,9 @@ mod errors;
 mod safeurl;
 
 // re-export these useful types from sn_data_types
-pub use sn_interface::types::{DataAddress, Keypair, PublicKey, RegisterAddress, SecretKey};
+pub use sn_interface::types::{
+    fees::SpendPriority, DataAddress, Keypair, PublicKey, RegisterAddress, SecretKey,
+};
 
 #[cfg(feature = "app")]
 pub use app::*;

--- a/sn_cli/src/subcommands/wallet.rs
+++ b/sn_cli/src/subcommands/wallet.rs
@@ -11,11 +11,13 @@ use super::{
     OutputFmt,
 };
 use crate::operations::config::Config;
+
+use sn_api::{wallet::DbcReason, Error as ApiError, Safe, SpendPriority};
+use sn_dbc::{Dbc, Error as DbcError};
+
 use bls::{PublicKey, SecretKey};
 use clap::Subcommand;
 use color_eyre::{eyre::eyre, eyre::Error, Help, Result};
-use sn_api::{wallet::DbcReason, Error as ApiError, Safe};
-use sn_dbc::{Dbc, Error as DbcError};
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
@@ -233,7 +235,13 @@ pub async fn wallet_commander(
                 None
             };
             let dbc = safe
-                .wallet_reissue(&from, &amount, pk, reason.unwrap_or_default())
+                .wallet_reissue(
+                    &from,
+                    &amount,
+                    pk,
+                    reason.unwrap_or_default(),
+                    SpendPriority::Normal,
+                )
                 .await?;
             let dbc_hex = dbc.to_hex()?;
 

--- a/sn_client/src/api/spend_queries.rs
+++ b/sn_client/src/api/spend_queries.rs
@@ -15,7 +15,10 @@ use sn_interface::{
         data::{ClientMsg, DataQuery, Error as ErrorMsg, QueryResponse, SpendQuery},
         ClientAuth, WireMsg,
     },
-    types::{fees::RequiredFee, NodeId},
+    types::{
+        fees::{RequiredFee, SpendPriority},
+        NodeId,
+    },
 };
 
 use backoff::{backoff::Backoff, ExponentialBackoff};
@@ -30,8 +33,9 @@ impl Client {
     pub async fn get_section_fees(
         &self,
         dbc_id: PublicKey,
+        priority: SpendPriority,
     ) -> Result<BTreeMap<NodeId, RequiredFee>> {
-        let fee_query = DataQuery::Spentbook(SpendQuery::GetFees(dbc_id));
+        let fee_query = DataQuery::Spentbook(SpendQuery::GetFees { dbc_id, priority });
 
         let (_, elders) = self
             .session

--- a/sn_client/src/api/spentbook_apis.rs
+++ b/sn_client/src/api/spentbook_apis.rs
@@ -129,14 +129,18 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::send_tokens;
-    use crate::utils::test_utils::{
-        create_test_client_with, init_logger, read_genesis_dbc_from_first_node,
+    use crate::{
+        api::send_tokens,
+        utils::test_utils::{
+            create_test_client_with, init_logger, read_genesis_dbc_from_first_node,
+        },
+        Client,
     };
-    use crate::Client;
-    use eyre::{bail, Result};
+
     use sn_dbc::{rng, OwnerOnce, Token};
-    use sn_interface::messaging::data::Error as ErrorMsg;
+    use sn_interface::{messaging::data::Error as ErrorMsg, types::fees::SpendPriority};
+
+    use eyre::{bail, Result};
 
     const ONE_BN_NANOS: u64 = 1_000_000_000;
 
@@ -158,7 +162,13 @@ mod tests {
         let recipients = vec![(Token::from_nano(half_amount), recipient)];
 
         // Send the tokens..
-        let (_, change) = send_tokens(&client, vec![genesis_dbc], recipients).await?;
+        let (_, change) = send_tokens(
+            &client,
+            vec![genesis_dbc],
+            recipients,
+            SpendPriority::Normal,
+        )
+        .await?;
 
         // We only assert that we have some change back
         // since we don't need/want to account for the fees here.
@@ -200,7 +210,13 @@ mod tests {
             .collect();
 
         // Send the tokens..
-        let result = send_tokens(&client, vec![genesis_dbc], recipients).await;
+        let result = send_tokens(
+            &client,
+            vec![genesis_dbc],
+            recipients,
+            SpendPriority::Normal,
+        )
+        .await;
 
         match result {
             Ok(_) => bail!("We expected an error to be returned"),
@@ -241,7 +257,13 @@ mod tests {
         let genesis_dbc_owner_pk = genesis_dbc.owner_base().public_key();
 
         // Send the tokens..
-        let result = send_tokens(&client, vec![genesis_dbc], recipients).await;
+        let result = send_tokens(
+            &client,
+            vec![genesis_dbc],
+            recipients,
+            SpendPriority::Normal,
+        )
+        .await;
 
         match result {
             Ok(_) => bail!("We expected an error to be returned"),
@@ -281,6 +303,7 @@ mod tests {
             &client,
             vec![genesis_dbc.clone()],
             vec![(Token::from_nano(ONE_BN_NANOS), recipient_1)],
+            SpendPriority::Normal,
         )
         .await?;
 
@@ -302,6 +325,7 @@ mod tests {
             &client,
             vec![output_dbc_1],
             vec![(Token::from_nano(ONE_BN_NANOS / 2), recipient_2)],
+            SpendPriority::Normal,
         )
         .await?;
 
@@ -323,6 +347,7 @@ mod tests {
             &client,
             vec![output_dbc_2],
             vec![(Token::from_nano(ONE_BN_NANOS / 4), recipient_3)],
+            SpendPriority::Normal,
         )
         .await;
 

--- a/sn_client/src/sessions/messaging.rs
+++ b/sn_client/src/sessions/messaging.rs
@@ -345,7 +345,7 @@ impl Session {
             payload,
             MsgKind::Client {
                 auth,
-                is_spend: matches!(query, DataQuery::Spentbook(SpendQuery::GetFees(_))),
+                is_spend: matches!(query, DataQuery::Spentbook(SpendQuery::GetFees { .. })),
                 query_index: None,
             },
             Dst {
@@ -414,7 +414,7 @@ impl Session {
         };
         let kind = MsgKind::Client {
             auth,
-            is_spend: matches!(query, DataQuery::Spentbook(SpendQuery::GetFees(_))),
+            is_spend: matches!(query, DataQuery::Spentbook(SpendQuery::GetFees { .. })),
             query_index: Some(query_node_index),
         };
         let wire_msg = WireMsg::new_msg(msg_id, payload, kind, dst);

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -30,6 +30,7 @@ itertools = "~0.10.0"
 lazy_static = "1"
 multibase = "~0.9.1"
 num_cpus = "1.13.0"
+priority-queue = { version = "1.3.1" }
 proptest = { version = "1.0.0", optional = true }
 qp2p = "~0.36.2"
 rand = "~0.8.5"

--- a/sn_interface/src/lib.rs
+++ b/sn_interface/src/lib.rs
@@ -33,6 +33,8 @@ pub mod dbcs;
 pub mod messaging;
 // Knowledge of the safe network
 pub mod network_knowledge;
+// Cost of write ops on the safe network.
+pub mod op_cost;
 // Types on the safe network
 pub mod types;
 // Statemap states

--- a/sn_interface/src/op_cost/mod.rs
+++ b/sn_interface/src/op_cost/mod.rs
@@ -1,0 +1,238 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use self_encryption::MAX_CHUNK_SIZE;
+use sn_dbc::Token;
+use tracing::debug;
+
+/// The conversion from token to raw value.
+const TOKEN_TO_RAW_CONVERSION: u64 = 1_000_000_000;
+/// The maximum supply of SNT, also the larges value that can be represented by a single `Token`.
+const MAX_SUPPLY: u64 = (u32::max_value() as u64 + 1) * TOKEN_TO_RAW_CONVERSION;
+
+/// Calculation of required tokens for writes.
+
+/// Calculates the required tokens of write operations,
+/// as a number of tokens to be paid for a certain number of bytes,
+/// given the current section prefix its number of storage nodes, and percent filled.
+///
+/// This uses an algorithm to calculate a fee with supply/demand adjusting properties
+/// (although indirect and therefore arguably sluggish) based on:
+/// 1. Network size (contributing to the deflationary character of SNT).
+/// 2. Storage used.
+/// 3. Requirements for space margin (1/3).
+/// 4. Requirement for as low fee as possible for as long as possible.
+/// (Point 3. and 4. are achieved by the specific design of the required tokens curve.)
+///
+/// It is assumed that a larger network means the token has a greater value, and therefore
+/// the required number of tokens per operation is also lower, following a curve as per above.
+/// The constants used may seem arbitrary but have been carefully chosen as to model the desired behaviour.
+pub fn required_tokens(
+    bytes: usize,
+    prefix_len: usize,
+    num_storage_nodes: u8,
+    percent_filled: f64,
+) -> Token {
+    debug!(
+        "required_tokens input values; bytes: {bytes}, prefix_len: {prefix_len}, num_storage_nodes: {num_storage_nodes}, percent_filled: {percent_filled}",
+    );
+    let available_nodes = num_storage_nodes as f64;
+    let supply_demand_factor =
+        0.001 + (1_f64 / (20_f64 * available_nodes)).powf(8_f64) + percent_filled.powf(3_f64);
+    let byte_size_share = bytes as f64 / MAX_CHUNK_SIZE as f64;
+    let data_size_factor = byte_size_share + byte_size_share.powf(2_f64);
+    let steepness_reductor = prefix_len as f64 + 1_f64;
+    let supply_share = max_supply_share_per_section(prefix_len) as f64;
+    let token_source = steepness_reductor * supply_share.powf(0.5_f64);
+    let required_tokens = (token_source * data_size_factor * supply_demand_factor).round() as u64;
+    Token::from_nano(u64::max(1, required_tokens)) // always return > 0
+}
+
+// The proportion of total supply "available" per section,
+// given a certain network size (i.e. prefix len).
+// This is not an actual allocation, just a theoretical value used for the calc of required tokens.
+fn max_supply_share_per_section(prefix_len: usize) -> u64 {
+    (MAX_SUPPLY as f64 / 2_f64.powf(prefix_len as f64)).floor() as u64
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::messaging::data::DataCmd;
+    use std::mem;
+
+    #[test]
+    fn calculates_required_tokens() {
+        let bytes = MAX_CHUNK_SIZE;
+        let prefix_len = 4;
+        let num_storage_nodes = 24;
+        let percent_filled = 3_f64 / num_storage_nodes as f64;
+        let required_tokens =
+            required_tokens(bytes, prefix_len, num_storage_nodes, percent_filled).as_nano();
+        println!("required_tokens: {required_tokens}");
+        assert_eq!(required_tokens, 15_300_364); // 0.01500364 tokens
+    }
+
+    #[test]
+    fn section_share_of_max_supply_decreases_as_network_grows() {
+        // Prefix zero is one section so low usage (lots available).
+        let first_section_nanos = max_supply_share_per_section(0);
+        assert_eq!(MAX_SUPPLY, first_section_nanos);
+        // First split leads to each section "sharing" half the token supply.
+        let first_split_nanos = max_supply_share_per_section(1);
+        assert_eq!(MAX_SUPPLY / 2, first_split_nanos);
+        // At least one token available in up to 2.3 * 10^18 sections, (which is more than one billion times one billion sections).
+        let last_split_nanos = max_supply_share_per_section(61);
+        assert!(last_split_nanos > 0);
+    }
+
+    // -------------------------------------------------------------
+    // --------------- Required Tokens Common Sense ---------------------
+    // -------------------------------------------------------------
+    // Test various different comparisons of the OpCost.
+    // These tests are of the type 'all things being equal, then ...'
+    // Thanks to @IanColeman for these constributions.
+
+    #[test]
+    fn smaller_chunks_require_fewer_tokens() {
+        let max_chunk_size = MAX_CHUNK_SIZE;
+        let prefix_len = 0;
+        let num_storage_nodes = 8;
+        let percent_filled = 7_f64 / num_storage_nodes as f64;
+        let standard_fee = required_tokens(
+            max_chunk_size,
+            prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+
+        // smaller chunks require fewer tokens
+        let max_chunk_size_less_one_byte = max_chunk_size - 1;
+        let small_chunk_fee = required_tokens(
+            max_chunk_size_less_one_byte,
+            prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        assert!(
+            small_chunk_fee <= standard_fee,
+            "small chunks don't require fewer tokens, expect {} <= {}",
+            small_chunk_fee,
+            standard_fee
+        );
+    }
+
+    #[test]
+    fn fewer_tokens_required_in_larger_net() {
+        let max_chunk_size = MAX_CHUNK_SIZE;
+        let prefix_len = 2; // first couple of sections see an increase in required tokens, whereafter it is strictly decreasing
+        let num_storage_nodes = 8;
+        let percent_filled = 7_f64 / num_storage_nodes as f64;
+        let standard_fee = required_tokens(
+            max_chunk_size,
+            prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        // ops require fewer tokens in a larger network than in a smaller network
+        let larger_prefix = prefix_len + 1;
+        let large_network_fee = required_tokens(
+            max_chunk_size,
+            larger_prefix,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        assert!(
+            large_network_fee <= standard_fee,
+            "larger network is not cheaper, expect {} <= {}",
+            large_network_fee,
+            standard_fee
+        );
+    }
+
+    #[test]
+    fn emptier_section_requires_fewer_tokens() {
+        let max_chunk_size = MAX_CHUNK_SIZE;
+        let prefix_len = 0;
+        let num_storage_nodes = 8;
+        let percent_filled = 7_f64 / num_storage_nodes as f64;
+        let standard_fee = required_tokens(
+            max_chunk_size,
+            prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        // less filled section require fewer tokens than more filled section
+        let less_percent_filled = 6_f64 / num_storage_nodes as f64;
+        let lower_fee = required_tokens(
+            max_chunk_size,
+            prefix_len,
+            num_storage_nodes,
+            less_percent_filled,
+        )
+        .as_nano();
+        assert!(
+            lower_fee <= standard_fee,
+            "less filled section does not require fewer tokens, expect {} <= {}",
+            lower_fee,
+            standard_fee
+        );
+    }
+
+    #[test]
+    fn splitting_into_multiple_chunks_require_fewer_tokens_than_same_bytes_in_single_chunk() {
+        // we encourage more granularity in data chunking
+        let max_chunk_size = MAX_CHUNK_SIZE;
+        let prefix_len = 2;
+        let num_storage_nodes = 8;
+        let percent_filled = 7_f64 / num_storage_nodes as f64;
+        let standard_fee = required_tokens(
+            max_chunk_size,
+            prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        // many tiny chunks require fewer tokens than the same bytes in one big chunk
+        let one_kb_bytes = 1024;
+        let reduced_fee =
+            required_tokens(one_kb_bytes, prefix_len, num_storage_nodes, percent_filled).as_nano();
+        let combined_fee = reduced_fee * (MAX_CHUNK_SIZE / one_kb_bytes) as u64;
+        assert!(
+            combined_fee <= standard_fee,
+            "many small chunks does not require fewer tokens than one big chunk, expect {} <= {}",
+            combined_fee,
+            standard_fee,
+        );
+    }
+
+    #[test]
+    fn tokens_are_required_up_to_max_network_size() {
+        // The size of the actual DataCmd is used for OpCost calc.
+        // In general, the size of a type is not stable across compilations,
+        // but it is close enough for our purposes here.
+        let minimum_storage_bytes = mem::size_of::<DataCmd>();
+        let big_prefix_len = 256;
+        let num_storage_nodes = 20;
+        let percent_filled = 10_f64 / num_storage_nodes as f64;
+        // tokens are required up to 2.3 * 10^78 nodes.
+        let required_tokens = required_tokens(
+            minimum_storage_bytes,
+            big_prefix_len,
+            num_storage_nodes,
+            percent_filled,
+        )
+        .as_nano();
+        assert!(required_tokens > 0, "tokens are not always required",);
+    }
+}

--- a/sn_interface/src/statemap.rs
+++ b/sn_interface/src/statemap.rs
@@ -61,6 +61,7 @@ pub enum State {
     Propose,
     Node,
     Data,
+    Spend,
 }
 
 impl State {

--- a/sn_interface/src/types/fees/mod.rs
+++ b/sn_interface/src/types/fees/mod.rs
@@ -42,14 +42,18 @@
 ///         they can still not verify the amounts by this. So that example is still not feasible. TBD.
 mod errors;
 mod fee_ciphers;
+mod priority;
 mod required_fee;
 mod required_fee_content;
+mod spend_queue;
 
 pub use self::{
     errors::{Error, Result},
     fee_ciphers::FeeCiphers,
+    priority::SpendPriority,
     required_fee::RequiredFee,
     required_fee_content::RequiredFeeContent,
+    spend_queue::{SpendQ, SpendQSnapshot, SpendQStats},
 };
 
 #[cfg(test)]

--- a/sn_interface/src/types/fees/priority.rs
+++ b/sn_interface/src/types/fees/priority.rs
@@ -1,0 +1,22 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+/// Used by client to choose how fast their spend will be processed.
+/// The chosen variant will map to a fee using the spend queue stats fetched from Elders.
+#[derive(
+    Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, serde::Serialize, serde::Deserialize,
+)]
+pub enum SpendPriority {
+    Highest,    // -> `High` + 1 std dev.
+    High,       // -> The highest fee in spend queue.
+    MediumHigh, // -> Avg of `High` and `Normal`
+    Normal,     // -> The avg fee in spend queue.
+    MediumLow,  // -> Avg of `Normal` and `Low`.
+    Low,        // -> The lowest fee in spend queue.
+    Lowest,     // -> `Low` - 1 std dev
+}

--- a/sn_interface/src/types/fees/spend_queue.rs
+++ b/sn_interface/src/types/fees/spend_queue.rs
@@ -1,0 +1,554 @@
+// Copyright 2023 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! An implementation of a spend queue for SNT spends.
+//!
+//! The purpose of this spend queue is to further enhance
+//! the supply/demand properties of the payment network.
+//!
+//! It allows for Clients to set priority for their spends,
+//! and for the network to moderate the load of incoming spends
+//! in times of high demand.
+//!
+//! Additionally, the network can now be even nimbler than with
+//! only the growth-parameters-based supply/demand properties of the fees
+//! (see op_cost::required_tokens). The spend queue will give an immediate
+//! response to high demand from Clients.
+//!
+//! Knock on effects are increased incentives for nodes to join
+//! the network, as high demand increases the rewards paid to Elders.
+
+use std::{hash::Hash, time::Duration};
+
+use super::SpendPriority;
+use priority_queue::PriorityQueue;
+use tokio::time::Instant;
+
+/// The queue of pending spends, sorted by
+/// the fee paid.
+///
+/// Implemented with generic arg to simplify testing,
+/// as the `SpentProofShare` type, that we know spend queue will
+/// be used with, requires lots of plumbing to setup.
+#[derive(custom_debug::Debug)]
+pub struct SpendQ<T: Eq + Hash> {
+    #[debug(skip)]
+    queue: PriorityQueue<T, u64>,
+    #[debug(skip)]
+    snapshot: SpendQSnapshot,
+    last_pop: Instant,
+}
+
+/// A snapshot of the sorted fees in the spend queue.
+/// Used to calculate the stats of the spend queue.
+#[derive(Clone, custom_debug::Debug)]
+pub struct SpendQSnapshot {
+    #[debug(skip)]
+    queue: Vec<u64>,
+}
+
+/// Stats of the spend queue, listing the number of spends currently queued,
+/// the highest and lowest fee in the queue, as well as the average fee and
+/// standard deviation.
+/// The spend queue stats is not meant to return 100% consistent data,
+/// but an approximation which is good enough.
+///
+/// If the queue becomes empty, the last value popped will be used
+/// for `high`, `low` and `avg`, with a zero `std_dev`.
+/// Before any item has been pushed to the queue, the value with which
+/// the spend queue was instantiated will be used. And if spend queue was
+/// instantiated with no value, the passed in fallback value (current op_cost)
+/// will be used.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SpendQStats {
+    pub high: u64,
+    pub low: u64,
+    pub len: usize,
+    pub avg: u64,
+    pub std_dev: u64,
+}
+
+impl SpendQStats {
+    /// Validate that the fee is high enough to push it to the spend queue,
+    /// otherwise it is dropped and an error returned to Client.
+    /// Returns if the fee paid was valid or not, and the currently lowest valid fee.
+    ///
+    /// The basic rule for now is that if the paid fee is over 10% less
+    /// than the lowest fee in queue minus std dev, then we don't accept the fee.
+    /// This is a temporary diff value/design.
+    /// (And yes, this means that for now, the Client can try to get away cheaper by sending in up to 10% less than lowest priority fee.)
+    pub fn validate_fee(&self, fee_paid: u64) -> (bool, u64) {
+        // There should be no way that `std_dev` could be larger than or equal to `low`.
+        let lowest = ((self.low - self.std_dev) as f64 / 0.90) as u64;
+        let valid = fee_paid >= lowest;
+        (valid, lowest)
+    }
+
+    /// Derive a fee to pay based on the sender priority
+    /// and current state of the spend queue.
+    pub fn derive_fee(&self, priority: &SpendPriority) -> u64 {
+        let medium_high = (self.high + self.avg) / 2;
+        let medium_low = (self.low + self.avg) / 2;
+        let highest = self.high + self.std_dev;
+        let lowest = self.low - self.std_dev;
+        // There should be no way that `std_dev` could be larger than or equal to `low`.
+        match priority {
+            SpendPriority::Highest => highest,
+            SpendPriority::High => self.high,
+            SpendPriority::MediumHigh => medium_high,
+            SpendPriority::Normal => self.avg,
+            SpendPriority::MediumLow => medium_low,
+            SpendPriority::Low => self.low,
+            SpendPriority::Lowest => lowest,
+        }
+    }
+}
+
+impl SpendQSnapshot {
+    /// This is not meant to return 100% consistent state,
+    /// but an approximation which is good enough.
+    ///
+    /// If the queue becomes empty, the last value popped will be used
+    /// for `high`, `low` and `avg`, with a zero `std_dev`.
+    /// Before any item has been pushed to spend queue, the value with which
+    /// the spend queue was instantiated will be used. And if spend queue was
+    /// instantiated with no value, the passed in fallback value (current op_cost)
+    /// will be used, until the very first item has been pushed to spend queue.
+    pub fn stats(&self) -> SpendQStats {
+        let default_val = 4;
+        let high = self.queue.first().copied().unwrap_or(2 * default_val);
+        let low = self.queue.last().copied().unwrap_or(default_val / 2);
+        let (avg, std_dev, len) = calc_stats(&self.queue);
+        SpendQStats {
+            high,
+            low,
+            len,
+            avg,
+            std_dev,
+        }
+    }
+}
+
+impl<T: Eq + Hash> SpendQ<T> {
+    /// Create a new instance of the spend queue, with an initial value
+    /// that will populate the stats, by which fee can be derived.
+    /// The snapshot will have non zero values, replaced when values are pushed onto the spend queue.
+    pub fn with_fee(current_fee: u64) -> Self {
+        let default_val = u64::max(4, current_fee);
+        Self {
+            queue: PriorityQueue::new(),
+            snapshot: SpendQSnapshot {
+                queue: vec![2 * default_val, default_val, default_val / 2],
+            },
+            last_pop: Instant::now(),
+        }
+    }
+
+    /// We set a limit on how many tx will be processed per s.
+    /// As the network grows, the total capacity will grow as well.
+    ///
+    /// Example:
+    /// 1 tps for a group of 4 gives
+    /// -> 25600 tps with 102400 nodes
+    /// -> 76800 tps with 307200 nodes
+    /// -> etc..
+    /// ..and for a group of 8 gives
+    /// -> 12800 tps with 102400 nodes
+    /// -> 38400 tps with 307200 nodes
+    /// -> etc..
+    pub fn elapsed(&self) -> bool {
+        Instant::now() - self.last_pop > Duration::from_secs(1)
+    }
+
+    /// Return a snapshot of the fees in the queue, with preserved order.
+    pub fn snapshot(&self) -> SpendQSnapshot {
+        self.snapshot.clone()
+    }
+
+    /// This requires all validation of the fee to have already been made.
+    /// There is no validation here!
+    pub fn push(&mut self, item: T, priority: u64) {
+        let _ = self.queue.push(item, priority);
+        // We update our snapshot after every change to the queue.
+        self.set_snapshot();
+    }
+
+    pub fn pop(&mut self) -> Option<(T, u64)> {
+        let item = self.queue.pop();
+
+        // Preserve last 3 items in snapshot, as to preserve the current fee.
+        if self.queue.len() > 3 {
+            // We update our snapshot after every change to the queue, except when only 3 left.
+            self.set_snapshot();
+        }
+        // To achieve our desired tsp, we set the `last_pop` time to now.
+        self.last_pop = Instant::now();
+
+        item
+    }
+
+    // Populate the snapshot with the fees only, and
+    // sort them, so that stats are properly calculated over them.
+    // Makes sure at least 3 items are in the snapshot.
+    fn set_snapshot(&mut self) {
+        let mut queue: Vec<_> = self.queue.iter().map(|(_, fee)| *fee).collect();
+        queue.sort();
+        queue.reverse(); // highest first
+        let queue = if self.queue.is_empty() {
+            // this should be unreachable
+            let default_val = 4;
+            vec![2 * default_val, default_val, default_val / 2]
+        } else if queue.len() == 1 {
+            // with one value, the spread is large
+            vec![2 * queue[0], queue[0], queue[0] / 2]
+        } else if self.queue.len() == 2 {
+            // with two values, the spread is lower
+            vec![queue[0], (queue[0] + queue[1]) / 2, queue[1]]
+        } else {
+            queue
+        };
+
+        self.snapshot = SpendQSnapshot { queue };
+    }
+
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.queue.len()
+    }
+}
+
+/// Calculate the avg value of the set.
+fn avg(data: &Vec<u64>) -> Option<u64> {
+    let sum: u64 = data.iter().sum();
+    let count = data.len();
+    if count > 0 {
+        Some((sum as f64 / count as f64).round() as u64)
+    } else {
+        None
+    }
+}
+
+/// Calculates the standard deviation of the set of fees.
+/// If the set is empty the provided `fallback_value` is used
+/// as `avg`, and zero as `std_dev`.
+fn calc_stats(data: &Vec<u64>) -> (u64, u64, usize) {
+    match (avg(data), data.len()) {
+        (Some(avg), count) if count > 0 => {
+            let variance = data
+                .iter()
+                .map(|value| {
+                    let diff = avg as i64 - *value as i64;
+                    (diff * diff) as f64
+                })
+                .sum::<f64>()
+                / count as f64;
+
+            let std_dev = variance.sqrt().round() as u64;
+            (avg, std_dev, count)
+        }
+        _ => (0, 0, 0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Result;
+    use super::*;
+
+    #[test]
+    fn spendq_snapshot_is_sorted_highest_first() -> Result<()> {
+        let mut spendq = SpendQ::<usize>::with_fee(0);
+
+        for i in 0..10 {
+            let rand_item: usize = rand::random();
+            spendq.push(rand_item, i);
+        }
+
+        let snapshot = spendq.snapshot();
+
+        let non_sorted_vec: Vec<_> = spendq.queue.iter().map(|(_, fee)| *fee).collect();
+        let sorted_vec = snapshot.queue;
+
+        // This shall show that we are required to sort the vec,
+        // it's not enough to just collect the prios, because they
+        // come ordered by the hash of the item they carry in the queue.
+        assert_ne!(non_sorted_vec, sorted_vec);
+
+        // this is the expected outcome, largest value first
+        let expected_vec = vec![9, 8, 7, 6, 5, 4, 3, 2, 1, 0];
+        assert_eq!(sorted_vec, expected_vec);
+
+        Ok(())
+    }
+
+    #[test]
+    fn zero_init_spendq_default_stats_values() -> Result<()> {
+        let spendq = SpendQ::<usize>::with_fee(0);
+
+        let snapshot = spendq.snapshot();
+        let stats = snapshot.stats();
+
+        assert_eq!(stats.high, 8);
+        assert_eq!(stats.low, 2);
+        assert_eq!(stats.avg, 5);
+        assert_eq!(stats.std_dev, 3);
+
+        assert_eq!(snapshot.queue.len(), 3);
+        assert!(spendq.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn spendq_instantiated_with_fee_gives_initial_value_in_stats() -> Result<()> {
+        // We can pass in an initial value to spend queue, which will reflect in stats
+        // while we haven't had any values pushed onto the spend queue.
+        let initial_value = 42;
+        let spendq = SpendQ::<usize>::with_fee(initial_value);
+
+        let snapshot = spendq.snapshot();
+        let stats = snapshot.stats();
+
+        assert_eq!(stats.high, 2 * initial_value);
+        assert_eq!(stats.low, initial_value / 2);
+        assert_eq!(stats.avg, 49);
+        assert_eq!(stats.std_dev, 26);
+
+        assert_eq!(snapshot.queue.len(), 3);
+        assert!(spendq.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn pushing_an_item_sets_stats() -> Result<()> {
+        // We use an initial value.
+        let initial_value = 42;
+        let mut spendq = SpendQ::<usize>::with_fee(initial_value);
+        let snapshot = spendq.snapshot();
+
+        let stats = snapshot.stats();
+
+        // A single value gives high spread stats.
+        assert_eq!(stats.high, 2 * initial_value);
+        assert_eq!(stats.low, initial_value / 2);
+        assert_eq!(stats.avg, 49);
+        assert_eq!(stats.std_dev, 26);
+
+        // The initial value will be what we have in the snapshot queue.
+        assert_eq!(snapshot.queue.len(), 3);
+        assert!(spendq.queue.is_empty());
+
+        // We push an item, and take a new snapshot..
+        let rand_item: usize = rand::random();
+        let actual_value = 24;
+        spendq.push(rand_item, actual_value);
+
+        let snapshot = spendq.snapshot();
+
+        let stats = snapshot.stats();
+
+        // It's the items in the spend queue that are counted towards the stats.
+        assert_eq!(stats.high, 2 * actual_value);
+        assert_eq!(stats.low, actual_value / 2);
+        assert_eq!(stats.avg, 28);
+        assert_eq!(stats.std_dev, 15);
+
+        assert_eq!(snapshot.queue.len(), 3);
+        assert!(!spendq.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn when_pushed_to_empty_popped_item_is_preserved_in_stats_until_new_item_is_pushed(
+    ) -> Result<()> {
+        let mut spendq = SpendQ::<usize>::with_fee(0);
+
+        // We push an item
+        let rand_item: usize = rand::random();
+        let value_42 = 42;
+        spendq.push(rand_item, value_42);
+
+        let snapshot = spendq.snapshot();
+        let stats_value_42 = snapshot.stats();
+
+        let popped_item_42 = spendq.pop();
+
+        assert_eq!(popped_item_42, Some((rand_item, value_42)));
+
+        // Take a new snapshot..
+        let snapshot = spendq.snapshot();
+
+        // Last item is still in the snapshot queue, to preserve the value (the last price)
+        // for stats queries. But the actual spend queue is empty.
+        assert_eq!(snapshot.queue.len(), 3);
+        assert!(spendq.is_empty());
+
+        assert_eq!(snapshot.queue, vec![2 * value_42, value_42, value_42 / 2]);
+
+        let stats_value_42_preserved = snapshot.stats();
+
+        // The stats will be the same as it was when the popped item was still in the queue.
+        assert_eq!(stats_value_42, stats_value_42_preserved);
+
+        // ------------------------------------------------
+        // The spend queue is now empty. Let's try again.
+        // ------------------------------------------------
+
+        // We push a new item.
+        let other_rand_item: usize = rand::random();
+        let value_66 = 66;
+        spendq.push(other_rand_item, value_66);
+
+        // Take a new snapshot..
+        let snapshot = spendq.snapshot();
+
+        assert_eq!(snapshot.queue.len(), 3);
+        assert_eq!(spendq.len(), 1);
+
+        let stats_value_66 = snapshot.stats();
+
+        // The stats will now be updated by the new item in the queue,
+        // i.e. `stats_value_66` is not equal to `stats_preserved_value_42`.
+        assert_ne!(stats_value_66, stats_value_42_preserved);
+
+        // The previously preserved value has been replaced.
+        assert_eq!(snapshot.queue, vec![2 * value_66, value_66, value_66 / 2]);
+
+        let popped_item_66 = spendq.pop();
+        // The last item in the queue now, is the `value_66`.
+        assert_eq!(popped_item_66, Some((other_rand_item, value_66)));
+
+        // And same as the previous time, when we take a new snapshot..
+        let snapshot = spendq.snapshot();
+
+        // ..last item is still in the snapshot queue.
+        // But the actual spend queue is empty.
+        assert_eq!(snapshot.queue.len(), 3);
+        assert!(spendq.is_empty());
+
+        assert_eq!(snapshot.queue, vec![2 * value_66, value_66, value_66 / 2]);
+
+        let stats_value_66_preserved = snapshot.stats();
+
+        // The stats will be the same as it was when the popped item was still in the queue.
+        assert_eq!(stats_value_66, stats_value_66_preserved);
+
+        Ok(())
+    }
+
+    #[test]
+    fn last_three_item_are_preserved_in_stats_until_new_item_is_pushed() -> Result<()> {
+        let mut spendq = SpendQ::<usize>::with_fee(0);
+
+        // We push three items
+        let item_1 = rand::random();
+        let item_2 = rand::random();
+        let item_3 = rand::random();
+        let value_41 = 41;
+        let value_42 = 42;
+        let value_43 = 43;
+        spendq.push(item_1, value_41);
+        spendq.push(item_2, value_42);
+        spendq.push(item_3, value_43);
+
+        let snapshot = spendq.snapshot();
+        let stats_3_values = snapshot.stats();
+
+        let popped_item_43 = spendq.pop();
+
+        assert_eq!(popped_item_43, Some((item_3, value_43)));
+
+        // Take a new snapshot..
+        let snapshot = spendq.snapshot();
+
+        // Last three items are still in the snapshot queue, to preserve the value (the last price)
+        // for stats queries. But the actual spend queue has one item less.
+        assert_eq!(snapshot.queue, vec![43, 42, 41]);
+        assert_eq!(spendq.len(), 2);
+
+        let stats_2_values = snapshot.stats();
+
+        // The stats will be the same as it was when the popped item was still in the queue.
+        assert_eq!(stats_3_values, stats_2_values);
+
+        // ------------------------------------------------
+        // Pop the last two items as well.
+        // ------------------------------------------------
+
+        let popped_item_42 = spendq.pop();
+        assert_eq!(popped_item_42, Some((item_2, value_42)));
+        let popped_item_41 = spendq.pop();
+        assert_eq!(popped_item_41, Some((item_1, value_41)));
+
+        // Take a new snapshot..
+        let snapshot = spendq.snapshot();
+
+        // Last three items are still in the snapshot queue, to preserve the value (the last price)
+        // for stats queries. But the actual spend queue is empty.
+        assert_eq!(snapshot.queue, vec![43, 42, 41]);
+        assert!(spendq.is_empty());
+
+        let stats_0_values = snapshot.stats();
+
+        // The stats will be the same as it was when the three last popped item were still in the queue.
+        assert_eq!(stats_3_values, stats_0_values);
+
+        // ------------------------------------------------
+        // The spend queue is now empty. Let's try again.
+        // ------------------------------------------------
+
+        // We push a new item.
+        let other_rand_item: usize = rand::random();
+        let value_66 = 66;
+        spendq.push(other_rand_item, value_66);
+
+        // Take a new snapshot..
+        let snapshot = spendq.snapshot();
+
+        // The old values are evicted from snapshot.
+        assert_eq!(snapshot.queue.len(), 3);
+        assert_eq!(spendq.len(), 1);
+
+        let stats_value_66 = snapshot.stats();
+
+        // The stats will now be updated by the new item in the queue,
+        // i.e. `stats_value_66` is not equal to `stats_0_values`.
+        assert_ne!(stats_value_66, stats_0_values);
+
+        // The previously preserved value has been replaced.
+        assert_eq!(snapshot.queue, vec![2 * value_66, value_66, value_66 / 2]);
+
+        let popped_item_66 = spendq.pop();
+        // The last item in the queue now, is the `value_66`.
+        assert_eq!(popped_item_66, Some((other_rand_item, value_66)));
+
+        // And same as the previous time, when we take a new snapshot..
+        let snapshot = spendq.snapshot();
+
+        // ..last item is still in the snapshot queue.
+        // But the actual spend queue is empty.
+        assert_eq!(snapshot.queue.len(), 3);
+        assert!(spendq.is_empty());
+
+        assert_eq!(snapshot.queue, vec![2 * value_66, value_66, value_66 / 2]);
+
+        let stats_value_66_preserved = snapshot.stats();
+
+        // The stats will be the same as it was when the popped item was still in the queue.
+        assert_eq!(stats_value_66, stats_value_66_preserved);
+
+        Ok(())
+    }
+}

--- a/sn_node/src/node/error.rs
+++ b/sn_node/src/node/error.rs
@@ -10,7 +10,7 @@ use super::{flow_ctrl::RejoinReason, Prefix};
 
 use crate::node::handover::Error as HandoverError;
 
-use sn_dbc::Error as DbcError;
+use sn_dbc::{Error as DbcError, Token};
 use sn_interface::{
     dbcs::Error as GenesisError,
     messaging::{data::Error as ErrorMsg, system::DkgSessionId},
@@ -69,8 +69,8 @@ pub enum Error {
     MissingFee,
     #[error("Invalid fee blinded amount.")]
     InvalidFeeBlindedAmount,
-    #[error("Too low amount for the transfer fee.")]
-    FeeTooLow,
+    #[error("Too low amount for the transfer fee: {paid}. Min required: {min_required}.")]
+    FeeTooLow { paid: Token, min_required: Token },
     #[error("The secret key share is missing for public key {0:?}")]
     MissingSecretKeyShare(bls::PublicKey),
     #[error("Messaging protocol error: {0}")]

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -38,7 +38,11 @@ use sn_interface::{
         RelocationInfo, RelocationProof, SectionTreeUpdate, SectionsDAG, MIN_ADULT_AGE,
     },
     test_utils::*,
-    types::{fees::FeeCiphers, keys::ed25519, Participant, PublicKey},
+    types::{
+        fees::{FeeCiphers, SpendPriority},
+        keys::ed25519,
+        Participant, PublicKey,
+    },
 };
 
 use assert_matches::assert_matches;
@@ -1100,7 +1104,7 @@ fn get_spend(dbc: sn_dbc::Dbc, context: NodeContext) -> Result<Spend> {
     let change_owner = OwnerOnce::from_owner_base(dbc.owner_base().clone(), &mut rng);
 
     #[cfg(not(feature = "data-network"))]
-    let fee = context.current_fee();
+    let fee = context.current_fee(&SpendPriority::Normal);
 
     #[cfg(feature = "data-network")]
     let change_amount = Token::from_nano(dbc_amount.value());

--- a/sn_node/src/node/flow_ctrl/tests/mod.rs
+++ b/sn_node/src/node/flow_ctrl/tests/mod.rs
@@ -1099,10 +1099,13 @@ fn get_spend(dbc: sn_dbc::Dbc, context: NodeContext) -> Result<Spend> {
     let dbc_amount = dbc.revealed_amount_bearer()?;
     let change_owner = OwnerOnce::from_owner_base(dbc.owner_base().clone(), &mut rng);
 
+    #[cfg(not(feature = "data-network"))]
+    let fee = context.current_fee();
+
     #[cfg(feature = "data-network")]
     let change_amount = Token::from_nano(dbc_amount.value());
     #[cfg(not(feature = "data-network"))]
-    let change_amount = Token::from_nano(dbc_amount.value() - context.store_cost.as_nano());
+    let change_amount = Token::from_nano(dbc_amount.value() - fee.as_nano());
 
     #[cfg(not(feature = "data-network"))]
     let fee_derived_owner = {
@@ -1116,7 +1119,7 @@ fn get_spend(dbc: sn_dbc::Dbc, context: NodeContext) -> Result<Spend> {
     #[cfg(not(feature = "data-network"))]
     let outputs = {
         vec![
-            (context.store_cost, fee_derived_owner.clone()),
+            (fee, fee_derived_owner.clone()),
             (change_amount, change_owner),
         ]
     };

--- a/sn_node/src/node/messaging/client_msgs.rs
+++ b/sn_node/src/node/messaging/client_msgs.rs
@@ -63,7 +63,7 @@ impl MyNode {
             // The required fee content is encrypted to that dbc id, and so only the holder of the dbc secret
             // key can unlock the contents.
             let required_fee =
-                RequiredFee::new(context.store_cost, dbc_id, &context.reward_secret_key);
+                RequiredFee::new(context.current_fee(), dbc_id, &context.reward_secret_key);
             NodeQueryResponse::GetFees(Ok(required_fee))
         } else {
             context
@@ -262,7 +262,7 @@ impl MyNode {
         // verify that fee is paid to us
         #[cfg(not(feature = "data-network"))]
         MyNode::verify_fee(
-            context.store_cost,
+            context.current_fee(),
             context.reward_secret_key.as_ref(),
             tx,
             context.name,

--- a/sn_node/src/node/mod.rs
+++ b/sn_node/src/node/mod.rs
@@ -137,7 +137,6 @@ impl MyNode {
             dkg_voter: self.dkg_voter.clone(),
             dkg_sessions_info: self.dkg_sessions_info.clone(),
             reward_secret_key: self.reward_secret_key.clone(),
-            store_cost: sn_dbc::Token::from_nano(1), // hard coded for now
             network_knowledge: self.network_knowledge().clone(),
             section_keys_provider: self.section_keys_provider.clone(),
             comm: self.comm.clone(),

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -187,9 +187,15 @@ impl DataStorage {
                 }
             }
             // this should be unreachable
-            DataQuery::Spentbook(SpendQuery::GetFees(dbc_id)) => {
+            DataQuery::Spentbook(SpendQuery::GetFees { dbc_id, priority }) => {
                 NodeQueryResponse::GetFees(Err(sn_interface::messaging::data::Error::DataNotFound(
-                    DataAddress::Spentbook(SpendQuery::GetFees(*dbc_id).dst_address()),
+                    DataAddress::Spentbook(
+                        SpendQuery::GetFees {
+                            dbc_id: *dbc_id,
+                            priority: *priority,
+                        }
+                        .dst_address(),
+                    ),
                 )))
             }
         }

--- a/sn_node/src/storage/mod.rs
+++ b/sn_node/src/storage/mod.rs
@@ -59,6 +59,11 @@ impl DataStorage {
         }
     }
 
+    /// Returns the ratio of used storage space to min capacity.
+    pub(crate) fn used_space_ratio(&self) -> f64 {
+        self.used_space.ratio()
+    }
+
     /// Returns whether the storage min capacity has been reached or not.
     pub(crate) fn has_reached_min_capacity(&self) -> bool {
         self.used_space.has_reached_min_capacity()


### PR DESCRIPTION
This PR adds a mempool which prioritises spends based on the fee paid.

This is a large leap forward towards a true market, where the supply/demand properties of the system are nimble and responsive.

The benefits of implementing a mempool are the following:

- Clients can get a lower price for their storage if demand is low.
- Elders can get a higher reward for their services if demand is high.
- Incentives for node operators to run additional nodes increase when demand increases.
- The network becomes more responsive and can grow faster when demand increases.
- The continuous operation of nodes is more protected from overload of client spends.
- The load on the network is spread out over time as people defer spends at time of high load, and move them to times of lower load.
- There is potential for Elders to access their rewards faster, as they can gather them and reissue into a larger Dbc when fees are low.

***
**NB 1**: The spend priority is not yet exposed to the UI, and is set at default level of `Normal` for now, which equates to paying the avg value of the fees in the mempool.

**NB 2**: With 1 fee per spend, the fee amount in the dbc is not accessible to the Elder until the required fee for
a spend has decreased below the amount in the dbc. In effect, with this design there is currently a lock-in
effect on Elder rewards which either require the demand to go down or the network to grow for the fees to go down and make the amount paid to them be accessible.
***

1. ✔️ `Previous PR`: The query and handling of it on Elders for their reward keys and hard coded fee: #2184.
2. ✔️ `Previous PR`: The logic for including Elders to outputs: #2180.
3. ✔️ `Previous feat`: Including fee ciphers for Elders in spend: #2249.
4. ✔️ `Previous feat`: Elders confirming that spends contain outputs with sufficient amount, destined for them: #2246.
5. `Pending PR`: Use a fee calc algo with supply/demand adjusting properties #2247.
6. `This PR`: Use a mempool to increase supply/demand properties of the system and protect the network.

Steps in the fee/reward feature:
- <s> 1. The query and handling of it on Elders for their reward keys and hard coded fee.</s>
- <s> 2. Including Elders in outputs (any value) when spending Dbcs.</s>
- <s> 3. Including fee ciphers for Elders so that they can confirm fee paid.</s>
- <s> 4. Elders confirming that spends contain outputs with sufficient amount, destined for them.</s>
- <s> 5. Implementing a commonly known deterministic transfer/store cost paid to nodes.</s>
- <s> 5. Including supply/demand adjusting fee in outputs when spending Dbcs.</s>
- <s> 6. A mempool which orders incoming spends by fee amount, and a Client UI option to choose priority of their spend.</s> (`This PR`)
7. Elders fetching and storing their payment to a local wallet.

