### PR TITLE
feat: register spends in the network

### DIFF
--- a/safenode/src/network_transfers/mod.rs
+++ b/safenode/src/network_transfers/mod.rs
@@ -23,6 +23,11 @@ use sn_dbc::{DbcId, DbcTransaction, MainKey, SignedSpend, Token};
 
 use std::collections::{BTreeMap, BTreeSet};
 
+/// This is an arbitrary number.
+/// The supply/demand dynamics enabled by the
+/// spend queue, will give the price discovery
+/// that results in the correct levels of fees
+/// as deemed by the market.
 const STARTING_FEE: u64 = 4000; // 0.000004 SNT
 
 pub(super) struct Transfers {
@@ -87,14 +92,14 @@ impl Transfers {
     pub(crate) async fn try_add(
         &mut self,
         signed_spend: Box<SignedSpend>,
-        source_tx: Box<DbcTransaction>,
+        parent_tx: Box<DbcTransaction>,
         fee_ciphers: BTreeMap<NodeId, FeeCiphers>,
         parent_spends: BTreeSet<SignedSpend>,
     ) -> Result<()> {
         // 1. Validate the tx hash.
         // Ensure that the provided src tx is the same as the
         // one we have the hash of in the signed spend.
-        let provided_src_tx_hash = source_tx.hash();
+        let provided_src_tx_hash = parent_tx.hash();
         let signed_src_tx_hash = signed_spend.src_tx_hash();
 
         if provided_src_tx_hash != signed_src_tx_hash {
@@ -105,14 +110,14 @@ impl Transfers {
         }
 
         // 2. Try extract the fee paid for this spend, and validate it.
-        let paid_fee = self.validate_fee(source_tx.as_ref(), fee_ciphers)?;
+        let paid_fee = self.validate_fee(parent_tx.as_ref(), fee_ciphers)?;
 
         // 3. Validate the spend itself.
         self.storage.validate(signed_spend.as_ref()).await?;
 
         // 4. Validate the parents of the spend.
         // This also ensures that all parent's dst tx's are the same as the src tx of this spend.
-        validate_parent_spends(signed_spend.as_ref(), source_tx.as_ref(), parent_spends)?;
+        validate_parent_spends(signed_spend.as_ref(), parent_tx.as_ref(), parent_spends)?;
 
         // This spend is valid and goes into the queue.
         self.spend_queue.push(*signed_spend, paid_fee.as_nano());
@@ -132,10 +137,10 @@ impl Transfers {
 
     fn validate_fee(
         &self,
-        tx: &DbcTransaction,
+        parent_tx: &DbcTransaction,
         fee_ciphers: BTreeMap<NodeId, FeeCiphers>,
     ) -> Result<Token> {
-        let fee_paid = decipher_fee(&self.node_reward_key, tx, self.node_id, fee_ciphers)?;
+        let fee_paid = decipher_fee(&self.node_reward_key, parent_tx, self.node_id, fee_ciphers)?;
 
         let spend_q_snapshot = self.spend_queue.snapshot();
         let spend_q_stats = spend_q_snapshot.stats();
@@ -157,7 +162,7 @@ impl Transfers {
 /// The signed_spend.dbc_id() shall exist among its outputs.
 fn validate_parent_spends(
     signed_spend: &SignedSpend,
-    source_tx: &DbcTransaction,
+    parent_tx: &DbcTransaction,
     parent_spends: BTreeSet<SignedSpend>,
 ) -> Result<()> {
     // The parent_spends will be different spends,
@@ -179,11 +184,11 @@ fn validate_parent_spends(
         .map(|s| s.spend.blinded_amount)
         .collect();
     // Here we check that the spend that is attempted, was created in a valid tx.
-    let src_tx_validity = source_tx.verify(&known_parent_blinded_amounts);
+    let src_tx_validity = parent_tx.verify(&known_parent_blinded_amounts);
     if src_tx_validity.is_err() {
         return Err(Error::InvalidSourceTxProvided {
             signed_src_tx_hash: signed_spend.src_tx_hash(),
-            provided_src_tx_hash: source_tx.hash(),
+            provided_src_tx_hash: parent_tx.hash(),
         });
     }
 
@@ -194,13 +199,17 @@ fn validate_parent_spends(
 #[cfg(not(feature = "data-network"))]
 fn decipher_fee(
     node_reward_key: &MainKey,
-    tx: &DbcTransaction,
+    parent_tx: &DbcTransaction,
     node_id: NodeId,
     fee_ciphers: BTreeMap<NodeId, FeeCiphers>,
 ) -> Result<Token> {
     let fee_ciphers = fee_ciphers.get(&node_id).ok_or(Error::MissingFee)?;
     let (dbc_id, revealed_amount) = fee_ciphers.decrypt(node_reward_key)?;
-    let output_proof = match tx.outputs.iter().find(|proof| proof.dbc_id() == &dbc_id) {
+    let output_proof = match parent_tx
+        .outputs
+        .iter()
+        .find(|proof| proof.dbc_id() == &dbc_id)
+    {
         Some(proof) => proof,
         None => return Err(Error::MissingFee),
     };

--- a/safenode/src/protocol/messages/cmd.rs
+++ b/safenode/src/protocol/messages/cmd.rs
@@ -49,7 +49,7 @@ pub enum Cmd {
         signed_spend: Box<SignedSpend>,
         /// The transaction that this spend was created in.
         #[debug(skip)]
-        source_tx: Box<DbcTransaction>,
+        parent_tx: Box<DbcTransaction>,
         /// As to avoid impl separate cmd flow, we send
         /// all fee ciphers to all Nodes for now.
         #[debug(skip)]

--- a/safenode/src/protocol/wallet/local_store.rs
+++ b/safenode/src/protocol/wallet/local_store.rs
@@ -168,6 +168,7 @@ impl SendWallet for LocalWallet {
         let TransferDetails {
             change_dbc,
             created_dbcs,
+            ..
         } = client.send(available_dbcs, to, self.address()).await?;
 
         let spent_dbc_ids: BTreeSet<_> = created_dbcs


### PR DESCRIPTION
Resolves #117.

- This is the final step in making a transfer valid in the network.
- Fees are paid to nodes.

***

**NB1**: Some additional validation of responses is needed to make sure we
error if not enough nodes could handle the request.

**NB2**: Nodes still need to store the rewards in their wallet, TBD.

**NB3**: There are still some code reuse work to be done between
transfer online and offline files.