### PR TITLE
fix(handover): check current elders against all pks in case of split

### DIFF
--- a/sn_interface/src/network_knowledge/section_authority_provider.rs
+++ b/sn_interface/src/network_knowledge/section_authority_provider.rs
@@ -90,11 +90,12 @@ impl SapCandidate {
         }
     }
 
-    pub fn public_key_set(&self) -> PublicKeySet {
+    pub fn public_key_sets(&self) -> BTreeSet<PublicKeySet> {
         match self {
-            SapCandidate::ElderHandover(sap) => sap.public_key_set(),
-            // TODO: consider return both?
-            SapCandidate::SectionSplit(sap1, _sap2) => sap1.public_key_set(),
+            SapCandidate::ElderHandover(sap) => BTreeSet::from_iter([sap.public_key_set()]),
+            SapCandidate::SectionSplit(sap1, sap2) => {
+                BTreeSet::from_iter([sap1.public_key_set(), sap2.public_key_set()])
+            }
         }
     }
 }

--- a/sn_node/src/node/handover/handover_consensus.rs
+++ b/sn_node/src/node/handover/handover_consensus.rs
@@ -44,7 +44,7 @@ impl Handover {
 
     pub(crate) fn propose(&mut self, proposal: SapCandidate) -> Result<SignedVote<SapCandidate>> {
         // Do not cast a vote equals to self sap
-        if self.consensus.elders == proposal.public_key_set() {
+        if proposal.public_key_sets().contains(&self.consensus.elders) {
             error!("Cannot casting a proposal {proposal:?} as we are already on it");
             return Err(Error::FaultyProposal);
         }


### PR DESCRIPTION
Ensures that the fix in #2248 also applies during a split