### PR TITLE
ci: remove duplicate run skipping

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,53 +20,6 @@ env:
   NODE_COUNT: 14
 
 jobs:
-  # make sure all the jobs are not failed.
-  # Note that the duplicated jobs might be skipped.
-  merge-after-tests:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
-    name: Allow merge if all tests have passed
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    needs:
-      - unit
-      - e2e
-      - e2e-msg-happy-path
-      - api
-      - cli
-    steps:
-      - run: echo "All checks passed, ready to merge"
-
-  # make sure all the os agnostic specific jobs pass
-  # (those that are not os dependent, so we only run once)
-  merge-after-os-agnostic-only-tests:
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
-    name: Allow merge if all os-agnostic code quality checks pass
-    runs-on: ubuntu-latest
-    needs:
-      - cargo-udeps
-      - lint
-      - checks
-      - build-arm
-    steps:
-      - run: echo "All os agnostic checks passed, ready to merge"
-
-  pre_job:
-    # continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          # All of these options are optional, so you can remove them if you are happy with the defaults
-          concurrent_skipping: 'never'
-          skip_after_successful_duplicate: 'true'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-
   cargo-udeps:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Unused dependency check
@@ -142,8 +95,6 @@ jobs:
         run: RUSTDOCFLAGS="--deny=warnings" cargo doc --no-deps
 
   build-arm:
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
     name: build arm
     runs-on: ${{ matrix.os }}
     strategy:
@@ -175,8 +126,7 @@ jobs:
             !artifacts/.cargo-lock
 
   unit:
-    needs: pre_job
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):') && needs.pre_job.outputs.should_skip != 'true'"
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -238,8 +188,7 @@ jobs:
         run: cd sn_cli && cargo test --release --bin safe --features data-network
 
   e2e:
-    needs: pre_job
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):') && needs.pre_job.outputs.should_skip != 'true'"
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: E2E tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -386,8 +335,7 @@ jobs:
         continue-on-error: true
 
   e2e-msg-happy-path:
-    needs: pre_job
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):') && needs.pre_job.outputs.should_skip != 'true'"
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: E2E tests (msg happy path)
     runs-on: ${{ matrix.os }}
     strategy:
@@ -534,8 +482,7 @@ jobs:
         continue-on-error: true
 
   e2e-churn:
-    needs: pre_job
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):') && needs.pre_job.outputs.should_skip != 'true'"
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: E2E Churn test
     runs-on: ubuntu-latest
     env:
@@ -787,8 +734,7 @@ jobs:
   #         rm -rf ~/.safe
 
   api:
-    needs: pre_job
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):') && needs.pre_job.outputs.should_skip != 'true'"
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Run API tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -919,8 +865,7 @@ jobs:
         continue-on-error: true
 
   cli:
-    needs: pre_job
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):') && needs.pre_job.outputs.should_skip != 'true'"
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     name: Run CLI tests
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
removes the pre_job check and related job deps
this was not at all stable and proving to be more
pain than it was worth

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md

Write your comment below this line: -->
