### PR TITLE
chore: re-enable tracing env-filter feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "sn_fault_detection"
-version = "0.15.6"
+version = "0.15.5"
 dependencies = [
  "eyre",
  "itertools",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "sn_interface"
-version = "0.22.4"
+version = "0.22.3"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "sn_node"
-version = "0.82.6"
+version = "0.82.5"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "sn_testnet"
-version = "0.1.5"
+version = "0.1.4"
 dependencies = [
  "assert_fs",
  "clap",

--- a/log_cmds_inspector/Cargo.toml
+++ b/log_cmds_inspector/Cargo.toml
@@ -27,4 +27,4 @@ clap = { version = "3.0.0", features = ["derive", "env"] }
 strum = "0.24"
 strum_macros = "0.24"
 walkdir = "2"
-sn_interface = { path = "../sn_interface", version = "^0.22.4" }
+sn_interface = { path = "../sn_interface", version = "^0.22.3" }

--- a/sn_fault_detection/CHANGELOG.md
+++ b/sn_fault_detection/CHANGELOG.md
@@ -5,55 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.15.6 (2023-03-31)
-
-### Chore
-
- - <csr-id-169f7c2a4d2a30c32381ef7e2e7b6e09243b8164/> remove env filter where not needed
-
-### Other
-
- - <csr-id-9f6760f5c341e9d2925c3f99ebdf93f8e23162d1/> cleanup some deps
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 30 days passed between releases.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Remove env filter where not needed ([`169f7c2`](https://github.com/maidsafe/safe_network/commit/169f7c2a4d2a30c32381ef7e2e7b6e09243b8164))
-    - Cleanup some deps ([`9f6760f`](https://github.com/maidsafe/safe_network/commit/9f6760f5c341e9d2925c3f99ebdf93f8e23162d1))
-</details>
-
 ## v0.15.5 (2023-02-28)
-
-<csr-id-3fda80a40c508d16fbe097091252a98b01f8f339/>
 
 ### Refactor
 
  - <csr-id-3fda80a40c508d16fbe097091252a98b01f8f339/> remove unused pub fn/methods
 
-### Chore
-
- - <csr-id-558061d5eea7bc1f0feac310afb91ef9ca7c681e/> sn_interface-0.19.1/sn_fault_detection-0.15.5/sn_node-0.77.1/sn_cli-0.72.1
-
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 2 commits contributed to the release.
+ - 1 commit contributed to the release.
  - 20 days passed between releases.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
 ### Commit Details
@@ -63,14 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Sn_interface-0.19.1/sn_fault_detection-0.15.5/sn_node-0.77.1/sn_cli-0.72.1 ([`558061d`](https://github.com/maidsafe/safe_network/commit/558061d5eea7bc1f0feac310afb91ef9ca7c681e))
     - Remove unused pub fn/methods ([`3fda80a`](https://github.com/maidsafe/safe_network/commit/3fda80a40c508d16fbe097091252a98b01f8f339))
 </details>
 
 ## v0.15.4 (2023-02-07)
 
 <csr-id-677ef5cc8b1935b94641c61c53429faf2c58c261/>
-<csr-id-3c34a731eca9d5b37d2574e3e16c7f089c7cc8b2/>
 
 ### Chore
 

--- a/sn_fault_detection/Cargo.toml
+++ b/sn_fault_detection/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_fault_detection"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.15.6"
+version = "0.15.5"
 
 [features]
 default = []

--- a/sn_interface/CHANGELOG.md
+++ b/sn_interface/CHANGELOG.md
@@ -6,41 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## v0.22.4 (2023-03-31)
-
-### Chore
-
- - <csr-id-841eaff15bab9cab5454b2b42790e48df5a316e1/> remove qp2p dep
-
-### Other
-
- - <csr-id-9f6760f5c341e9d2925c3f99ebdf93f8e23162d1/> cleanup some deps
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 1 day passed between releases.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Cleanup some deps ([`9f6760f`](https://github.com/maidsafe/safe_network/commit/9f6760f5c341e9d2925c3f99ebdf93f8e23162d1))
-    - Remove qp2p dep ([`841eaff`](https://github.com/maidsafe/safe_network/commit/841eaff15bab9cab5454b2b42790e48df5a316e1))
-</details>
-
 ## v0.22.3 (2023-03-30)
-
-### Chore
-
- - <csr-id-350fcec1913f38a63620f4d51486809e429e7d88/> sn_interface-0.22.3/sn_node-0.82.5
 
 ### Bug Fixes
 
@@ -50,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 2 commits contributed to the release.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 1 commit contributed to the release.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
 ### Commit Details
@@ -61,13 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Sn_interface-0.22.3/sn_node-0.82.5 ([`350fcec`](https://github.com/maidsafe/safe_network/commit/350fcec1913f38a63620f4d51486809e429e7d88))
     - Check current elders against all pks in case of split ([`c74b1ff`](https://github.com/maidsafe/safe_network/commit/c74b1ff022d62067cfe6c6c5ed3880aefe82e149))
 </details>
 
 ## v0.22.2 (2023-03-29)
-
-<csr-id-1aeaafa940fc9ada35cfbcfc95f28c7478d4a2da/>
 
 ### Chore
 
@@ -174,6 +137,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - <csr-id-94d20504b58cb09a203ffd9c03fdcab07a810d0b/> new cmds to interact with a safenode RPC service
    - The new `node` CLI subcommand is made available only when building
    with `node-ctl` feature flag.
+- Adding a new RPC service to safenode to request it to update itself.
+- Migrate sn_api and sn_cli CI tests to use sn_testnet 'verify-nodes' feature.
 
 ### Commit Statistics
 
@@ -193,9 +158,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Sn_updater-0.2.0/sn_interface-0.21.0/sn_comms-0.7.0/sn_client-0.83.0/sn_node-0.81.0/sn_api-0.81.0/sn_cli-0.75.0 ([`0e9db2d`](https://github.com/maidsafe/safe_network/commit/0e9db2da4ed28d36d8ee866c9e941ab39e155e28))
     - New cmds to interact with a safenode RPC service ([`94d2050`](https://github.com/maidsafe/safe_network/commit/94d20504b58cb09a203ffd9c03fdcab07a810d0b))
 </details>
-
-<csr-unknown>
-Adding a new RPC service to safenode to request it to update itself.Migrate sn_api and sn_cli CI tests to use sn_testnet ‘verify-nodes’ feature.<csr-unknown/>
 
 ## v0.20.12 (2023-03-27)
 

--- a/sn_interface/Cargo.toml
+++ b/sn_interface/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_interface"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.22.4"
+version = "0.22.3"
 
 [features]
 test-utils = ["proptest"]

--- a/sn_node/CHANGELOG.md
+++ b/sn_node/CHANGELOG.md
@@ -5,18 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.82.6 (2023-03-31)
+## v0.82.5 (2023-03-30)
 
 ### Bug Fixes
 
- - <csr-id-41ccde7ec4e7b5918ce25c074e724491d6db845a/> avoid block handover vote for split
+ - <csr-id-c74b1ff022d62067cfe6c6c5ed3880aefe82e149/> check current elders against all pks in case of split
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
  - 1 commit contributed to the release.
- - 1 day passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -27,41 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Avoid block handover vote for split ([`41ccde7`](https://github.com/maidsafe/safe_network/commit/41ccde7ec4e7b5918ce25c074e724491d6db845a))
-</details>
-
-## v0.82.5 (2023-03-30)
-
-### Chore
-
- - <csr-id-350fcec1913f38a63620f4d51486809e429e7d88/> sn_interface-0.22.3/sn_node-0.82.5
-
-### Bug Fixes
-
- - <csr-id-c74b1ff022d62067cfe6c6c5ed3880aefe82e149/> check current elders against all pks in case of split
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Sn_interface-0.22.3/sn_node-0.82.5 ([`350fcec`](https://github.com/maidsafe/safe_network/commit/350fcec1913f38a63620f4d51486809e429e7d88))
     - Check current elders against all pks in case of split ([`c74b1ff`](https://github.com/maidsafe/safe_network/commit/c74b1ff022d62067cfe6c6c5ed3880aefe82e149))
 </details>
 
 ## v0.82.4 (2023-03-29)
-
-<csr-id-787347eda7a075092a1682cc38d64e06c0fa80f8/>
 
 ### Chore
 

--- a/sn_node/Cargo.toml
+++ b/sn_node/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_node"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.82.6"
+version = "0.82.5"
 
 [[bin]]
 name = "safenode"
@@ -72,8 +72,8 @@ sn_consensus = "3.3.3"
 sn_updater = { path = "../sn_updater", version = "^0.2.0" }
 sn_comms = { path = "../sn_comms", version = "^0.8.0" }
 sn_dbc = { version = "12.0.0", features = ["serdes"] }
-sn_fault_detection = { path = "../sn_fault_detection", version = "^0.15.6" }
-sn_interface = { path = "../sn_interface", version = "^0.22.4" }
+sn_fault_detection = { path = "../sn_fault_detection", version = "^0.15.5" }
+sn_interface = { path = "../sn_interface", version = "^0.22.3" }
 sn_sdkg = "3.1.3"
 serde = { version = "1.0.111", features = ["derive", "rc"] }
 serde_bytes = "~0.11.5"
@@ -124,7 +124,7 @@ rand = { version = "~0.8.5", features = ["small_rng"] }
 tokio-util = { version = "~0.7", features = ["time"] }
 walkdir = "2"
 sn_comms = { path = "../sn_comms", version = "^0.8.0", features = ["test"] }
-sn_interface = { path = "../sn_interface", version = "^0.22.4", features= ["test-utils", "proptest"] }
+sn_interface = { path = "../sn_interface", version = "^0.22.3", features= ["test-utils", "proptest"] }
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"

--- a/sn_testnet/CHANGELOG.md
+++ b/sn_testnet/CHANGELOG.md
@@ -5,18 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.1.5 (2023-03-31)
+## v0.1.4 (2023-03-23)
 
-### Chore
+### New Features
 
- - <csr-id-169f7c2a4d2a30c32381ef7e2e7b6e09243b8164/> remove env filter where not needed
+ - <csr-id-16bb3389cdd665fe9a577587d9b7a6e8d21a3028/> exposing a gRPC interface on safenode bin/app
+   - The safenode RPC service is exposed only when built with 'rpc-service' feature.
+   - The safenode RPC service code is generated automatically using gRPC (`tonic` crate)
+   from a `proto` file with messages definitions added to sn_interface.
+   - The RPC is exposed at the same address as the node's address used for network connections,
+   but using the subsequent port number.
+   - A new final step was implemented for the sn_testnet tool, to run a check on the launched nodes,
+   verifying their names and network knowledge are the expected for the launched testnet.
+   - The new sn_testnet tool step is run only if built with 'verify-nodes' feature.
+   - Running the `verify-nodes` check of sn_testnet in CI previous to sn_client e2e tests.
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
  - 1 commit contributed to the release.
- - 7 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -27,44 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
-    - Remove env filter where not needed ([`169f7c2`](https://github.com/maidsafe/safe_network/commit/169f7c2a4d2a30c32381ef7e2e7b6e09243b8164))
-</details>
-
-## v0.1.4 (2023-03-23)
-
-### Chore
-
- - <csr-id-358174ab1503fc8cf1b07ab66be397f3e853a14c/> sn_testnet-0.1.4/sn_interface-0.20.9/sn_node-0.80.3
-
-### New Features
-
- - <csr-id-16bb3389cdd665fe9a577587d9b7a6e8d21a3028/> exposing a gRPC interface on safenode bin/app
-   - The safenode RPC service is exposed only when built with 'rpc-service' feature.
-- The safenode RPC service code is generated automatically using gRPC (`tonic` crate)
-   from a `proto` file with messages definitions added to sn_interface.
-- The RPC is exposed at the same address as the node's address used for network connections,
-   but using the subsequent port number.
-- A new final step was implemented for the sn_testnet tool, to run a check on the launched nodes,
-   verifying their names and network knowledge are the expected for the launched testnet.
-- The new sn_testnet tool step is run only if built with 'verify-nodes' feature.
-- Running the `verify-nodes` check of sn_testnet in CI previous to sn_client e2e tests.
-
-### Commit Statistics
-
-<csr-read-only-do-not-edit/>
-
- - 2 commits contributed to the release.
- - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - Sn_testnet-0.1.4/sn_interface-0.20.9/sn_node-0.80.3 ([`358174a`](https://github.com/maidsafe/safe_network/commit/358174ab1503fc8cf1b07ab66be397f3e853a14c))
     - Exposing a gRPC interface on safenode bin/app ([`16bb338`](https://github.com/maidsafe/safe_network/commit/16bb3389cdd665fe9a577587d9b7a6e8d21a3028))
 </details>
 
@@ -76,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-id-807d69ef609decfe94230e2086144afc5cc56d7b/>
 <csr-id-1a8b9c9ba5b98c0f1176a0ccbce53d4acea8c84c/>
 <csr-id-d3c6c9727a69389f4204b746c54a537cd783232c/>
-<csr-id-22c6e341d28c913a3acaaeae0ceeb8c0a1ef4d4e/>
 
 ### Chore
 

--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -32,7 +32,7 @@ regex = "1.7.1"
 tonic = { version = "~0.8.3", optional = true }
 tracing = "~0.1.26"
 tracing-core = "~0.1.21"
-tracing-subscriber = { version = "~0.3.1", features = ["json"] }
+tracing-subscriber = { version = "~0.3.1", features = ["env-filter", "json"] }
 xor_name = { version = "~5.0.0", optional = true }
 walkdir = "2"
 

--- a/sn_testnet/Cargo.toml
+++ b/sn_testnet/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "sn_testnet"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_network"
-version = "0.1.5"
+version = "0.1.4"
 
 [features]
 # required to pass on flag to node builds


### PR DESCRIPTION
- 05bfc6aaa **Revert "chore(release): sn_testnet-0.1.5/sn_interface-0.22.4/sn_fault_detection-0.15.6/sn_node-0.82.6"**

  This reverts commit 995f26ec09b5a22910e7b7f747e32ac7a426bd06.

- c606fc639 **chore: re-enable tracing env-filter feature**

  The `sn_testnet` crate still requires this feature or it won't compile.

  The release commit that bumped the versions after this change was reverted because the `sn_testnet`
  crate couldn't be published. This is the first crate in the chain, so we can just revert the whole
  release commit and the next time we merge we will get a version bump without the `sn_testnet`
  change.